### PR TITLE
Use GITHUB_ACTOR name when release script is run on GH

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -53,7 +53,9 @@ def main():
 
     commit_sha = sys.argv[1]
     release_number = sys.argv[2]
-    releaser_email = shell_cmd('git config --get user.email')
+    releaser_email = os.environ[
+        'GITHUB_ACTOR'] if 'GITHUB_ACTOR' in os.environ else shell_cmd(
+            'git config --get user.email')
 
     ################################################################################
     # Resolve and validate GitHub token, check auth


### PR DESCRIPTION
When the release script is run using GH actions, there is no configured git user name or email so instead we use the GITHUB_ACTOR environment variable.