### PR TITLE
Change label from implicit to explicit for radio buttons

### DIFF
--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -8,7 +8,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.LabelTag;
+import j2html.tags.specialized.InputTag;
 import java.util.Comparator;
+import org.apache.commons.lang3.RandomStringUtils;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -54,25 +56,27 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   private DivTag renderRadioOption(
       String selectionPath, LocalizedQuestionOption option, boolean checked) {
-    String id = option.optionText().replaceAll("\\s+", "_");
+    String id = RandomStringUtils.randomAlphabetic(8);
 
     LabelTag labelTag =
         label()
-            .withClasses(
-                ReferenceClasses.RADIO_OPTION,
-                BaseStyles.RADIO_LABEL,
-                checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
-            .with(
-                input()
-                    .withId(id)
-                    .withType("radio")
-                    .withName(selectionPath)
-                    .withValue(String.valueOf(option.id()))
-                    .withCondChecked(checked)
-                    .withClasses(
-                        StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO)))
+            .withFor(id)
             .withText(option.optionText());
+    InputTag inputTag = 
+        input()
+            .withId(id)
+            .withType("radio")
+            .withName(selectionPath)
+            .withValue(String.valueOf(option.id()))
+            .withCondChecked(checked)
+            .withClasses(
+                StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO));
 
-    return div().withClasses(Styles.MY_2, Styles.RELATIVE).with(labelTag);
+    return div().withClasses(Styles.MY_2, Styles.RELATIVE, 
+                  ReferenceClasses.RADIO_OPTION,
+                  BaseStyles.RADIO_LABEL,
+                  checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+                .with(inputTag)
+                .with(labelTag);
   }
 }

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -7,8 +7,8 @@ import static j2html.TagCreator.label;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
-import j2html.tags.specialized.LabelTag;
 import j2html.tags.specialized.InputTag;
+import j2html.tags.specialized.LabelTag;
 import java.util.Comparator;
 import org.apache.commons.lang3.RandomStringUtils;
 import services.Path;
@@ -58,25 +58,24 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
       String selectionPath, LocalizedQuestionOption option, boolean checked) {
     String id = RandomStringUtils.randomAlphabetic(8);
 
-    LabelTag labelTag =
-        label()
-            .withFor(id)
-            .withText(option.optionText());
-    InputTag inputTag = 
+    LabelTag labelTag = label().withFor(id).withText(option.optionText());
+    InputTag inputTag =
         input()
             .withId(id)
             .withType("radio")
             .withName(selectionPath)
             .withValue(String.valueOf(option.id()))
             .withCondChecked(checked)
-            .withClasses(
-                StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO));
+            .withClasses(StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO));
 
-    return div().withClasses(Styles.MY_2, Styles.RELATIVE, 
-                  ReferenceClasses.RADIO_OPTION,
-                  BaseStyles.RADIO_LABEL,
-                  checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
-                .with(inputTag)
-                .with(labelTag);
+    return div()
+        .withClasses(
+            Styles.MY_2,
+            Styles.RELATIVE,
+            ReferenceClasses.RADIO_OPTION,
+            BaseStyles.RADIO_LABEL,
+            checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+        .with(inputTag)
+        .with(labelTag);
   }
 }

--- a/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -65,10 +65,12 @@ public class RadioButtonQuestionRendererTest {
   }
 
   @Test
-  public void render_generatesIds_formatsWhitespaceAsUnderscore() {
+  public void render_generatesIdsForExplicitLabels() {
     DivTag result = renderer.render(params);
 
-    assertThat(result.render()).contains("id=\"peanut_butter\"");
+    // Verify we use explicit labels linked to inputs by id for a11y.
+    assertThat(result.render()).contains("<label for=");
+    assertThat(result.render()).contains("<input id=");
   }
 
   @Test
@@ -79,7 +81,7 @@ public class RadioButtonQuestionRendererTest {
 
     assertThat(result.render())
         .contains(
-            "<input id=\"peanut_butter\" type=\"radio\""
+            "type=\"radio\""
                 + " name=\"applicant.favorite_ice_cream.selection\""
                 + " value=\"2\" checked");
   }


### PR DESCRIPTION
### Description

Explicit labels (where `label` and `input` are linked by IDs) are better supported by assistive technology than implicit labels (where the `label` element wraps the `input` element). See [link](https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly). This PR does not affect styling.

Also updates the input id to be randomly generated instead of using the text. The text is not unique per page (e.g. we could have 2 different radio questions with the same answer).

Before:
![AT5vCqyrUdRx2Zu](https://user-images.githubusercontent.com/9094240/183746674-34ea1721-27a2-48cb-903b-30f06419984d.png)

After (no change in UI):
![7q4KfYwsFXgxh6z](https://user-images.githubusercontent.com/9094240/183746683-7a76cd13-0132-4f7f-a609-a138e2ab0072.png)

## Release notes:

Change label from implicit to explicit for radio buttons for accessibility.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
