### PR TITLE
Move certificate and task count variables from app.tf to config.

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -168,9 +168,9 @@ module "td" {
 }
 
 module "ecs_fargate_service" {
-  source        = "cn-terraform/ecs-fargate-service/aws"
-  name_prefix   = var.app_prefix
-  desired_count = var.fargate_desired_task_count
+  source                  = "cn-terraform/ecs-fargate-service/aws"
+  name_prefix             = var.app_prefix
+  desired_count           = var.fargate_desired_task_count
   default_certificate_arn = var.ssl_certificate_arn
   ssl_policy              = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   vpc_id                  = module.vpc.vpc_id

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -170,9 +170,8 @@ module "td" {
 module "ecs_fargate_service" {
   source        = "cn-terraform/ecs-fargate-service/aws"
   name_prefix   = var.app_prefix
-  desired_count = 0 # TODO: set this to actual value
-  # TODO: use https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate
-  default_certificate_arn = "arn:aws:acm:us-east-1:664198874744:certificate/1f04bb7f-aab7-444a-8fea-398a3ec34e39"
+  desired_count = var.fargate_desired_task_count
+  default_certificate_arn = var.ssl_certificate_arn
   ssl_policy              = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   vpc_id                  = module.vpc.vpc_id
   task_definition_arn     = module.td.aws_ecs_task_definition_td_arn

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -101,6 +101,6 @@
     "required": true,
     "secret": false,
     "tfvar": true,
-    "type": "number"
+    "type": "integer"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -90,5 +90,17 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
+  },
+  "SSL_CERTIFICATE_ARN": {
+    "required": true,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "FARGATE_DESIRED_TASK_COUNT": {
+    "required": true,
+    "secret": false,
+    "tfvar": true,
+    "type": "number"
   }
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -265,3 +265,13 @@ variable "civiform_mode" {
   type        = string
   description = "The civiform environment mode (test/dev/staging/prod)"
 }
+
+variable "ssl_certificate_arn" {
+  type        = string
+  description = "ARN of the certificate that will be used to handle SSL traffic. Certificate should be validated."
+}
+
+variable "fargate_desired_task_count" {
+  type        = number
+  description = "Number of Civiform server tasks to run. Can be set to 0 to shutdown server."
+}

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -79,7 +79,8 @@ class ValidateVariableDefinitions:
         if validator:
             errors.extend(validator(variable_definition))
         else:
-            errors.append("Unknown or missing 'type' field.")
+            supported_typed = list(type_specific_validators.keys())
+            errors.append(f"Unknown or missing 'type' field. Supported types {supported_typed}")
 
         return errors
 


### PR DESCRIPTION
### Description

Certificate at the moment is created outside of terraform. So it should be passed as a config variable rather than hardcoded in app.tf.

Desired task count is used to stop/start services and useful during development to stop crashing service.
