### PR TITLE
Add heading level one to applicant facing program details page.

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -154,8 +154,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(pageObject)
     })
 
-    // TODO(#3016): Enable test after fixing h1 a11y issue.
-    it.skip('program details page has no accessiblity violations', async () => {
+    it('program details page has no accessiblity violations', async () => {
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')
       await applicantQuestions.clickProgramDetails(programName)

--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -3,7 +3,7 @@ package views.applicant;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.h2;
+import static j2html.TagCreator.h1;
 import static j2html.TagCreator.span;
 
 import com.google.common.collect.ImmutableList;
@@ -12,7 +12,7 @@ import controllers.routes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
-import j2html.tags.specialized.H2Tag;
+import j2html.tags.specialized.H1Tag;
 import java.util.Locale;
 import java.util.Optional;
 import play.i18n.Messages;
@@ -68,8 +68,8 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
             .withClasses(Styles.TEXT_GRAY_500, Styles.TEXT_LEFT)
             .with(span().withText(programsLinkText).withClasses(Styles.PX_4));
 
-    H2Tag titleDiv =
-        h2().withText(programTitle)
+    H1Tag titleDiv =
+        h1().withText(programTitle)
             .withClasses(
                 BaseStyles.TEXT_SEATTLE_BLUE,
                 Styles.TEXT_2XL,


### PR DESCRIPTION
### Description

This bumps up the existing h2 heading to an h1. Manually verified UI is not affected. Also enabled the accessibility test for this page.

## Release notes:

Add heading level one to program details page for a11y.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3016
