### PR TITLE
Build dev images for arm

### DIFF
--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -24,9 +24,11 @@ jobs:
           - version: prod
             image: 'civiform/civiform:latest'
             script: 'bin/build-prod'
+            platform: 'linux/amd64'
           - version: dev
             image: 'civiform/civiform-dev:latest'
             script: 'bin/build-dev'
+            platform: 'linux/amd64,linux/arm64' # build for m1 mac, too
     concurrency:
       group: build_civiform-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -42,6 +44,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           PUSH_IMAGE: 1
+          PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: ${{ matrix.script }}
@@ -57,18 +60,22 @@ jobs:
             image: 'civiform/formatter:latest'
             script: 'bin/build-formatter'
             file_pattern: 'formatter/'
+            platform: 'linux/amd64,linux/arm64' # build for m1 mac, too
           - version: localstack
             image: 'civiform/civiform-localstack:latest'
             script: 'bin/build-localstack-env'
             file_pattern: 'localstack/'
+            platform: 'linux/amd64'
           - version: browser_test
             image: 'civiform/civiform-browser-test:latest'
             script: 'bin/build-browser-tests'
             file_pattern: 'browser-test/'
+            platform: 'linux/amd64'
           - version: oidc
             image: 'civiform/oidc-provider:latest'
             script: 'bin/build-dev-oidc'
             file_pattern: 'test-support/'
+            platform: 'linux/amd64'
     concurrency:
       group: build_dependancies-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -97,6 +104,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           PUSH_IMAGE: 1
+          PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: ${{ matrix.script }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk-alpine
 
 ENV SBT_VERSION "1.6.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk-alpine
+FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk
+FROM --platform=$BUILDPLATFORM alpine
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local
@@ -15,7 +15,7 @@ RUN set -o pipefail && \
   apk update && \
   apk add --upgrade apk-tools && \
   apk upgrade --available && \
-  apk add --no-cache --update bash wget npm git openssh ncurses
+  apk add --no-cache --update openjdk11 bash wget npm git openssh ncurses
 
 RUN set -o pipefail && \
   npm install -g npm@8.5.1

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -3,9 +3,12 @@
 # DOC: Build a new development docker image and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
 
 source bin/lib.sh
+export DOCKER_BUILDKIT=1
+
+PLATFORM="${PLATFORM:-"linux/amd64"}"
 
 # Build the new development image.
-docker build \
+docker buildx build --platform="${PLATFORM}" \
   -t civiform-dev:latest \
   --cache-from civiform/civiform-dev:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -5,7 +5,7 @@
 source bin/lib.sh
 export DOCKER_BUILDKIT=1
 
-PLATFORM="${PLATFORM:-"linux/amd64"}"
+PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
 
 # Build the new development image.
 docker buildx build --platform="${PLATFORM}" \

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -3,8 +3,11 @@
 # DOC: Build a new fake oidc docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
 
 source bin/lib.sh
+export DOCKER_BUILDKIT=1
 
-docker build \
+PLATFORM="${PLATFORM:-"linux/amd64"}"
+
+docker buildx build --platform="${PLATFORM}" \
   -t civiform/oidc-provider:latest \
   -f test-support/oidc.Dockerfile \
   --cache-from civiform/oidc-provider:latest \

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -3,8 +3,11 @@
 # DOC: Build a new formatter docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
 
 source bin/lib.sh
+export DOCKER_BUILDKIT=1
 
-docker build \
+PLATFORM="${PLATFORM:-"linux/amd64"}"
+
+docker buildx build --platform="${PLATFORM}" \
   -t civiform/formatter:latest \
   -f formatter/formatter.Dockerfile \
   --cache-from civiform/formatter:latest \

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -3,10 +3,13 @@
 # DOC: Build a new docker image for running the localstack container and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
 
 source bin/lib.sh
+export DOCKER_BUILDKIT=1
+
+PLATFORM="${PLATFORM:-"linux/amd64"}"
 
 # A separate image is to include our customizations for
 # https://github.com/seattle-uat/civiform/issues/2639.
-docker build \
+docker buildx build --platform="${PLATFORM}" \
   -t civiform-localstack:latest \
   -f localstack/localstack.Dockerfile \
   --cache-from civiform/civiform-localstack:latest \

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -4,13 +4,17 @@
 
 source bin/lib.sh
 
+export DOCKER_BUILDKIT=1
 readonly SHORT_SHA="$(git rev-parse --short HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
 readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
 
 echo "Building ${SNAPSHOT_TAG}..."
 
-docker build -f prod.Dockerfile \
+PLATFORM="${PLATFORM:-"linux/amd64"}"
+
+docker buildx build --platform="${PLATFORM}" \
+  -f prod.Dockerfile \
   -t civiform:latest \
   --cache-from civiform/civiform:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM mcr.microsoft.com/playwright:focal
 
 ENV PROJECT_DIR /usr/src/civiform-browser-tests

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk
+FROM --platform=$BUILDPLATFORM alpine
 
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
 
 RUN apk update && apk add --no-cache --update \
-  bash wget npm shfmt git py3-pip
+  openjdk11 bash wget npm shfmt git py3-pip
 
 RUN npm install -g typescript \
   prettier \

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM eclipse-temurin:11.0.15_10-jdk-alpine
+FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk
 
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM eclipse-temurin:11.0.15_10-jdk-alpine
 
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"

--- a/localstack/localstack.Dockerfile
+++ b/localstack/localstack.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM localstack/localstack
 
 # Localstack tries to connect to the host specified

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# For production images, use the adoptium.net official JRE & JDK docker images.
 FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk-alpine AS stage1
 
 ENV SBT_VERSION "1.6.2"

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM eclipse-temurin:11.0.15_10-jdk-alpine AS stage1
 
 ENV SBT_VERSION "1.6.2"

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -30,7 +30,7 @@ RUN cd "${PROJECT_LOC}" && \
 
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
-FROM eclipse-temurin:11-jdk-alpine AS stage2
+FROM eclipse-temurin:11.0.15_10-jre-alpine AS stage2
 COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM eclipse-temurin:11.0.15_10-jdk-alpine AS stage1
+FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.15_10-jdk-alpine AS stage1
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local

--- a/test-support/oidc.Dockerfile
+++ b/test-support/oidc.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:15-alpine
 
 WORKDIR /usr/app


### PR DESCRIPTION
### Description

Use the base Alpine image (since eclipse-temurin doesn't build alpine for arm), and docker buildx to enable multiplatform builds for the dev & formatter docker images.
 
## Release notes:

n/a

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

