### PR TITLE
Disable local OIDC testing due to issue #3102

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,8 @@ services:
       # Hard coded in test-support/test_oidc_provider.js
       - IDCS_CLIENT_ID=foo
       - IDCS_SECRET=bar
-      - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
+      # TODO(#3102): Fix dev-oidc issue and re-enable.
+      # - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - ADFS_CLIENT_ID
       - ADFS_SECRET
       - APPLICANT_OIDC_PROVIDER_NAME


### PR DESCRIPTION
### Description

Disable dev-oidc configuration as it is failing which block CiviForm from working..

## Release notes:

NA - dev only

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
