### PR TITLE
Replace assertThrows with assertThatThrownBy

### DIFF
--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -58,7 +58,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void create_withInvalidProgram_notFound() {
     Request request = fakeRequest().build();
-    assertThrows(NotChangeableException.class, () -> controller.create(request, 1L));
+    assertThatThrownBy(() -> controller.create(request, 1L))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
@@ -100,7 +101,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void edit_withInvalidProgram_notFound() {
     Request request = fakeRequest().build();
-    assertThrows(NotChangeableException.class, () -> controller.edit(request, 1L, 1L));
+    assertThatThrownBy(() -> controller.edit(request, 1L, 1L))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
@@ -147,7 +149,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
-    assertThrows(NotChangeableException.class, () -> controller.update(request, 1L, 1L));
+    assertThatThrownBy(() -> controller.update(request, 1L, 1L))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
@@ -191,7 +194,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void destroy_withInvalidProgram_notFound() {
-    assertThrows(NotChangeableException.class, () -> controller.destroy(1L, 1L));
+    assertThatThrownBy(() -> controller.destroy(1L, 1L)).isInstanceOf(NotChangeableException.class);
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -223,7 +223,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
-    assertThrows(NotChangeableException.class, () -> controller.update(request, 1L));
+    assertThatThrownBy(() -> controller.update(request, 1L))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test

--- a/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
+++ b/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
@@ -145,10 +145,9 @@ public class ProgramApplicationsApiControllerTest extends AbstractExporterTest {
                 /* pageSize= */ Optional.empty())
             .url();
 
-    var exception =
-        assertThrows(UnauthorizedApiRequestException.class, () -> doRequest(requestUrl));
-
-    assertThat(exception).hasMessage("API key key-id does not have access to test-program");
+    assertThatThrownBy(() -> doRequest(requestUrl))
+        .isInstanceOf(UnauthorizedApiRequestException.class)
+        .hasMessage("API key key-id does not have access to test-program");
   }
 
   private Result doRequest(String requestUrl) {

--- a/server/test/services/applicant/ApplicantDataTest.java
+++ b/server/test/services/applicant/ApplicantDataTest.java
@@ -1,7 +1,7 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -61,6 +61,6 @@ public class ApplicantDataTest {
     data.setFailedUpdates(ImmutableMap.of(samplePath, "invalid_value"));
 
     assertThat(data.getFailedUpdates()).isEqualTo(ImmutableMap.of(samplePath, "invalid_value"));
-    assertThrows(IllegalStateException.class, () -> data.asJsonString());
+    assertThatThrownBy(() -> data.asJsonString()).isInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
### Description

We use AssertJ in java unit tests to perform assertions, including for asserting exceptions. There are few places where we use Junit's `assertThrows` though. This PR migrates those calls to use `assertThatThrownBy`. Improves consistency. Downside is that it's harder to remember compared to simple `assertThrows` :/