### PR TITLE
Add axe a11y testing for overall applicant flow

### DIFF
--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -110,6 +110,7 @@ describe('normal application flow', () => {
     await applicantQuestions.answerNumberQuestion('1600')
     await applicantQuestions.clickNext()
     await applicantQuestions.submitFromReviewPage(programName)
+    await applicantQuestions.returnToProgramsFromSubmissionPage()
 
     // Apply to the program again as the same user
     await applicantQuestions.clickApplyProgramButton(programName)

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -9,9 +9,10 @@ import {
   selectApplicantLanguage,
   startSession,
   resetSession,
+  validateAccessibility,
 } from './support'
 
-describe('applicant navigation flow', () => {
+describe('Applicant navigation flow', () => {
   let pageObject: Page
 
   beforeAll(async () => {
@@ -126,6 +127,111 @@ describe('applicant navigation flow', () => {
       expect(await pageObject.innerText('h1')).toContain(
         'Program application preview',
       )
+    })
+
+    it('login page has no accessiblity violations', async () => {
+      // Verify we are on login page.
+      expect(await pageObject.innerText('head')).toContain('Login')
+      await validateAccessibility(pageObject)
+    })
+
+    it('language selection page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+
+      // Verify we are on language selection page.
+      expect(await pageObject.innerText('main')).toContain(
+        'Please select your preferred language.',
+      )
+      await validateAccessibility(pageObject)
+    })
+
+    it('program list page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Verify we are on program list page.
+      expect(await pageObject.innerText('h1')).toContain('Get benefits')
+      await validateAccessibility(pageObject)
+    })
+
+    // TODO(#3016): Enable test after fixing h1 a11y issue.
+    it.skip('program details page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+      await applicantQuestions.clickProgramDetails(programName)
+
+      // Verify we are on program details page. Url should end in "/programs/{program ID}"
+      expect(pageObject.url()).toMatch(/\/programs\/[0-9]+$/)
+      await validateAccessibility(pageObject)
+    })
+
+    it('program preview page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+      await applicantQuestions.clickApplyProgramButton(programName)
+
+      // Verify we are on program preview page.
+      expect(await pageObject.innerText('h1')).toContain(
+        'Program application preview',
+      )
+      await validateAccessibility(pageObject)
+    })
+
+    it('program review page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+      await applicantQuestions.applyProgram(programName)
+
+      // Answer all program questions
+      await applicantQuestions.answerDateQuestion('2021-11-01')
+      await applicantQuestions.answerEmailQuestion('test1@gmail.com')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerAddressQuestion(
+        '1234 St',
+        'Unit B',
+        'Sim',
+        'Ames',
+        '54321',
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerRadioButtonQuestion('one')
+      await applicantQuestions.clickNext()
+
+      // Verify we are on program review page.
+      expect(await pageObject.innerText('h1')).toContain(
+        'Program application review',
+      )
+      await validateAccessibility(pageObject)
+    })
+
+    it('program submission page has no accessiblity violations', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+      await applicantQuestions.applyProgram(programName)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerDateQuestion('2021-11-01')
+      await applicantQuestions.answerEmailQuestion('test1@gmail.com')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerAddressQuestion(
+        '1234 St',
+        'Unit B',
+        'Sim',
+        'Ames',
+        '54321',
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerRadioButtonQuestion('one')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.submitFromReviewPage(programName)
+
+      // Verify we are on program submission page.
+      expect(await pageObject.innerText('h1')).toContain(
+        'Application confirmation',
+      )
+      await validateAccessibility(pageObject)
     })
   })
 

--- a/browser-test/src/application_optional_questions.test.ts
+++ b/browser-test/src/application_optional_questions.test.ts
@@ -78,6 +78,7 @@ describe('optional application flow', () => {
 
     // Submit the first program
     await applicantQuestions.submitFromReviewPage(programName)
+    await applicantQuestions.returnToProgramsFromSubmissionPage()
 
     // Complete the second program
     await applicantQuestions.applyProgram(programName2)

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -13,7 +13,7 @@ import {
   userDisplayName,
 } from './support'
 
-describe('normal application flow', () => {
+describe('Program admin review of submitted applications', () => {
   it('all major steps', async () => {
     const {browser, page} = await startSession()
     page.setDefaultTimeout(5000)

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -51,8 +51,7 @@ describe('Static text question for applicant flow', () => {
 
     await applicantQuestions.applyProgram(programName)
 
-    const staticId = '.cf-question-static'
-    expect(await pageObject.innerText(staticId)).toContain(staticText)
+    applicantQuestions.seeStaticQuestion(staticText)
   })
 
   it('has no accessiblity violations', async () => {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -182,6 +182,13 @@ export class ApplicantQuestions {
     await waitForPageJsLoad(this.page)
   }
 
+  async clickProgramDetails(programName: string) {
+    await this.page.click(
+      `.cf-application-card:has-text("${programName}") >> text=Program details`,
+    )
+    await waitForPageJsLoad(this.page)
+  }
+
   async expectProgramPublic(programName: string, description: string) {
     const tableInnerText = await this.page.innerText('main')
 
@@ -253,6 +260,18 @@ export class ApplicantQuestions {
     return readFileSync(path, 'utf8')
   }
 
+  async returnToProgramsFromSubmissionPage() {
+    // Assert that we're on the submission page.
+    expect(await this.page.innerText('h1')).toContain(
+      'Application confirmation',
+    )
+    await this.page.click('text="Apply to another program"')
+    await waitForPageJsLoad(this.page)
+
+    // Ensure that we redirected to the programs list page.
+    expect(this.page.url().split('/').pop()).toEqual('programs')
+  }
+
   async submitFromReviewPage(programName: string) {
     // Assert that we're on the review page.
     expect(await this.page.innerText('h1')).toContain(
@@ -262,12 +281,6 @@ export class ApplicantQuestions {
     // Click on submit button.
     await this.page.click('text="Submit"')
     await waitForPageJsLoad(this.page)
-
-    await this.page.click('text="Apply to another program"')
-    await waitForPageJsLoad(this.page)
-
-    // Ensure that we redirected to the programs list page.
-    expect(await this.page.url().split('/').pop()).toEqual('programs')
   }
 
   async submitFromPreviewPage(programName: string) {
@@ -279,12 +292,6 @@ export class ApplicantQuestions {
     // Click on submit button.
     await this.page.click('text="Submit"')
     await waitForPageJsLoad(this.page)
-
-    await this.page.click('text="Apply to another program"')
-    await waitForPageJsLoad(this.page)
-
-    // Ensure that we redirected to the programs list page.
-    expect(await this.page.url().split('/').pop()).toEqual('programs')
   }
 
   async validateHeader(lang: string) {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -260,6 +260,18 @@ export class ApplicantQuestions {
     return readFileSync(path, 'utf8')
   }
 
+  async returnToProgramsFromSubmissionPage() {
+    // Assert that we're on the submission page.
+    expect(await this.page.innerText('h1')).toContain(
+      'Application confirmation',
+    )
+    await this.page.click('text="Apply to another program"')
+    await waitForPageJsLoad(this.page)
+
+    // Ensure that we redirected to the programs list page.
+    expect(this.page.url().split('/').pop()).toEqual('programs')
+  }
+
   async submitFromReviewPage(programName: string) {
     // Assert that we're on the review page.
     expect(await this.page.innerText('h1')).toContain(

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -260,18 +260,6 @@ export class ApplicantQuestions {
     return readFileSync(path, 'utf8')
   }
 
-  async returnToProgramsFromSubmissionPage() {
-    // Assert that we're on the submission page.
-    expect(await this.page.innerText('h1')).toContain(
-      'Application confirmation',
-    )
-    await this.page.click('text="Apply to another program"')
-    await waitForPageJsLoad(this.page)
-
-    // Ensure that we redirected to the programs list page.
-    expect(this.page.url().split('/').pop()).toEqual('programs')
-  }
-
   async submitFromReviewPage(programName: string) {
     // Assert that we're on the review page.
     expect(await this.page.innerText('h1')).toContain(


### PR DESCRIPTION
### Description

Add axe accessibility testing for each page of the applicant flow. Per question tests were added in #2989, and documentation was added in https://github.com/civiform/docs/pull/84

## Release notes:

N/A - adding testing.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2388
