### PR TITLE
Always set FieldWithLabel id

### DIFF
--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -317,7 +317,6 @@ public class FieldWithLabel {
 
   /** Public final tag getters * */
   public DivTag getTextareaTag() throws RuntimeException {
-    genRandIdIfEmpty();
     if (isTagTypeTextarea()) {
       TextareaTag textareaFieldTag = TagCreator.textarea();
       applyAttributesFromSet(textareaFieldTag);
@@ -381,7 +380,7 @@ public class FieldWithLabel {
             fieldErrors.isEmpty() || !showFieldErrors ? Styles.HIDDEN : "");
   }
 
-  protected void genRandIdIfEmpty() {
+  private void genRandIdIfEmpty() {
     // In order for the labels to be associated with the fields (mandatory for screen readers)
     // we need an id.  Generate a reasonable one if none is provided.
     if (this.id.isEmpty()) {
@@ -473,6 +472,7 @@ public class FieldWithLabel {
 
   protected <T extends EmptyTag<T> & IChecked<T> & IName<T> & IDisabled<T>>
       LabelTag checkboxApplyAttrsAndGenLabel(T fieldTag) throws RuntimeException {
+    genRandIdIfEmpty();
     // Apply attributes
     applyAttrsGenFieldErrorsInfo(fieldTag);
 
@@ -484,6 +484,7 @@ public class FieldWithLabel {
   }
 
   protected <T extends Tag<T> & IName<T> & IDisabled<T>> DivTag applyAttrsAndGenLabel(T fieldTag) {
+    genRandIdIfEmpty();
     // Apply attributes
     FieldErrorsInfo fieldErrorsInfo = applyAttrsGenFieldErrorsInfo(fieldTag);
     LabelTag labelTag = genLabelTag();

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -45,6 +45,62 @@ public class FieldWithLabelTest {
   }
 
   @Test
+  public void createTextArea_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.textArea().setId("id");
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getTextareaTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getTextareaTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createRadio_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.radio();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getRadioTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getRadioTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createCurrency_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.currency();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getCurrencyTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getCurrencyTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createInput_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.input();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getInputTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getInputTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createNumber_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.number();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getNumberTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getNumberTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createDate_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.date();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getDateTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getDateTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
+  public void createEmail_setsRandomId() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.email();
+    // Check that we do not have an empty id.
+    assertThat(fieldWithLabel.getEmailTag().render()).doesNotContain("id ");
+    assertThat(fieldWithLabel.getEmailTag().render()).doesNotContain("id=\"\"");
+  }
+
+  @Test
   public void number_setsNoValueByDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number();
     // No "value"="some-value" attribute. But allow "this.value" in script.


### PR DESCRIPTION
### Description
Always set FieldWithLabel id. If missing, generates a random one.

We used to always generate a random ID if one was not set, but this was accidentally removed due to some refactoring in #2281.

One known issue this causes is that labels are no longer linked to inputs, which is a problem for screen readers.

## Release notes:

Fix screenreader bug where labels and inputs are not linked with ID.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2388 
