### PR TITLE
Update README to remove coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![CI status](https://github.com/seattle-uat/civiform/actions/workflows/push.yaml/badge.svg)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6008/badge)](https://bestpractices.coreinfrastructure.org/projects/6008)
 [![Seattle Staging Deploy](https://github.com/seattle-uat/civiform-deploy/actions/workflows/deploy-staging.yml/badge.svg?branch=main)](https://github.com/seattle-uat/civiform-deploy/actions/workflows/deploy-staging.yml)
-![Coverage](.github/badges/jacoco.svg)
 
 # CiviForm
 


### PR DESCRIPTION
### Description
Removed the Coverage badge from README as it was not working as intended. Cicirello requires the badge to commited inthe branch using Github action and it get more complicated as our branches are protected and commits will not be pushed without reviewers. Hence reverting this change. I am investigating other tools to show the badge.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
