### PR TITLE
Convert application sorting test to use guest user login

### DIFF
--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -1,4 +1,4 @@
-import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+import { startSession, loginAsAdmin, loginAsGuest, loginAsProgramAdmin, loginAsTestUser, AdminQuestions, AdminPrograms, endSession, logout, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
 
 describe('normal application flow', () => {
   it('all major steps', async () => {
@@ -165,7 +165,7 @@ describe('normal application flow', () => {
     // Submit applications from different users.
     const answers = ['apple', 'banana', 'cherry', 'durian'];
     for (const answer of answers) {
-      await loginAsTestUser(page);
+      await loginAsGuest(page);
       await selectApplicantLanguage(page, 'English');
 
       const applicantQuestions = new ApplicantQuestions(page);


### PR DESCRIPTION
Convert application sorting test to use guest user for application submission.

### Description
In the prober, loginAsTestUser uses IDCS for test user account login, but this seems to time out when creating several applications in a tight loop. Converting to guest user login should avoid this (mirrors local dev environment), and the applications will also come from different users as originally intended in the test design.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)

