### PR TITLE
Revert "Disable local OIDC testing due to issue #3102"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,7 @@ services:
       # Hard coded in test-support/test_oidc_provider.js
       - IDCS_CLIENT_ID=foo
       - IDCS_SECRET=bar
-      # TODO(#3102): Fix dev-oidc issue and re-enable.
-      # - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
+      - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - ADFS_CLIENT_ID
       - ADFS_SECRET
       - APPLICANT_OIDC_PROVIDER_NAME


### PR DESCRIPTION
Issue looks to have been caused by an eslint change that is reverted in #3107