### PR TITLE
Add civiform.git.commit_sha label when building an image.

### DIFF
--- a/bin/build-prod
+++ b/bin/build-prod
@@ -5,6 +5,7 @@
 source bin/lib.sh
 
 readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+readonly GIT_SHA="$(git rev-parse HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
 readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
 
@@ -14,6 +15,7 @@ docker build -f prod.Dockerfile \
   -t civiform:latest \
   --cache-from civiform/civiform:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg "git_commit_sha=${GIT_SHA}" \
   --build-arg "image_tag=${SNAPSHOT_TAG}" \
   .
 

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -43,4 +43,7 @@ RUN set -o pipefail && \
 ARG image_tag
 ENV CIVIFORM_IMAGE_TAG=$image_tag
 
+ARG git_commit_sha
+LABEL civiform.git.commit_sha=$git_commit_sha
+
 CMD ["/civiform-server-0.0.1/bin/civiform-server", "-Dconfig.file=/civiform-server-0.0.1/conf/application.conf"]


### PR DESCRIPTION
### Description

Adding an immutable label indicating the GIT commit SHA associated with the built image (from  https://github.com/civiform/civiform/issues/2926#issuecomment-1195759925).

## Release notes:

Adding the immutable `civiform.git.commit_sha_label` to the built image.

## Tested:

https://github.com/civiform/civiform/issues/2926#issuecomment-1195808099

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#2926