### PR TITLE
Add test coverage for ActiveAndDraftQuestions and extend publish draft test coverage

### DIFF
--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -68,6 +68,11 @@ public class Version extends BaseModel {
     return this;
   }
 
+  public Version addQuestion(Question question) {
+    this.questions.add(question);
+    return this;
+  }
+
   public Version setLifecycleStage(LifecycleStage lifecycleStage) {
     this.lifecycleStage = lifecycleStage;
     return this;

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -36,7 +36,7 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 
 /** A repository object for dealing with versioning of questions and programs. */
-public class VersionRepository {
+public final class VersionRepository {
 
   private static final Logger logger = LoggerFactory.getLogger(VersionRepository.class);
   private final Database database;
@@ -260,7 +260,7 @@ public class VersionRepository {
   // Update the referenced question IDs in all leaf nodes. Since nodes are immutable, we
   // recursively recreate the tree with updated leaf nodes.
   @VisibleForTesting
-  protected PredicateExpressionNode updatePredicateNode(PredicateExpressionNode current) {
+  PredicateExpressionNode updatePredicateNode(PredicateExpressionNode current) {
     switch (current.getType()) {
       case AND:
         AndNode and = current.getAndNode();

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -86,10 +86,12 @@ public final class ActiveAndDraftQuestions {
   }
 
   public Optional<QuestionDefinition> getActiveQuestionDefinition(String name) {
-    return versionedByName.get(name).first();
+    return versionedByName.containsKey(name) ? versionedByName.get(name).first() : Optional.empty();
   }
 
   public Optional<QuestionDefinition> getDraftQuestionDefinition(String name) {
-    return versionedByName.get(name).second();
+    return versionedByName.containsKey(name)
+        ? versionedByName.get(name).second()
+        : Optional.empty();
   }
 }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -54,12 +54,12 @@ public class VersionRepositoryTest extends ResetPostgres {
             .withBlock("Screen 1")
             .withRequiredQuestion(secondQuestion)
             .build();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
-    secondQuestionUpdated.addVersion(versionRepository.getDraftVersion()).save();
+    Question secondQuestionDraft = resourceCreator.insertQuestion("second-question");
+    secondQuestionDraft.addVersion(versionRepository.getDraftVersion()).save();
     Program secondProgramDraft =
         ProgramBuilder.newDraftProgram("bar")
             .withBlock("Screen 1")
-            .withRequiredQuestion(secondQuestionUpdated)
+            .withRequiredQuestion(secondQuestionDraft)
             .build();
 
     assertThat(versionRepository.getActiveVersion().getPrograms().stream().map(p -> p.id))
@@ -69,7 +69,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     assertThat(versionRepository.getDraftVersion().getPrograms().stream().map(p -> p.id))
         .containsExactlyInAnyOrder(secondProgramDraft.id);
     assertThat(versionRepository.getDraftVersion().getQuestions().stream().map(q -> q.id))
-        .containsExactlyInAnyOrder(secondQuestionUpdated.id);
+        .containsExactlyInAnyOrder(secondQuestionDraft.id);
 
     Version oldDraft = versionRepository.getDraftVersion();
     Version oldActive = versionRepository.getActiveVersion();
@@ -89,7 +89,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     assertThat(versionRepository.getActiveVersion().getPrograms().stream().map(p -> p.id))
         .containsExactlyInAnyOrder(secondProgramDraft.id, firstProgramActive.id);
     assertThat(versionRepository.getActiveVersion().getQuestions().stream().map(q -> q.id))
-        .containsExactlyInAnyOrder(firstQuestion.id, secondQuestionUpdated.id);
+        .containsExactlyInAnyOrder(firstQuestion.id, secondQuestionDraft.id);
   }
 
   @Test

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -39,17 +39,57 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublish() {
-    resourceCreator.insertActiveProgram("foo");
-    resourceCreator.insertActiveProgram("bar");
-    resourceCreator.insertDraftProgram("bar");
-    assertThat(versionRepository.getActiveVersion().getPrograms()).hasSize(2);
-    assertThat(versionRepository.getDraftVersion().getPrograms()).hasSize(1);
+    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
+    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
+
+    Program firstProgramActive =
+        ProgramBuilder.newActiveProgram("foo")
+            .withBlock("Screen 1")
+            .withRequiredQuestion(firstQuestion)
+            .build();
+    Program secondProgramActive =
+        ProgramBuilder.newActiveProgram("bar")
+            .withBlock("Screen 1")
+            .withRequiredQuestion(secondQuestion)
+            .build();
+    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    secondQuestionUpdated.addVersion(versionRepository.getDraftVersion()).save();
+    Program secondProgramDraft =
+        ProgramBuilder.newDraftProgram("bar")
+            .withBlock("Screen 1")
+            .withRequiredQuestion(secondQuestionUpdated)
+            .build();
+
+    assertThat(versionRepository.getActiveVersion().getPrograms().stream().map(p -> p.id))
+        .containsExactlyInAnyOrder(firstProgramActive.id, secondProgramActive.id);
+    assertThat(versionRepository.getActiveVersion().getQuestions().stream().map(q -> q.id))
+        .containsExactlyInAnyOrder(firstQuestion.id, secondQuestion.id);
+    assertThat(versionRepository.getDraftVersion().getPrograms().stream().map(p -> p.id))
+        .containsExactlyInAnyOrder(secondProgramDraft.id);
+    assertThat(versionRepository.getDraftVersion().getQuestions().stream().map(q -> q.id))
+        .containsExactlyInAnyOrder(secondQuestionUpdated.id);
+
     Version oldDraft = versionRepository.getDraftVersion();
+    Version oldActive = versionRepository.getActiveVersion();
+
+    // Now actually publish the version and assert the results.
     versionRepository.publishNewSynchronizedVersion();
-    assertThat(versionRepository.getActiveVersion().getPrograms()).hasSize(2);
-    assertThat(versionRepository.getDraftVersion().getPrograms()).hasSize(0);
+
     oldDraft.refresh();
     assertThat(oldDraft.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
+    oldActive.refresh();
+    assertThat(oldActive.getLifecycleStage()).isEqualTo(LifecycleStage.OBSOLETE);
+
+    // The newly created draft should not contain any questions or programs.
+    assertThat(versionRepository.getDraftVersion().getPrograms()).isEmpty();
+    assertThat(versionRepository.getDraftVersion().getQuestions()).isEmpty();
+
+    assertThat(versionRepository.getActiveVersion().getPrograms().stream().map(p -> p.id))
+        .containsExactlyInAnyOrder(secondProgramDraft.id, firstProgramActive.id);
+    assertThat(versionRepository.getActiveVersion().getQuestions().stream().map(q -> q.id))
+        .containsExactlyInAnyOrder(firstQuestion.id, secondQuestionUpdated.id);
   }
 
   @Test

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -15,6 +15,8 @@ import support.ProgramBuilder;
 
 public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
+  private static final String TEST_QUESTION_NAME = "test-question";
+
   private VersionRepository versionRepository;
 
   @Before
@@ -26,25 +28,20 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
   public void getQuestionNames() {
     Question tombstonedQuestionFromActiveVersion =
         resourceCreator.insertQuestion("tombstoned-question");
-    Question activeAndDraftQuestion = resourceCreator.insertQuestion("active-and-draft-question");
-    Question activeOnlyQuestion = resourceCreator.insertQuestion("active-only-question");
-    Question activeAndDraftQuestionUpdated =
-        resourceCreator.insertQuestion("active-and-draft-question");
-    Question draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
 
     versionRepository
         .getActiveVersion()
         .addQuestion(tombstonedQuestionFromActiveVersion)
-        .addQuestion(activeAndDraftQuestion)
-        .addQuestion(activeOnlyQuestion)
+        .addQuestion(resourceCreator.insertQuestion("active-and-draft-question"))
+        .addQuestion(resourceCreator.insertQuestion("active-only-question"))
         .save();
     addTombstoneToVersion(
         versionRepository.getActiveVersion(), tombstonedQuestionFromActiveVersion);
 
     versionRepository
         .getDraftVersion()
-        .addQuestion(activeAndDraftQuestionUpdated)
-        .addQuestion(draftOnlyQuestion)
+        .addQuestion(resourceCreator.insertQuestion("active-and-draft-question"))
+        .addQuestion(resourceCreator.insertQuestion("draft-only-question"))
         .save();
 
     assertThat(newActiveAndDraftQuestions().getQuestionNames())
@@ -135,32 +132,34 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getDeletionStatus_notPartOfEitherVersion() {
-    resourceCreator.insertQuestion("some-question");
+    resourceCreator.insertQuestion(TEST_QUESTION_NAME);
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.NOT_ACTIVE);
   }
 
   @Test
   public void getDeletionStatus_tombstoned() {
-    Question questionActive = resourceCreator.insertQuestion("some-question");
-    versionRepository.getActiveVersion().addQuestion(questionActive).save();
-    addTombstoneToVersion(versionRepository.getDraftVersion(), questionActive);
+    Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    versionRepository.getActiveVersion().addQuestion(question).save();
+    addTombstoneToVersion(versionRepository.getDraftVersion(), question);
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
 
     // Create an edited version of the question in the draft version
     // and ensure that it's still considered as pending deletion.
-    Question questionDraft = resourceCreator.insertQuestion("some-question");
-    versionRepository.getDraftVersion().addQuestion(questionDraft).save();
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    versionRepository
+        .getDraftVersion()
+        .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
+        .save();
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
   }
 
   @Test
   public void getDeletionStatus_stillReferencedInActiveVersion() {
-    Question questionActive = resourceCreator.insertQuestion("some-question");
+    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(questionActive).save();
     // newActiveProgram automatically adds the program to the active version.
     ProgramBuilder.newActiveProgram("foo")
@@ -168,14 +167,14 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         .withRequiredQuestion(questionActive)
         .build();
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.NOT_DELETABLE);
 
     // An invalid state where the question has been tombstoned even though it's still referenced.
     // TODO(#2788): Prevent allowing this state to occur and adjust the expectation accordingly.
     addTombstoneToVersion(versionRepository.getDraftVersion(), questionActive);
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
   }
 
@@ -184,7 +183,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     // Simulates the state where the question was created in the active version
     // and wasn't referenced. Then it was referenced by a program in the draft
     // version. In this case, the draft won't yet contain a reference to the question.
-    Question questionActive = resourceCreator.insertQuestion("some-question");
+    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(questionActive).save();
     // newDraftProgram automatically adds the program to the draft version.
     ProgramBuilder.newDraftProgram("foo")
@@ -192,15 +191,61 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         .withRequiredQuestion(questionActive)
         .build();
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.NOT_DELETABLE);
 
     // An invalid state where the question has been tombstoned even though it's still referenced.
     // TODO(#2788): Prevent allowing this state to occur and adjust the expectation accordingly.
     addTombstoneToVersion(versionRepository.getDraftVersion(), questionActive);
 
-    assertThat(newActiveAndDraftQuestions().getDeletionStatus("some-question"))
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
+  }
+
+  @Test
+  public void getDeletionStatus_noLongerReferencedInDraftVersion() {
+    // Simulate the only reference to the question having been removed in an edit of the program.
+    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    versionRepository.getActiveVersion().addQuestion(questionActive).save();
+    // newActiveProgram automatically adds the program to the active version.
+    ProgramBuilder.newActiveProgram("foo")
+        .withBlock("Screen 1")
+        .withRequiredQuestion(questionActive)
+        .build();
+    // Create a draft version of the program that no longer references the question.
+    // newDraftProgram automatically adds the program to the draft version.
+    ProgramBuilder.newDraftProgram("foo").withBlock("Screen 1").build();
+
+    // TODO(#2788): Allow archiving questions that aren't referenced in the draft
+    // version of the program.
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
+        .isEqualTo(DeletionStatus.NOT_DELETABLE);
+
+    // Adding a draft edit of the question continues to be considered deletable.
+    Question questionDraft = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    versionRepository.getDraftVersion().addQuestion(questionDraft).save();
+
+    // TODO(#2788): Allow archiving questions that aren't referenced in the draft
+    // version of the program.
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
+        .isEqualTo(DeletionStatus.NOT_DELETABLE);
+  }
+
+  @Test
+  public void getDeletionStatus_notReferencedByProgramInEitherVersion() {
+    // Create an active and draft version of a question that isn't referenced
+    // by any programs.
+    versionRepository
+        .getActiveVersion()
+        .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
+        .save();
+    versionRepository
+        .getDraftVersion()
+        .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
+        .save();
+
+    assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
+        .isEqualTo(DeletionStatus.DELETABLE);
   }
 
   private ActiveAndDraftQuestions newActiveAndDraftQuestions() {
@@ -212,11 +257,4 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     assertThat(version.addTombstoneForQuestion(question)).isTrue();
     version.save();
   }
-
-  // TODO(clouser): Still need tests for a draft edit of a question.
-
-  // Referenced only in draft -> NOT_DELETABLE.
-  // Not referenced in draft, but referenced in active -> DELETABLE
-  // Not referenced in active or draft -> DELETABLE
-  // Referenced in active program, but there's an edit that removes it in draft -> DELETABLE
 }

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -1,0 +1,147 @@
+package services.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import models.LifecycleStage;
+import models.Question;
+import models.Version;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.question.types.QuestionDefinition;
+
+public class ActiveAndDraftQuestionsTest extends ResetPostgres {
+  @Test
+  public void getQuestionNames() {
+    Version activeVersion = new Version(LifecycleStage.ACTIVE);
+    activeVersion.insert();
+    Version draftVersion = new Version(LifecycleStage.DRAFT);
+    draftVersion.insert();
+
+    Question tombstonedQuestionFromActiveVersion =
+        resourceCreator.insertQuestion("tombstoned-question");
+    Question activeAndDraftQuestion = resourceCreator.insertQuestion("active-and-draft-question");
+    Question activeOnlyQuestion = resourceCreator.insertQuestion("active-only-question");
+    Question activeAndDraftQuestionUpdated =
+        resourceCreator.insertQuestion("active-and-draft-question");
+    Question draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
+
+    activeVersion =
+        activeVersion
+            .addQuestion(tombstonedQuestionFromActiveVersion)
+            .addQuestion(activeAndDraftQuestion)
+            .addQuestion(activeOnlyQuestion);
+    assertThat(activeVersion.addTombstoneForQuestion(tombstonedQuestionFromActiveVersion)).isTrue();
+    activeVersion.save();
+
+    draftVersion =
+        draftVersion.addQuestion(activeAndDraftQuestionUpdated).addQuestion(draftOnlyQuestion);
+    draftVersion.save();
+
+    ActiveAndDraftQuestions questions = new ActiveAndDraftQuestions(activeVersion, draftVersion);
+    assertThat(questions.getQuestionNames())
+        .containsExactly(
+            "tombstoned-question",
+            "active-and-draft-question",
+            "active-only-question",
+            "draft-only-question");
+  }
+
+  @Test
+  public void getActiveOrDraftQuestionDefinition() {
+    Version activeVersion = new Version(LifecycleStage.ACTIVE);
+    activeVersion.insert();
+    Version draftVersion = new Version(LifecycleStage.DRAFT);
+    draftVersion.insert();
+
+    Question tombstonedQuestionFromActiveVersion =
+        resourceCreator.insertQuestion("tombstoned-question");
+    Question activeAndDraftQuestion = resourceCreator.insertQuestion("active-and-draft-question");
+    Question activeOnlyQuestion = resourceCreator.insertQuestion("active-only-question");
+    Question activeAndDraftQuestionUpdated =
+        resourceCreator.insertQuestion("active-and-draft-question");
+    Question draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
+
+    activeVersion =
+        activeVersion
+            .addQuestion(tombstonedQuestionFromActiveVersion)
+            .addQuestion(activeAndDraftQuestion)
+            .addQuestion(activeOnlyQuestion);
+    assertThat(activeVersion.addTombstoneForQuestion(tombstonedQuestionFromActiveVersion)).isTrue();
+    activeVersion.save();
+
+    draftVersion =
+        draftVersion.addQuestion(activeAndDraftQuestionUpdated).addQuestion(draftOnlyQuestion);
+    draftVersion.save();
+
+    ActiveAndDraftQuestions questions = new ActiveAndDraftQuestions(activeVersion, draftVersion);
+    assertThat(
+            questions
+                .getActiveQuestionDefinition("tombstoned-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.of(tombstonedQuestionFromActiveVersion.id));
+    assertThat(
+            questions
+                .getDraftQuestionDefinition("tombstoned-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            questions
+                .getActiveQuestionDefinition("active-and-draft-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.of(activeAndDraftQuestion.id));
+    assertThat(
+            questions
+                .getDraftQuestionDefinition("active-and-draft-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.of(activeAndDraftQuestionUpdated.id));
+    assertThat(
+            questions
+                .getActiveQuestionDefinition("active-only-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.of(activeOnlyQuestion.id));
+    assertThat(
+            questions
+                .getDraftQuestionDefinition("active-only-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            questions
+                .getActiveQuestionDefinition("draft-only-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            questions
+                .getDraftQuestionDefinition("draft-only-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.of(draftOnlyQuestion.id));
+    assertThat(
+            questions
+                .getActiveQuestionDefinition("non-existent-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.empty());
+    assertThat(
+            questions
+                .getDraftQuestionDefinition("non-existent-question")
+                .map(QuestionDefinition::getId))
+        .isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void getDeletionStatus() {
+    Version activeVersion = new Version(LifecycleStage.ACTIVE);
+    activeVersion.insert();
+    Version draftVersion = new Version(LifecycleStage.DRAFT);
+    draftVersion.insert();
+
+    // TODO(clouser): Still need tests for a draft edit of a question.
+
+    // Not present in either. -> NOT_ACTIVE
+    // Present in tombstoned list for draft -> PENDING_DELETION
+    // Still referenced in active -> NOT_DELETABLE
+    // Still referenced in draft -> NOT_DELETABLE
+    // Not referenced in active, but referenced in draft -> NOT_DELETABLE
+    // Not referenced in active or draft -> DELETABLE
+    // Referenced in active program, but there's an edit that removes it in draft -> DELETABLE
+  }
+}


### PR DESCRIPTION
### Description

As part of #2788, I'll be modifying the logic for how we determine how many programs reference a question. A follow-on from this will hopefully simplify the logic for whether a question can be archived. Prior to this refactoring, I've added tests for the existing functionality in `ActiveAndDraftQuestions` and left TODOs for places where the resulting behavior actually is a bug in the intended design. These will be fixed in a follow-on PR.

I also augmented the correctness tests for publishing a draft version (which I'll also be touching as part of #2788.

While here, I also:
  * Added `Versions.addQuestion` to update the M2M from the Version side. This made tests much simpler to write and I eventually intend to modify VersionRepository to call this when publishing a version.
  * Marked VersionRepository as final since there's no need to allow subclassing currently.
  * Fixed a minor null-pointer exception exposed when writing tests for getActiveQuestionDefinition / getDraftQuestionDefinition.
 
## Release notes:

N/A.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)

### Issue(s)

#2788