### PR TITLE
Edit and continue text should not get cut off in summary view on mobile

### DIFF
--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -209,7 +209,11 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       ContainerTag editContent =
           div(editAction)
               .withClasses(
-                  Styles.FLEX_AUTO, Styles.TEXT_RIGHT, Styles.FONT_MEDIUM, Styles.RELATIVE, Styles.BREAK_NORMAL);
+                  Styles.FLEX_AUTO,
+                  Styles.TEXT_RIGHT,
+                  Styles.FONT_MEDIUM,
+                  Styles.RELATIVE,
+                  Styles.BREAK_NORMAL);
 
       answerDiv.with(editContent);
     }


### PR DESCRIPTION
### Description
Remove the word break setting for "edit", "continue" and "start here" in the question summary view and update the width for upload links. I unfortunately can't test the upload text locally, since I'm having issues with localstack, but I checked all the other cases and this works. I've also modified the CSS on staging and prod to make sure this change works for the upload case. I'll plan to look into the localstack issue as a followup. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1638
