### PR TITLE
Setting PUSH_IMAGE env variable for bin/build-[dev|prod] scripts.

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Check if we should push
         if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'push') }}
-        run: echo "PUSH=1" >> $GITHUB_ENV
+        run: echo "PUSH_IMAGE=1" >> $GITHUB_ENV
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         id: build_and_push
         env:
@@ -113,7 +113,7 @@ jobs:
 
       - name: Check if we should push
         if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'push') }}
-        run: echo "PUSH=1" >> $GITHUB_ENV
+        run: echo "PUSH_IMAGE=1" >> $GITHUB_ENV
 
       - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
         if: ${{ steps.check_build.outputs.build == 'build' }}


### PR DESCRIPTION
### Description

We haven't been pushing new images to DockerHub in the past 2 days since we're not setting the `PUSH_IMAGE` environment variable expected by [`bin/build-prod`](https://github.com/civiform/civiform/blob/2fefe4065d9422a64f6beb43c40ffadaff0b53fa/bin/build-prod#L39) / [`bin/build-dev`](https://github.com/civiform/civiform/blob/2fefe4065d9422a64f6beb43c40ffadaff0b53fa/bin/build-dev#L30).

It appears that #2982 accidentally set the `PUSH` environment variable instead.

## Release notes:

Fix bug where CI no longer pushes new images to DockerHub.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

