### PR TITLE
Remove warning when running setup.py

### DIFF
--- a/cloud/shared/bin/lib/terraform.py
+++ b/cloud/shared/bin/lib/terraform.py
@@ -2,6 +2,7 @@ import subprocess
 import os
 import shutil
 import shlex
+from typing import Optional
 
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 
@@ -10,7 +11,7 @@ from cloud.shared.bin.lib.config_loader import ConfigLoader
 def perform_apply(
         config_loader: ConfigLoader,
         is_destroy=False,
-        terraform_template_dir=None):
+        terraform_template_dir: Optional[str] = None):
     '''Generates terraform variable files and runs terraform init and apply.'''
     if not terraform_template_dir:
         terraform_template_dir = config_loader.get_template_dir()

--- a/cloud/shared/bin/lib/terraform.py
+++ b/cloud/shared/bin/lib/terraform.py
@@ -3,9 +3,14 @@ import os
 import shutil
 import shlex
 
+from cloud.shared.bin.lib.config_loader import ConfigLoader
+
 
 # TODO(#2741): When using this for Azure make sure to setup backend bucket prior to calling these functions.
-def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
+def perform_apply(
+        config_loader: ConfigLoader,
+        is_destroy=False,
+        terraform_template_dir=None):
     '''Generates terraform variable files and runs terraform init and apply.'''
     if not terraform_template_dir:
         terraform_template_dir = config_loader.get_template_dir()
@@ -19,10 +24,12 @@ def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
             shlex.split(f'{terraform_cmd} init -upgrade -reconfigure'))
     else:
         print(" - Run terraform init -upgrade -reconfigure")
-        subprocess.check_call(
-            shlex.split(
-                f'{terraform_cmd} init -input=false -upgrade -backend-config={os.getenv("BACKEND_VARS_FILENAME")}'
-            ))
+        init_cmd = f'{terraform_cmd} init -input=false -upgrade'
+        # backend vars file can be absent when pre-terraform setup is running
+        if os.path.exists(os.path.join(terraform_template_dir,
+                                       config_loader.backend_vars_filename)):
+            init_cmd += f' -backend-config={config_loader.backend_vars_filename}'
+        subprocess.check_call(shlex.split(init_cmd))
 
     if os.path.exists(os.path.join(terraform_template_dir, tf_vars_filename)):
         print(
@@ -40,7 +47,7 @@ def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
     return True
 
 
-def copy_backend_override(config_loader):
+def copy_backend_override(config_loader: ConfigLoader):
     ''' 
     Copies the terraform backend_override to backend_override.tf (used to
     make backend local instead of a shared state for dev deploys)


### PR DESCRIPTION
### Description

Currently pre-terraform setup stage which creates s3 bucket for the state shows warning because we pass non-existing -`-backend-config` param. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
