### PR TITLE
Program admins get http 403 errors

### DIFF
--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -195,7 +195,7 @@ public class SecurityModule extends AbstractModule {
                 // Display the string "403 forbidden" to forbidden requests.
                 // Helpful for test assertions.
                 HttpConstants.FORBIDDEN,
-                forbidden("403 forbidden").as(HttpConstants.HTML_CONTENT_TYPE)));
+                redirect(routes.HomeController.loginForm(Optional.of("login")))));
 
     return actionAdapter;
   }


### PR DESCRIPTION
Program admins get http 403 errors. This can be reproduced by logging in as guest or an applicant, then navigating to [example](https://staging.seattle.civiform.com/admin/programs/33437/applications). This change will redirect to the login page instead of showing text '403 forbidden'.

If you are not logged in at all and try going to the example link the application already redirects to the login page. So in both cases the user would get the same behavior.

A nice to have would be to automatically redirect back to the page they attempted to go to, but I haven't found a good way to do this yet.

My concern is the comments that the 403 is helpful for test assertions. Is this going to cause ripples that mess other things up?



