### PR TITLE
Temporarily marking code coverage upload failures as non-blocking.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,9 @@ jobs:
         with:
           file: server/code-coverage/report/jacoco.xml
           verbose: true
-          fail_ci_if_error: true
+          # TODO(#2976): Convert this back to true once code coverage
+          # integration is working again.
+          fail_ci_if_error: false
 
   run_browser_tests_aws:
     strategy:


### PR DESCRIPTION
### Description

Unblocks PR runs while we wait for codecov integration to be re-enabled. Left a TODO against https://github.com/civiform/civiform/issues/2976 to ensure that we consider these blocking after the integration has been fixed.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2976