### PR TITLE
Add `storage_encrypted` param to AWS DB

### DIFF
--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -43,6 +43,7 @@ resource "aws_db_instance" "civiform" {
   final_snapshot_identifier       = "${var.app_prefix}-civiform-db-finalsnapshot"
   backup_retention_period         = var.postgres_backup_retention_days
   kms_key_id                      = aws_kms_key.civiform_kms_key.arn
+  storage_encrypted               = true
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 


### PR DESCRIPTION
### Description

This param is required when KMS is used.

### Checklist

- [s] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

