### PR TITLE
Add axe accessibility tests to browser tests for question types

### DIFF
--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
       tsconfig: 'src/tsconfig.json',
     },
   },
+  setupFilesAfterEnv: ['./src/support/setup-jest.ts'],
 }

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/jest": "27.5.2",
     "@types/node": "16.11.45",
+    "axe-core": "^4.4.3",
     "axios": "0.27.2",
     "jest": "27.5.1",
     "jest-playwright-preset": "1.7.2",

--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -9,6 +9,7 @@ import {
   resetSession,
   selectApplicantLanguage,
   startSession,
+  validateAccessibility,
 } from './support'
 
 describe('address applicant flow', () => {
@@ -250,7 +251,7 @@ describe('address applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 

--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -243,6 +243,15 @@ describe('address applicant flow', () => {
       error = pageObject.locator('.cf-address-zip-error >> nth=1')
       expect(await error.isHidden()).toEqual(false)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 
   // One optional address followed by one required address.

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -203,5 +203,14 @@ describe('Checkbox question for applicant flow', () => {
 
       expect(await pageObject.isHidden(checkboxError)).toEqual(false)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Checkbox question for applicant flow', () => {
@@ -210,7 +211,7 @@ describe('Checkbox question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -158,5 +158,14 @@ describe('currency applicant flow', () => {
 
       expect(await pageObject.isHidden(currencyError)).toEqual(false)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('currency applicant flow', () => {
@@ -165,7 +166,7 @@ describe('currency applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -119,5 +119,14 @@ describe('Date question for applicant flow', () => {
 
       await applicantQuestions.submitFromReviewPage(programName)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Date question for applicant flow', () => {
@@ -126,7 +127,7 @@ describe('Date question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Dropdown question for applicant flow', () => {
@@ -134,7 +135,7 @@ describe('Dropdown question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -127,5 +127,14 @@ describe('Dropdown question for applicant flow', () => {
 
       await applicantQuestions.submitFromReviewPage(programName)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Email question for applicant flow', () => {
@@ -125,7 +126,7 @@ describe('Email question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -118,5 +118,14 @@ describe('Email question for applicant flow', () => {
 
       await applicantQuestions.submitFromReviewPage(programName)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -134,9 +134,13 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.answerNameQuestion('Porky', 'Pig')
     await applicantQuestions.clickNext()
 
+    // Validate that enumerators are accessible
+    await applicantQuestions.validateAccessibility()
+
     // Put in two things in the enumerator question
     await applicantQuestions.addEnumeratorAnswer('Bugs')
     await applicantQuestions.addEnumeratorAnswer('Daffy')
+
     await applicantQuestions.clickNext()
 
     // FIRST REPEATED ENTITY

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -7,6 +7,7 @@ import {
   ApplicantQuestions,
   selectApplicantLanguage,
   endSession,
+  validateAccessibility,
   waitForPageJsLoad,
 } from './support'
 
@@ -135,7 +136,7 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.clickNext()
 
     // Validate that enumerators are accessible
-    await applicantQuestions.validateAccessibility()
+    await validateAccessibility(pageObject)
 
     // Put in two things in the enumerator question
     await applicantQuestions.addEnumeratorAnswer('Bugs')

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -92,6 +92,16 @@ describe('file upload applicant flow', () => {
       const error = await pageObject.$('.cf-fileupload-error')
       expect(await error?.isHidden()).toEqual(false)
     })
+
+    // Failing because no associated label
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 
   // Optional file upload.

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -95,14 +95,14 @@ describe('file upload applicant flow', () => {
     })
 
     // TODO(#2988) Enable test once a11y issues are fixed.
-    // it('has no accessiblity violations', async () => {
-    //   await loginAsGuest(pageObject)
-    //   await selectApplicantLanguage(pageObject, 'English')
+    it.skip('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
 
-    //   await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.applyProgram(programName)
 
-    //   await validateAccessibility(pageObject)
-    // })
+      await validateAccessibility(pageObject)
+    })
   })
 
   // Optional file upload.

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -93,15 +93,15 @@ describe('file upload applicant flow', () => {
       expect(await error?.isHidden()).toEqual(false)
     })
 
-    // Failing because no associated label
-    it('has no accessiblity violations', async () => {
-      await loginAsGuest(pageObject)
-      await selectApplicantLanguage(pageObject, 'English')
+    // TODO(#2988) Enable test once a11y issues are fixed.
+    // it('has no accessiblity violations', async () => {
+    //   await loginAsGuest(pageObject)
+    //   await selectApplicantLanguage(pageObject, 'English')
 
-      await applicantQuestions.applyProgram(programName)
+    //   await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
-    })
+    //   await applicantQuestions.validateAccessibility()
+    // })
   })
 
   // Optional file upload.

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -11,6 +11,7 @@ import {
   resetSession,
   selectApplicantLanguage,
   startSession,
+  validateAccessibility,
 } from './support'
 
 describe('file upload applicant flow', () => {
@@ -100,7 +101,7 @@ describe('file upload applicant flow', () => {
 
     //   await applicantQuestions.applyProgram(programName)
 
-    //   await applicantQuestions.validateAccessibility()
+    //   await validateAccessibility(pageObject)
     // })
   })
 

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -199,5 +199,14 @@ describe('Id question for applicant flow', () => {
         'Must contain only numbers.',
       )
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Id question for applicant flow', () => {
@@ -206,7 +207,7 @@ describe('Id question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -9,6 +9,7 @@ import {
   resetSession,
   selectApplicantLanguage,
   startSession,
+  validateAccessibility,
 } from './support'
 
 const NAME_FIRST = '.cf-name-first'
@@ -170,7 +171,7 @@ describe('name applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 

--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -163,6 +163,15 @@ describe('name applicant flow', () => {
       error = await pageObject.$(`${NAME_LAST}-error >> nth=1`)
       expect(await error?.isHidden()).toEqual(false)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 
   // One optional name followed by one required name.

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Number question for applicant flow', () => {
@@ -173,7 +174,7 @@ describe('Number question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -166,5 +166,14 @@ describe('Number question for applicant flow', () => {
         false,
       )
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Radio button question for applicant flow', () => {
@@ -136,7 +137,7 @@ describe('Radio button question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -129,5 +129,14 @@ describe('Radio button question for applicant flow', () => {
 
       await applicantQuestions.submitFromReviewPage(programName)
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -1,4 +1,5 @@
 import {Page} from 'playwright'
+// import axe = require('axe-core')
 import {
   AdminPrograms,
   AdminQuestions,
@@ -10,6 +11,41 @@ import {
   startSession,
   resetSession,
 } from './support'
+
+// //  https://jestjs.io/docs/expect
+// interface CustomMatchers<R = unknown> {
+//   toHaveNoViolations(): R
+// }
+
+// declare global {
+//   namespace jest {
+//     interface Expect extends CustomMatchers {}
+//     interface Matchers<R> extends CustomMatchers<R> {}
+//     interface InverseAsymmetricMatchers extends CustomMatchers {}
+//   }
+// }
+
+// // Print out all accessibility violations, and link to how to fix?
+// expect.extend({
+//   toHaveNoViolations(results: axe.AxeResults) {
+//     const numViolations = results.violations.length
+//     const pass = numViolations == 0
+//     if (pass) {
+//       return {
+//         message: () => `Expected axe accessibility violations, found none`,
+//         pass: true,
+//       }
+//     } else {
+//       return {
+//         message: () =>
+//           `Expected no axe accessibility violations, found ${numViolations} violations:\n ${JSON.stringify(
+//             results.violations,
+//           )}`,
+//         pass: false,
+//       }
+//     }
+//   },
+// })
 
 describe('Static text question for applicant flow', () => {
   const staticText = 'Hello, I am some static text!'
@@ -52,5 +88,44 @@ describe('Static text question for applicant flow', () => {
 
     const staticId = '.cf-question-static'
     expect(await pageObject.innerText(staticId)).toContain(staticText)
+  })
+
+  it('has no accessiblity violations', async () => {
+    await loginAsGuest(pageObject)
+    await selectApplicantLanguage(pageObject, 'English')
+
+    await applicantQuestions.applyProgram(programName)
+
+    await applicantQuestions.validateAccessibility()
+
+    // Wrap this in a function?
+
+    // // Inject axe and run.
+    // await pageObject.addScriptTag({path: 'node_modules/axe-core/axe.min.js'})
+    // const results = await pageObject.evaluate(() => {
+    //   return axe.run()
+    // })
+
+    // // expect.extend({
+    // //   jeannie(received: number) {
+    // //     if (received == 2) {
+    // //       return {
+    // //         message: () =>
+    // //           `Expected axe accessibility violdations, found none`,
+    // //         pass: true,
+    // //       };
+    // //     } else {
+    // //       return {
+    // //         message: () =>
+    // //           `Expected no axe accessibility violdations, found ${received} violations`,
+    // //         pass: false,
+    // //       };
+    // //     }
+    // //   },
+    // // });
+    // // expect(0).jeannie();
+    // console.log(JSON.stringify(results.violations, null, 2))
+
+    // expect(results).toHaveNoViolations()
   })
 })

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -1,5 +1,4 @@
 import {Page} from 'playwright'
-// import axe = require('axe-core')
 import {
   AdminPrograms,
   AdminQuestions,
@@ -11,41 +10,6 @@ import {
   startSession,
   resetSession,
 } from './support'
-
-// //  https://jestjs.io/docs/expect
-// interface CustomMatchers<R = unknown> {
-//   toHaveNoViolations(): R
-// }
-
-// declare global {
-//   namespace jest {
-//     interface Expect extends CustomMatchers {}
-//     interface Matchers<R> extends CustomMatchers<R> {}
-//     interface InverseAsymmetricMatchers extends CustomMatchers {}
-//   }
-// }
-
-// // Print out all accessibility violations, and link to how to fix?
-// expect.extend({
-//   toHaveNoViolations(results: axe.AxeResults) {
-//     const numViolations = results.violations.length
-//     const pass = numViolations == 0
-//     if (pass) {
-//       return {
-//         message: () => `Expected axe accessibility violations, found none`,
-//         pass: true,
-//       }
-//     } else {
-//       return {
-//         message: () =>
-//           `Expected no axe accessibility violations, found ${numViolations} violations:\n ${JSON.stringify(
-//             results.violations,
-//           )}`,
-//         pass: false,
-//       }
-//     }
-//   },
-// })
 
 describe('Static text question for applicant flow', () => {
   const staticText = 'Hello, I am some static text!'
@@ -97,35 +61,5 @@ describe('Static text question for applicant flow', () => {
     await applicantQuestions.applyProgram(programName)
 
     await applicantQuestions.validateAccessibility()
-
-    // Wrap this in a function?
-
-    // // Inject axe and run.
-    // await pageObject.addScriptTag({path: 'node_modules/axe-core/axe.min.js'})
-    // const results = await pageObject.evaluate(() => {
-    //   return axe.run()
-    // })
-
-    // // expect.extend({
-    // //   jeannie(received: number) {
-    // //     if (received == 2) {
-    // //       return {
-    // //         message: () =>
-    // //           `Expected axe accessibility violdations, found none`,
-    // //         pass: true,
-    // //       };
-    // //     } else {
-    // //       return {
-    // //         message: () =>
-    // //           `Expected no axe accessibility violdations, found ${received} violations`,
-    // //         pass: false,
-    // //       };
-    // //     }
-    // //   },
-    // // });
-    // // expect(0).jeannie();
-    // console.log(JSON.stringify(results.violations, null, 2))
-
-    // expect(results).toHaveNoViolations()
   })
 })

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Static text question for applicant flow', () => {
@@ -60,6 +61,6 @@ describe('Static text question for applicant flow', () => {
 
     await applicantQuestions.applyProgram(programName)
 
-    await applicantQuestions.validateAccessibility()
+    await validateAccessibility(pageObject)
   })
 })

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -306,6 +306,6 @@ export class ApplicantQuestions {
       return axe.run()
     })
 
-    expect(results).toHaveNoViolations()
+    expect(results).toHaveNoA11yViolations()
   }
 }

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,7 +1,6 @@
 import {Page} from 'playwright'
 import {readFileSync} from 'fs'
 import {waitForPageJsLoad} from './wait'
-import axe = require('axe-core')
 
 export class ApplicantQuestions {
   public page!: Page
@@ -297,15 +296,5 @@ export class ApplicantQuestions {
 
   async seeStaticQuestion(questionText: string) {
     expect(await this.page.textContent('html')).toContain(questionText)
-  }
-
-  async validateAccessibility() {
-    // Inject axe and run.
-    await this.page.addScriptTag({path: 'node_modules/axe-core/axe.min.js'})
-    const results = await this.page.evaluate(() => {
-      return axe.run()
-    })
-
-    expect(results).toHaveNoA11yViolations()
   }
 }

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,6 +1,7 @@
 import {Page} from 'playwright'
 import {readFileSync} from 'fs'
 import {waitForPageJsLoad} from './wait'
+import axe = require('axe-core')
 
 export class ApplicantQuestions {
   public page!: Page
@@ -296,5 +297,15 @@ export class ApplicantQuestions {
 
   async seeStaticQuestion(questionText: string) {
     expect(await this.page.textContent('html')).toContain(questionText)
+  }
+
+  async validateAccessibility() {
+    // Inject axe and run.
+    await this.page.addScriptTag({path: 'node_modules/axe-core/axe.min.js'})
+    const results = await this.page.evaluate(() => {
+      return axe.run()
+    })
+
+    expect(results).toHaveNoViolations()
   }
 }

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -1,3 +1,4 @@
+import axe = require('axe-core')
 import {Browser, BrowserContext, chromium, Page} from 'playwright'
 import * as path from 'path'
 import {waitForPageJsLoad} from './wait'
@@ -192,4 +193,14 @@ export const closeWarningMessage = async (page: Page) => {
         ),
       )
   }
+}
+
+export const validateAccessibility = async (page: Page) => {
+  // Inject axe and run accessibility test.
+  await page.addScriptTag({path: 'node_modules/axe-core/axe.min.js'})
+  const results = await page.evaluate(() => {
+    return axe.run()
+  })
+
+  expect(results).toHaveNoA11yViolations()
 }

--- a/browser-test/src/support/setup-jest.ts
+++ b/browser-test/src/support/setup-jest.ts
@@ -13,7 +13,8 @@ declare global {
 }
 
 // Custom matcher that outputs accessibility violations using axe.
-// See https://jestjs.io/docs/expect#expectextendmatchers for more info on custom matchers in jest.
+// See https://jestjs.io/docs/expect#expectextendmatchers and
+// https://jestjs.io/docs/configuration#setupfilesafterenv-array for more info on custom matchers in jest.
 expect.extend({
   toHaveNoA11yViolations(results: axe.AxeResults) {
     const numViolations = results.violations.length

--- a/browser-test/src/support/setup-jest.ts
+++ b/browser-test/src/support/setup-jest.ts
@@ -1,6 +1,5 @@
 import axe = require('axe-core')
 
-//  https://jestjs.io/docs/expect
 interface CustomMatchers<R = unknown> {
   toHaveNoViolations(): R
 }
@@ -13,7 +12,7 @@ declare global {
   }
 }
 
-// Print out all accessibility violations, and link to how to fix?
+// Custom matcher that outputs accessibility violations using axe.
 expect.extend({
   toHaveNoViolations(results: axe.AxeResults) {
     const numViolations = results.violations.length

--- a/browser-test/src/support/setup-jest.ts
+++ b/browser-test/src/support/setup-jest.ts
@@ -1,7 +1,7 @@
 import axe = require('axe-core')
 
 interface CustomMatchers<R = unknown> {
-  toHaveNoViolations(): R
+  toHaveNoA11yViolations(): R
 }
 
 declare global {
@@ -14,7 +14,7 @@ declare global {
 
 // Custom matcher that outputs accessibility violations using axe.
 expect.extend({
-  toHaveNoViolations(results: axe.AxeResults) {
+  toHaveNoA11yViolations(results: axe.AxeResults) {
     const numViolations = results.violations.length
     const pass = numViolations == 0
     if (pass) {

--- a/browser-test/src/support/setup-jest.ts
+++ b/browser-test/src/support/setup-jest.ts
@@ -13,13 +13,13 @@ declare global {
 }
 
 // Custom matcher that outputs accessibility violations using axe.
+// See https://jestjs.io/docs/expect#expectextendmatchers for more info on custom matchers in jest.
 expect.extend({
   toHaveNoA11yViolations(results: axe.AxeResults) {
     const numViolations = results.violations.length
-    const pass = numViolations == 0
-    if (pass) {
+    if (numViolations == 0) {
       return {
-        message: () => `Expected axe accessibility violations, found none`,
+        message: () => 'Expected axe accessibility violations, found none',
         pass: true,
       }
     } else {

--- a/browser-test/src/support/setup-jest.ts
+++ b/browser-test/src/support/setup-jest.ts
@@ -1,0 +1,38 @@
+import axe = require('axe-core')
+
+//  https://jestjs.io/docs/expect
+interface CustomMatchers<R = unknown> {
+  toHaveNoViolations(): R
+}
+
+declare global {
+  namespace jest {
+    interface Expect extends CustomMatchers {}
+    interface Matchers<R> extends CustomMatchers<R> {}
+    interface InverseAsymmetricMatchers extends CustomMatchers {}
+  }
+}
+
+// Print out all accessibility violations, and link to how to fix?
+expect.extend({
+  toHaveNoViolations(results: axe.AxeResults) {
+    const numViolations = results.violations.length
+    const pass = numViolations == 0
+    if (pass) {
+      return {
+        message: () => `Expected axe accessibility violations, found none`,
+        pass: true,
+      }
+    } else {
+      return {
+        message: () =>
+          `Expected no axe accessibility violations, found ${numViolations} violations:\n ${JSON.stringify(
+            results.violations,
+            null,
+            2,
+          )}`,
+        pass: false,
+      }
+    }
+  },
+})

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -9,6 +9,7 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
 describe('Text question for applicant flow', () => {
@@ -204,7 +205,7 @@ describe('Text question for applicant flow', () => {
 
       await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.validateAccessibility()
+      await validateAccessibility(pageObject)
     })
   })
 })

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -197,5 +197,14 @@ describe('Text question for applicant flow', () => {
         'Must contain at most 20 characters.',
       )
     })
+
+    it('has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.validateAccessibility()
+    })
   })
 })


### PR DESCRIPTION
### Description

Add axe (https://github.com/dequelabs/axe-core) accessibility browser tests. This also adds a custom expect matcher, that outputs the accessibility violations on failure. Here is an example of how the test failure message looks:

![axe failure example](https://user-images.githubusercontent.com/9094240/181346442-81fd65eb-218d-44e3-8b2e-ed8ba104e338.png)

This PR just adds it for all question types. I will send a separate PR to cover the overall applicant's experience (e.g. a11y testing per page). I will also update the docs with debugging instructions.



## Release notes:

Add Axe accessibility testing framework to browser tests.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#2388 
