### PR TITLE
Fix layout for User name and Export to PDF button row

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
-import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.p;
 
@@ -63,8 +62,20 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .withClasses(Styles.PX_20)
             .with(
                 h2("Program: " + programName).withClasses(Styles.MY_4),
-                h1(applicantNameWithApplicationId).withClasses(Styles.MY_4),
-                renderDownloadButton(programId, applicationId),
+                div()
+                    .withClasses(Styles.MY_4, Styles.FLEX)
+                    .with(
+                        p(applicantNameWithApplicationId)
+                            .withClasses(
+                                Styles.MY_4,
+                                Styles.TEXT_BLACK,
+                                Styles.FONT_BOLD,
+                                Styles.TEXT_XL,
+                                Styles.MB_2),
+                        // Spread out the items, so the following are right
+                        // aligned.
+                        p().withClasses(Styles.FLEX_GROW),
+                        renderDownloadButton(programId, applicationId)),
                 each(
                     blocks,
                     block -> renderApplicationBlock(programId, block, blockToAnswers.get(block))));

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -63,14 +63,13 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .with(
                 h2("Program: " + programName).withClasses(Styles.MY_4),
                 div()
-                    .withClasses(Styles.MY_4, Styles.FLEX)
+                    .withClasses(Styles.FLEX)
                     .with(
                         p(applicantNameWithApplicationId)
                             .withClasses(
                                 Styles.MY_4,
                                 Styles.TEXT_BLACK,
-                                Styles.FONT_BOLD,
-                                Styles.TEXT_XL,
+                                Styles.TEXT_2XL,
                                 Styles.MB_2),
                         // Spread out the items, so the following are right
                         // aligned.

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -67,10 +67,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     .with(
                         p(applicantNameWithApplicationId)
                             .withClasses(
-                                Styles.MY_4,
-                                Styles.TEXT_BLACK,
-                                Styles.TEXT_2XL,
-                                Styles.MB_2),
+                                Styles.MY_4, Styles.TEXT_BLACK, Styles.TEXT_2XL, Styles.MB_2),
                         // Spread out the items, so the following are right
                         // aligned.
                         p().withClasses(Styles.FLEX_GROW),

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -46,7 +46,6 @@ public class LinkElement {
   private static final String RIGHT_ALIGNED_LINK_BUTTON_STYLES =
       StyleUtils.joinStyles(
           Styles.FLOAT_RIGHT,
-          Styles._MT_14,
           Styles.INLINE_BLOCK,
           Styles.CURSOR_POINTER,
           Styles.P_2,


### PR DESCRIPTION
### Description

Fixes the layout of the User name and Export to PDF button column

Currently:
 * User name: H1 which consumes the max width
 * Button has a large negative margin to account for the H1 taking the full width.

A key change is that the User name should not be an H1 as it comes after a H2 (the program name) H tags need to be in numerical order, it is now a `<p>` with the same styling as the Screen headers.  If anything the screen names should be headers I think.

Put the row items in a div with flex layout.

## Release notes:

Changes the rendering process for the Program Admin Application view for the User name and Export button.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
