### PR TITLE
Change DB password after initial terraform setup is done.

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -1,0 +1,22 @@
+"""
+This module contains names of AWS resources that are created by the Terraform
+and which also referenced in python scripts. Each resource should contain
+a comment with a link pointing to the Terraform file that defines it as
+at the moment we don't have a better way to synchronize them.
+
+Resource names use pattern {app_prefix}-{name} and this file contains only the
+second part, name.
+"""
+
+# Defined in file cloud/aws/templates/aws_oidc/secrets.tf
+ADFS_CLIENT_ID = 'adfs_client_id'
+ADFS_SECRET = 'adfs_secret'
+APPLICANT_OIDC_CLIENT_ID = 'applicant_oidc_client_id'
+APPLICANT_OIDC_CLIENT_SECRET = 'applicant_oidc_client_secret'
+POSTGRES_PASSWORD = 'postgres_password'
+
+# Defined in file cloud/aws/templates/aws_oidc/main.tf
+DATABASE = 'civiform-db'
+
+# Defined by fargate modules file cloud/aws/templates/aws_oidc/app.tf
+FARGATE_SERVICE = 'service'

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -1,3 +1,4 @@
+import secrets
 import subprocess
 import shlex
 from getpass import getpass
@@ -56,10 +57,18 @@ class Setup(AwsSetupTemplate):
         for name, doc in SECRETS.items():
             self._maybe_set_secret_value(
                 f'{self.config.app_prefix}-{name}', doc)
+        self._maybe_change_default_db_password()
 
     def _maybe_set_secret_value(self, secret_name: str, documentation: str):
+        """
+        Some secrets like login integration credentials created empty in
+        terraform. The values need to be provided by users. This method runs
+        after terraform created empty secrets and it asks user to provide
+        actual secret values. Without these values server will not start so
+        it has be run immediately after the initial setup is done.
+        """
         print('')
-        url = f'https://{self.config.aws_region}.console.aws.amazon.com/secretsmanager/secret?name={secret_name}'
+        url = self._aws_cli.get_url_of_secret(secret_name)
         if self._aws_cli.is_secret_empty(secret_name):
             print(
                 f'Secret {secret_name} is not set. It needs to be set to a non-empty value.'
@@ -75,3 +84,33 @@ class Setup(AwsSetupTemplate):
         else:
             print(f'Secret {secret_name} already has a value set.')
             print(f'You can check and update it in AWS console: {url}')
+
+    def _maybe_change_default_db_password(self):
+        """
+        Terraform creates database password secret with a random value and
+        creates database and ECS service that use that password. The problem
+        is that because password generated within terraform - its value is
+        stored in the Terraform state. To avoid exposing password in the state
+        this method regenerates password and updates database and server to use
+        the new password.
+        """
+        print()
+        print('Checking database password...')
+        app_prefix = self.config.app_prefix
+        secret_name = f'{app_prefix}-postgres_password'
+        url = self._aws_cli.get_url_of_secret(secret_name)
+        if self._aws_cli.is_db_password_default(secret_name):
+            new_password = secrets.token_urlsafe(40)
+            print(
+                'Default database is used. Generating new password and updating deployment.'
+            )
+            self._aws_cli.update_master_password_in_database(
+                f'{self.config.app_prefix}-civiform-db', new_password)
+            print('Database password has been changed.')
+            self._aws_cli.set_secret_value(secret_name, new_password)
+            self._aws_cli.restart_ecs_service(
+                app_prefix, f'{app_prefix}-service')
+            print(f'ECS service has been restarted to pickup the new password.')
+        else:
+            print('Password has already been changed. Not touching it.')
+        print(f'You can see the password here: {url}')

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -71,7 +71,10 @@ resource "aws_secretsmanager_secret" "postgres_password_secret" {
 # Creating a AWS secret versions for postgres_password
 resource "aws_secretsmanager_secret_version" "postgres_password_secret_version" {
   secret_id     = aws_secretsmanager_secret.postgres_password_secret.id
-  secret_string = random_password.postgres_password.result
+  # Prefix secret value with 'default-' so that we can detect it in the
+  # deployment script and regenerate. See
+  # Setup._maybe_change_default_db_password() in aws_oidc/bin/setup.py
+  secret_string = "default-${random_password.postgres_password.result}"
 }
 
 # Create a random generated password to use for app_secret_key.

--- a/cloud/aws/templates/aws_oidc/secrets.tf
+++ b/cloud/aws/templates/aws_oidc/secrets.tf
@@ -70,7 +70,7 @@ resource "aws_secretsmanager_secret" "postgres_password_secret" {
 
 # Creating a AWS secret versions for postgres_password
 resource "aws_secretsmanager_secret_version" "postgres_password_secret_version" {
-  secret_id     = aws_secretsmanager_secret.postgres_password_secret.id
+  secret_id = aws_secretsmanager_secret.postgres_password_secret.id
   # Prefix secret value with 'default-' so that we can detect it in the
   # deployment script and regenerate. See
   # Setup._maybe_change_default_db_password() in aws_oidc/bin/setup.py


### PR DESCRIPTION
### Description

Original DB password generated by the Terraform is stored in the Terraform state. We want to avoid exposing such info in the state even though access to the state should be limited. To achieve that we now regenerate password. Update database to use the new password, update the secret value and restart ECS service to pickup the new secret value.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2918
