### PR TITLE
Style improvements in deploy AWS python scripts

### DIFF
--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -28,7 +28,8 @@ class AwsCli:
         return res['SecretString'].startswith('default-')
 
     def get_current_user(self) -> str:
-        return self._call_cli('sts get-caller-identity')['UserId']
+        res = self._call_cli('sts get-caller-identity')
+        return res['UserId']
 
     def update_master_password_in_database(self, db_name: str, password: str):
         self._call_cli(

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -1,7 +1,7 @@
+import shlex
 import subprocess
 import json
 from typing import Dict
-from typing import List
 
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 
@@ -14,51 +14,39 @@ class AwsCli:
 
     def is_secret_empty(self, secret_name: str) -> bool:
         res = self._call_cli(
-            [
-                'secretsmanager', 'get-secret-value',
-                f'--secret-id={secret_name}'
-            ])
+            f'secretsmanager get-secret-value --secret-id={secret_name}')
         return res['SecretString'].strip() == ''
 
-    def set_secret_value(self, secret_name: str, new_value: str) -> None:
+    def set_secret_value(self, secret_name: str, new_value: str):
         self._call_cli(
-            [
-                'secretsmanager', 'update-secret', f'--secret-id={secret_name}',
-                f'--secret-string={new_value}'
-            ])
+            f'secretsmanager update-secret --secret-id={secret_name} --secret-string={new_value}'
+        )
 
     def is_db_password_default(self, secret_name: str) -> bool:
         res = self._call_cli(
-            [
-                'secretsmanager', 'get-secret-value',
-                f'--secret-id={secret_name}'
-            ])
-        return res['SecretString'].startswith("default-")
+            f'secretsmanager get-secret-value --secret-id={secret_name}')
+        return res['SecretString'].startswith('default-')
 
     def get_current_user(self) -> str:
-        return self._call_cli(['sts', 'get-caller-identity'])['UserId']
+        return self._call_cli('sts get-caller-identity')['UserId']
 
     def update_master_password_in_database(self, db_name: str, password: str):
         self._call_cli(
-            [
-                'rds', 'modify-db-instance',
-                f'--db-instance-identifier={db_name}',
-                f'--master-user-password={password}'
-            ])
+            f'rds modify-db-instance --db-instance-identifier={db_name} --master-user-password={password} '
+        )
 
     def restart_ecs_service(self, cluster: str, service_name: str):
         self._call_cli(
-            [
-                'ecs', 'update-service', '--force-new-deployment',
-                f'--service={service_name}', f'--cluster={cluster}'
-            ])
+            f'ecs update-service --force-new-deployment --service={service_name} --cluster={cluster}'
+        )
 
     def get_url_of_secret(self, secret_name: str) -> str:
         return f'https://{self.config.aws_region}.console.aws.amazon.com/secretsmanager/secret?name={secret_name}'
 
-    def _call_cli(self, args: List[str]) -> Dict:
-        args = [
-            'aws', '--output=json', f'--region={self.config.aws_region}'
-        ] + args
-        out = subprocess.check_output(args=args)
+    def get_url_of_s3_bucket(self, bucket_name: str) -> str:
+        return f'https://{self.config.aws_region}.console.aws.amazon.com/s3/buckets/{bucket_name}'
+
+    def _call_cli(self, command: str) -> Dict:
+        command = f'aws --output=json --region={self.config.aws_region} ' + command
+        out = subprocess.check_output(shlex.split(command))
         return json.loads(out.decode('ascii'))

--- a/cloud/aws/templates/aws_oidc/bin/destroy.py
+++ b/cloud/aws/templates/aws_oidc/bin/destroy.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
-
+from cloud.aws.templates.aws_oidc.bin import resources
+from cloud.aws.templates.aws_oidc.bin.aws_cli import AwsCli
 from cloud.aws.templates.aws_oidc.bin.aws_template import AwsSetupTemplate
 """
 Destroy the setup
@@ -19,6 +20,8 @@ class Destroy(AwsSetupTemplate):
             print(
                 'Not destroying S3 bucket that contains terraform state. ' +
                 'You have to destroy it manually:')
-            print(
-                f'https://s3.console.aws.amazon.com/s3/buckets/{self.config.app_prefix}-backendstate'
+            aws_cli = AwsCli(self.config)
+            bucket_url = aws_cli.get_url_of_s3_bucket(
+                f'{self.config.app_prefix}-{resources.S3_TERRAFORM_STATE_BUCKET}'
             )
+            print(bucket_url)

--- a/cloud/aws/templates/aws_oidc/bin/destroy.py
+++ b/cloud/aws/templates/aws_oidc/bin/destroy.py
@@ -21,6 +21,7 @@ class Destroy(AwsSetupTemplate):
                 'Not destroying S3 bucket that contains terraform state. ' +
                 'You have to destroy it manually:')
             aws_cli = AwsCli(self.config)
-            print(aws_cli.get_url_of_s3_bucket(
-                f'{self.config.app_prefix}-{resources.S3_TERRAFORM_STATE_BUCKET}'
-            ))
+            print(
+                aws_cli.get_url_of_s3_bucket(
+                    f'{self.config.app_prefix}-{resources.S3_TERRAFORM_STATE_BUCKET}'
+                ))

--- a/cloud/aws/templates/aws_oidc/bin/destroy.py
+++ b/cloud/aws/templates/aws_oidc/bin/destroy.py
@@ -21,7 +21,6 @@ class Destroy(AwsSetupTemplate):
                 'Not destroying S3 bucket that contains terraform state. ' +
                 'You have to destroy it manually:')
             aws_cli = AwsCli(self.config)
-            bucket_url = aws_cli.get_url_of_s3_bucket(
+            print(aws_cli.get_url_of_s3_bucket(
                 f'{self.config.app_prefix}-{resources.S3_TERRAFORM_STATE_BUCKET}'
-            )
-            print(bucket_url)
+            ))

--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -8,15 +8,18 @@ Resource names use pattern {app_prefix}-{name} and this file contains only the
 second part, name.
 """
 
-# Defined in file cloud/aws/templates/aws_oidc/secrets.tf
+# Defined in cloud/aws/templates/aws_oidc/secrets.tf
 ADFS_CLIENT_ID = 'adfs_client_id'
 ADFS_SECRET = 'adfs_secret'
 APPLICANT_OIDC_CLIENT_ID = 'applicant_oidc_client_id'
 APPLICANT_OIDC_CLIENT_SECRET = 'applicant_oidc_client_secret'
 POSTGRES_PASSWORD = 'postgres_password'
 
-# Defined in file cloud/aws/templates/aws_oidc/main.tf
+# Defined in cloud/aws/templates/aws_oidc/main.tf
 DATABASE = 'civiform-db'
 
-# Defined by fargate modules file cloud/aws/templates/aws_oidc/app.tf
+# Defined by fargate modules in cloud/aws/templates/aws_oidc/app.tf
 FARGATE_SERVICE = 'service'
+
+# Defined in cloud/aws/modules/setup/backend_storage.tf
+S3_TERRAFORM_STATE_BUCKET = 'backendstate'


### PR DESCRIPTION
### Description

1. Pass command line as a string instead of list of parameters as it's easier to read that way.
2. Extract s3 bucket name to a constant in resources.py so that more terraform-related constants in that file.
3. Move code that builds urls for AWS console to AwsCli.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
