### PR TITLE
Fix several causes of browser test instability.

### DIFF
--- a/browser-test/src/application_optional_questions.test.ts
+++ b/browser-test/src/application_optional_questions.test.ts
@@ -12,7 +12,7 @@ describe('optional application flow', () => {
     const questions = await adminQuestions.addAllNonSingleBlockQuestionTypes('optional-');
     await adminQuestions.addFileUploadQuestion({questionName: 'optional-file-upload'});
 
-    const programName = 'Optional Questions Program';
+    const programName = 'Optional Questions Program 1';
     await adminPrograms.addProgram(programName);
     await adminPrograms.editProgramBlockWithOptional(programName, 'first description', [], 'optional-file-upload');
 
@@ -20,7 +20,9 @@ describe('optional application flow', () => {
       await adminPrograms.addProgramBlockWithOptional(programName, 'description', [], questions[i]);
     }
 
-    const programName2 = 'Second Optional Questions Program';
+    // Program names cannot be substrings of each other otherwise our text
+    // selectors can match the wrong one.
+    const programName2 = 'Optional Questions Program 2';
     await adminPrograms.addProgram(programName2);
     await adminPrograms.editProgramBlockWithOptional(programName2, 'first description', [], 'optional-file-upload');
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -194,11 +194,11 @@ export class AdminPrograms {
     await this.page.click('#update-block-button:not([disabled])');
     // Wait for submit and redirect back to this page.
     await this.page.waitForURL(this.page.url());
-    waitForPageJsLoad(this.page);
+    await waitForPageJsLoad(this.page);
 
     for (const questionName of questionNames) {
       await this.page.click(`button:text("${questionName}")`);
-      waitForPageJsLoad(this.page);
+      await waitForPageJsLoad(this.page);
       // Make sure the question is successfully added to the screen.
       await this.page.waitForSelector(`div.cf-program-question p:text("${questionName}")`);
     }
@@ -226,8 +226,6 @@ export class AdminPrograms {
       await this.page.click(`button:text("${questionName}")`);
       await waitForPageJsLoad(this.page);
     }
-
-    return await this.page.$eval('#block-name-input', el => (el as HTMLInputElement).value);
   }
 
   async addProgramRepeatedBlock(programName: string,

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -343,7 +343,7 @@ export class AdminQuestions {
     await this.page.click('#create-question-button');
     await this.page.click('#create-dropdown-question');
     await this.page.waitForURL('**/admin/questions/new?type=dropdown');
-    waitForPageJsLoad(this.page);
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -58,7 +58,8 @@ export const loginAsGuest = async (page: Page) => {
 export const loginAsTestUser = async (page: Page) => {
   if (isTestUser()) {
     await page.click('#idcs');
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+    // Wait for the IDCS login page to make sure we've followed all redirects.
+    await page.waitForURL('**/#/login*');
     await page.fill('input[name=userName]', TEST_USER_LOGIN);
     await page.fill('input[name=password]', TEST_USER_PASSWORD);
     await page.click('button:has-text("Login"):not([disabled])');


### PR DESCRIPTION
### Description
- Removed unused code from addProgramBlockWithOptional that was causing problems
- Disambiguated application_optional_questions.test.ts program names to prevent ambiguous text selector matches
- Hopefully fixed IDCS login issues by explicitly waiting redirect destination URL
- Not essential, but made sure all calls to waitForPageJsLoad use await

### Checklist
- [X] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1631 
