### PR TITLE
Remove OIDC TF variables that were moved to secret manager.

### DIFF
--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -31,24 +31,6 @@
     "tfvar": true,
     "type": "string"
   },
-  "APPLICANT_OIDC_CLIENT_ID": {
-    "required": true,
-    "secret": true,
-    "tfvar": true,
-    "type": "string"
-  },
-  "APPLICANT_OIDC_CLIENT_SECRET": {
-    "required": true,
-    "secret": true,
-    "tfvar": true,
-    "type": "string"
-  },
-  "APPLICANT_OIDC_DISCOVERY_URI": {
-    "required": true,
-    "secret": false,
-    "tfvar": true,
-    "type": "string"
-  },
   "APPLICANT_OIDC_RESPONSE_MODE": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -31,6 +31,12 @@
     "tfvar": true,
     "type": "string"
   },
+  "APPLICANT_OIDC_DISCOVERY_URI": {
+    "required": true,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
   "APPLICANT_OIDC_RESPONSE_MODE": {
     "required": false,
     "secret": false,

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -230,24 +230,6 @@ variable "civiform_applicant_idp" {
   default     = ""
 }
 
-variable "applicant_oidc_client_id" {
-  type        = string
-  description = "Client ID"
-  default     = ""
-}
-
-variable "applicant_oidc_client_secret" {
-  type        = string
-  description = "Client Secret"
-  default     = ""
-}
-
-variable "applicant_oidc_discovery_uri" {
-  type        = string
-  description = "Discovery URI"
-  default     = ""
-}
-
 variable "custom_hostname" {
   type        = string
   description = "The custom hostname this app is deployed on"

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -230,6 +230,13 @@ variable "civiform_applicant_idp" {
   default     = ""
 }
 
+
+variable "applicant_oidc_discovery_uri" {
+  type        = string
+  description = "Discovery URI"
+  default     = ""
+}
+
 variable "custom_hostname" {
   type        = string
   description = "The custom hostname this app is deployed on"

--- a/cloud/aws/templates/aws_oidc/vpc.tf
+++ b/cloud/aws/templates/aws_oidc/vpc.tf
@@ -88,13 +88,3 @@ resource "aws_security_group" "rds" {
     cidr_blocks = var.private_subnets
   }
 }
-
-resource "aws_apprunner_vpc_connector" "connector" {
-  tags = {
-    Name = "${var.app_prefix} Civiform Apprunner VPC Connector"
-    Type = "Civiform Apprunner VPC Connector"
-  }
-  vpc_connector_name = "${var.app_prefix}-civiform_connector"
-  subnets            = module.vpc.private_subnets
-  security_groups    = [aws_security_group.rds.id]
-}


### PR DESCRIPTION
### Description

The following variables are now created in AWS Secret manager and are not passed from terraform config: `APPLICANT_OIDC_CLIENT_ID`, `APPLICANT_OIDC_CLIENT_SECRET`, `APPLICANT_OIDC_DISCOVERY_URI`.

Also removes `aws_apprunner_vpc_connector` resource that no longer used since deployment was moved to fargate.