### PR TITLE
Update question/program translation views for consistency and usability

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -238,12 +238,10 @@ describe('Admin can manage translations', () => {
     // View the question translations and check that the Spanish translations for question help text are gone.
     await adminQuestions.goToQuestionTranslationPage(questionName)
     await adminTranslations.selectLanguage('Spanish')
-    expect(await page.inputValue('label:has-text("Question text")')).toContain(
+    expect(await page.inputValue('text=Question text')).toContain(
       'something different',
     )
-    expect(
-      await page.inputValue('label:has-text("Question help text")'),
-    ).toEqual('')
+    expect(await page.inputValue('text=Question help text')).toEqual('')
 
     await endSession(browser)
   })

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -204,9 +204,9 @@ describe('Admin can manage translations', () => {
     // View the question translations and check that the Spanish translations are still there.
     await adminQuestions.goToQuestionTranslationPage(questionName)
     await adminTranslations.selectLanguage('Spanish')
-    expect(
-      await page.getAttribute('#localize-question-text', 'value'),
-    ).toContain('something different')
+    expect(await page.inputValue('label:has-text("Question text")')).toContain(
+      'something different',
+    )
     await endSession(browser)
   })
 
@@ -238,11 +238,11 @@ describe('Admin can manage translations', () => {
     // View the question translations and check that the Spanish translations for question help text are gone.
     await adminQuestions.goToQuestionTranslationPage(questionName)
     await adminTranslations.selectLanguage('Spanish')
+    expect(await page.inputValue('label:has-text("Question text")')).toContain(
+      'something different',
+    )
     expect(
-      await page.getAttribute('#localize-question-text', 'value'),
-    ).toContain('something different')
-    expect(
-      await page.getAttribute('#localize-question-help-text', 'value'),
+      await page.inputValue('label:has-text("Question help text")'),
     ).toEqual('')
 
     await endSession(browser)

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -204,7 +204,7 @@ describe('Admin can manage translations', () => {
     // View the question translations and check that the Spanish translations are still there.
     await adminQuestions.goToQuestionTranslationPage(questionName)
     await adminTranslations.selectLanguage('Spanish')
-    expect(await page.inputValue('label:has-text("Question text")')).toContain(
+    expect(await page.inputValue('text=Question text')).toContain(
       'something different',
     )
     await endSession(browser)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -122,7 +122,7 @@ export class AdminPrograms {
       ),
     )
     await waitForPageJsLoad(this.page)
-    await this.expectProgramManageTranslationsPage()
+    await this.expectProgramManageTranslationsPage(programName)
   }
 
   async gotoManageProgramAdminsPage(programName: string) {
@@ -173,9 +173,9 @@ export class AdminPrograms {
     )
   }
 
-  async expectProgramManageTranslationsPage() {
+  async expectProgramManageTranslationsPage(programName: string) {
     expect(await this.page.innerText('h1')).toContain(
-      'Manage program translations',
+      `Manage program translations: ${programName}`,
     )
   }
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -230,7 +230,7 @@ export class AdminQuestions {
       ),
     )
     await waitForPageJsLoad(this.page)
-    await this.expectQuestionTranslationPage()
+    await this.expectQuestionTranslationPage(questionName)
   }
 
   async expectQuestionEditPage(questionName: string) {
@@ -240,9 +240,9 @@ export class AdminQuestions {
     ).toEqual(questionName)
   }
 
-  async expectQuestionTranslationPage() {
+  async expectQuestionTranslationPage(questionName: string) {
     expect(await this.page.innerText('h1')).toContain(
-      'Manage Question Translations',
+      `Manage Question Translations: ${questionName}`,
     )
   }
 

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -12,8 +12,8 @@ export class AdminTranslations {
   }
 
   async editProgramTranslations(name: string, description: string) {
-    await this.page.fill('#localize-display-name', name)
-    await this.page.fill('#localize-display-description', description)
+    await this.page.fill('text=Program name', name)
+    await this.page.fill('text=Program description', description)
     await this.page.click('#update-localizations-button')
   }
 
@@ -22,8 +22,8 @@ export class AdminTranslations {
     helpText: string,
     configText: string[] = [],
   ) {
-    await this.page.fill('label:has-text("Question text")', text)
-    await this.page.fill('label:has-text("Question help text")', helpText)
+    await this.page.fill('text=Question text', text)
+    await this.page.fill('text=Question help text', helpText)
 
     // If there are multi-option inputs to translate, fill them in
     // with the provided translations in configText

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -22,8 +22,8 @@ export class AdminTranslations {
     helpText: string,
     configText: string[] = [],
   ) {
-    await this.page.fill('#localize-question-text', text)
-    await this.page.fill('#localize-question-help-text', helpText)
+    await this.page.fill('label:has-text("Question text")', text)
+    await this.page.fill('label:has-text("Question help text")', helpText)
 
     // If there are multi-option inputs to translate, fill them in
     // with the provided translations in configText

--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -43,21 +43,17 @@ public class AdminProgramTranslationsController extends CiviFormController {
    *     for the given locale
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public Result edit(Http.Request request, long id, String locale) {
-    try {
-      ProgramDefinition program = service.getProgramDefinition(id);
-      Locale localeToEdit = Locale.forLanguageTag(locale);
-      return ok(
-          translationView.render(
-              request,
-              localeToEdit,
-              program.id(),
-              program.localizedName().maybeGet(localeToEdit),
-              program.localizedDescription().maybeGet(localeToEdit),
-              Optional.empty()));
-    } catch (ProgramNotFoundException e) {
-      return notFound(String.format("Program ID %d not found.", id));
-    }
+  public Result edit(Http.Request request, long id, String locale) throws ProgramNotFoundException {
+    ProgramDefinition program = service.getProgramDefinition(id);
+    Locale localeToEdit = Locale.forLanguageTag(locale);
+    return ok(
+        translationView.render(
+            request,
+            localeToEdit,
+            program,
+            program.localizedName().maybeGet(localeToEdit),
+            program.localizedDescription().maybeGet(localeToEdit),
+            Optional.empty()));
   }
 
   /**
@@ -70,7 +66,9 @@ public class AdminProgramTranslationsController extends CiviFormController {
    *     same {@link ProgramTranslationView} with error messages
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public Result update(Http.Request request, long id, String locale) {
+  public Result update(Http.Request request, long id, String locale)
+      throws ProgramNotFoundException {
+    ProgramDefinition program = service.getProgramDefinition(id);
     Form<ProgramTranslationForm> translationForm = formFactory.form(ProgramTranslationForm.class);
     if (translationForm.hasErrors()) {
       return badRequest();
@@ -82,14 +80,14 @@ public class AdminProgramTranslationsController extends CiviFormController {
 
     try {
       ErrorAnd<ProgramDefinition, CiviFormError> result =
-          service.updateLocalization(id, updatedLocale, displayName, displayDescription);
+          service.updateLocalization(program.id(), updatedLocale, displayName, displayDescription);
       if (result.isError()) {
         String errorMessage = joinErrors(result.getErrors());
         return ok(
             translationView.render(
                 request,
                 updatedLocale,
-                id,
+                program,
                 displayName,
                 displayDescription,
                 Optional.of(errorMessage)));

--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -88,8 +88,8 @@ public class AdminProgramTranslationsController extends CiviFormController {
                 request,
                 updatedLocale,
                 program,
-                displayName,
-                displayDescription,
+                Optional.of(displayName),
+                Optional.of(displayDescription),
                 Optional.of(errorMessage)));
       }
       return redirect(routes.AdminProgramController.index().url());

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -3,13 +3,16 @@ package views.admin;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
+import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
+import static j2html.TagCreator.legend;
 import static j2html.TagCreator.p;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.Tag;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.FormTag;
 import java.util.Locale;
 import play.i18n.Lang;
@@ -96,6 +99,15 @@ public abstract class TranslationFormView extends BaseHtmlView {
   }
 
   protected final DivTag defaultLocaleTextHint(LocalizedStrings localizedStrings) {
-    return div().with(p(String.format("English text: %s", localizedStrings.getDefault())));
+    return div()
+        .withClasses(Styles.W_2_3, Styles.ML_2, Styles.P_2, Styles.TEXT_SM, Styles.BG_GRAY_200)
+        .with(p("Default text:").withClass(Styles.FONT_MEDIUM), p(localizedStrings.getDefault()));
+  }
+
+  protected final FieldsetTag fieldSetForFields(String legendText, ImmutableList<DivTag> fields) {
+    return fieldset()
+        .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
+        .with(
+            legend(legendText), div().withClasses(Styles.FLEX_ROW, Styles.SPACE_Y_4).with(fields));
   }
 }

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -120,8 +120,8 @@ public abstract class TranslationFormView extends BaseHtmlView {
             legend(legendText), div().withClasses(Styles.FLEX_ROW, Styles.SPACE_Y_4).with(fields));
   }
 
+  /** TODO(#2752): Remove this once English translations have been disabled. */
   protected final boolean isDefaultLocale(Locale locale) {
-    // TODO(#2752): Remove isDefaultLocale once English translations have been disabled.
     return LocalizedStrings.DEFAULT_LOCALE.equals(locale);
   }
 }

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -9,7 +9,7 @@ import static j2html.TagCreator.legend;
 import static j2html.TagCreator.p;
 
 import com.google.common.collect.ImmutableList;
-import j2html.tags.Tag;
+import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
@@ -81,8 +81,11 @@ public abstract class TranslationFormView extends BaseHtmlView {
    * Renders a form that allows an admin to enter localized text for an entity's applicant-visible
    * fields.
    */
-  protected final <T extends Tag<T>> FormTag renderTranslationForm(
-      Http.Request request, Locale locale, String formAction, ImmutableList<T> formFieldContent) {
+  protected final FormTag renderTranslationForm(
+      Http.Request request,
+      Locale locale,
+      String formAction,
+      ImmutableList<DomContent> formFieldContent) {
     FormTag form =
         form()
             .withMethod("POST")
@@ -104,7 +107,8 @@ public abstract class TranslationFormView extends BaseHtmlView {
         .with(p("Default text:").withClass(Styles.FONT_MEDIUM), p(localizedStrings.getDefault()));
   }
 
-  protected final FieldsetTag fieldSetForFields(String legendText, ImmutableList<DivTag> fields) {
+  protected final FieldsetTag fieldSetForFields(
+      String legendText, ImmutableList<DomContent> fields) {
     return fieldset()
         .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
         .with(

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
+import static j2html.TagCreator.p;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.Tag;
@@ -92,5 +93,9 @@ public abstract class TranslationFormView extends BaseHtmlView {
                             locale.getDisplayLanguage(LocalizedStrings.DEFAULT_LOCALE)))
                     .withId("update-localizations-button"));
     return form;
+  }
+
+  protected final DivTag defaultLocaleTextHint(LocalizedStrings localizedStrings) {
+    return div().with(p(String.format("English text: %s", localizedStrings.getDefault())));
   }
 }

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -101,12 +101,17 @@ public abstract class TranslationFormView extends BaseHtmlView {
     return form;
   }
 
+  /**
+   * Returns a div containing the default text to be translated. This allows for admins to more
+   * easily identify which text to translate.
+   */
   protected final DivTag defaultLocaleTextHint(LocalizedStrings localizedStrings) {
     return div()
         .withClasses(Styles.W_2_3, Styles.ML_2, Styles.P_2, Styles.TEXT_SM, Styles.BG_GRAY_200)
         .with(p("Default text:").withClass(Styles.FONT_MEDIUM), p(localizedStrings.getDefault()));
   }
 
+  /** Creates a fieldset wrapping several form fields to be rendered. */
   protected final FieldsetTag fieldSetForFields(
       String legendText, ImmutableList<DomContent> fields) {
     return fieldset()

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -114,4 +114,9 @@ public abstract class TranslationFormView extends BaseHtmlView {
         .with(
             legend(legendText), div().withClasses(Styles.FLEX_ROW, Styles.SPACE_Y_4).with(fields));
   }
+
+  protected final boolean isDefaultLocale(Locale locale) {
+    // TODO(#2752): Remove isDefaultLocale once English translations have been disabled.
+    return LocalizedStrings.DEFAULT_LOCALE.equals(locale);
+  }
 }

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -34,7 +34,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
   }
 
   /** Render a list of languages, with the currently selected language underlined. */
-  public DivTag renderLanguageLinks(long entityId, Locale currentlySelected) {
+  protected final DivTag renderLanguageLinks(long entityId, Locale currentlySelected) {
     return div()
         .withClasses(Styles.M_2)
         .with(
@@ -77,7 +77,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
    * Renders a form that allows an admin to enter localized text for an entity's applicant-visible
    * fields.
    */
-  protected <T extends Tag<T>> FormTag renderTranslationForm(
+  protected final <T extends Tag<T>> FormTag renderTranslationForm(
       Http.Request request, Locale locale, String formAction, ImmutableList<T> formFieldContent) {
     FormTag form =
         form()

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -46,22 +46,6 @@ public final class ProgramTranslationView extends TranslationFormView {
       Http.Request request,
       Locale locale,
       ProgramDefinition program,
-      String localizedName,
-      String localizedDescription,
-      Optional<String> errors) {
-    return render(
-        request,
-        locale,
-        program,
-        Optional.of(localizedName),
-        Optional.of(localizedDescription),
-        errors);
-  }
-
-  public Content render(
-      Http.Request request,
-      Locale locale,
-      ProgramDefinition program,
       Optional<String> localizedName,
       Optional<String> localizedDescription,
       Optional<String> errors) {
@@ -71,7 +55,10 @@ public final class ProgramTranslationView extends TranslationFormView {
             .url();
     FormTag form =
         renderTranslationForm(
-            request, locale, formAction, formFields(localizedName, localizedDescription));
+            request,
+            locale,
+            formAction,
+            formFields(program, locale, localizedName, localizedDescription));
 
     String title = String.format("Manage program translations: %s", program.adminName());
 
@@ -92,7 +79,10 @@ public final class ProgramTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<FieldsetTag> formFields(
-      Optional<String> localizedName, Optional<String> localizedDescription) {
+      ProgramDefinition program,
+      Locale locale,
+      Optional<String> localizedName,
+      Optional<String> localizedDescription) {
     ImmutableList.Builder<FieldsetTag> result =
         ImmutableList.<FieldsetTag>builder()
             .add(
@@ -104,14 +94,12 @@ public final class ProgramTranslationView extends TranslationFormView {
                             .setId("localize-display-name")
                             .setFieldName("displayName")
                             .setLabelText("Program name")
-                            .setScreenReaderText("Program display name")
                             .setValue(localizedName)
                             .getInputTag(),
                         FieldWithLabel.input()
                             .setId("localize-display-description")
                             .setFieldName("displayDescription")
                             .setLabelText("Program description")
-                            .setScreenReaderText("Program description")
                             .setValue(localizedDescription)
                             .getInputTag()));
     if (statusTrackingEnabled) {

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 import play.i18n.Langs;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.program.ProgramDefinition;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
@@ -44,14 +45,14 @@ public class ProgramTranslationView extends TranslationFormView {
   public Content render(
       Http.Request request,
       Locale locale,
-      long programId,
+      ProgramDefinition program,
       String localizedName,
       String localizedDescription,
       Optional<String> errors) {
     return render(
         request,
         locale,
-        programId,
+        program,
         Optional.of(localizedName),
         Optional.of(localizedDescription),
         errors);
@@ -60,25 +61,25 @@ public class ProgramTranslationView extends TranslationFormView {
   public Content render(
       Http.Request request,
       Locale locale,
-      long programId,
+      ProgramDefinition program,
       Optional<String> localizedName,
       Optional<String> localizedDescription,
       Optional<String> errors) {
     String formAction =
         controllers.admin.routes.AdminProgramTranslationsController.update(
-                programId, locale.toLanguageTag())
+                program.id(), locale.toLanguageTag())
             .url();
     FormTag form =
         renderTranslationForm(
             request, locale, formAction, formFields(localizedName, localizedDescription));
 
-    String title = "Manage program translations";
+    String title = String.format("Manage program translations: %s", program.adminName());
 
     HtmlBundle htmlBundle =
         layout
             .getBundle()
             .setTitle(title)
-            .addMainContent(renderHeader(title), renderLanguageLinks(programId, locale), form);
+            .addMainContent(renderHeader(title), renderLanguageLinks(program.id(), locale), form);
 
     errors.ifPresent(s -> htmlBundle.addToastMessages(ToastMessage.error(s).setDismissible(false)));
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -28,7 +28,7 @@ import views.components.ToastMessage;
 import views.style.Styles;
 
 /** Renders a list of languages to select from, and a form for updating program information. */
-public class ProgramTranslationView extends TranslationFormView {
+public final class ProgramTranslationView extends TranslationFormView {
   private final AdminLayout layout;
   private final boolean statusTrackingEnabled;
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -3,8 +3,6 @@ package views.admin.programs;
 import static annotations.FeatureFlags.ApplicationStatusTrackingEnabled;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.fieldset;
-import static j2html.TagCreator.legend;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -27,7 +25,6 @@ import views.admin.AdminLayoutFactory;
 import views.admin.TranslationFormView;
 import views.components.FieldWithLabel;
 import views.components.ToastMessage;
-import views.style.Styles;
 
 /** Renders a list of languages to select from, and a form for updating program information. */
 public final class ProgramTranslationView extends TranslationFormView {
@@ -84,10 +81,9 @@ public final class ProgramTranslationView extends TranslationFormView {
     ImmutableList.Builder<FieldsetTag> result =
         ImmutableList.<FieldsetTag>builder()
             .add(
-                fieldset()
-                    .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
-                    .with(
-                        legend("Program details (visible to applicants)"),
+                fieldSetForFields(
+                    "Program details (visible to applicants)",
+                    ImmutableList.of(
                         div()
                             .with(
                                 FieldWithLabel.input()
@@ -103,7 +99,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                                     .setLabelText("Program description")
                                     .setValue(localizedDescription)
                                     .getInputTag(),
-                                defaultLocaleTextHint(program.localizedDescription()))));
+                                defaultLocaleTextHint(program.localizedDescription())))));
     if (statusTrackingEnabled) {
       // TODO(#2752): Use real statuses from the program.
       ImmutableList<ApplicationStatus> statusesWithEmail =
@@ -112,10 +108,9 @@ public final class ProgramTranslationView extends TranslationFormView {
               ApplicationStatus.create("Needs more information", "Other email content"));
       for (ApplicationStatus s : statusesWithEmail) {
         result.add(
-            fieldset()
-                .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
-                .with(
-                    legend(String.format("Application status: %s", s.statusName())),
+            fieldSetForFields(
+                String.format("Application status: %s", s.statusName()),
+                ImmutableList.of(
                     div()
                         .with(
                             FieldWithLabel.input()
@@ -134,7 +129,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                                 .setRows(OptionalLong.of(8))
                                 .getTextareaTag(),
                             defaultLocaleTextHint(
-                                LocalizedStrings.withDefaultValue(s.emailContent())))));
+                                LocalizedStrings.withDefaultValue(s.emailContent()))))));
       }
     }
     return result.build();

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -7,7 +7,7 @@ import static j2html.TagCreator.div;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
-import j2html.tags.specialized.FieldsetTag;
+import j2html.tags.DomContent;
 import j2html.tags.specialized.FormTag;
 import java.util.Locale;
 import java.util.Optional;
@@ -74,12 +74,12 @@ public final class ProgramTranslationView extends TranslationFormView {
     return routes.AdminProgramTranslationsController.edit(programId, locale.toLanguageTag()).url();
   }
 
-  private ImmutableList<FieldsetTag> formFields(
+  private ImmutableList<DomContent> formFields(
       ProgramDefinition program,
       Optional<String> localizedName,
       Optional<String> localizedDescription) {
-    ImmutableList.Builder<FieldsetTag> result =
-        ImmutableList.<FieldsetTag>builder()
+    ImmutableList.Builder<DomContent> result =
+        ImmutableList.<DomContent>builder()
             .add(
                 fieldSetForFields(
                     "Program details (visible to applicants)",

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -91,7 +91,6 @@ public final class ProgramTranslationView extends TranslationFormView {
                         div()
                             .with(
                                 FieldWithLabel.input()
-                                    .setId("localize-display-name")
                                     .setFieldName("displayName")
                                     .setLabelText("Program name")
                                     .setValue(localizedName)
@@ -100,7 +99,6 @@ public final class ProgramTranslationView extends TranslationFormView {
                         div()
                             .with(
                                 FieldWithLabel.input()
-                                    .setId("localize-display-description")
                                     .setFieldName("displayDescription")
                                     .setLabelText("Program description")
                                     .setValue(localizedDescription)

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -54,7 +54,10 @@ public final class ProgramTranslationView extends TranslationFormView {
             .url();
     FormTag form =
         renderTranslationForm(
-            request, locale, formAction, formFields(program, localizedName, localizedDescription));
+            request,
+            locale,
+            formAction,
+            formFields(program, locale, localizedName, localizedDescription));
 
     String title = String.format("Manage program translations: %s", program.adminName());
 
@@ -76,6 +79,7 @@ public final class ProgramTranslationView extends TranslationFormView {
 
   private ImmutableList<DomContent> formFields(
       ProgramDefinition program,
+      Locale locale,
       Optional<String> localizedName,
       Optional<String> localizedDescription) {
     ImmutableList.Builder<DomContent> result =
@@ -90,7 +94,9 @@ public final class ProgramTranslationView extends TranslationFormView {
                                     .setFieldName("displayName")
                                     .setLabelText("Program name")
                                     .setValue(localizedName)
-                                    .getInputTag(),
+                                    .getInputTag())
+                            .condWith(
+                                !isDefaultLocale(locale),
                                 defaultLocaleTextHint(program.localizedName())),
                         div()
                             .with(
@@ -98,7 +104,9 @@ public final class ProgramTranslationView extends TranslationFormView {
                                     .setFieldName("displayDescription")
                                     .setLabelText("Program description")
                                     .setValue(localizedDescription)
-                                    .getInputTag(),
+                                    .getInputTag())
+                            .condWith(
+                                !isDefaultLocale(locale),
                                 defaultLocaleTextHint(program.localizedDescription())))));
     if (statusTrackingEnabled) {
       // TODO(#2752): Use real statuses from the program.
@@ -117,7 +125,9 @@ public final class ProgramTranslationView extends TranslationFormView {
                                 .setLabelText("Status name")
                                 .setScreenReaderText("Status name")
                                 .setValue(s.statusName())
-                                .getInputTag(),
+                                .getInputTag())
+                        .condWith(
+                            !isDefaultLocale(locale),
                             defaultLocaleTextHint(
                                 LocalizedStrings.withDefaultValue(s.statusName()))),
                     div()
@@ -127,7 +137,9 @@ public final class ProgramTranslationView extends TranslationFormView {
                                 .setScreenReaderText("Email content")
                                 .setValue(s.emailContent())
                                 .setRows(OptionalLong.of(8))
-                                .getTextareaTag(),
+                                .getTextareaTag())
+                        .condWith(
+                            !isDefaultLocale(locale),
                             defaultLocaleTextHint(
                                 LocalizedStrings.withDefaultValue(s.emailContent()))))));
       }

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -2,6 +2,7 @@ package views.admin.programs;
 
 import static annotations.FeatureFlags.ApplicationStatusTrackingEnabled;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.legend;
 
@@ -17,6 +18,7 @@ import javax.inject.Inject;
 import play.i18n.Langs;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.LocalizedStrings;
 import services.program.ProgramDefinition;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -55,10 +57,7 @@ public final class ProgramTranslationView extends TranslationFormView {
             .url();
     FormTag form =
         renderTranslationForm(
-            request,
-            locale,
-            formAction,
-            formFields(program, locale, localizedName, localizedDescription));
+            request, locale, formAction, formFields(program, localizedName, localizedDescription));
 
     String title = String.format("Manage program translations: %s", program.adminName());
 
@@ -80,7 +79,6 @@ public final class ProgramTranslationView extends TranslationFormView {
 
   private ImmutableList<FieldsetTag> formFields(
       ProgramDefinition program,
-      Locale locale,
       Optional<String> localizedName,
       Optional<String> localizedDescription) {
     ImmutableList.Builder<FieldsetTag> result =
@@ -90,18 +88,24 @@ public final class ProgramTranslationView extends TranslationFormView {
                     .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
                     .with(
                         legend("Program details (visible to applicants)"),
-                        FieldWithLabel.input()
-                            .setId("localize-display-name")
-                            .setFieldName("displayName")
-                            .setLabelText("Program name")
-                            .setValue(localizedName)
-                            .getInputTag(),
-                        FieldWithLabel.input()
-                            .setId("localize-display-description")
-                            .setFieldName("displayDescription")
-                            .setLabelText("Program description")
-                            .setValue(localizedDescription)
-                            .getInputTag()));
+                        div()
+                            .with(
+                                FieldWithLabel.input()
+                                    .setId("localize-display-name")
+                                    .setFieldName("displayName")
+                                    .setLabelText("Program name")
+                                    .setValue(localizedName)
+                                    .getInputTag(),
+                                defaultLocaleTextHint(program.localizedName())),
+                        div()
+                            .with(
+                                FieldWithLabel.input()
+                                    .setId("localize-display-description")
+                                    .setFieldName("displayDescription")
+                                    .setLabelText("Program description")
+                                    .setValue(localizedDescription)
+                                    .getInputTag(),
+                                defaultLocaleTextHint(program.localizedDescription()))));
     if (statusTrackingEnabled) {
       // TODO(#2752): Use real statuses from the program.
       ImmutableList<ApplicationStatus> statusesWithEmail =
@@ -114,17 +118,25 @@ public final class ProgramTranslationView extends TranslationFormView {
                 .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
                 .with(
                     legend(String.format("Application status: %s", s.statusName())),
-                    FieldWithLabel.input()
-                        .setLabelText("Status name")
-                        .setScreenReaderText("Status name")
-                        .setValue(s.statusName())
-                        .getInputTag(),
-                    FieldWithLabel.textArea()
-                        .setLabelText("Email content")
-                        .setScreenReaderText("Email content")
-                        .setValue(s.emailContent())
-                        .setRows(OptionalLong.of(8))
-                        .getTextareaTag()));
+                    div()
+                        .with(
+                            FieldWithLabel.input()
+                                .setLabelText("Status name")
+                                .setScreenReaderText("Status name")
+                                .setValue(s.statusName())
+                                .getInputTag(),
+                            defaultLocaleTextHint(
+                                LocalizedStrings.withDefaultValue(s.statusName()))),
+                    div()
+                        .with(
+                            FieldWithLabel.textArea()
+                                .setLabelText("Email content")
+                                .setScreenReaderText("Email content")
+                                .setValue(s.emailContent())
+                                .setRows(OptionalLong.of(8))
+                                .getTextareaTag(),
+                            defaultLocaleTextHint(
+                                LocalizedStrings.withDefaultValue(s.emailContent())))));
       }
     }
     return result.build();

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -26,7 +26,7 @@ import views.components.FieldWithLabel;
 import views.components.ToastMessage;
 
 /** Renders a list of languages to select from, and a form for updating question information. */
-public class QuestionTranslationView extends TranslationFormView {
+public final class QuestionTranslationView extends TranslationFormView {
 
   private final AdminLayout layout;
 

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -60,7 +60,7 @@ public class QuestionTranslationView extends TranslationFormView {
 
     FormTag form = renderTranslationForm(request, locale, formAction, inputFields.build());
 
-    String title = "Manage Question Translations";
+    String title = String.format("Manage Question Translations: %s", question.getName());
 
     HtmlBundle htmlBundle =
         layout

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -120,7 +120,6 @@ public final class QuestionTranslationView extends TranslationFormView {
         div()
             .with(
                 FieldWithLabel.input()
-                    .setId("localize-question-text")
                     .setFieldName("questionText")
                     .setLabelText("Question text")
                     .setValue(questionText.maybeGet(locale))
@@ -133,7 +132,6 @@ public final class QuestionTranslationView extends TranslationFormView {
           div()
               .with(
                   FieldWithLabel.input()
-                      .setId("localize-question-help-text")
                       .setFieldName("questionHelpText")
                       .setLabelText("Question help text")
                       .setValue(helpText.maybeGet(locale))

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -2,8 +2,6 @@ package views.admin.questions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.fieldset;
-import static j2html.TagCreator.legend;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.specialized.DivTag;
@@ -26,7 +24,6 @@ import views.admin.AdminLayoutFactory;
 import views.admin.TranslationFormView;
 import views.components.FieldWithLabel;
 import views.components.ToastMessage;
-import views.style.Styles;
 
 /** Renders a list of languages to select from, and a form for updating question information. */
 public final class QuestionTranslationView extends TranslationFormView {
@@ -134,7 +131,8 @@ public final class QuestionTranslationView extends TranslationFormView {
                   defaultLocaleTextHint(helpText)));
     }
 
-    return fields.build();
+    return ImmutableList.of(
+        div().with(fieldSetForFields("Question details (visible to applicants)", fields.build())));
   }
 
   private ImmutableList<DivTag> multiOptionQuestionFields(
@@ -157,12 +155,7 @@ public final class QuestionTranslationView extends TranslationFormView {
     }
 
     return ImmutableList.of(
-        div()
-            .with(
-                fieldset()
-                    .withClasses(Styles.MY_4, Styles.PT_1, Styles.PB_2, Styles.PX_2, Styles.BORDER)
-                    .with(legend("Answer options"))
-                    .with(optionFieldsBuilder.build())));
+        div().with(fieldSetForFields("Answer options", optionFieldsBuilder.build())));
   }
 
   private ImmutableList<DivTag> enumeratorQuestionFields(

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.legend;
-import static j2html.TagCreator.p;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.specialized.DivTag;
@@ -107,10 +106,6 @@ public final class QuestionTranslationView extends TranslationFormView {
       default:
         return ImmutableList.of();
     }
-  }
-
-  private DivTag defaultLocaleTextHint(LocalizedStrings localizedStrings) {
-    return div().with(p(String.format("English text: %s", localizedStrings.getDefault())));
   }
 
   private ImmutableList<DivTag> questionTextFields(

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -118,8 +118,8 @@ public final class QuestionTranslationView extends TranslationFormView {
                     .setFieldName("questionText")
                     .setLabelText("Question text")
                     .setValue(questionText.maybeGet(locale))
-                    .getInputTag(),
-                defaultLocaleTextHint(questionText)));
+                    .getInputTag())
+            .condWith(!isDefaultLocale(locale), defaultLocaleTextHint(questionText)));
 
     // Help text is optional - only show if present.
     if (!helpText.isEmpty()) {
@@ -130,8 +130,8 @@ public final class QuestionTranslationView extends TranslationFormView {
                       .setFieldName("questionHelpText")
                       .setLabelText("Question help text")
                       .setValue(helpText.maybeGet(locale))
-                      .getInputTag(),
-                  defaultLocaleTextHint(helpText)));
+                      .getInputTag())
+              .condWith(!isDefaultLocale(locale), defaultLocaleTextHint(helpText)));
     }
 
     return fieldSetForFields("Question details (visible to applicants)", fields.build());
@@ -152,8 +152,8 @@ public final class QuestionTranslationView extends TranslationFormView {
                       .setFieldName("options[]")
                       .setLabelText(String.format("Answer option #%d", optionIdx + 1))
                       .setValue(option.optionText().maybeGet(toUpdate).orElse(""))
-                      .getInputTag(),
-                  defaultLocaleTextHint(option.optionText())));
+                      .getInputTag())
+              .condWith(!isDefaultLocale(toUpdate), defaultLocaleTextHint(option.optionText())));
     }
 
     return Optional.of(fieldSetForFields("Answer options", optionFieldsBuilder.build()));
@@ -168,7 +168,7 @@ public final class QuestionTranslationView extends TranslationFormView {
                     .setFieldName("entityType")
                     .setLabelText("What is being enumerated")
                     .setValue(entityType.maybeGet(toUpdate).orElse(""))
-                    .getInputTag(),
-                defaultLocaleTextHint(entityType)));
+                    .getInputTag())
+            .condWith(!isDefaultLocale(toUpdate), defaultLocaleTextHint(entityType)));
   }
 }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -152,7 +152,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
   private Program createProgram(
       String adminName, LocalizedStrings localizedName, LocalizedStrings localizedDescription) {
     Program initialProgram = ProgramBuilder.newDraftProgram(adminName).build();
-    // ProgamBuilder initializes the localized name and doesn't currently support providding
+    // ProgramBuilder initializes the localized name and doesn't currently support providing
     // overrides. Here we manually update the localized string in a separate update.
     Program program =
         initialProgram.getProgramDefinition().toBuilder()

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -17,6 +17,7 @@ import play.mvc.Http;
 import play.mvc.Result;
 import repository.ProgramRepository;
 import repository.ResetPostgres;
+import services.LocalizedStrings;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
 
@@ -85,7 +86,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void update_validationErrors_rendersEditFormWithMessages() {
-    Program program = ProgramBuilder.newDraftProgram().build();
+    Program program =
+        ProgramBuilder.newDraftProgram()
+            .withName("Internal program name")
+            .withLocalizedName(LocalizedStrings.DEFAULT_LOCALE, "External program name")
+            .build();
     Http.RequestBuilder requestBuilder =
         fakeRequest().bodyForm(ImmutableMap.of("displayName", "", "displayDescription", ""));
 
@@ -94,7 +99,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
         .contains(
-            "Manage program translations",
+            String.format("Manage program translations: Internal program name"),
             "program display name cannot be blank",
             "program display description cannot be blank");
   }

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -55,7 +55,12 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains("Manage Question Translations", "English", "Spanish", "what is your name?");
+        .contains(
+            String.format(
+                "Manage Question Translations: %s", question.getQuestionDefinition().getName()),
+            "English",
+            "Spanish",
+            "what is your name?");
   }
 
   @Test
@@ -146,7 +151,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains("Manage Question Translations", "Question text cannot be blank");
+        .contains(
+            String.format(
+                "Manage Question Translations: %s", question.getQuestionDefinition().getName()),
+            "Question text cannot be blank");
   }
 
   /** Creates a draft question, since only draft questions are editable. */


### PR DESCRIPTION
### Description

As part of adding translatable content for status tracking, we discussed improving the usability of the current translation views. Note that in a follow-on PR we'll be removing the English translation tab since it's duplicative with the existing content in the program/question configuration screens.

The UI changes here include (see screenshots below):
  * Adding the program / question name to the title so one knows which entity translations are being edited for
  * Add a consistent label for each field for what's being set. Previously, question translations used the English text for the field label
  * Using fieldsets for better information organization
  * Add a small section below the field that indicates the English version of the text (hidden for the English translation tab)

While updating, a few cleanups were made on the server side:
  * Marked a few classes as final to make the choice to subclass explicit
  * Switched browser test code to drive updates via user-visible text rather than by IDs. Allowed us to remove a few hard-coded IDs within the translations view.
 
## Screenshots

Questions (before):
<img width="812" alt="Screen Shot 2022-08-04 at 9 47 32 AM" src="https://user-images.githubusercontent.com/1870301/182906167-dd42be5c-0c5f-4586-b20e-67487f7d5cf3.png">

Questions (after):
<img width="1242" alt="Screen Shot 2022-08-04 at 9 18 31 AM" src="https://user-images.githubusercontent.com/1870301/182906557-ef016f9f-85ba-4541-a0a0-eaa9fdbfb55f.png">


Programs (before):
<img width="806" alt="Screen Shot 2022-08-04 at 9 47 15 AM" src="https://user-images.githubusercontent.com/1870301/182906324-d48d8c4b-25c4-43ed-bcd4-9cf56bd69322.png">

Programs (after):
<img width="1143" alt="Screen Shot 2022-08-04 at 9 19 12 AM" src="https://user-images.githubusercontent.com/1870301/182906439-2ef05d0b-4794-4095-81e7-2b070ec57dc2.png">

## Release notes:

Reorganizes program and question translation editing for increased usability.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#2754
