### PR TITLE
Fix bin/pull-image for macOS

### DIFF
--- a/bin/pull-image
+++ b/bin/pull-image
@@ -7,7 +7,7 @@
 
 source bin/lib.sh
 
-if [[ ! -z "${USE_LOCAL_CIVIFORM}" ]]; then
+if [[ -n "${USE_LOCAL_CIVIFORM}" ]]; then
   echo "Using local civiform and dependency docker images"
   exit 0
 fi


### PR DESCRIPTION
macOS is on an older version of bash which does not support the `-v` flag in conditionals. This change swaps using `-v` for `! -z` in the `bin/pull-image` flag for compatibility.