### PR TITLE
Make applicant_oidc_discovery_uri a regular variable instead of secret

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -55,7 +55,6 @@ module "td" {
               aws_secretsmanager_secret.adfs_discovery_uri_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_secret_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_id_secret.arn,
-              aws_secretsmanager_secret.applicant_oidc_discovery_uri_secret.arn,
             ]
           },
           {
@@ -70,7 +69,7 @@ module "td" {
             "Resource" : [aws_kms_key.civiform_kms_key.arn]
           },
         ]
-      }
+        }
     )
   ]
 
@@ -98,10 +97,6 @@ module "td" {
     {
       name      = "ADFS_CLIENT_ID"
       valueFrom = aws_secretsmanager_secret_version.applicant_oidc_client_id_secret_version.arn
-    },
-    {
-      name      = "APPLICANT_OIDC_DISCOVERY_URI"
-      valueFrom = aws_secretsmanager_secret_version.applicant_oidc_discovery_uri_secret_version.arn
     },
     {
       name      = "APPLICANT_OIDC_CLIENT_ID"
@@ -148,6 +143,7 @@ module "td" {
     APPLICANT_OIDC_FIRST_NAME_ATTRIBUTE  = var.applicant_oidc_first_name_attribute
     APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE = var.applicant_oidc_middle_name_attribute
     APPLICANT_OIDC_LAST_NAME_ATTRIBUTE   = var.applicant_oidc_last_name_attribute
+    APPLICANT_OIDC_DISCOVERY_URI         = var.applicant_oidc_discovery_uri
   }
   log_configuration = {
     logDriver = "awslogs"
@@ -170,7 +166,7 @@ module "ecs_fargate_service" {
   name_prefix   = var.app_prefix
   desired_count = 0 # TODO: set this to actual value
   # TODO: use https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate
-  default_certificate_arn = "arn:aws:acm:us-east-1:664198874744:certificate/2b765469-2ddd-4b03-94b4-fc670e80f84b"
+  default_certificate_arn = "arn:aws:acm:us-east-1:664198874744:certificate/1f04bb7f-aab7-444a-8fea-398a3ec34e39"
   ssl_policy              = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   vpc_id                  = module.vpc.vpc_id
   task_definition_arn     = module.td.aws_ecs_task_definition_td_arn

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -69,7 +69,7 @@ module "td" {
             "Resource" : [aws_kms_key.civiform_kms_key.arn]
           },
         ]
-        }
+      }
     )
   ]
 

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -156,15 +156,3 @@ resource "aws_secretsmanager_secret_version" "applicant_oidc_client_id_secret_ve
   secret_id     = aws_secretsmanager_secret.applicant_oidc_client_id_secret.id
   secret_string = " "
 }
-
-# Creating a AWS secret for applicant_oidc_discovery_uri
-resource "aws_secretsmanager_secret" "applicant_oidc_discovery_uri_secret" {
-  name       = "${var.app_prefix}-applicant_oidc_discovery_uri"
-  kms_key_id = aws_kms_key.civiform_kms_key.arn
-}
-
-# Creating a AWS secret versions for applicant_oidc_discovery_uri
-resource "aws_secretsmanager_secret_version" "applicant_oidc_discovery_uri_secret_version" {
-  secret_id     = aws_secretsmanager_secret.applicant_oidc_discovery_uri_secret.id
-  secret_string = " "
-}

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -14,7 +14,7 @@
     "type": "string"
   },
   "BASE_URL": {
-    "required": false,
+    "required": true,
     "secret": false,
     "tfvar": true,
     "type": "string"

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -63,7 +63,7 @@
     "values": ["prod", "staging", "dev", "test"]
   },
   "CUSTOM_HOSTNAME": {
-    "required": true,
+    "required": false,
     "secret": false,
     "tfvar": true,
     "type": "string"


### PR DESCRIPTION
### Description

`applicant_oidc_discovery_uri` is passed from civiform_config.sh and shouldn't be stored as secret. 

Additionally make BASE_URL required param over CUSTOM_HOSTNAME as the latter doesn't seem to provide useful functionality.
