### PR TITLE
Don't validate GITHUB_TOKEN prefix

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -67,12 +67,6 @@ def main():
         with open(GH_RELEASE_TOKEN_FILENAME, 'r') as file:
             gh_token = file.read().rstrip()
 
-    if not gh_token.startswith('ghp_'):
-        print(
-            f'Invalid token found in {GH_RELEASE_TOKEN_FILENAME}',
-            file=sys.stderr)
-        exit(1)
-
     check_gh_auth_response = requests.get(
         'https://api.github.com/repos/civiform/civiform',
         headers={'Authorization': f'token {gh_token}'})


### PR DESCRIPTION
The script originally included a validation ensuring that the auth token was prefixed with `"ghp_"`. This is apparently only true for personal access tokens and not the auth token provided in GH actions.