### PR TITLE
Pass github token to release script in action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run bin/create-release
-        run: 'bin/create-release ${{ github.event.inputs.commit_sha }} ${{ github.event.inputs.release_number }}'
+        run: 'GH_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/create-release ${{ github.event.inputs.commit_sha }} ${{ github.event.inputs.release_number }}'


### PR DESCRIPTION
The create release action needs the github auth token to run