### PR TITLE
remove fail for duplicated drafts. pick latest

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -92,6 +92,8 @@ public class ApplicationRepository {
       ImmutableList<Application> drafts =
           oldApplications.stream()
               .filter(app -> app.getLifecycleStage().equals(LifecycleStage.DRAFT))
+              // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to fail.
+              // Sort by create time DESC. We want the latest draft to be the first in the list.
               .sorted((app1, app2) -> app1.getCreateTime().isAfter(app2.getCreateTime()) ? -1 : 1)
               .collect(ImmutableList.toImmutableList());
       if (drafts.size() > 1) {

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -92,9 +92,11 @@ public class ApplicationRepository {
       ImmutableList<Application> drafts =
           oldApplications.stream()
               .filter(app -> app.getLifecycleStage().equals(LifecycleStage.DRAFT))
+              .sorted((app1, app2) -> app1.getCreateTime().isAfter(app2.getCreateTime()) ? -1 : 1)
               .collect(ImmutableList.toImmutableList());
       if (drafts.size() > 1) {
-        throw new RuntimeException(
+        // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to fail.
+        logger.error(
             String.format(
                 "Found more than one DRAFT application for applicant %d, program %d.",
                 applicant.id, program.id));

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.ExpressionList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -95,14 +96,14 @@ public class ApplicationRepository {
               // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to
               // fail.
               // Sort by create time DESC. We want the latest draft to be the first in the list.
-              .sorted((app1, app2) -> app1.getCreateTime().isAfter(app2.getCreateTime()) ? -1 : 1)
+              .sorted(Comparator.comparing(Application::getCreateTime).reversed())
               .collect(ImmutableList.toImmutableList());
       if (drafts.size() > 1) {
         // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to fail.
         logger.error(
-            String.format(
-                "Found more than one DRAFT application for applicant %d, program %d.",
-                applicant.id, program.id));
+            "Found more than one DRAFT application for applicant {}, program {}.",
+            applicant.id,
+            program.id);
       }
 
       Application application =

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -92,7 +92,8 @@ public class ApplicationRepository {
       ImmutableList<Application> drafts =
           oldApplications.stream()
               .filter(app -> app.getLifecycleStage().equals(LifecycleStage.DRAFT))
-              // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to fail.
+              // TODO(#3045): Revert this after the issue is fixed in prod. Desired behavior is to
+              // fail.
               // Sort by create time DESC. We want the latest draft to be the first in the list.
               .sorted((app1, app2) -> app1.getCreateTime().isAfter(app2.getCreateTime()) ? -1 : 1)
               .collect(ImmutableList.toImmutableList());


### PR DESCRIPTION
### Description

Temporary fix for https://github.com/civiform/civiform/issues/2969. If there are multiple DRAFT applications pick the latest and mark everything else OBSOLETE.

## Release notes:

Temporary fix for https://github.com/civiform/civiform/issues/2969.  If there are multiple DRAFT applications pick the latest and mark everything else OBSOLETE.
Should be reverted later.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
