### PR TITLE
Add screen reader label for file upload field

### DIFF
--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -94,8 +94,7 @@ describe('file upload applicant flow', () => {
       expect(await error?.isHidden()).toEqual(false)
     })
 
-    // TODO(#2988) Enable test once a11y issues are fixed.
-    it.skip('has no accessiblity violations', async () => {
+    it('has no accessiblity violations', async () => {
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')
 

--- a/server/app/views/AwsFileUploadViewStrategy.java
+++ b/server/app/views/AwsFileUploadViewStrategy.java
@@ -12,7 +12,8 @@ import services.cloud.aws.SignedS3UploadRequest;
 public final class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
 
   @Override
-  protected ImmutableList<InputTag> fileUploadFields(Optional<StorageUploadRequest> request) {
+  protected ImmutableList<InputTag> fileUploadFields(
+      Optional<StorageUploadRequest> request, String fileInputId) {
     if (request.isEmpty()) {
       return ImmutableList.of();
     }
@@ -49,7 +50,12 @@ public final class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
     // after that. See #2653 /
     // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html
     // for more context.
-    builder.add(input().withType("file").withName("file").withAccept(MIME_TYPES_IMAGES_AND_PDF));
+    builder.add(
+        input()
+            .withId(fileInputId)
+            .withType("file")
+            .withName("file")
+            .withAccept(MIME_TYPES_IMAGES_AND_PDF));
     return builder.build();
   }
 

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -21,7 +21,9 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
   }
 
   @Override
-  protected ImmutableList<InputTag> fileUploadFields(Optional<StorageUploadRequest> request) {
+  protected ImmutableList<InputTag> fileUploadFields(
+      Optional<StorageUploadRequest> request, String fileInputId) {
+    // Need to add either label here or pass in an id to use.
     if (request.isEmpty()) {
       return ImmutableList.of();
     }
@@ -40,7 +42,11 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
             .withType("hidden")
             .withName("successActionRedirect")
             .withValue(signedRequest.successActionRedirect()),
-        input().withType("file").withName("file").withAccept(MIME_TYPES_IMAGES_AND_PDF));
+        input()
+            .withId(fileInputId)
+            .withType("file")
+            .withName("file")
+            .withAccept(MIME_TYPES_IMAGES_AND_PDF));
     return builder.build();
   }
 

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -23,7 +23,6 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
   @Override
   protected ImmutableList<InputTag> fileUploadFields(
       Optional<StorageUploadRequest> request, String fileInputId) {
-    // Need to add either label here or pass in an id to use.
     if (request.isEmpty()) {
       return ImmutableList.of();
     }

--- a/server/app/views/FileUploadViewStrategy.java
+++ b/server/app/views/FileUploadViewStrategy.java
@@ -52,14 +52,16 @@ public abstract class FileUploadViewStrategy extends ApplicationBaseView {
    * @return a container tag with the necessary fields
    */
   public final DivTag signedFileUploadFields(
-      ApplicantQuestionRendererParams params, FileUploadQuestion fileUploadQuestion) {
+      ApplicantQuestionRendererParams params,
+      FileUploadQuestion fileUploadQuestion,
+      String fileInputId) {
     Optional<String> uploaded =
         fileUploadQuestion
             .getFilename()
             .map(f -> params.messages().at(MessageKey.INPUT_FILE_ALREADY_UPLOADED.getKeyName(), f));
 
     DivTag result = div().with(div().withText(uploaded.orElse("")));
-    result.with(fileUploadFields(params.signedFileUploadRequest()));
+    result.with(fileUploadFields(params.signedFileUploadRequest(), fileInputId));
     result.with(
         div(fileUploadQuestion.fileRequiredMessage().getMessage(params.messages()))
             .withClasses(
@@ -68,7 +70,7 @@ public abstract class FileUploadViewStrategy extends ApplicationBaseView {
   }
 
   protected abstract ImmutableList<InputTag> fileUploadFields(
-      Optional<StorageUploadRequest> request);
+      Optional<StorageUploadRequest> request, String fileInputId);
 
   /**
    * Method to render the UI for uploading a file.

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -46,7 +46,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
     super(question);
     this.fileUploadQuestion = question.createFileUploadQuestion();
     this.fileUploadViewStrategy = fileUploadViewStrategy;
-    fileInputId = RandomStringUtils.randomAlphabetic(8);
+    this.fileInputId = RandomStringUtils.randomAlphabetic(8);
   }
 
   @Override

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -1,8 +1,12 @@
 package views.questiontypes;
 
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.label;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
+import org.apache.commons.lang3.RandomStringUtils;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -10,6 +14,7 @@ import services.applicant.question.FileUploadQuestion;
 import views.FileUploadViewStrategy;
 import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
+import views.style.Styles;
 
 /**
  * Renders a file upload question.
@@ -19,17 +24,19 @@ import views.style.ReferenceClasses;
  */
 public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   private final FileUploadViewStrategy fileUploadViewStrategy;
-  private final FileUploadQuestion fileuploadQuestion;
+  private final FileUploadQuestion fileUploadQuestion;
+  // The ID used to associate the file input field with its label for screen readers.
+  private final String fileInputId;
 
   public static DivTag renderFileKeyField(
       ApplicantQuestion question, ApplicantQuestionRendererParams params, boolean clearData) {
-    FileUploadQuestion fileuploadQuestion = question.createFileUploadQuestion();
-    String value = fileuploadQuestion.getFileKeyValue().orElse("");
+    FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
+    String value = fileUploadQuestion.getFileKeyValue().orElse("");
     if (clearData) {
       value = "";
     }
     return FieldWithLabel.input()
-        .setFieldName(fileuploadQuestion.getFileKeyPath().toString())
+        .setFieldName(fileUploadQuestion.getFileKeyPath().toString())
         .setValue(value)
         .getInputTag();
   }
@@ -37,15 +44,23 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   public FileUploadQuestionRenderer(
       ApplicantQuestion question, FileUploadViewStrategy fileUploadViewStrategy) {
     super(question);
-    this.fileuploadQuestion = question.createFileUploadQuestion();
+    this.fileUploadQuestion = question.createFileUploadQuestion();
     this.fileUploadViewStrategy = fileUploadViewStrategy;
+    fileInputId = RandomStringUtils.randomAlphabetic(8);
   }
 
   @Override
   protected DivTag renderTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
-    return fileUploadViewStrategy.signedFileUploadFields(params, fileuploadQuestion);
+    return div()
+        .with(
+            label()
+                .withFor(fileInputId)
+                .withClass(Styles.SR_ONLY)
+                .withText(question.getQuestionText()))
+        .with(
+            fileUploadViewStrategy.signedFileUploadFields(params, fileUploadQuestion, fileInputId));
   }
 
   @Override

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -25,7 +25,7 @@ import views.style.Styles;
 public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   private final FileUploadViewStrategy fileUploadViewStrategy;
   private final FileUploadQuestion fileUploadQuestion;
-  // The ID used to associate the file input field with its label for screen readers.
+  // The ID used to associate the file input field with its screen reader label.
   private final String fileInputId;
 
   public static DivTag renderFileKeyField(


### PR DESCRIPTION
### Description

Adds a screenreader `label` for the file input field. This follows the existing pattern from other fields ([code](https://github.com/civiform/civiform/blob/main/server/app/views/components/FieldWithLabel.java#L399-L407)). Manually verified behavior.

Also enables the file accessibility test.

## Release notes:

Add screenreader label for file uploads.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2988
