### PR TITLE
Update email-related setters for StatusDefinitions.Status.Builder to take an Optional<> instead of the raw value

### DIFF
--- a/server/app/controllers/admin/AdminProgramStatusesController.java
+++ b/server/app/controllers/admin/AdminProgramStatusesController.java
@@ -129,9 +129,9 @@ public final class AdminProgramStatusesController extends CiviFormController {
       if (!formData.getEmailBody().isBlank()) {
         newStatusBuilder =
             newStatusBuilder
-                .setEmailBodyText(formData.getEmailBody())
+                .setEmailBodyText(Optional.of(formData.getEmailBody()))
                 .setLocalizedEmailBodyText(
-                    LocalizedStrings.withDefaultValue(formData.getEmailBody()));
+                    Optional.of(LocalizedStrings.withDefaultValue(formData.getEmailBody())));
       }
       return service.appendStatus(program.id(), newStatusBuilder.build());
     }
@@ -150,10 +150,10 @@ public final class AdminProgramStatusesController extends CiviFormController {
                   // editing status.
                   .setLocalizedStatusText(existingStatus.localizedStatusText());
           if (existingStatus.localizedEmailBodyText().isPresent()) {
-            builder.setLocalizedEmailBodyText(existingStatus.localizedEmailBodyText().get());
+            builder.setLocalizedEmailBodyText(existingStatus.localizedEmailBodyText());
           }
           if (!formData.getEmailBody().isBlank()) {
-            builder.setEmailBodyText(formData.getEmailBody());
+            builder.setEmailBodyText(Optional.of(formData.getEmailBody()));
           }
           return builder.build();
         });

--- a/server/app/services/program/StatusDefinitions.java
+++ b/server/app/services/program/StatusDefinitions.java
@@ -86,10 +86,10 @@ public class StatusDefinitions {
       public abstract Builder setLocalizedStatusText(LocalizedStrings value);
 
       @JsonProperty("email_body")
-      public abstract Builder setEmailBodyText(String value);
+      public abstract Builder setEmailBodyText(Optional<String> value);
 
       @JsonProperty("email_body_localized")
-      public abstract Builder setLocalizedEmailBodyText(LocalizedStrings value);
+      public abstract Builder setLocalizedEmailBodyText(Optional<LocalizedStrings> value);
 
       public abstract Status build();
     }

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -1168,16 +1168,17 @@ public class ProgramServiceImplTest extends ResetPostgres {
       StatusDefinitions.Status.builder()
           .setStatusText("Approved")
           .setLocalizedStatusText(LocalizedStrings.of(Locale.US, "Approved"))
-          .setEmailBodyText("I'm an email!")
-          .setLocalizedEmailBodyText(LocalizedStrings.of(Locale.US, "I'm a US email!"))
+          .setEmailBodyText(Optional.of("I'm an email!"))
+          .setLocalizedEmailBodyText(Optional.of(LocalizedStrings.of(Locale.US, "I'm a US email!")))
           .build();
 
   private static final StatusDefinitions.Status REJECTED_STATUS =
       StatusDefinitions.Status.builder()
           .setStatusText("Rejected")
           .setLocalizedStatusText(LocalizedStrings.of(Locale.US, "Rejected"))
-          .setEmailBodyText("I'm a rejection email!")
-          .setLocalizedEmailBodyText(LocalizedStrings.of(Locale.US, "I'm a US rejection email!"))
+          .setEmailBodyText(Optional.of("I'm a rejection email!"))
+          .setLocalizedEmailBodyText(
+              Optional.of(LocalizedStrings.of(Locale.US, "I'm a US rejection email!")))
           .build();
 
   @Test
@@ -1219,8 +1220,9 @@ public class ProgramServiceImplTest extends ResetPostgres {
         StatusDefinitions.Status.builder()
             .setStatusText(APPROVED_STATUS.statusText())
             .setLocalizedStatusText(LocalizedStrings.withDefaultValue(APPROVED_STATUS.statusText()))
-            .setEmailBodyText("A new email")
-            .setLocalizedEmailBodyText(LocalizedStrings.withDefaultValue("A new US email"))
+            .setEmailBodyText(Optional.of("A new email"))
+            .setLocalizedEmailBodyText(
+                Optional.of(LocalizedStrings.withDefaultValue("A new US email")))
             .build();
 
     DuplicateStatusException exc =
@@ -1240,8 +1242,9 @@ public class ProgramServiceImplTest extends ResetPostgres {
         StatusDefinitions.Status.builder()
             .setStatusText("New status text")
             .setLocalizedStatusText(LocalizedStrings.withDefaultValue("New status text"))
-            .setEmailBodyText("A new email")
-            .setLocalizedEmailBodyText(LocalizedStrings.withDefaultValue("A new US email"))
+            .setEmailBodyText(Optional.of("A new email"))
+            .setLocalizedEmailBodyText(
+                Optional.of(LocalizedStrings.withDefaultValue("A new US email")))
             .build();
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -1292,9 +1295,9 @@ public class ProgramServiceImplTest extends ResetPostgres {
                           .setStatusText(APPROVED_STATUS.statusText())
                           .setLocalizedStatusText(
                               LocalizedStrings.withDefaultValue("New status text"))
-                          .setEmailBodyText("A new email")
+                          .setEmailBodyText(Optional.of("A new email"))
                           .setLocalizedEmailBodyText(
-                              LocalizedStrings.withDefaultValue("A new US email"))
+                              Optional.of(LocalizedStrings.withDefaultValue("A new US email")))
                           .build();
                     }),
             DuplicateStatusException.class);


### PR DESCRIPTION
### Description

This is necessary since these setters are used by Jackson when deserializing. If 'null' is persisted, then deserialization using the non-optional variants will pass null to the builder, which will throw a runtime exception. Added a regression test as well.

## Release notes:

Fixes error when creating a status with an empty email.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2752