### PR TITLE
When no status is set on an application show an empty option.

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -102,8 +102,8 @@ describe('view program statuses', () => {
       expect(await adminPrograms.isStatusSelectorVisible()).toBe(true)
     })
 
-    it('shows default option as blank', async () => {
-      expect(await adminPrograms.getStatusOption()).toBe('')
+    it('shows default option as placeholder', async () => {
+      expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
     })
   })
 })

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -26,10 +26,6 @@ describe('view program statuses', () => {
     adminProgramStatuses = new AdminProgramStatuses(pageObject)
   })
 
-  afterEach(async () => {
-    await logout(pageObject)
-  })
-
   describe('without program statuses', () => {
     const programWithoutStatusesName = 'test program without statuses'
     beforeAll(async () => {
@@ -53,6 +49,10 @@ describe('view program statuses', () => {
       await logout(pageObject)
     })
 
+    afterAll(async () => {
+      await logout(pageObject)
+    })
+
     it('does not Show status options', async () => {
       await loginAsProgramAdmin(pageObject)
 
@@ -63,6 +63,7 @@ describe('view program statuses', () => {
       expect(await adminPrograms.isStatusSelectorVisible()).toBe(false)
     })
   })
+
   describe('with program statuses', () => {
     const programWithStatusesName = 'test program with statuses'
     const statusName = 'Status 1'
@@ -87,15 +88,22 @@ describe('view program statuses', () => {
       await applicantQuestions.submitFromPreviewPage(programWithStatusesName)
 
       await logout(pageObject)
-    })
-
-    it('shows status selector', async () => {
       await loginAsProgramAdmin(pageObject)
 
       await adminPrograms.viewApplications(programWithStatusesName)
       await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    })
 
+    afterAll(async () => {
+      await logout(pageObject)
+    })
+
+    it('shows status selector', async () => {
       expect(await adminPrograms.isStatusSelectorVisible()).toBe(true)
+    })
+
+    it('shows default option as blank', async () => {
+      expect(await adminPrograms.getStatusOption()).toBe('')
     })
   })
 })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -483,6 +483,16 @@ export class AdminPrograms {
       .isVisible()
   }
 
+  async getStatusOption(): Promise<string> {
+    const selectedValue = this.applicationFrame()
+      .locator('.cf-program-admin-status-selector')
+      .evaluate((el: HTMLSelectElement) => el.options[el.selectedIndex].value)
+    // @ts-ignore
+    return selectedValue === null
+      ? 'selected option was not found'
+      : selectedValue
+  }
+
   async getJson(applyFilters: boolean) {
     await clickAndWaitForModal(this.page, 'download-program-applications-modal')
     if (applyFilters) {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -484,13 +484,9 @@ export class AdminPrograms {
   }
 
   async getStatusOption(): Promise<string> {
-    const selectedValue = this.applicationFrame()
-      .locator('.cf-program-admin-status-selector')
-      .evaluate((el: HTMLSelectElement) => el.options[el.selectedIndex].value)
-    // @ts-ignore
-    return selectedValue === null
-      ? 'selected option was not found'
-      : selectedValue
+    return this.applicationFrame()
+      .locator('.cf-program-admin-status-selector-label')
+      .inputValue()
   }
 
   async getJson(applyFilters: boolean) {

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -10,6 +10,7 @@ import static j2html.TagCreator.option;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.select;
 
+import annotations.BindingAnnotations.EnUsLang;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
@@ -24,7 +25,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Collection;
+import org.apache.commons.lang3.RandomStringUtils;
+import play.i18n.Messages;
 import play.twirl.api.Content;
+import services.MessageKey;
 import services.applicant.AnswerData;
 import services.applicant.Block;
 import services.program.StatusDefinitions;
@@ -40,10 +44,12 @@ import views.style.Styles;
 /** Renders a page for a program admin to view a single submitted application. */
 public final class ProgramApplicationView extends BaseHtmlView {
   private final BaseHtmlLayout layout;
+  private final Messages enUsMessages;
 
   @Inject
-  public ProgramApplicationView(BaseHtmlLayout layout) {
+  public ProgramApplicationView(BaseHtmlLayout layout, @EnUsLang Messages enUsMessages) {
     this.layout = checkNotNull(layout);
+    this.enUsMessages = checkNotNull(enUsMessages);
   }
 
   public Content render(
@@ -166,8 +172,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     Styles.FLEX_AUTO, Styles.TEXT_RIGHT, Styles.FONT_LIGHT, Styles.TEXT_XS));
   }
 
-  private static DivTag renderStatusOptionsSelector(StatusDefinitions statusDefinitions) {
-    final String SELECTOR_ID = "status-selector";
+  private DivTag renderStatusOptionsSelector(StatusDefinitions statusDefinitions) {
+    final String SELECTOR_ID = RandomStringUtils.randomAlphabetic(8);
     DivTag container =
         div()
             .withClasses(Styles.FLEX)
@@ -194,8 +200,12 @@ public final class ProgramApplicationView extends BaseHtmlView {
                 StyleUtils.focus(BaseStyles.BORDER_SEATTLE_BLUE));
 
     // Add the options available to the admin.
-    // When no status is currently applied to the application, add an empty option that is selected.
-    dropdownTag.with(option("").withValue("").isSelected());
+    // When no status is currently applied to the application, add a placeholder option that is
+    // selected.
+    dropdownTag.with(
+        option(enUsMessages.at(MessageKey.DROPDOWN_PLACEHOLDER.getKeyName()))
+            .isDisabled()
+            .isSelected());
 
     // Add statuses in the order they're provided.
     statusDefinitions

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -176,6 +176,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
     SelectTag dropdownTag =
         select()
             .withClasses(
+                ReferenceClasses.PROGRAM_ADMIN_STATUS_SELECTOR,
                 Styles.OUTLINE_NONE,
                 Styles.PX_3,
                 Styles.PY_1,
@@ -187,6 +188,9 @@ public final class ProgramApplicationView extends BaseHtmlView {
                 Styles.BG_WHITE,
                 Styles.TEXT_XS,
                 StyleUtils.focus(BaseStyles.BORDER_SEATTLE_BLUE));
+
+    // When no status is currently set, add an empty option.
+    dropdownTag.with(option("").withValue(""));
 
     // Add statuses in the order they're provided.
     statusDefinitions

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.h2;
+import static j2html.TagCreator.label;
 import static j2html.TagCreator.option;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.select;
@@ -82,14 +83,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     // Status options if configured on the program.
                     .condWith(
                         !statusDefinitions.getStatuses().isEmpty(),
-                        div()
-                            .withClasses(Styles.FLEX)
-                            .with(
-                                div("Status:")
-                                    .withClasses(
-                                        Styles.SELF_CENTER,
-                                        ReferenceClasses.PROGRAM_ADMIN_STATUS_SELECTOR_LABEL),
-                                renderStatusOptionsSelector(statusDefinitions)))
+                        renderStatusOptionsSelector(statusDefinitions))
                     .with(renderDownloadButton(programId, applicationId)))
             .with(
                 each(
@@ -172,11 +166,21 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     Styles.FLEX_AUTO, Styles.TEXT_RIGHT, Styles.FONT_LIGHT, Styles.TEXT_XS));
   }
 
-  private static SelectTag renderStatusOptionsSelector(StatusDefinitions statusDefinitions) {
+  private static DivTag renderStatusOptionsSelector(StatusDefinitions statusDefinitions) {
+    final String SELECTOR_ID = "status-selector";
+    DivTag container =
+        div()
+            .withClasses(Styles.FLEX)
+            .with(
+                label("Status:")
+                    .withClasses(
+                        Styles.SELF_CENTER, ReferenceClasses.PROGRAM_ADMIN_STATUS_SELECTOR_LABEL)
+                    .withFor(SELECTOR_ID));
+
     SelectTag dropdownTag =
         select()
+            .withId(SELECTOR_ID)
             .withClasses(
-                ReferenceClasses.PROGRAM_ADMIN_STATUS_SELECTOR,
                 Styles.OUTLINE_NONE,
                 Styles.PX_3,
                 Styles.PY_1,
@@ -189,8 +193,9 @@ public final class ProgramApplicationView extends BaseHtmlView {
                 Styles.TEXT_XS,
                 StyleUtils.focus(BaseStyles.BORDER_SEATTLE_BLUE));
 
-    // When no status is currently set, add an empty option.
-    dropdownTag.with(option("").withValue(""));
+    // Add the options available to the admin.
+    // When no status is currently applied to the application, add an empty option that is selected.
+    dropdownTag.with(option("").withValue("").isSelected());
 
     // Add statuses in the order they're provided.
     statusDefinitions
@@ -201,6 +206,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
               OptionTag optionTag = option(value).withValue(value);
               dropdownTag.with(optionTag);
             });
-    return dropdownTag;
+    return container.with(dropdownTag);
   }
 }

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -46,8 +46,6 @@ public final class ReferenceClasses {
 
   public static final String WITH_DROPDOWN = "cf-with-dropdown";
 
-  public static final String PROGRAM_ADMIN_STATUS_SELECTOR = "cf-program-admin-status-selector";
-
   public static final String PROGRAM_ADMIN_STATUS_SELECTOR_LABEL =
       "cf-program-admin-status-selector-label";
 

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -46,6 +46,8 @@ public final class ReferenceClasses {
 
   public static final String WITH_DROPDOWN = "cf-with-dropdown";
 
+  public static final String PROGRAM_ADMIN_STATUS_SELECTOR = "cf-program-admin-status-selector";
+
   public static final String PROGRAM_ADMIN_STATUS_SELECTOR_LABEL =
       "cf-program-admin-status-selector-label";
 


### PR DESCRIPTION
### Description

When no status is specified for an Application, add an empty selected option.

## Release notes:

NA

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2911
