### PR TITLE
Pass AWS_REGION to terraform backend config

### DIFF
--- a/cloud/aws/bin/lib/backend_setup.py
+++ b/cloud/aws/bin/lib/backend_setup.py
@@ -7,6 +7,6 @@ def setup_backend_config(config):
     with open(backend_file_location, 'w') as f:
         f.write(f'bucket         = "{config.app_prefix}-backendstate"\n')
         f.write(f'key            = "tfstate/terraform.tfstate"\n')
-        f.write(f'region         = "us-east-1"\n')
+        f.write(f'region         = "{config.aws_region}"\n')
         f.write(f'dynamodb_table = "{config.app_prefix}-locktable"\n')
         f.write(f'encrypt        = true\n')

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -28,6 +28,12 @@ class ConfigLoader:
         return os.environ['APP_PREFIX']
 
     @property
+    def aws_region(self):
+        # NOTE: should we make AWS_REGION required and avoid having a default
+        # value here?
+        return os.environ.get('AWS_REGION', 'us-east-1')
+
+    @property
     def civiform_mode(self):
         return os.environ['CIVIFORM_MODE']
 


### PR DESCRIPTION
### Description

Currently it's hardcoded to us-east-1. With this change it is now can be read from civiform_config.sh