### PR TITLE
Move ADFS_DISCOVERY_URI and AWS_REGION to civiform_config.sh

### DIFF
--- a/cloud/aws/modules/setup/variables.tf
+++ b/cloud/aws/modules/setup/variables.tf
@@ -11,5 +11,4 @@ variable "civiform_mode" {
 variable "aws_region" {
   type        = string
   description = "Region where the AWS servers will live"
-  default     = "us-east-1"
 }

--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -52,7 +52,6 @@ module "td" {
               aws_secretsmanager_secret.app_secret_key_secret.arn,
               aws_secretsmanager_secret.adfs_secret_secret.arn,
               aws_secretsmanager_secret.adfs_client_id_secret.arn,
-              aws_secretsmanager_secret.adfs_discovery_uri_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_secret_secret.arn,
               aws_secretsmanager_secret.applicant_oidc_client_id_secret.arn,
             ]
@@ -85,10 +84,6 @@ module "td" {
     {
       name      = "SECRET_KEY"
       valueFrom = aws_secretsmanager_secret_version.app_secret_key_secret_version.arn
-    },
-    {
-      name      = "ADFS_DISCOVERY_URI"
-      valueFrom = aws_secretsmanager_secret_version.adfs_discovery_uri_secret_version.arn
     },
     {
       name      = "ADFS_SECRET"
@@ -144,6 +139,7 @@ module "td" {
     APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE = var.applicant_oidc_middle_name_attribute
     APPLICANT_OIDC_LAST_NAME_ATTRIBUTE   = var.applicant_oidc_last_name_attribute
     APPLICANT_OIDC_DISCOVERY_URI         = var.applicant_oidc_discovery_uri
+    ADFS_DISCOVERY_URI                   = var.adfs_discovery_uri
   }
   log_configuration = {
     logDriver = "awslogs"

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -131,23 +131,6 @@ resource "aws_secretsmanager_secret_version" "adfs_client_id_secret_version" {
   secret_string = " "
 }
 
-# Creating a AWS secret for adfs_discovery_uri
-resource "aws_secretsmanager_secret" "adfs_discovery_uri_secret" {
-  tags = {
-    Name = "${var.app_prefix} Civiform ADFS Discovery URI Secret"
-    Type = "Civiform ADFS Discovery URI Secret"
-  }
-  name                    = "${var.app_prefix}-adfs_discovery_uri"
-  kms_key_id              = aws_kms_key.civiform_kms_key.arn
-  recovery_window_in_days = local.secret_recovery_window_in_days
-}
-
-# Creating a AWS secret versions for adfs_discovery_uri
-resource "aws_secretsmanager_secret_version" "adfs_discovery_uri_secret_version" {
-  secret_id     = aws_secretsmanager_secret.adfs_discovery_uri_secret.id
-  secret_string = " "
-}
-
 # Creating a AWS secret for applicant_oidc_secret
 resource "aws_secretsmanager_secret" "applicant_oidc_client_secret_secret" {
   name                    = "${var.app_prefix}-applicant_oidc_client_secret"

--- a/cloud/aws/templates/aws_oidc/setup/main.tf
+++ b/cloud/aws/templates/aws_oidc/setup/main.tf
@@ -2,4 +2,5 @@ module "setup" {
   source        = "../../../modules/setup"
   app_prefix    = var.app_prefix
   civiform_mode = var.civiform_mode
+  aws_region    = var.aws_region
 }

--- a/cloud/aws/templates/aws_oidc/setup/variables.tf
+++ b/cloud/aws/templates/aws_oidc/setup/variables.tf
@@ -6,4 +6,8 @@ variable "civiform_mode" {
   type        = string
   description = "The civiform environment mode (test/dev/staging/prod)"
 }
-
+variable "aws_region" {
+  type        = string
+  description = "Region where the AWS servers will live"
+  default     = "us-east-1"
+}

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -7,6 +7,40 @@
     "value_regex": "[a-z0-9]{1}[a-z0-9-]+",
     "value_regex_error_message": "only lowercase alphanumeric characters and hyphens allowed."
   },
+  "AWS_REGION": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "enum",
+    "values": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "us-gov-west-1",
+      "us-gov-east-1",
+      "ca-central-1",
+      "eu-north-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "eu-central-1",
+      "eu-south-1",
+      "af-south-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-southeast-3",
+      "ap-east-1",
+      "ap-south-1",
+      "sa-east-1",
+      "me-south-1",
+      "cn-north-1",
+      "cn-northwest-1"
+    ]
+  },
   "STAGING_HOSTNAME": {
     "required": false,
     "secret": false,
@@ -86,6 +120,12 @@
   },
   "APPLICANT_OIDC_LAST_NAME_ATTRIBUTE": {
     "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
+  },
+  "ADFS_DISCOVERY_URI": {
+    "required": true,
     "secret": false,
     "tfvar": true,
     "type": "string"

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -230,10 +230,15 @@ variable "civiform_applicant_idp" {
   default     = ""
 }
 
-
 variable "applicant_oidc_discovery_uri" {
   type        = string
   description = "Discovery URI"
+  default     = ""
+}
+
+variable "adfs_discovery_uri" {
+  type        = string
+  description = "ADFS Discovery URI"
   default     = ""
 }
 


### PR DESCRIPTION
### Description

`ADFS_DISCOVERY_URI` is currently a secret. It should be a regular variable instead, similar to `APPLICANT_OIDC_DISCOVERY_URI`. 

`AWS_REGION` is currently hardcoded to us-east-1 and user can't change it without updating `variables.tf` which should be considered immutable to deployers. This PR reads `AWS_REGION` from the `civiform_config.sh` if it's present and defaults to us-east-1 if it's absent.
