### PR TITLE
Add aria-describedby for question description and errors for input fields

### DIFF
--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -75,6 +75,7 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
 
     // Add the hidden enumerator field template
     if (params.block().isEnumerator()) {
+      // DELETE: get description ID of this?
       bundle.addMainContent(
           EnumeratorQuestionRenderer.newEnumeratorFieldTemplate(
               params.block().getEnumeratorQuestion().getContextualizedPath(),

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -75,7 +75,6 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
 
     // Add the hidden enumerator field template
     if (params.block().isEnumerator()) {
-      // DELETE: get description ID of this?
       bundle.addMainContent(
           EnumeratorQuestionRenderer.newEnumeratorFieldTemplate(
               params.block().getEnumeratorQuestion().getContextualizedPath(),

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -53,7 +53,7 @@ public class FieldWithLabel {
   protected String labelText = "";
   protected String placeholderText = "";
   protected String screenReaderText = "";
-  protected ArrayList<String> ariaDescribedByIds;
+  protected ArrayList<String> ariaDescribedByIds = new ArrayList<String>();
   protected Messages messages;
   protected ImmutableSet<ValidationError> fieldErrors = ImmutableSet.of();
   protected boolean showFieldErrors = true;
@@ -239,7 +239,7 @@ public class FieldWithLabel {
    * Set the list of HTML tag IDs that should be used for a11y descriptions.
    */
   public FieldWithLabel setAriaDescribedByIds(ArrayList<String> ariaDescribedByIds) {
-    this.ariaDescribedByIds = ariaDescribedByIds;
+    this.ariaDescribedByIds = new ArrayList<String>(ariaDescribedByIds);
     return this;
   }
 

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -24,7 +24,9 @@ import views.style.BaseStyles;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-/** Utility class for rendering an input field with an optional label. */
+/**
+ * Utility class for rendering an input field with an optional label.
+ */
 public class FieldWithLabel {
 
   private static final ImmutableSet<String> STRING_TYPES =
@@ -35,7 +37,9 @@ public class FieldWithLabel {
   protected String fieldType = "text";
   protected String fieldValue = "";
 
-  /** For use with fields of type `number`. */
+  /**
+   * For use with fields of type `number`.
+   */
   protected OptionalLong fieldValueNumber = OptionalLong.empty();
 
   protected OptionalLong minValue = OptionalLong.empty();
@@ -46,6 +50,7 @@ public class FieldWithLabel {
   protected String labelText = "";
   protected String placeholderText = "";
   protected String screenReaderText = "";
+  protected String descriptionId = "";
   protected Messages messages;
   protected ImmutableSet<ValidationError> fieldErrors = ImmutableSet.of();
   protected boolean showFieldErrors = true;
@@ -97,7 +102,9 @@ public class FieldWithLabel {
     return new FieldWithLabel(fieldTag).setFieldType("email");
   }
 
-  /** Add a reference class from {@link views.style.ReferenceClasses} to this element. */
+  /**
+   * Add a reference class from {@link views.style.ReferenceClasses} to this element.
+   */
   public FieldWithLabel addReferenceClass(String referenceClass) {
     referenceClassesBuilder.add(referenceClass);
     return this;
@@ -145,7 +152,9 @@ public class FieldWithLabel {
     return this;
   }
 
-  /** Sets a valueless attribute. */
+  /**
+   * Sets a valueless attribute.
+   */
   public FieldWithLabel setAttribute(String attribute) {
     this.fieldTag.attr(attribute, null);
     return this;
@@ -221,6 +230,14 @@ public class FieldWithLabel {
     return this;
   }
 
+  /**
+   * Set the HTML tag ID of the question description. This is used for aria attributes.
+   */
+  public FieldWithLabel setDescriptionId(String descriptionId) {
+    this.descriptionId = descriptionId;
+    return this;
+  }
+
   public FieldWithLabel setFieldErrors(
       Messages messages, ImmutableSet<ValidationErrorMessage> errors) {
     this.messages = messages;
@@ -283,10 +300,17 @@ public class FieldWithLabel {
     }
 
     boolean hasFieldErrors = !fieldErrors.isEmpty() && showFieldErrors;
+    String ariaDescribedBy = "";
     if (hasFieldErrors) {
       fieldTag.attr("aria-invalid", "true");
-      fieldTag.attr("aria-describedBy", fieldErrorsId);
+      ariaDescribedBy = fieldErrorsId;
     }
+    if (!descriptionId.isEmpty()) {
+      // Add a space to separate multiple IDs.
+      ariaDescribedBy += ariaDescribedBy.isEmpty() ? "" : " ";
+      ariaDescribedBy += descriptionId;
+    }
+    fieldTag.condAttr(!ariaDescribedBy.isEmpty(), "aria-describedBy", ariaDescribedBy);
 
     fieldTag
         .withClasses(
@@ -311,9 +335,9 @@ public class FieldWithLabel {
             .withText(labelText.isEmpty() ? screenReaderText : labelText);
 
     return div(
-            labelTag,
-            div(fieldTag, buildFieldErrorsTag(fieldErrorsId))
-                .withClasses(Styles.FLEX, Styles.FLEX_COL))
+        labelTag,
+        div(fieldTag, buildFieldErrorsTag(fieldErrorsId))
+            .withClasses(Styles.FLEX, Styles.FLEX_COL))
         .withClasses(
             StyleUtils.joinStyles(referenceClassesBuilder.build().toArray(new String[0])),
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM);

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -13,7 +13,6 @@ import j2html.TagCreator;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -27,9 +26,7 @@ import views.style.BaseStyles;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-/**
- * Utility class for rendering an input field with an optional label.
- */
+/** Utility class for rendering an input field with an optional label. */
 public class FieldWithLabel {
 
   private static final ImmutableSet<String> STRING_TYPES =
@@ -40,9 +37,7 @@ public class FieldWithLabel {
   protected String fieldType = "text";
   protected String fieldValue = "";
 
-  /**
-   * For use with fields of type `number`.
-   */
+  /** For use with fields of type `number`. */
   protected OptionalLong fieldValueNumber = OptionalLong.empty();
 
   protected OptionalLong minValue = OptionalLong.empty();
@@ -107,9 +102,7 @@ public class FieldWithLabel {
     return new FieldWithLabel(fieldTag).setFieldType("email");
   }
 
-  /**
-   * Add a reference class from {@link views.style.ReferenceClasses} to this element.
-   */
+  /** Add a reference class from {@link views.style.ReferenceClasses} to this element. */
   public FieldWithLabel addReferenceClass(String referenceClass) {
     referenceClassesBuilder.add(referenceClass);
     return this;
@@ -157,9 +150,7 @@ public class FieldWithLabel {
     return this;
   }
 
-  /**
-   * Sets a valueless attribute.
-   */
+  /** Sets a valueless attribute. */
   public FieldWithLabel setAttribute(String attribute) {
     this.fieldTag.attr(attribute, null);
     return this;
@@ -235,17 +226,13 @@ public class FieldWithLabel {
     return this;
   }
 
-  /**
-   * Set the list of HTML tag IDs that should be used for a11y descriptions.
-   */
+  /** Set the list of HTML tag IDs that should be used for a11y descriptions. */
   public FieldWithLabel setAriaDescribedByIds(ArrayList<String> ariaDescribedByIds) {
     this.ariaDescribedByIds = new ArrayList<String>(ariaDescribedByIds);
     return this;
   }
 
-  /**
-   * Set whether the question this field belongs to has errors.
-   */
+  /** Set whether the question this field belongs to has errors. */
   public FieldWithLabel setHasQuestionErrors(boolean hasQuestionErrors) {
     this.hasQuestionErrors = hasQuestionErrors;
     return this;
@@ -319,7 +306,9 @@ public class FieldWithLabel {
     if (hasFieldErrors) {
       allAriaDescribedByIds.add(0, fieldErrorsId);
     }
-    fieldTag.condAttr(!allAriaDescribedByIds.isEmpty(), "aria-describedBy",
+    fieldTag.condAttr(
+        !allAriaDescribedByIds.isEmpty(),
+        "aria-describedBy",
         StringUtils.join(allAriaDescribedByIds, " "));
 
     fieldTag
@@ -345,9 +334,9 @@ public class FieldWithLabel {
             .withText(labelText.isEmpty() ? screenReaderText : labelText);
 
     return div(
-        labelTag,
-        div(fieldTag, buildFieldErrorsTag(fieldErrorsId))
-            .withClasses(Styles.FLEX, Styles.FLEX_COL))
+            labelTag,
+            div(fieldTag, buildFieldErrorsTag(fieldErrorsId))
+                .withClasses(Styles.FLEX, Styles.FLEX_COL))
         .withClasses(
             StyleUtils.joinStyles(referenceClassesBuilder.build().toArray(new String[0])),
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM);

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -14,6 +14,7 @@ import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -48,7 +49,7 @@ public class FieldWithLabel {
   protected String labelText = "";
   protected String placeholderText = "";
   protected String screenReaderText = "";
-  protected ArrayList<String> ariaDescribedByIds = new ArrayList<String>();
+  protected List<String> ariaDescribedByIds = new ArrayList<>();
   protected Messages messages;
   protected ImmutableSet<ValidationError> fieldErrors = ImmutableSet.of();
   protected boolean showFieldErrors = true;
@@ -227,8 +228,8 @@ public class FieldWithLabel {
   }
 
   /** Set the list of HTML tag IDs that should be used for a11y descriptions. */
-  public FieldWithLabel setAriaDescribedByIds(ArrayList<String> ariaDescribedByIds) {
-    this.ariaDescribedByIds = new ArrayList<String>(ariaDescribedByIds);
+  public FieldWithLabel setAriaDescribedByIds(List<String> ariaDescribedByIds) {
+    this.ariaDescribedByIds = new ArrayList<>(ariaDescribedByIds);
     return this;
   }
 

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -30,7 +31,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 
@@ -44,7 +46,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setPlaceholderText(
                         messages.at(MessageKey.ADDRESS_PLACEHOLDER_STREET.getKeyName()))
                     .setValue(addressQuestion.getStreetValue().orElse(""))
-                    .setDescriptionId(getDescriptionId())
+                    .setAriaDescribedByIds(ariaDescribedByIds)
+                    .setHasQuestionErrors(hasQuestionErrors)
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -58,7 +61,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setPlaceholderText(
                         messages.at(MessageKey.ADDRESS_PLACEHOLDER_LINE_2.getKeyName()))
                     .setValue(addressQuestion.getLine2Value().orElse(""))
-                    .setDescriptionId(getDescriptionId())
+                    .setAriaDescribedByIds(ariaDescribedByIds)
+                    .setHasQuestionErrors(hasQuestionErrors)
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -74,7 +78,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_CITY.getKeyName()))
                             .setValue(addressQuestion.getCityValue().orElse(""))
                             .addReferenceClass(ReferenceClasses.ADDRESS_CITY)
-                            .setDescriptionId(getDescriptionId())
+                            .setAriaDescribedByIds(ariaDescribedByIds)
+                            .setHasQuestionErrors(hasQuestionErrors)
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(
@@ -84,7 +89,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setFieldName(addressQuestion.getStatePath().toString())
                             .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_STATE.getKeyName()))
                             .setValue(addressQuestion.getStateValue().orElse(""))
-                            .setDescriptionId(getDescriptionId())
+                            .setAriaDescribedByIds(ariaDescribedByIds)
+                            .setHasQuestionErrors(hasQuestionErrors)
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(
@@ -96,7 +102,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setLabelText(
                                 messages.at(MessageKey.ADDRESS_LABEL_ZIPCODE.getKeyName()))
                             .setValue(addressQuestion.getZipValue().orElse(""))
-                            .setDescriptionId(getDescriptionId())
+                            .setAriaDescribedByIds(ariaDescribedByIds)
+                            .setHasQuestionErrors(hasQuestionErrors)
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -44,6 +44,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setPlaceholderText(
                         messages.at(MessageKey.ADDRESS_PLACEHOLDER_STREET.getKeyName()))
                     .setValue(addressQuestion.getStreetValue().orElse(""))
+                    .setDescriptionId(getDescriptionId())
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -57,6 +58,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setPlaceholderText(
                         messages.at(MessageKey.ADDRESS_PLACEHOLDER_LINE_2.getKeyName()))
                     .setValue(addressQuestion.getLine2Value().orElse(""))
+                    .setDescriptionId(getDescriptionId())
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -72,6 +74,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_CITY.getKeyName()))
                             .setValue(addressQuestion.getCityValue().orElse(""))
                             .addReferenceClass(ReferenceClasses.ADDRESS_CITY)
+                            .setDescriptionId(getDescriptionId())
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(
@@ -81,6 +84,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setFieldName(addressQuestion.getStatePath().toString())
                             .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_STATE.getKeyName()))
                             .setValue(addressQuestion.getStateValue().orElse(""))
+                            .setDescriptionId(getDescriptionId())
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(
@@ -92,6 +96,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
                             .setLabelText(
                                 messages.at(MessageKey.ADDRESS_LABEL_ZIPCODE.getKeyName()))
                             .setValue(addressQuestion.getZipValue().orElse(""))
+                            .setDescriptionId(getDescriptionId())
                             .setFieldErrors(
                                 messages,
                                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -32,7 +32,8 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -5,7 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -32,7 +32,7 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -46,10 +46,6 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
 
-  // Add comments?
-  // A list of HTML ids, used to provide question-level details for accessibility. This is currently
-  // used by the "aria-describedby" attribute for each input for this question.
-
   protected abstract Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
@@ -98,8 +94,6 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
-      // DELETE: if multiple errors, how will screen reader read this out? I think will read all out
-      // based on manual test with currency example
       hasQuestionErrors = true;
       questionTextDiv.with(
           BaseHtmlView.fieldErrors(
@@ -126,9 +120,5 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
         .with(questionTextDiv)
         .with(renderTag(params, validationErrors, ariaDescribedByIds, hasQuestionErrors));
-
-    // DELETE - what's the cleanest way to pass this data in? (hasQuestionErrors and question level
-    // aria-describedby)
-    // Add wrapper struct? Refactor it to make it a property of the class?
   }
 }

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.ArrayList;
+import java.util.List;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -52,7 +53,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
   protected abstract Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors);
 
   @Override

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -38,6 +38,11 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
 
+  // DELETE: if we dont have help text, should we still tag
+  public final String getDescriptionId() {
+    return String.format("%s-description", question.getContextualizedPath().toString());
+  }
+
   @Override
   public final Tag render(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
@@ -52,6 +57,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
             // Question help text
             .with(
                 div()
+                    .withId(getDescriptionId())
                     .withClasses(
                         ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
                         ApplicantStyles.QUESTION_HELP_TEXT)

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -26,25 +27,38 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
 
   protected final ApplicantQuestion question;
 
+  // HTML id tags for various elements within this question.
+  private final String id;
+  private final String descriptionId;
+  private final String requiredErrorId;
+  private final String validationErrorId;
+
   ApplicantQuestionRendererImpl(ApplicantQuestion question) {
     this.question = checkNotNull(question);
+    id = question.getContextualizedPath().toString();
+    descriptionId = String.format("%s-description", id);
+    requiredErrorId = String.format("%s-required-error", id);
+    validationErrorId = String.format("%s-validation-error", id);
   }
 
   private String getRequiredClass() {
     return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
+  
+  // Add comments?
+  // A list of HTML ids, used to provide question-level details for accessibility. This is currently
+  // used by the "aria-describedby" attribute for each input for this question.
 
   protected abstract Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
-
-  // DELETE: if we dont have help text, should we still tag
-  public final String getDescriptionId() {
-    return String.format("%s-description", question.getContextualizedPath().toString());
-  }
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors);
 
   @Override
   public final Tag render(ApplicantQuestionRendererParams params) {
+    var ariaDescribedByIds = new ArrayList<String>();
+    ariaDescribedByIds.add(descriptionId);
+
     Messages messages = params.messages();
     ContainerTag questionTextDiv =
         div()
@@ -57,7 +71,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
             // Question help text
             .with(
                 div()
-                    .withId(getDescriptionId())
+                    .withId(descriptionId)
                     .withClasses(
                         ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
                         ApplicantStyles.QUESTION_HELP_TEXT)
@@ -77,27 +91,41 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
             String.format("Unhandled error display mode: %s", params.errorDisplayMode()));
     }
 
+    boolean hasQuestionErrors = false;
     ImmutableSet<ValidationErrorMessage> questionErrors =
         validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
+      // DELETE: if multiple errors, how will screen reader read this out? I think will read all out based on manual test with currency example
+      hasQuestionErrors = true;
       questionTextDiv.with(
           BaseHtmlView.fieldErrors(
-              messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS));
+              messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
+              .withId(validationErrorId));
+      // Insert error message to be read first.
+      ariaDescribedByIds.add(0, validationErrorId);
     }
 
     if (question.isRequiredButWasSkippedInCurrentProgram()) {
+      hasQuestionErrors = true;
       String requiredQuestionMessage = messages.at(MessageKey.VALIDATION_REQUIRED.getKeyName());
       questionTextDiv.with(
           div()
+              .withId(requiredErrorId)
               .withClasses(Styles.P_1, Styles.TEXT_RED_600)
               .withText("*" + requiredQuestionMessage));
+      // Insert error message to be read first.
+      ariaDescribedByIds.add(0, requiredErrorId);
     }
 
     return div()
-        .withId(question.getContextualizedPath().toString())
+        .withId(id)
         .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
         .with(questionTextDiv)
-        .with(renderTag(params, validationErrors));
+        .with(renderTag(params, validationErrors, ariaDescribedByIds, hasQuestionErrors));
+
+
+    // DELETE - what's the cleanest way to pass this data in? (hasQuestionErrors and question level aria-describedby)
+    // Add wrapper struct? Refactor it to make it a property of the class?
   }
 }

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -44,7 +44,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
   private String getRequiredClass() {
     return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
-  
+
   // Add comments?
   // A list of HTML ids, used to provide question-level details for accessibility. This is currently
   // used by the "aria-describedby" attribute for each input for this question.
@@ -52,7 +52,8 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
   protected abstract Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors);
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors);
 
   @Override
   public final Tag render(ApplicantQuestionRendererParams params) {
@@ -96,11 +97,12 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
-      // DELETE: if multiple errors, how will screen reader read this out? I think will read all out based on manual test with currency example
+      // DELETE: if multiple errors, how will screen reader read this out? I think will read all out
+      // based on manual test with currency example
       hasQuestionErrors = true;
       questionTextDiv.with(
           BaseHtmlView.fieldErrors(
-              messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
+                  messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
               .withId(validationErrorId));
       // Insert error message to be read first.
       ariaDescribedByIds.add(0, validationErrorId);
@@ -124,8 +126,8 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         .with(questionTextDiv)
         .with(renderTag(params, validationErrors, ariaDescribedByIds, hasQuestionErrors));
 
-
-    // DELETE - what's the cleanest way to pass this data in? (hasQuestionErrors and question level aria-describedby)
+    // DELETE - what's the cleanest way to pass this data in? (hasQuestionErrors and question level
+    // aria-describedby)
     // Add wrapper struct? Refactor it to make it a property of the class?
   }
 }

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -37,7 +37,8 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
     Tag checkboxQuestionFormContent =

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import java.util.Comparator;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -35,7 +36,8 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
     Tag checkboxQuestionFormContent =

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -9,8 +9,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -37,7 +37,7 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -5,7 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -29,7 +29,7 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -27,7 +28,8 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =
@@ -35,7 +37,8 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
             .setFieldName(currencyQuestion.getCurrencyPath().toString())
             .addReferenceClass(ReferenceClasses.CURRENCY_VALUE)
             .setScreenReaderText(question.getQuestionText())
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -35,6 +35,7 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
             .setFieldName(currencyQuestion.getCurrencyPath().toString())
             .addReferenceClass(ReferenceClasses.CURRENCY_VALUE)
             .setScreenReaderText(question.getQuestionText())
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -29,7 +29,8 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -34,6 +34,7 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.date()
             .setFieldName(dateQuestion.getDatePath().toString())
             .setScreenReaderText(question.getQuestionText())
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(dateQuestion.getDatePath(), ImmutableSet.of()));

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -29,7 +29,8 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -29,7 +29,7 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     DateQuestion dateQuestion = question.createDateQuestion();
 

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Optional;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -27,14 +28,16 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =
         FieldWithLabel.date()
             .setFieldName(dateQuestion.getDatePath().toString())
             .setScreenReaderText(question.getQuestionText())
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(dateQuestion.getDatePath(), ImmutableSet.of()));

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import java.util.Comparator;
 import play.i18n.Messages;
 import services.MessageKey;
@@ -31,7 +32,8 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 
@@ -48,7 +50,8 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
                             LocalizedQuestionOption::optionText,
                             option -> String.valueOf(option.id()))));
     select.setScreenReaderText(question.getQuestionText())
-        .setDescriptionId(getDescriptionId());
+        .setAriaDescribedByIds(ariaDescribedByIds)
+        .setHasQuestionErrors(hasQuestionErrors);
 
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -33,7 +33,8 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 
@@ -49,7 +50,8 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
                         toImmutableMap(
                             LocalizedQuestionOption::optionText,
                             option -> String.valueOf(option.id()))));
-    select.setScreenReaderText(question.getQuestionText())
+    select
+        .setScreenReaderText(question.getQuestionText())
         .setAriaDescribedByIds(ariaDescribedByIds)
         .setHasQuestionErrors(hasQuestionErrors);
 

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -47,7 +47,8 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
                         toImmutableMap(
                             LocalizedQuestionOption::optionText,
                             option -> String.valueOf(option.id()))));
-    select.setScreenReaderText(question.getQuestionText());
+    select.setScreenReaderText(question.getQuestionText())
+        .setDescriptionId(getDescriptionId());
 
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -6,8 +6,8 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -33,7 +33,7 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -27,7 +27,8 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
     Tag questionFormContent =

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -3,6 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -25,14 +26,16 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
     Tag questionFormContent =
         FieldWithLabel.email()
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setValue(emailQuestion.getEmailValue().orElse(""))
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(emailQuestion.getEmailPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -32,6 +32,7 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.email()
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setValue(emailQuestion.getEmailValue().orElse(""))
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(emailQuestion.getEmailPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -3,7 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -27,7 +27,7 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -67,6 +67,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
               messages,
               localizedEntityType,
               question.getContextualizedPath(),
+              getDescriptionId(),
               Optional.of(entityNames.get(index)),
               Optional.of(index)));
     }
@@ -98,6 +99,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Messages messages,
       String localizedEntityType,
       Path contextualizedPath,
+      String descriptionId,
       Optional<String> existingEntity,
       Optional<Integer> existingIndex) {
 
@@ -114,6 +116,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
                     localizedEntityType))
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT)
+            .setDescriptionId(descriptionId)
             .getContainer();
     String confirmationMessage =
         messages.at(MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE.getKeyName(), localizedEntityType);
@@ -139,13 +142,14 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
     return div().withClasses(ENUMERATOR_FIELD_CLASSES).with(entityNameInput, removeEntityButton);
   }
 
+  // DELETE: what does this do? Where would I find description Id?
   /**
    * Create an enumerator field template for new entries. These come with a button to delete itself.
    */
   public static Tag newEnumeratorFieldTemplate(
       Path contextualizedPath, String localizedEntityType, Messages messages) {
     return enumeratorField(
-            messages, localizedEntityType, contextualizedPath, Optional.empty(), Optional.empty())
+            messages, localizedEntityType, contextualizedPath, "", Optional.empty(), Optional.empty())
         .withId(ENUMERATOR_FIELD_TEMPLATE_ID)
         .withClasses(StyleUtils.joinStyles(ENUMERATOR_FIELD_CLASSES, Styles.HIDDEN));
   }

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -11,6 +11,7 @@ import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.EmptyTag;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import java.util.Optional;
 import play.i18n.Messages;
 import services.MessageKey;
@@ -54,7 +55,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();
@@ -67,7 +69,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
               messages,
               localizedEntityType,
               question.getContextualizedPath(),
-              getDescriptionId(),
+              // .setAriaDescribedByIds(ariaDescribedByIds)
+              // .setHasQuestionErrors(hasQuestionErrors)
               Optional.of(entityNames.get(index)),
               Optional.of(index)));
     }
@@ -99,7 +102,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Messages messages,
       String localizedEntityType,
       Path contextualizedPath,
-      String descriptionId,
+      // String descriptionId,
       Optional<String> existingEntity,
       Optional<Integer> existingIndex) {
 
@@ -116,7 +119,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
                     localizedEntityType))
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT)
-            .setDescriptionId(descriptionId)
+            // .setDescriptionId(descriptionId)
             .getContainer();
     String confirmationMessage =
         messages.at(MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE.getKeyName(), localizedEntityType);
@@ -149,7 +152,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   public static Tag newEnumeratorFieldTemplate(
       Path contextualizedPath, String localizedEntityType, Messages messages) {
     return enumeratorField(
-            messages, localizedEntityType, contextualizedPath, "", Optional.empty(), Optional.empty())
+            messages, localizedEntityType, contextualizedPath, Optional.empty(), Optional.empty())
         .withId(ENUMERATOR_FIELD_TEMPLATE_ID)
         .withClasses(StyleUtils.joinStyles(ENUMERATOR_FIELD_CLASSES, Styles.HIDDEN));
   }

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -13,6 +13,7 @@ import j2html.tags.EmptyTag;
 import j2html.tags.Tag;
 import java.util.ArrayList;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -69,8 +70,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
               messages,
               localizedEntityType,
               question.getContextualizedPath(),
-              // .setAriaDescribedByIds(ariaDescribedByIds)
-              // .setHasQuestionErrors(hasQuestionErrors)
+              ariaDescribedByIds,
+              hasQuestionErrors,
               Optional.of(entityNames.get(index)),
               Optional.of(index)));
     }
@@ -87,6 +88,9 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
                             messages.at(
                                 MessageKey.ENUMERATOR_BUTTON_ADD_ENTITY.getKeyName(),
                                 localizedEntityType)))
+                    .condAttr(hasQuestionErrors, "aria-invalid", "true")
+                    .condAttr(!ariaDescribedByIds.isEmpty(), "aria-describedby",
+                        StringUtils.join(ariaDescribedByIds, " "))
                     .withClasses(
                         ApplicantStyles.BUTTON_ENUMERATOR_ADD_ENTITY,
                         StyleUtils.disabled(Styles.BG_GRAY_200, Styles.TEXT_GRAY_400)));
@@ -102,7 +106,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Messages messages,
       String localizedEntityType,
       Path contextualizedPath,
-      // String descriptionId,
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors,
       Optional<String> existingEntity,
       Optional<Integer> existingIndex) {
 
@@ -119,7 +124,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
                     localizedEntityType))
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT)
-            // .setDescriptionId(descriptionId)
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .getContainer();
     String confirmationMessage =
         messages.at(MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE.getKeyName(), localizedEntityType);
@@ -145,14 +151,15 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
     return div().withClasses(ENUMERATOR_FIELD_CLASSES).with(entityNameInput, removeEntityButton);
   }
 
-  // DELETE: what does this do? Where would I find description Id?
   /**
    * Create an enumerator field template for new entries. These come with a button to delete itself.
    */
   public static Tag newEnumeratorFieldTemplate(
       Path contextualizedPath, String localizedEntityType, Messages messages) {
+    // TODO(#1879): Set aria-describedby.
     return enumeratorField(
-            messages, localizedEntityType, contextualizedPath, Optional.empty(), Optional.empty())
+        messages, localizedEntityType, contextualizedPath, new ArrayList<String>(), false,
+        Optional.empty(), Optional.empty())
         .withId(ENUMERATOR_FIELD_TEMPLATE_ID)
         .withClasses(StyleUtils.joinStyles(ENUMERATOR_FIELD_CLASSES, Styles.HIDDEN));
   }

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -11,7 +11,6 @@ import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.EmptyTag;
 import j2html.tags.Tag;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -12,6 +12,8 @@ import j2html.tags.ContainerTag;
 import j2html.tags.EmptyTag;
 import j2html.tags.Tag;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import play.i18n.Messages;
@@ -57,7 +59,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
@@ -109,7 +111,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Messages messages,
       String localizedEntityType,
       Path contextualizedPath,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors,
       Optional<String> existingEntity,
       Optional<Integer> existingIndex) {
@@ -164,7 +166,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
             messages,
             localizedEntityType,
             contextualizedPath,
-            new ArrayList<String>(),
+            Collections.emptyList(),
             false,
             Optional.empty(),
             Optional.empty())

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -57,7 +57,8 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();
@@ -89,7 +90,9 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
                                 MessageKey.ENUMERATOR_BUTTON_ADD_ENTITY.getKeyName(),
                                 localizedEntityType)))
                     .condAttr(hasQuestionErrors, "aria-invalid", "true")
-                    .condAttr(!ariaDescribedByIds.isEmpty(), "aria-describedby",
+                    .condAttr(
+                        !ariaDescribedByIds.isEmpty(),
+                        "aria-describedby",
                         StringUtils.join(ariaDescribedByIds, " "))
                     .withClasses(
                         ApplicantStyles.BUTTON_ENUMERATOR_ADD_ENTITY,
@@ -158,8 +161,13 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Path contextualizedPath, String localizedEntityType, Messages messages) {
     // TODO(#1879): Set aria-describedby.
     return enumeratorField(
-        messages, localizedEntityType, contextualizedPath, new ArrayList<String>(), false,
-        Optional.empty(), Optional.empty())
+            messages,
+            localizedEntityType,
+            contextualizedPath,
+            new ArrayList<String>(),
+            false,
+            Optional.empty(),
+            Optional.empty())
         .withId(ENUMERATOR_FIELD_TEMPLATE_ID)
         .withClasses(StyleUtils.joinStyles(ENUMERATOR_FIELD_CLASSES, Styles.HIDDEN));
   }

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -51,7 +52,8 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     return fileUploadFields(params);
   }
 

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -53,7 +53,8 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     return fileUploadFields(params);
   }
 

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -53,7 +53,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     return fileUploadFields(params);
   }

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -3,7 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -26,7 +26,7 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     IdQuestion idQuestion = question.createIdQuestion();
 

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -26,7 +26,8 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     IdQuestion idQuestion = question.createIdQuestion();
 
     Tag questionFormContent =

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -3,6 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -24,14 +25,16 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     IdQuestion idQuestion = question.createIdQuestion();
 
     Tag questionFormContent =
         FieldWithLabel.input()
             .setFieldName(idQuestion.getIdPath().toString())
             .setValue(idQuestion.getIdValue().orElse(""))
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(idQuestion.getIdPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -31,6 +31,7 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.input()
             .setFieldName(idQuestion.getIdPath().toString())
             .setValue(idQuestion.getIdValue().orElse(""))
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(idQuestion.getIdPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -40,6 +40,7 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setFieldName(nameQuestion.getFirstNamePath().toString())
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_FIRST.getKeyName()))
                     .setValue(nameQuestion.getFirstNameValue().orElse(""))
+                    .setDescriptionId(getDescriptionId())
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -52,6 +53,7 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_MIDDLE.getKeyName()))
                     .setValue(nameQuestion.getMiddleNameValue().orElse(""))
                     .addReferenceClass(ReferenceClasses.NAME_MIDDLE)
+                    .setDescriptionId(getDescriptionId())
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -62,6 +64,7 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setFieldName(nameQuestion.getLastNamePath().toString())
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_LAST.getKeyName()))
                     .setValue(nameQuestion.getLastNameValue().orElse(""))
+                    .setDescriptionId(getDescriptionId())
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -29,7 +30,8 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 
@@ -40,7 +42,8 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setFieldName(nameQuestion.getFirstNamePath().toString())
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_FIRST.getKeyName()))
                     .setValue(nameQuestion.getFirstNameValue().orElse(""))
-                    .setDescriptionId(getDescriptionId())
+                    .setAriaDescribedByIds(ariaDescribedByIds)
+                    .setHasQuestionErrors(hasQuestionErrors)
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -53,7 +56,8 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_MIDDLE.getKeyName()))
                     .setValue(nameQuestion.getMiddleNameValue().orElse(""))
                     .addReferenceClass(ReferenceClasses.NAME_MIDDLE)
-                    .setDescriptionId(getDescriptionId())
+                    .setAriaDescribedByIds(ariaDescribedByIds)
+                    .setHasQuestionErrors(hasQuestionErrors)
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(
@@ -64,7 +68,8 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
                     .setFieldName(nameQuestion.getLastNamePath().toString())
                     .setLabelText(messages.at(MessageKey.NAME_LABEL_LAST.getKeyName()))
                     .setValue(nameQuestion.getLastNameValue().orElse(""))
-                    .setDescriptionId(getDescriptionId())
+                    .setAriaDescribedByIds(ariaDescribedByIds)
+                    .setHasQuestionErrors(hasQuestionErrors)
                     .setFieldErrors(
                         messages,
                         validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -5,7 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
@@ -31,7 +31,7 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -31,7 +31,8 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -29,7 +29,8 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import java.util.OptionalLong;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -27,7 +28,8 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =
@@ -36,7 +38,8 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
             .setScreenReaderText(question.getQuestionText())
             .setMin(numberQuestion.getQuestionDefinition().getMin())
             .setMax(numberQuestion.getQuestionDefinition().getMax())
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(numberQuestion.getNumberPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -36,6 +36,7 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
             .setScreenReaderText(question.getQuestionText())
             .setMin(numberQuestion.getQuestionDefinition().getMin())
             .setMax(numberQuestion.getQuestionDefinition().getMax())
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(numberQuestion.getNumberPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -5,7 +5,7 @@ import static j2html.TagCreator.div;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.OptionalLong;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -29,7 +29,7 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import java.util.Comparator;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -35,7 +36,8 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -9,8 +9,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -37,7 +37,7 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -37,7 +37,8 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -31,6 +31,7 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.input()
             .setFieldName(textQuestion.getTextPath().toString())
             .setValue(textQuestion.getTextValue().orElse(""))
+            .setDescriptionId(getDescriptionId())
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(textQuestion.getTextPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -3,7 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
-import java.util.ArrayList;
+import java.util.List;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -26,7 +26,7 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds,
+      List<String> ariaDescribedByIds,
       boolean hasQuestionErrors) {
     TextQuestion textQuestion = question.createTextQuestion();
 

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -3,6 +3,7 @@ package views.questiontypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
+import java.util.ArrayList;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -24,14 +25,16 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   @Override
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
     TextQuestion textQuestion = question.createTextQuestion();
 
     Tag questionFormContent =
         FieldWithLabel.input()
             .setFieldName(textQuestion.getTextPath().toString())
             .setValue(textQuestion.getTextValue().orElse(""))
-            .setDescriptionId(getDescriptionId())
+            .setAriaDescribedByIds(ariaDescribedByIds)
+            .setHasQuestionErrors(hasQuestionErrors)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(textQuestion.getTextPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -26,7 +26,8 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   protected Tag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ArrayList<String> ariaDescribedByIds, boolean hasQuestionErrors) {
+      ArrayList<String> ariaDescribedByIds,
+      boolean hasQuestionErrors) {
     TextQuestion textQuestion = question.createTextQuestion();
 
     Tag questionFormContent =

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -3,6 +3,7 @@ package views.components;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.stubMessagesApi;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -90,7 +91,8 @@ public class FieldWithLabelTest {
   }
 
   @Test
-  public void withErrors() {
+  public void withFieldErrors() {
+    // Verify aria labels for field level errors.
     FieldWithLabel fieldWithLabel =
         FieldWithLabel.number()
             .setId("field-id")
@@ -99,6 +101,37 @@ public class FieldWithLabelTest {
 
     assertThat(rendered).contains("aria-invalid=\"true\"");
     assertThat(rendered).contains("aria-describedBy=\"field-id-errors\"");
+    assertThat(rendered).contains("id=\"field-id-errors\"");
+    assertThat(rendered).contains("an error message");
+  }
+
+  @Test
+  public void withQuestionErrors() {
+    // Verify aria labels for passed in question level errors.
+    FieldWithLabel fieldWithLabel =
+        FieldWithLabel.number()
+            .setId("field-id")
+            .setAriaDescribedByIds(ImmutableList.of("question-errors", "question-description"))
+            .setHasQuestionErrors(true);
+    String rendered = fieldWithLabel.getContainer().render();
+
+    assertThat(rendered).contains("aria-invalid=\"true\"");
+    assertThat(rendered).contains("aria-describedBy=\"question-errors question-description\"");
+  }
+
+  @Test
+  public void withFieldAndQuestionErrors() {
+    // Verify aria labels are merged properly when both field and question level errors are present.
+    FieldWithLabel fieldWithLabel =
+        FieldWithLabel.number()
+            .setId("field-id")
+            .setFieldErrors(messages, new ValidationError("", "an error message"))
+            .setAriaDescribedByIds(ImmutableList.of("question-errors", "question-description"))
+            .setHasQuestionErrors(true);
+    String rendered = fieldWithLabel.getContainer().render();
+
+    assertThat(rendered).contains("aria-invalid=\"true\"");
+    assertThat(rendered).contains("aria-describedBy=\"field-id-errors question-errors question-description\"");
     assertThat(rendered).contains("id=\"field-id-errors\"");
     assertThat(rendered).contains("an error message");
   }

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -131,7 +131,8 @@ public class FieldWithLabelTest {
     String rendered = fieldWithLabel.getContainer().render();
 
     assertThat(rendered).contains("aria-invalid=\"true\"");
-    assertThat(rendered).contains("aria-describedBy=\"field-id-errors question-errors question-description\"");
+    assertThat(rendered)
+        .contains("aria-describedBy=\"field-id-errors question-errors question-description\"");
     assertThat(rendered).contains("id=\"field-id-errors\"");
     assertThat(rendered).contains("an error message");
   }

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -7,7 +7,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -79,21 +78,21 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
+    assertThat(result.render())
+        .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 
   @Test
   public void render_withAriaLabelsOnError() {
     // Question level required error.
-    QuestionAnswerer.addMetadata(
-        applicantData, question.getContextualizedPath(), programId, 1L);
+    QuestionAnswerer.addMetadata(applicantData, question.getContextualizedPath(), programId, 1L);
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
     assertThat(result.render()).contains("aria-invalid=\"true\"");
-    assertThat(result.render()).contains("aria-describedBy="+ String.format("\"%s-required-error %s-description\"", id,  id));
+    assertThat(result.render())
+        .contains(
+            "aria-describedBy=" + String.format("\"%s-required-error %s-description\"", id, id));
     assertThat(result.render()).contains("This question is required");
-
   }
-
 }

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -41,8 +41,6 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    // question = new ApplicantQuestion(CURRENCY_QUESTION_DEFINITION, applicantData, Optional.empty());
-
     question =
         new ApplicantQuestion(
             ProgramQuestionDefinition.create(CURRENCY_QUESTION_DEFINITION, Optional.of(programId))

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -8,6 +8,7 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -75,5 +76,13 @@ public class DropdownQuestionRendererTest extends ResetPostgres {
 
     assertThat(result.render()).contains("hidden selected");
     assertThat(result.render()).contains("Choose an option");
+  }
+
+  @Test
+  public void render_withAriaLabels() {
+    Tag result = renderer.render(params);
+
+    String id = question.getContextualizedPath().toString();
+    assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -8,7 +8,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -83,6 +82,7 @@ public class DropdownQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
+    assertThat(result.render())
+        .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -7,6 +7,8 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import models.Program;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -88,5 +90,13 @@ public class IdQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     assertThat(result.render()).contains("Must contain only numbers.");
+  }
+
+  @Test
+  public void render_withAriaLabels() {
+    Tag result = renderer.render(params);
+
+    String id = question.getContextualizedPath().toString();
+    Assertions.assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -7,7 +7,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-import models.Program;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,6 +96,7 @@ public class IdQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    Assertions.assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
+    Assertions.assertThat(result.render())
+        .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -7,7 +7,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -96,7 +95,7 @@ public class IdQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    Assertions.assertThat(result.render())
+    assertThat(result.render())
         .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -87,6 +87,7 @@ public class TextQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    Assertions.assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
+    Assertions.assertThat(result.render())
+        .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -7,7 +7,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -87,7 +86,7 @@ public class TextQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     String id = question.getContextualizedPath().toString();
-    Assertions.assertThat(result.render())
+    assertThat(result.render())
         .contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -7,6 +7,7 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -79,5 +80,13 @@ public class TextQuestionRendererTest extends ResetPostgres {
     Tag result = renderer.render(params);
 
     assertThat(result.render()).contains("Must contain at most 3 characters.");
+  }
+
+  @Test
+  public void render_withAriaLabels() {
+    Tag result = renderer.render(params);
+
+    String id = question.getContextualizedPath().toString();
+    Assertions.assertThat(result.render()).contains("aria-describedBy=" + String.format("\"%s-description\"", id));
   }
 }


### PR DESCRIPTION
### Description
Adds question level `aria-describedby` attributes (e.g. question description and question-level errors) to each input of that question.

Previously, the screen reader would only read out field-level errors but not question-level errors (See https://github.com/seattle-uat/civiform/issues/1878#issuecomment-1136572406).

Note that this PR does not address radio buttons, checkboxes, and misses some corner cases for enumerators. I will follow up with separate fixes.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1878, #1879
