### PR TITLE
Remove auto-approve from setup.py

### DIFF
--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -17,106 +17,107 @@ Setup.py sets up and runs the initial terraform deployment. It's broken into
 The script generates a .tfvars file that is used to deploy via terraform.
 """
 
-###############################################################################
-# Load and Validate Inputs
-###############################################################################
 
-## Load the Config and Definitions
-config_loader = ConfigLoader()
+def main():
+    ###############################################################################
+    # Load and Validate Inputs
+    ###############################################################################
 
-validation_errors = config_loader.load_config()
-if validation_errors:
-    new_line = '\n\t'
-    exit(
-        f"Found the following validation errors: {new_line}{f'{new_line}'.join(validation_errors)}"
-    )
+    ## Load the Config and Definitions
+    config_loader = ConfigLoader()
 
-###############################################################################
-# Load Setup Class for the specific template directory
-###############################################################################
-
-terraform_template_dir = config_loader.get_template_dir()
-app_prefix = config_loader.app_prefix
-Setup = load_setup_class(terraform_template_dir)
-
-template_setup = Setup(config_loader)
-template_setup.setup_log_file()
-current_user = template_setup.get_current_user()
-
-image_tag = config_loader.get_config_var("IMAGE_TAG")
-log_args = f"\"{image_tag}\" {current_user}"
-
-print("Writing TF Vars file")
-terraform_tfvars_path = os.path.join(
-    terraform_template_dir, config_loader.tfvars_filename)
-
-# Write the passthrough vars to a temporary file
-tf_var_writter = TfVarWriter(terraform_tfvars_path)
-conf_variables = config_loader.get_terraform_variables()
-tf_var_writter.write_variables(conf_variables)
-
-try:
-    print("Starting pre-terraform setup")
-    template_setup.pre_terraform_setup()
+    validation_errors = config_loader.load_config()
+    if validation_errors:
+        new_line = '\n\t'
+        exit(
+            f"Found the following validation errors: {new_line}{f'{new_line}'.join(validation_errors)}"
+        )
 
     ###############################################################################
-    # Terraform Init/Plan/Apply
+    # Load Setup Class for the specific template directory
     ###############################################################################
-    print("Starting terraform setup")
-    # Note that the -chdir means we use the relative paths for
-    # both the backend config and the var file
-    terraform_init_args = [
-        "terraform", f"-chdir={terraform_template_dir}", "init", "-input=false",
-        "-upgrade", "-migrate-state"
-    ]
-    if config_loader.use_backend_config():
-        print(f"Using backend config {config_loader.backend_vars_filename}")
-        terraform_init_args.append(
-            f"-backend-config={config_loader.backend_vars_filename}")
 
-    print(" - Run terraform init")
-    subprocess.check_call(terraform_init_args)
+    terraform_template_dir = config_loader.get_template_dir()
+    Setup = load_setup_class(terraform_template_dir)
 
-    print(" - Run terraform apply")
-    tf_apply_args = [
-        "terraform", f"-chdir={terraform_template_dir}", "apply",
-        "-input=false", f"-var-file={config_loader.tfvars_filename}"
-    ]
+    template_setup = Setup(config_loader)
+    template_setup.setup_log_file()
+    current_user = template_setup.get_current_user()
 
-    if not config_loader.is_dev():
-        tf_apply_args.append("-auto-approve")
+    image_tag = config_loader.get_config_var("IMAGE_TAG")
+    log_args = f"\"{image_tag}\" {current_user}"
 
-    print(" - Run terraform apply in setup.py")
-    subprocess.check_call(tf_apply_args)
+    terraform_tfvars_path = os.path.join(
+        terraform_template_dir, config_loader.tfvars_filename)
 
-    ###############################################################################
-    # Post Run Setup Tasks (if needed)
-    ###############################################################################
-    if template_setup.requires_post_terraform_setup():
-        print("Starting port-terraform setup")
-        template_setup.post_terraform_setup()
+    # Write the passthrough vars to a temporary file
+    tf_var_writter = TfVarWriter(terraform_tfvars_path)
+    conf_variables = config_loader.get_terraform_variables()
+    tf_var_writter.write_variables(conf_variables)
 
-        subprocess.check_call(
+    try:
+        print("Starting pre-terraform setup")
+        template_setup.pre_terraform_setup()
+        # return
+        ###############################################################################
+        # Terraform Init/Plan/Apply
+        ###############################################################################
+        print("Starting terraform setup")
+        # Note that the -chdir means we use the relative paths for
+        # both the backend config and the var file
+        terraform_init_args = [
+            "terraform", f"-chdir={terraform_template_dir}", "init",
+            "-input=false", "-upgrade", "-migrate-state"
+        ]
+        if config_loader.use_backend_config():
+            print(f"Using backend config {config_loader.backend_vars_filename}")
+            terraform_init_args.append(
+                f"-backend-config={config_loader.backend_vars_filename}")
+
+        print(" - Run terraform init")
+        subprocess.check_call(terraform_init_args)
+
+        print(" - Run terraform apply")
+        tf_apply_args = [
+            "terraform", f"-chdir={terraform_template_dir}", "apply",
+            "-input=false", f"-var-file={config_loader.tfvars_filename}"
+        ]
+
+        print(" - Run terraform apply in setup.py")
+        subprocess.check_call(tf_apply_args)
+
+        ###############################################################################
+        # Post Run Setup Tasks (if needed)
+        ###############################################################################
+        if template_setup.requires_post_terraform_setup():
+            print("Starting port-terraform setup")
+            template_setup.post_terraform_setup()
+
+            subprocess.check_call(
+                [
+                    "terraform", f"-chdir={terraform_template_dir}", "apply",
+                    "-input=false", f"-var-file={config_loader.tfvars_filename}"
+                ])
+
+        subprocess.run(
             [
-                "terraform", f"-chdir={terraform_template_dir}", "apply",
-                "-input=false", f"-var-file={config_loader.tfvars_filename}"
-            ])
+                "/bin/bash", "-c",
+                f"source cloud/shared/bin/lib.sh && LOG_TEMPFILE={template_setup.log_file_path} log::deploy_succeeded {log_args}"
+            ],
+            check=True)
+    except BaseException as err:
+        subprocess.run(
+            [
+                "/bin/bash", "-c",
+                f"source cloud/shared/bin/lib.sh && LOG_TEMPFILE={template_setup.log_file_path} log::deploy_failed {log_args}"
+            ],
+            check=True)
+        print("Deployment Failed :(", file=sys.stderr)
+        print("error:", err)
 
-    subprocess.run(
-        [
-            "/bin/bash", "-c",
-            f"source cloud/shared/bin/lib.sh && LOG_TEMPFILE={template_setup.log_file_path} log::deploy_succeeded {log_args}"
-        ],
-        check=True)
-except BaseException as err:
-    subprocess.run(
-        [
-            "/bin/bash", "-c",
-            f"source cloud/shared/bin/lib.sh && LOG_TEMPFILE={template_setup.log_file_path} log::deploy_failed {log_args}"
-        ],
-        check=True)
-    print("Deployment Failed :(", file=sys.stderr)
-    print("error:", err)
+    finally:
+        template_setup.cleanup()
 
-finally:
-    template_setup.cleanup()
+
+if __name__ == "__main__":
+    main()

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -59,6 +59,7 @@ def main():
     try:
         print("Starting pre-terraform setup")
         template_setup.pre_terraform_setup()
+
         ###############################################################################
         # Terraform Init/Plan/Apply
         ###############################################################################

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -80,7 +80,9 @@ class ValidateVariableDefinitions:
             errors.extend(validator(variable_definition))
         else:
             supported_typed = list(type_specific_validators.keys())
-            errors.append(f"Unknown or missing 'type' field. Supported types {supported_typed}")
+            errors.append(
+                f"Unknown or missing 'type' field. Supported types {supported_typed}"
+            )
 
         return errors
 


### PR DESCRIPTION
### Description

Currently setup.py auto-approves and applies any changes when mode is staging or prod. It's dangerous as user should review those changes before applying them. The auto-approve seems to have been added for automation (CI tests) which currently are not implemented. In future, when we implement the tests, we can add this option back guarded by some flag or environment variable used only in tests. 