### PR TITLE
Move enumerator placeholder to be a permanent label

### DIFF
--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -99,16 +99,11 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
       Path contextualizedPath,
       Optional<String> existingEntity,
       Optional<Integer> existingIndex) {
-
     DivTag entityNameInput =
         FieldWithLabel.input()
             .setFieldName(contextualizedPath.toString())
             .setValue(existingEntity)
-            .setScreenReaderText(
-                messages.at(
-                    MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
-                    localizedEntityType))
-            .setPlaceholderText(
+            .setLabelText(
                 messages.at(
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
                     localizedEntityType))


### PR DESCRIPTION
### Description

Moves enumerator placeholder to be a permanent label. Verified with UX (@rahaghas) that this looks OK.

This is part of a larger change to remove placeholder text. Address and date still need to be updated, but since these come with additional localization/translation considerations, they will come in a separate PR.

Before:
<img width="1398" alt="Screen Shot 2022-08-05 at 4 17 36 PM" src="https://user-images.githubusercontent.com/9094240/183222708-b56ba67e-166e-4c44-bd29-0e5a0b2adb04.png">

After:
<img width="1399" alt="Screen Shot 2022-08-05 at 4 17 49 PM" src="https://user-images.githubusercontent.com/9094240/183222711-c0db7512-1cfb-4e4e-b9e9-48d58ae35914.png">

## Release notes:

Add label for individual enumerator fields.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2617 
