### PR TITLE
Using deep link does not create duplicate applications

### DIFF
--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -28,7 +28,7 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 
 /** API controller for admin access to a specific program's applications. */
-public class ProgramApplicationsApiController extends CiviFormApiController {
+public final class ProgramApplicationsApiController extends CiviFormApiController {
 
   public static final String PROGRAM_SLUG_PARAM_NAME = "programSlug";
   public static final String FROM_DATE_PARAM_NAME = "fromDate";

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -91,7 +91,7 @@ public class ProgramApplicationsApiController extends CiviFormApiController {
             .orElse(new IdentifierBasedPaginationSpec<>(pageSize, Long.MAX_VALUE));
 
     return programService
-        .getProgramDefinitionAsync(programSlug)
+        .getActiveProgramDefinitionAsync(programSlug)
         .thenApplyAsync(
             programDefinition -> {
               PaginationResult<Application> paginationResult;

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -62,7 +62,7 @@ public final class RedirectController extends CiviFormController {
     this.languageUtils = checkNotNull(languageUtils);
   }
 
-  public CompletionStage<Result> programByName(Http.Request request, String programSlug) {
+  public CompletionStage<Result> programBySlug(Http.Request request, String programSlug) {
     Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 
     if (profile.isEmpty()) {

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import models.Applicant;
 import models.LifecycleStage;
@@ -80,7 +79,7 @@ public final class RedirectController extends CiviFormController {
             (Applicant applicant) -> {
               // Attempt to set default language for the applicant.
               applicant = languageUtils.maybeSetDefaultLocale(applicant);
-              final AtomicLong applicantId = new AtomicLong(applicant.id);
+              final long applicantId = applicant.id;
 
               // If the applicant has not yet set their preferred language, redirect to
               // the information controller to ask for preferred language.
@@ -88,12 +87,12 @@ public final class RedirectController extends CiviFormController {
                 return CompletableFuture.completedFuture(
                     redirect(
                             controllers.applicant.routes.ApplicantInformationController.edit(
-                                applicantId.get()))
+                                applicantId))
                         .withSession(
                             request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri())));
               }
 
-              return getProgramVersionForApplicant(applicantId.get(), programSlug)
+              return getProgramVersionForApplicant(applicantId, programSlug)
                   .thenComposeAsync(
                       (Optional<ProgramDefinition> programForExistingApplication) -> {
                         // Check to see if the applicant already has an application
@@ -104,11 +103,10 @@ public final class RedirectController extends CiviFormController {
                               redirect(
                                   controllers.applicant.routes.ApplicantProgramReviewController
                                       .preview(
-                                          applicantId.get(),
-                                          programForExistingApplication.get().id())));
+                                          applicantId, programForExistingApplication.get().id())));
                         }
 
-                        return redirectToActiveProgram(applicantId.get(), programSlug);
+                        return redirectToActiveProgram(applicantId, programSlug);
                       },
                       httpContext.current());
             },

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -5,38 +5,42 @@ import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import controllers.LanguageUtils;
 import controllers.routes;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import models.Applicant;
-import models.Program;
+import models.LifecycleStage;
 import org.pac4j.play.java.Secure;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
-import repository.ProgramRepository;
 import services.applicant.ApplicantService;
 import services.applicant.ReadOnlyApplicantProgramService;
+import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import views.applicant.ApplicantUpsellCreateAccountView;
 
 /**
  * Controller for handling methods for deep links. Applicants will be asked to sign-in before they
  * can access the page.
  */
-public class RedirectController extends CiviFormController {
+public final class RedirectController extends CiviFormController {
 
   private final HttpExecutionContext httpContext;
   private final ApplicantService applicantService;
   private final ProfileUtils profileUtils;
-  private final ProgramRepository programRepository;
+  private final ProgramService programService;
   private final ApplicantUpsellCreateAccountView upsellView;
   private final MessagesApi messagesApi;
   private final LanguageUtils languageUtils;
@@ -46,20 +50,20 @@ public class RedirectController extends CiviFormController {
       HttpExecutionContext httpContext,
       ApplicantService applicantService,
       ProfileUtils profileUtils,
-      ProgramRepository programRepository,
+      ProgramService programService,
       ApplicantUpsellCreateAccountView upsellView,
       MessagesApi messagesApi,
       LanguageUtils languageUtils) {
     this.httpContext = checkNotNull(httpContext);
     this.applicantService = checkNotNull(applicantService);
     this.profileUtils = checkNotNull(profileUtils);
-    this.programRepository = checkNotNull(programRepository);
+    this.programService = checkNotNull(programService);
     this.upsellView = checkNotNull(upsellView);
     this.messagesApi = checkNotNull(messagesApi);
     this.languageUtils = checkNotNull(languageUtils);
   }
 
-  public CompletionStage<Result> programByName(Http.Request request, String programName) {
+  public CompletionStage<Result> programByName(Http.Request request, String programSlug) {
     Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 
     if (profile.isEmpty()) {
@@ -69,34 +73,69 @@ public class RedirectController extends CiviFormController {
       return CompletableFuture.completedFuture(result);
     }
 
-    CompletableFuture<Applicant> applicantFuture = profile.get().getApplicant();
-    CompletableFuture<Program> programFuture = programRepository.getForSlug(programName);
-
-    return CompletableFuture.allOf(applicantFuture, programFuture)
-        .thenApplyAsync(
-            empty -> {
-              if (applicantFuture.isCompletedExceptionally()) {
-                return notFound();
-              } else if (programFuture.isCompletedExceptionally()) {
-                return notFound();
-              }
-
-              Applicant applicant = applicantFuture.join();
+    return profile
+        .get()
+        .getApplicant()
+        .thenComposeAsync(
+            (Applicant applicant) -> {
               // Attempt to set default language for the applicant.
               applicant = languageUtils.maybeSetDefaultLocale(applicant);
+              final AtomicLong applicantId = new AtomicLong(applicant.id);
+
               // If the applicant has not yet set their preferred language, redirect to
               // the information controller to ask for preferred language.
               if (!applicant.getApplicantData().hasPreferredLocale()) {
-                return redirect(
-                        controllers.applicant.routes.ApplicantInformationController.edit(
-                            applicant.id))
-                    .withSession(request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri()));
+                return CompletableFuture.completedFuture(
+                    redirect(
+                            controllers.applicant.routes.ApplicantInformationController.edit(
+                                applicantId.get()))
+                        .withSession(
+                            request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri())));
               }
 
-              return redirect(
-                  controllers.applicant.routes.ApplicantProgramReviewController.preview(
-                      applicant.id, programFuture.join().id));
+              return getProgramVersionForApplicant(applicantId.get(), programSlug)
+                  .thenComposeAsync(
+                      (Optional<ProgramDefinition> programForExistingApplication) -> {
+                        // Check to see if the applicant already has an application
+                        // for this program, redirect to program version associated
+                        // with that application if so.
+                        if (programForExistingApplication.isPresent()) {
+                          return CompletableFuture.completedFuture(
+                              redirect(
+                                  controllers.applicant.routes.ApplicantProgramReviewController
+                                      .preview(
+                                          applicantId.get(),
+                                          programForExistingApplication.get().id())));
+                        }
+
+                        return redirectToActiveProgram(applicantId.get(), programSlug);
+                      },
+                      httpContext.current());
             },
+            httpContext.current());
+  }
+
+  private CompletionStage<Result> redirectToActiveProgram(long applicantId, String programSlug) {
+    return programService
+        .getActiveProgramDefinitionAsync(programSlug)
+        .thenApplyAsync(
+            (activeProgramDefinition) ->
+                redirect(
+                    controllers.applicant.routes.ApplicantProgramReviewController.preview(
+                        applicantId, activeProgramDefinition.id())),
+            httpContext.current());
+  }
+
+  private CompletionStage<Optional<ProgramDefinition>> getProgramVersionForApplicant(
+      long applicantId, String programSlug) {
+    return applicantService
+        .relevantPrograms(applicantId)
+        .thenApplyAsync(
+            (ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>> relevantPrograms) ->
+                relevantPrograms.values().stream()
+                    .flatMap(Collection::stream)
+                    .filter(program -> program.slug().equals(programSlug))
+                    .findAny(),
             httpContext.current());
   }
 

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -153,6 +153,7 @@ public class ProgramRepository {
     }
   }
 
+  /** Get the current active program with the provided slug. */
   public CompletableFuture<Program> getForSlug(String slug) {
     return supplyAsync(
         () -> {

--- a/server/app/services/applicant/ApplicantServiceImpl.java
+++ b/server/app/services/applicant/ApplicantServiceImpl.java
@@ -101,7 +101,7 @@ public class ApplicantServiceImpl implements ApplicantService {
     CompletableFuture<Optional<Applicant>> applicantCompletableFuture =
         userRepository.lookupApplicant(applicantId).toCompletableFuture();
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getActiveProgramDefinitionAsync(programId).toCompletableFuture();
 
     return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
         .thenApplyAsync(
@@ -164,7 +164,7 @@ public class ApplicantServiceImpl implements ApplicantService {
         userRepository.lookupApplicant(applicantId).toCompletableFuture();
 
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getActiveProgramDefinitionAsync(programId).toCompletableFuture();
 
     return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
         .thenComposeAsync(
@@ -269,7 +269,7 @@ public class ApplicantServiceImpl implements ApplicantService {
    */
   private CompletionStage<Void> updateStoredFileAclsForSubmit(long applicantId, long programId) {
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getActiveProgramDefinitionAsync(programId).toCompletableFuture();
 
     CompletableFuture<List<StoredFile>> storedFilesFuture =
         getReadOnlyApplicantProgramService(applicantId, programId)

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import models.Application;
-import models.Program;
 import play.libs.F;
 import repository.TimeFilter;
 import services.CiviFormError;
@@ -355,9 +354,6 @@ public interface ProgramService {
    * global admins if none.
    */
   ImmutableList<String> getNotificationEmailAddresses(String programName);
-
-  /** Get all other programs with the same name. */
-  ImmutableList<Program> getOtherProgramVersions(long programId);
 
   /** Get all versions of the program with a version matching programId, including that one */
   ImmutableList<ProgramDefinition> getAllProgramDefinitionVersions(long programId);

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -53,7 +53,7 @@ public interface ProgramService {
    *     ProgramNotFoundException is thrown when the future completes and ID does not correspond to
    *     a real Program
    */
-  CompletionStage<ProgramDefinition> getProgramDefinitionAsync(long id);
+  CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(long id);
 
   /**
    * Get the definition of a given program asynchronously. Gets the active version for the slug.
@@ -63,7 +63,7 @@ public interface ProgramService {
    *     ProgramNotFoundException is thrown when the future completes and slug does not correspond
    *     to a real Program
    */
-  CompletionStage<ProgramDefinition> getProgramDefinitionAsync(String programSlug);
+  CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(String programSlug);
 
   /**
    * Create a new program with an empty block.

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -70,7 +70,7 @@ public final class ProgramServiceImpl implements ProgramService {
   @Override
   public ProgramDefinition getProgramDefinition(long id) throws ProgramNotFoundException {
     try {
-      return getProgramDefinitionAsync(id).toCompletableFuture().join();
+      return getActiveProgramDefinitionAsync(id).toCompletableFuture().join();
     } catch (CompletionException e) {
       if (e.getCause() instanceof ProgramNotFoundException) {
         throw new ProgramNotFoundException(id);
@@ -86,7 +86,7 @@ public final class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public CompletionStage<ProgramDefinition> getProgramDefinitionAsync(long id) {
+  public CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(long id) {
     return programRepository
         .lookupProgram(id)
         .thenComposeAsync(
@@ -101,7 +101,7 @@ public final class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public CompletionStage<ProgramDefinition> getProgramDefinitionAsync(String programSlug) {
+  public CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(String programSlug) {
     return programRepository
         .getForSlug(programSlug)
         .thenComposeAsync(this::syncProgramAssociations, httpExecutionContext.current());

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -713,13 +713,6 @@ public final class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public ImmutableList<Program> getOtherProgramVersions(long programId) {
-    return programRepository.getAllProgramVersions(programId).stream()
-        .filter(program -> program.id != programId)
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  @Override
   public ImmutableList<ProgramDefinition> getAllProgramDefinitionVersions(long programId) {
     return programRepository.getAllProgramVersions(programId).stream()
         .map(program -> syncProgramAssociations(program).toCompletableFuture().join())

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -139,7 +139,7 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
                 input()
                     .withValue(
                         baseUrl
-                            + controllers.applicant.routes.RedirectController.programByName(
+                            + controllers.applicant.routes.RedirectController.programBySlug(
                                     displayProgram.slug())
                                 .url())
                     .isDisabled()

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -417,7 +417,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   ButtonTag renderShareLink(ProgramDefinition program) {
     String programLink =
         baseUrl
-            + controllers.applicant.routes.RedirectController.programByName(program.slug()).url();
+            + controllers.applicant.routes.RedirectController.programBySlug(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
         .withData("copyable-program-link", programLink);

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -140,7 +140,7 @@ GET     /support/unsupportedBrowser  controllers.SupportController.handleUnsuppo
 GET     /programAdmin       controllers.admin.ProgramAdminController.index(request: Request)
 
 # Deep-link methods
-GET     /programs/:programName      controllers.applicant.RedirectController.programByName(request: Request, programName: String)
+GET     /programs/:programSlug      controllers.applicant.RedirectController.programBySlug(request: Request, programSlug: String)
 GET     /considerSignIn             controllers.applicant.RedirectController.considerRegister(request: Request, applicantId: Long, programId: Long, applicationId: Long, redirectTo: String)
 
 # User profile pages

--- a/server/test/controllers/RedirectControllerTest.java
+++ b/server/test/controllers/RedirectControllerTest.java
@@ -25,10 +25,10 @@ import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Result;
-import repository.ProgramRepository;
 import repository.UserRepository;
 import services.applicant.ApplicantService;
 import services.program.ProgramDefinition;
+import services.program.ProgramService;
 import support.ProgramBuilder;
 import views.applicant.ApplicantUpsellCreateAccountView;
 
@@ -87,7 +87,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             instanceOf(HttpExecutionContext.class),
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
-            instanceOf(ProgramRepository.class),
+            instanceOf(ProgramService.class),
             instanceOf(ApplicantUpsellCreateAccountView.class),
             instanceOf(MessagesApi.class),
             languageUtils);
@@ -115,7 +115,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             instanceOf(HttpExecutionContext.class),
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
-            instanceOf(ProgramRepository.class),
+            instanceOf(ProgramService.class),
             instanceOf(ApplicantUpsellCreateAccountView.class),
             instanceOf(MessagesApi.class),
             languageUtils);

--- a/server/test/controllers/RedirectControllerTest.java
+++ b/server/test/controllers/RedirectControllerTest.java
@@ -65,7 +65,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void programByName_redirectsToPreviousProgramVersionForExistingApplications() {
+  public void programBySlug_redirectsToPreviousProgramVersionForExistingApplications() {
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
     Applicant applicant = createApplicantWithMockedProfile();
     applicant.getApplicantData().setPreferredLocale(Locale.ENGLISH);
@@ -78,7 +78,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
 
     Result result =
         instanceOf(RedirectController.class)
-            .programByName(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
+            .programBySlug(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -90,12 +90,12 @@ public class RedirectControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void programByName_testLanguageSelectorShown() {
+  public void programBySlug_testLanguageSelectorShown() {
     Applicant applicant = createApplicantWithMockedProfile();
     RedirectController controller = instanceOf(RedirectController.class);
     Result result =
         controller
-            .programByName(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
+            .programBySlug(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -105,7 +105,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void programByName_testLanguageSelectorNotShownOneLanguage() {
+  public void programBySlug_testLanguageSelectorNotShownOneLanguage() {
     Applicant applicant = createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
@@ -122,7 +122,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             languageUtils);
     Result result =
         controller
-            .programByName(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
+            .programBySlug(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())
@@ -133,7 +133,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void programByName_testLanguageSelectorNotShownNoLanguage() {
+  public void programBySlug_testLanguageSelectorNotShownNoLanguage() {
     Applicant applicant = createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of());
@@ -150,7 +150,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             languageUtils);
     Result result =
         controller
-            .programByName(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
+            .programBySlug(addCSRFToken(fakeRequest()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -323,7 +323,8 @@ public class ProgramServiceImplTest extends ResetPostgres {
   public void getProgramDefinitionAsync_getsRequestedProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
 
-    CompletionStage<ProgramDefinition> found = ps.getProgramDefinitionAsync(programDefinition.id());
+    CompletionStage<ProgramDefinition> found =
+        ps.getActiveProgramDefinitionAsync(programDefinition.id());
 
     assertThat(found.toCompletableFuture().join().adminName())
         .isEqualTo(programDefinition.adminName());
@@ -334,7 +335,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
-        ps.getProgramDefinitionAsync(programDefinition.id() + 1);
+        ps.getActiveProgramDefinitionAsync(programDefinition.id() + 1);
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
@@ -352,7 +353,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
             .buildDefinition();
 
     ProgramDefinition found =
-        ps.getProgramDefinitionAsync(program.id()).toCompletableFuture().join();
+        ps.getActiveProgramDefinitionAsync(program.id()).toCompletableFuture().join();
 
     QuestionDefinition foundQuestion =
         found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
@@ -1159,7 +1160,8 @@ public class ProgramServiceImplTest extends ResetPostgres {
             mapper.writeValueAsString(unorderedBlockDefinitions), programId);
     DB.sqlUpdate(updateString).execute();
 
-    ProgramDefinition found = ps.getProgramDefinitionAsync(programId).toCompletableFuture().get();
+    ProgramDefinition found =
+        ps.getActiveProgramDefinitionAsync(programId).toCompletableFuture().get();
 
     assertThat(found.hasOrderedBlockDefinitions()).isTrue();
   }


### PR DESCRIPTION
### Description

This fixes a bug wherein an applicant could have multiple drafts for the same program. This would happen when:

1. applicant answers a question for version A of a program, creating draft application A
1. CF admin publishes a new version of the program, version B
1. applicant navigates to the program using its deep link (e.g. from the index page), the deep link (previously) always links to the most recent version of the program, now version B
1. applicant answers a question for version B of the program, creating a second draft
1. applicant attempts to submit their application, encounter an error due to logic that asserts only one draft of a program at a time

The fix implemented here is to change the logic for deep links to redirect to the version of the program the applicant already has a draft application for, if one exists.

## Release notes:

Bugfix: duplicate draft applications when applicant uses deep links to updated program.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

fixes #2969