### PR TITLE
Handle unauth better and add an empty test file for AdminApplicationController

### DIFF
--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -27,6 +27,11 @@ public class CiviFormController extends Controller {
     return profileUtils.currentUserProfile(request).orElseThrow().checkAuthorization(applicantId);
   }
 
+  /**
+   * Checks that the profile in {@code request} is an admin for {@code programName}.
+   *
+   * @throws java.util.NoSuchElementException if there is not profile in request.
+   */
   protected CompletableFuture<Void> checkProgramAdminAuthorization(
       ProfileUtils profileUtils, Http.Request request, String programName) {
     return profileUtils

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -30,7 +30,7 @@ public class CiviFormController extends Controller {
   /**
    * Checks that the profile in {@code request} is an admin for {@code programName}.
    *
-   * @throws java.util.NoSuchElementException if there is not profile in request.
+   * @throws java.util.NoSuchElementException if there is no profile in request.
    */
   protected CompletableFuture<Void> checkProgramAdminAuthorization(
       ProfileUtils profileUtils, Http.Request request, String programName) {

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
@@ -105,7 +106,7 @@ public class AdminApplicationController extends CiviFormController {
     try {
       program = programService.getProgramDefinition(programId);
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
 
@@ -163,7 +164,7 @@ public class AdminApplicationController extends CiviFormController {
           .as(Http.MimeTypes.BINARY)
           .withHeader(
               "Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
   }
@@ -184,7 +185,7 @@ public class AdminApplicationController extends CiviFormController {
           .as(Http.MimeTypes.BINARY)
           .withHeader(
               "Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
   }
@@ -234,7 +235,7 @@ public class AdminApplicationController extends CiviFormController {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
 
@@ -267,7 +268,7 @@ public class AdminApplicationController extends CiviFormController {
       ProgramDefinition program = programService.getProgramDefinition(programId);
       programName = program.adminName();
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
 
@@ -331,7 +332,7 @@ public class AdminApplicationController extends CiviFormController {
     try {
       program = programService.getProgramDefinition(programId);
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
-    } catch (CompletionException e) {
+    } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
 

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -1,7 +1,42 @@
 package controllers.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static play.mvc.Http.Status.UNAUTHORIZED;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import play.test.Helpers;
 import repository.ResetPostgres;
+import support.ProgramBuilder;
 
 public class AdminApplicationControllerTest extends ResetPostgres {
-  // Currently empty test for code coverage.
+  // NOTE: the controller asserts the user is valid on the program that applications are requestd
+  // for.
+  // However, we currently have no pattern for setting a profile in a test request, so we can't make
+  // affirmative tests.
+  private AdminApplicationController controller;
+
+  @Before
+  public void setupController() {
+    controller = instanceOf(AdminApplicationController.class);
+  }
+
+  @Test
+  public void index_noUser_errors() throws Exception {
+    long programId = ProgramBuilder.newActiveProgram().buildDefinition().id();
+    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Result result =
+        controller.index(
+            request,
+            programId,
+            /* search= */ Optional.empty(),
+            /* page= */ Optional.of(1), // Needed to skip redirect.
+            /* fromDate= */ Optional.empty(),
+            /* untilDate= */ Optional.empty());
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
 }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -1,0 +1,7 @@
+package controllers.admin;
+
+import repository.ResetPostgres;
+
+public class AdminApplicationControllerTest extends ResetPostgres{
+  // Currently empty test for code coverage.
+}

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -2,6 +2,6 @@ package controllers.admin;
 
 import repository.ResetPostgres;
 
-public class AdminApplicationControllerTest extends ResetPostgres{
+public class AdminApplicationControllerTest extends ResetPostgres {
   // Currently empty test for code coverage.
 }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -14,10 +14,9 @@ import repository.ResetPostgres;
 import support.ProgramBuilder;
 
 public class AdminApplicationControllerTest extends ResetPostgres {
-  // NOTE: the controller asserts the user is valid on the program that applications are requestd
-  // for.
-  // However, we currently have no pattern for setting a profile in a test request, so we can't make
-  // affirmative tests.
+  // NOTE: the controller asserts the user is valid on the program that applications are requested
+  // for. However, we currently have no pattern for setting a profile in a test request, so we can't
+  // make affirmative tests.
   private AdminApplicationController controller;
 
   @Before


### PR DESCRIPTION
### Description

Updates AdminApplicationController to issue an unauthorized response if no user profile is present.

Adds an effectively empty test file for AdminApplicationController, to set the baseline code coverage before adding new ones.  A test is necessary to do so.

## Release notes:

NA

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
