### PR TITLE
Fix multi-platform image pushing

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -3,6 +3,10 @@ name: push_build_ci
 on:
   push:
     branches: main
+  pull_request:
+    branches:
+      - 'main'
+
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}
@@ -39,12 +43,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
+      - name: Check if we should push
+        if: ${{ (github.event_name == 'workflow_dispatch') ||  ${{ (github.event_name == 'push')
+        run: echo "PUSH=1" >> $GITHUB_ENV
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1
-          PUSH_IMAGE: 1
           PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -106,12 +111,15 @@ jobs:
         uses: docker/setup-buildx-action@v2
         if: ${{ steps.check_build.outputs.build == 'build' }}
 
+      - name: Check if we should push
+        if: ${{ (github.event_name == 'workflow_dispatch') ||  ${{ (github.event_name == 'push')
+        run: echo "PUSH=1" >> $GITHUB_ENV
+
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         if: ${{ steps.check_build.outputs.build == 'build' }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1
-          PUSH_IMAGE: 1
           PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -3,9 +3,6 @@ name: push_build_ci
 on:
   push:
     branches: main
-  pull_request:
-    branches:
-      - 'main'
 
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Run build-${{ matrix.version }} ${{ matrix.image }}
+      - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1
@@ -101,7 +101,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
 
-      - name: Run build-${{ matrix.version }} ${{ matrix.image }}
+      - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
         id: build_and_push
         env:

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Check build & push
         id: check_build
-        if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
+        if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) || contains(toJSON(steps.file_changes.outputs.files), matrix.script) || contains(toJSON(steps.file_changes.outputs.files), ".github") }}
         run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::true"
 
       - name: Skip build & push

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -35,6 +35,7 @@ jobs:
     concurrency:
       group: build_civiform-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    name: Build civiform ${{ matrix.version }} for ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -81,6 +82,7 @@ jobs:
             platform: 'linux/amd64'
     concurrency:
       group: build_dependancies-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}
+    name: Build civiform dependancy ${{ matrix.version }} for ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -92,19 +92,20 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Check build & push
+        id: check_build
         if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
-        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}"
+        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::true"
 
       - name: Skip build & push
-        if: ${{ github.event_name != 'workflow_dispatch' && !contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
+        if: ${{ steps.check_build.outputs.build != true }}
         run: echo "Skip ${{ matrix.image }} build for event ${{github.event_name}}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
+        if: ${{ steps.check_build.outputs.build == true }}
 
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
-        if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) }}
+        if: ${{ steps.check_build.outputs.build == true }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -3,6 +3,9 @@ name: push_build_ci
 on:
   push:
     branches: main
+  pull_request:
+    branches:
+      - 'main'
 
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -3,10 +3,6 @@ name: push_build_ci
 on:
   push:
     branches: main
-  pull_request:
-    branches:
-      - 'main'
-
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -103,15 +103,15 @@ jobs:
         run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::build"
 
       - name: Skip build & push
-        if: ${{ steps.check_build.outputs.build != "build" }}
+        if: ${{ steps.check_build.outputs.build != 'build' }}
         run: echo "Skip ${{ matrix.image }} build for event ${{github.event_name}}" "${{steps.check_build.outputs.build}}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ steps.check_build.outputs.build == "build" }}
+        if: ${{ steps.check_build.outputs.build == 'build' }}
 
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
-        if: ${{ steps.check_build.outputs.build == "build" }}
+        if: ${{ steps.check_build.outputs.build == 'build' }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -93,7 +93,11 @@ jobs:
 
       - name: Check build & push
         id: check_build
-        if: ${{ github.event_name == 'workflow_dispatch' || contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) || contains(toJSON(steps.file_changes.outputs.files), matrix.script) || contains(toJSON(steps.file_changes.outputs.files), ".github") }}
+        if: >
+          ${{ (github.event_name == 'workflow_dispatch') ||
+            contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) ||
+            contains(toJSON(steps.file_changes.outputs.files), matrix.script) ||
+            contains(toJSON(steps.file_changes.outputs.files), '.github') }}
         run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::true"
 
       - name: Skip build & push

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only build the latest version.
     strategy:
+      fail-fast: false
       matrix:
         version: ['prod', 'dev']
         include:
@@ -57,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only one at a time (but don't cancel currently running jobs).
     strategy:
+      fail-fast: false
       matrix:
         version: ['formatter', 'localstack', 'browser_test', 'oidc']
         include:

--- a/.github/workflows/push_build_ci.yaml
+++ b/.github/workflows/push_build_ci.yaml
@@ -98,18 +98,18 @@ jobs:
             contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) ||
             contains(toJSON(steps.file_changes.outputs.files), matrix.script) ||
             contains(toJSON(steps.file_changes.outputs.files), '.github') }}
-        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::true"
+        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::build"
 
       - name: Skip build & push
-        if: ${{ steps.check_build.outputs.build != true }}
-        run: echo "Skip ${{ matrix.image }} build for event ${{github.event_name}}"
+        if: ${{ steps.check_build.outputs.build != "build" }}
+        run: echo "Skip ${{ matrix.image }} build for event ${{github.event_name}}" "${{steps.check_build.outputs.build}}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ steps.check_build.outputs.build == true }}
+        if: ${{ steps.check_build.outputs.build == "build" }}
 
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
-        if: ${{ steps.check_build.outputs.build == true }}
+        if: ${{ steps.check_build.outputs.build == "build" }}
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM alpine
+FROM alpine
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -19,19 +19,19 @@ if [[ "${PLATFORM}" ]]; then
   PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
-echo "start ${IMAGE} build"
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
-echo "load ${IMAGE} build"
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  echo "push ${IMAGE} build"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -4,20 +4,31 @@
 
 source bin/lib.sh
 
-docker build \
-  -t civiform-browser-test:latest \
-  -f browser-test/playwright.Dockerfile \
-  --cache-from civiform/civiform-browser-test:latest \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  browser-test/
+IMAGE="civiform-browser-test"
+LOCATION="browser-test/"
+DOCKERFILE="browser-test/playwright.Dockerfile"
+
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}:latest"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  "${LOCATION}")
+
+PLATFORM_ARG=""
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG="--platform=${PLATFORM}"
+fi
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  docker tag \
-    civiform-browser-test:latest \
-    civiform/civiform-browser-test:latest
-
-  # Push the new image to the Docker Hub registry
-  docker push docker.io/civiform/civiform-browser-test:latest
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+
+docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -8,27 +8,30 @@ IMAGE="civiform-browser-test"
 LOCATION="browser-test/"
 DOCKERFILE="browser-test/playwright.Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}"
+BUILD_ARGS=("-f" "${DOCKERFILE}"
   -t "civiform/${IMAGE}:latest"
   --cache-from "civiform/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
-PLATFORM_ARG=""
+PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
-  PLATFORM_ARG="--platform=${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
+echo "start ${IMAGE} build"
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
+echo "load ${IMAGE} build"
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  echo "push ${IMAGE} build"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -14,13 +14,13 @@ BUILD_ARGS=(-f "${DOCKERFILE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
-PLATFORM_ARG=""
+PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
-  PLATFORM_ARG="--platform=${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
@@ -28,7 +28,7 @@ docker buildx build --load "${BUILD_ARGS[@]}"
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -1,24 +1,34 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new development docker image and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new development docker image and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
 
 source bin/lib.sh
-export DOCKER_BUILDKIT=1
 
-PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
+IMAGE="civiform-dev"
+LOCATION="."
+DOCKERFILE="Dockerfile"
 
-# Build the new development image.
-docker buildx build --load --platform="${PLATFORM}" \
-  -t civiform-dev:latest \
-  --cache-from civiform/civiform-dev:latest \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  .
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}:latest"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  "${LOCATION}")
+
+PLATFORM_ARG=""
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG="--platform=${PLATFORM}"
+fi
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  docker tag civiform-dev:latest civiform/civiform-dev:latest
-
-  # Push the new image to the Docker Hub registry.
-  docker push docker.io/civiform/civiform-dev:latest
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+
+docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -20,14 +20,17 @@ if [[ "${PLATFORM}" ]]; then
 fi
 
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -8,7 +8,7 @@ export DOCKER_BUILDKIT=1
 PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
 
 # Build the new development image.
-docker buildx build --platform="${PLATFORM}" \
+docker buildx build --load --platform="${PLATFORM}" \
   -t civiform-dev:latest \
   --cache-from civiform/civiform-dev:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -7,7 +7,7 @@ export DOCKER_BUILDKIT=1
 
 PLATFORM="${PLATFORM:-"linux/amd64"}"
 
-docker buildx build --platform="${PLATFORM}" \
+docker buildx build --load --platform="${PLATFORM}" \
   -t civiform/oidc-provider:latest \
   -f test-support/oidc.Dockerfile \
   --cache-from civiform/oidc-provider:latest \

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -1,22 +1,34 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new fake oidc docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new fake oidc docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
 
 source bin/lib.sh
-export DOCKER_BUILDKIT=1
 
-PLATFORM="${PLATFORM:-"linux/amd64"}"
+IMAGE="oidc-provider"
+LOCATION="test-support/"
+DOCKERFILE="test-support/oidc.Dockerfile"
 
-docker buildx build --load --platform="${PLATFORM}" \
-  -t civiform/oidc-provider:latest \
-  -f test-support/oidc.Dockerfile \
-  --cache-from civiform/oidc-provider:latest \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  test-support/
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}:latest"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  "${LOCATION}")
+
+PLATFORM_ARG=""
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG="--platform=${PLATFORM}"
+fi
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  # Push the new image to the Docker Hub registry.
-  docker push docker.io/civiform/oidc-provider:latest
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+
+docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -20,14 +20,17 @@ if [[ "${PLATFORM}" ]]; then
 fi
 
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -14,13 +14,13 @@ BUILD_ARGS=(-f "${DOCKERFILE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
-PLATFORM_ARG=""
+PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
-  PLATFORM_ARG="--platform=${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
@@ -28,7 +28,7 @@ docker buildx build --load "${BUILD_ARGS[@]}"
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -20,14 +20,17 @@ if [[ "${PLATFORM}" ]]; then
 fi
 
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -14,13 +14,13 @@ BUILD_ARGS=(-f "${DOCKERFILE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
-PLATFORM_ARG=""
+PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
-  PLATFORM_ARG="--platform=${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
@@ -28,6 +28,6 @@ docker buildx build --load "${BUILD_ARGS[@]}"
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -1,21 +1,33 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new formatter docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new formatter docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
 
 source bin/lib.sh
-export DOCKER_BUILDKIT=1
 
-PLATFORM="${PLATFORM:-"linux/amd64"}"
+IMAGE="formatter"
+LOCATION="."
+DOCKERFILE="formatter/formatter.Dockerfile"
 
-docker buildx build --load --platform="${PLATFORM}" \
-  -t civiform/formatter:latest \
-  -f formatter/formatter.Dockerfile \
-  --cache-from civiform/formatter:latest \
-  .
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}:latest"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  "${LOCATION}")
+
+PLATFORM_ARG=""
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG="--platform=${PLATFORM}"
+fi
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  # Push the new image to the Docker Hub registry.
-  docker push docker.io/civiform/formatter:latest
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -7,7 +7,7 @@ export DOCKER_BUILDKIT=1
 
 PLATFORM="${PLATFORM:-"linux/amd64"}"
 
-docker buildx build --platform="${PLATFORM}" \
+docker buildx build --load --platform="${PLATFORM}" \
   -t civiform/formatter:latest \
   -f formatter/formatter.Dockerfile \
   --cache-from civiform/formatter:latest \

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -1,28 +1,34 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new docker image for running the localstack container and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new docker image for running the localstack container and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
 
 source bin/lib.sh
-export DOCKER_BUILDKIT=1
 
-PLATFORM="${PLATFORM:-"linux/amd64"}"
+IMAGE="civiform-localstack"
+LOCATION="localstack/"
+DOCKERFILE="localstack/localstack.Dockerfile"
 
-# A separate image is to include our customizations for
-# https://github.com/seattle-uat/civiform/issues/2639.
-docker buildx build --load --platform="${PLATFORM}" \
-  -t civiform-localstack:latest \
-  -f localstack/localstack.Dockerfile \
-  --cache-from civiform/civiform-localstack:latest \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  localstack/
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}:latest"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  "${LOCATION}")
+
+PLATFORM_ARG=""
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG="--platform=${PLATFORM}"
+fi
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  docker tag \
-    civiform-localstack:latest \
-    civiform/civiform-localstack:latest
-
-  # push the new image to the Docker Hub registry
-  docker push docker.io/civiform/civiform-localstack:latest
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+
+docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -14,13 +14,13 @@ BUILD_ARGS=(-f "${DOCKERFILE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
-PLATFORM_ARG=""
+PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
-  PLATFORM_ARG="--platform=${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
 
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
@@ -28,7 +28,7 @@ docker buildx build --load "${BUILD_ARGS[@]}"
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -9,7 +9,7 @@ PLATFORM="${PLATFORM:-"linux/amd64"}"
 
 # A separate image is to include our customizations for
 # https://github.com/seattle-uat/civiform/issues/2639.
-docker buildx build --platform="${PLATFORM}" \
+docker buildx build --load --platform="${PLATFORM}" \
   -t civiform-localstack:latest \
   -f localstack/localstack.Dockerfile \
   --cache-from civiform/civiform-localstack:latest \

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -20,14 +20,17 @@ if [[ "${PLATFORM}" ]]; then
 fi
 
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -26,10 +26,10 @@ BUILD_ARGS=(-f "${DOCKERFILE}"
   "${LOCATION}")
 
 readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
-readonly PLATFORM_ARG="--platform=${PLATFORM}"
+readonly PLATFORM_ARG=(--platform "${PLATFORM}")
 
 # Build the multi-platform image
-docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 docker buildx build --load "${BUILD_ARGS[@]}"
@@ -37,7 +37,7 @@ docker buildx build --load "${BUILD_ARGS[@]}"
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -14,7 +14,7 @@ echo "Building ${SNAPSHOT_TAG}..."
 
 PLATFORM="${PLATFORM:-"linux/amd64"}"
 
-docker buildx build --platform="${PLATFORM}" \
+docker buildx build --load --platform="${PLATFORM}" \
   -f prod.Dockerfile \
   -t civiform:latest \
   --cache-from civiform/civiform:latest \

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -29,14 +29,17 @@ readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform
 readonly PLATFORM_ARG=(--platform "${PLATFORM}")
 
 # Build the multi-platform image
+echo "start ${IMAGE} build"
 docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
+echo "load ${IMAGE} build"
 docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp, and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
 
 source bin/lib.sh
 
@@ -9,26 +9,35 @@ readonly SHORT_SHA="$(git rev-parse --short HEAD)"
 readonly GIT_SHA="$(git rev-parse HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
 readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
+readonly IMAGE="civiform"
+readonly LOCATION="."
+readonly DOCKERFILE="prod.Dockerfile"
 
 echo "Building ${SNAPSHOT_TAG}..."
 
-PLATFORM="${PLATFORM:-"linux/amd64"}"
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "civiform/${IMAGE}"
+  -t "civiform/${IMAGE}:latest"
+  -t "civiform/${IMAGE}:${SNAPSHOT_TAG}"
+  --cache-from "civiform/${IMAGE}"
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  --build-arg "git_commit_sha=${GIT_SHA}"
+  --build-arg "image_tag=${SNAPSHOT_TAG}"
+  "${LOCATION}")
 
-docker buildx build --load --platform="${PLATFORM}" \
-  -f prod.Dockerfile \
-  -t civiform:latest \
-  --cache-from civiform/civiform:latest \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg "git_commit_sha=${GIT_SHA}" \
-  --build-arg "image_tag=${SNAPSHOT_TAG}" \
-  .
+readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
+readonly PLATFORM_ARG="--platform=${PLATFORM}"
+
+# Build the multi-platform image
+docker buildx build "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
+
+# Load the image from the cache
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
-
-  docker tag civiform:latest civiform/civiform:latest
-  docker tag civiform:latest "civiform/civiform:${SNAPSHOT_TAG}"
-
-  # push the new image to the Docker Hub registry
-  docker push --all-tags civiform/civiform
+  # Push the image from the cache to dockerhub
+  docker buildx build --push "${PLATFORM_ARG}" "${BUILD_ARGS[@]}"
 fi
+
+docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/remove-dev
+++ b/bin/remove-dev
@@ -8,11 +8,11 @@ docker::set_project_name_dev
 set +e # errors are OK
 
 echo "Stopping & deleting local civiform emulators"
-docker::compose_dev --profile emulator down
+docker::compose_dev --profile emulator down -v
 echo "Stopping & deletng local civiform shell"
-docker::compose_dev --profile shell down
+docker::compose_dev --profile shell down -v
 echo "Stopping & deletng local civiform container"
-docker::compose_dev down --remove-orphans
+docker::compose_dev down --remove-orphans -v
 
 docker network rm "${DOCKER_NETWORK_NAME}" 2>/dev/null
 


### PR DESCRIPTION
### Description

Docker buildx requires explicit loading into the local image cache (which is what push uses to find image)
We need to use the --load command to be able to use the image locally, and --push to push the mutli-platform image remotly.

Modifies the scripts to use these commands explicitly (and cache between the build).
Also adds clarifying comments to the github action, and runs the build whenever the github action file or build script changes.
## Release notes:
n/a 
### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
