### PR TITLE
Simplify setup.py and few other things

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -1,23 +1,27 @@
 #! /usr/bin/env python3
-import subprocess
-import os
 import sys
 
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib import tf_apply_setup
 from cloud.aws.bin.lib import backend_setup
 
-config_loader = tf_apply_setup.load_config()
 
-if config_loader.is_dev():
-    terraform.copy_backend_override(config_loader)
-else:
-    backend_setup.setup_backend_config(config_loader)
+def main():
+    config_loader = tf_apply_setup.load_config()
 
-if not terraform.perform_apply(config_loader):
-    sys.stderr.write('Terraform deployment failed.')
-    # TODO(#2606): write and upload logs.
-    raise ValueError('Terraform deployment failed.')
+    if config_loader.is_dev():
+        terraform.copy_backend_override(config_loader)
+    else:
+        backend_setup.setup_backend_config(config_loader)
 
-if config_loader.is_test():
-    print('Test completed')
+    if not terraform.perform_apply(config_loader):
+        sys.stderr.write('Terraform deployment failed.')
+        # TODO(#2606): write and upload logs.
+        raise ValueError('Terraform deployment failed.')
+
+    if config_loader.is_test():
+        print('Test completed')
+
+
+if __name__ == "__main__":
+    main()

--- a/cloud/shared/bin/deploy
+++ b/cloud/shared/bin/deploy
@@ -7,7 +7,7 @@ source cloud/shared/bin/lib.sh
 cloud/shared/bin/validate_cloud_provider
 
 if [[ "${IMAGE_TAG}" == "latest" ]]; then
-  out::error "--tag must reference a specific image, not 'latest'."
+  out::error "--tag must reference a specific image, not 'latest'. Check available versions on https://hub.docker.com/r/civiform/civiform"
   exit 1
 fi
 

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -7,6 +7,7 @@ import sys
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 from cloud.shared.bin.lib.write_tfvars import TfVarWriter
 from setup_class_loader import load_setup_class
+from cloud.shared.bin.lib import terraform
 """
 Setup.py sets up and runs the initial terraform deployment. It's broken into
 3 parts:
@@ -63,29 +64,8 @@ def main():
         ###############################################################################
         # Terraform Init/Plan/Apply
         ###############################################################################
-        print("Starting terraform setup")
-        # Note that the -chdir means we use the relative paths for
-        # both the backend config and the var file
-        terraform_init_args = [
-            "terraform", f"-chdir={terraform_template_dir}", "init",
-            "-input=false", "-upgrade", "-migrate-state"
-        ]
-        if config_loader.use_backend_config():
-            print(f"Using backend config {config_loader.backend_vars_filename}")
-            terraform_init_args.append(
-                f"-backend-config={config_loader.backend_vars_filename}")
-
-        print(" - Run terraform init")
-        subprocess.check_call(terraform_init_args)
-
-        print(" - Run terraform apply")
-        tf_apply_args = [
-            "terraform", f"-chdir={terraform_template_dir}", "apply",
-            "-input=false", f"-var-file={config_loader.tfvars_filename}"
-        ]
-
-        print(" - Run terraform apply in setup.py")
-        subprocess.check_call(tf_apply_args)
+        print("Starting terraform deploy")
+        terraform.perform_apply(config_loader)
 
         ###############################################################################
         # Post Run Setup Tasks (if needed)

--- a/cloud/shared/bin/lib/setup_template.py
+++ b/cloud/shared/bin/lib/setup_template.py
@@ -44,7 +44,7 @@ class SetupTemplate:
         return False
 
     def post_terraform_setup(self):
-        print(" - TODO: Post terraform setup.")
+        raise NotImplementedError('post-terraform setup is not needed in AWS')
 
     def cleanup(self):
         print(" - TODO: cleanup. Upload log files.")

--- a/cloud/shared/bin/lib/setup_template.py
+++ b/cloud/shared/bin/lib/setup_template.py
@@ -44,7 +44,9 @@ class SetupTemplate:
         return False
 
     def post_terraform_setup(self):
-        raise NotImplementedError('post-terraform setup is not needed in AWS')
+        raise NotImplementedError(
+            'post_terraform_setup not implemented while ' +
+            'subclass indicated support via requires_post_terraform_setup')
 
     def cleanup(self):
         print(" - TODO: cleanup. Upload log files.")


### PR DESCRIPTION
### Description

Currently setup.py calls terraform using the same code as in terraform.py. This PR updates setup.py to use terraform.py instead. The only difference is that setup.py calls `terraform init` with `-migrate-state` option, while terraform.py doesn't use that option. Given that setup.py is expected to be called on empty repo there no need to migrate anything as state should be immediately created on s3. Here are docs for the [backend initialization](https://www.terraform.io/cli/commands/init#backend-initialization).

Additional changes:
1. Add main() to AWS' deploy.py.
2. Change post_terraform_setup() to throw error by default as it should be called only when post-terraform setup is enabled by the subclass.
3. Make "you are using incorrect image tag" message a bit more helpful.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

