### PR TITLE
Make AWS secrets immediately deletable on staging

### DIFF
--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -1,3 +1,12 @@
+locals {
+  # Make secrets immediately deletable on 'staging' and 'dev' for easy
+  # development iteration. By default secrets are not deleted immediately and
+  # instead scheduled for deletion in 30 days. Whey they are not deleted
+  # immediately - you can't destroy and re-create environment from scratch
+  # without force-deleting secrets using aws cli.
+  secret_recovery_window_in_days = var.civiform_mode == "prod" ? 30 : 0
+}
+
 # Create a KMS key to encrypt the secrets. Note this
 # isn't totally necessary, but allows for custom IAM
 # policies on the key
@@ -28,6 +37,7 @@ resource "aws_secretsmanager_secret" "postgres_username_secret" {
   }
   name       = "${var.app_prefix}-postgres_username"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for postgres_username
@@ -55,6 +65,7 @@ resource "aws_secretsmanager_secret" "postgres_password_secret" {
   }
   name       = "${var.app_prefix}-postgres_password"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for postgres_password
@@ -77,6 +88,7 @@ resource "aws_secretsmanager_secret" "app_secret_key_secret" {
     Type = "Civiform App Secret Secret"
   }
   name = "${var.app_prefix}-app_secret_key"
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for app_secret_key
@@ -93,6 +105,7 @@ resource "aws_secretsmanager_secret" "adfs_secret_secret" {
   }
   name       = "${var.app_prefix}-adfs_secret"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for adfs_secret
@@ -109,6 +122,7 @@ resource "aws_secretsmanager_secret" "adfs_client_id_secret" {
   }
   name       = "${var.app_prefix}-adfs_client_id"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for adfs_client_id
@@ -125,6 +139,7 @@ resource "aws_secretsmanager_secret" "adfs_discovery_uri_secret" {
   }
   name       = "${var.app_prefix}-adfs_discovery_uri"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for adfs_discovery_uri
@@ -137,6 +152,7 @@ resource "aws_secretsmanager_secret_version" "adfs_discovery_uri_secret_version"
 resource "aws_secretsmanager_secret" "applicant_oidc_client_secret_secret" {
   name       = "${var.app_prefix}-applicant_oidc_client_secret"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for applicant_oidc_secret
@@ -149,6 +165,7 @@ resource "aws_secretsmanager_secret_version" "applicant_oidc_client_secret_secre
 resource "aws_secretsmanager_secret" "applicant_oidc_client_id_secret" {
   name       = "${var.app_prefix}-applicant_oidc_client_id"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
+  recovery_window_in_days = local.secret_recovery_window_in_days
 }
 
 # Creating a AWS secret versions for applicant_oidc_client_id


### PR DESCRIPTION
### Description

When deployment is done in staging or dev modes mark secrets as non-recoverable which immediately destroys them during `terraform destroy`. That helps with local iterations when engineer needs to re-create environment multiple times.
