### PR TITLE
Stitch lines of stacktrace to a single log even in AWS deployment

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -155,7 +155,13 @@ module "td" {
       "awslogs-region"        = var.aws_region
       "awslogs-stream-prefix" = "ecs"
       "awslogs-group"         = module.aws_cw_logs.logs_path
-      "awslogs-create-group"  = "true",
+      "awslogs-create-group"  = "true"
+      # Use https://docs.docker.com/config/containers/logging/awslogs/#awslogs-multiline-pattern
+      # Logs are streamed via container's stdout. Each line is considered a
+      # separate log messsage. To collect stacktraces, which take multiple line,
+      # to a single event we consider all lines which start with a whitespace character to be
+      # part of the previous line and not a standalone event.
+      "awslogs-multiline-pattern" = "^[^\\s]"
     }
     secretOptions = null
   }


### PR DESCRIPTION
### Description

Adds option to treat all lines that start with whitespace (space, tab) as part of the previous line. It collapses stacktraces to a single event. Ideally we would use something more versatile, like making sure that single logging call in java gets propagated as single logging event in CloudWatch. But that requires more custom integration. 

Here is example of how errors look in CloudWatch after this change:
![image](https://user-images.githubusercontent.com/252053/181878325-ce925cd8-b914-4174-8124-e376c6dfcd0d.png)


