### PR TITLE
Use dedicated volume for node_modules when running browser test

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -6,8 +6,15 @@ source bin/lib.sh
 docker::set_project_name_browser_tests
 bin/pull-image
 
+docker volume create browser-tests-node-modules
+
+# Run browser tests from within the civiform-browser-test container. We map
+# full browser-test local directory to the container so that it uses local changes.
+# Additionally we map node_modules to a separate volume so that it doesn't
+# conflict with node_modules created locally.
 docker run --rm -it \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
+  -v "browser-tests-node-modules:/usr/src/civiform-browser-tests/node_modules" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform/civiform-browser-test:latest \

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -7,8 +7,10 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 source bin/lib.sh
 docker::set_project_name_browser_tests
 
+docker volume create browser-tests-node-modules
 docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
+  -v "browser-tests-node-modules:/usr/src/civiform-browser-tests/node_modules" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \


### PR DESCRIPTION
### Description

Currently, when browser tests run, dependencies pulled from the docker container are stored in local `browser-test/node_modules` directory which might cause issues and conflict when running npm/yarn commands locally from that directory. This change introduces dedicated volume where node_modules will be stored and shared between browser test runs.
