### PR TITLE
Add more descriptive page title for application blocks

### DIFF
--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -51,17 +51,18 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
             .with(div(renderBlockWithSubmitForm(params)).withClasses(Styles.MY_8))
             .withClasses(Styles.MY_8, Styles.M_AUTO);
 
+    String pageTitle =
+        params.programTitle()
+            + " — "
+            + (params.blockIndex() + 1)
+            + " of "
+            + params.totalBlockCount();
+
     HtmlBundle bundle =
         layout
             .getBundle()
-            .setTitle(params.programTitle())
-            .addMainContent(
-                h1(params.programTitle()
-                        + " "
-                        + (params.blockIndex() + 1)
-                        + " of "
-                        + params.totalBlockCount())
-                    .withClasses(Styles.SR_ONLY))
+            .setTitle(pageTitle)
+            .addMainContent(h1(pageTitle).withClasses(Styles.SR_ONLY))
             .addMainContent(
                 layout.renderProgramApplicationTitleAndProgressIndicator(
                     params.programTitle(), params.blockIndex(), params.totalBlockCount(), false),


### PR DESCRIPTION
### Description

Based on feedback from accessibility experts, this PR updates the page title to indicate the progress, to better reflect the content of the page. e.g.
* Before: "Recreation Scholarship Program — CiviForm"
* After: "Recreation Scholarship Program — 3 of 8 — CiviForm"

Manually verified this change.

## Release notes:
Add progress indication to page title for accessibility.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2628 
