### PR TITLE
Print some few links at the end of AWS setup and deploy

### DIFF
--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python3
 import sys
 
+from cloud.aws.templates.aws_oidc.bin import resources
+from cloud.aws.templates.aws_oidc.bin.aws_cli import AwsCli
 from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib import tf_apply_setup
 from cloud.aws.bin.lib import backend_setup
@@ -21,6 +23,14 @@ def main():
 
     if config_loader.is_test():
         print('Test completed')
+
+    aws_cli = AwsCli(config_loader)
+    fargate_service = f'{config_loader.app_prefix}-{resources.FARGATE_SERVICE}'
+    tasks_url = aws_cli.get_url_of_fargate_tasks(
+        config_loader.app_prefix, fargate_service)
+    print()
+    print('Deployment finished. You can monitor civiform tasks status here:')
+    print(tasks_url)
 
 
 if __name__ == "__main__":

--- a/cloud/aws/bin/deploy.py
+++ b/cloud/aws/bin/deploy.py
@@ -24,13 +24,12 @@ def main():
     if config_loader.is_test():
         print('Test completed')
 
-    aws_cli = AwsCli(config_loader)
-    fargate_service = f'{config_loader.app_prefix}-{resources.FARGATE_SERVICE}'
-    tasks_url = aws_cli.get_url_of_fargate_tasks(
-        config_loader.app_prefix, fargate_service)
     print()
     print('Deployment finished. You can monitor civiform tasks status here:')
-    print(tasks_url)
+    fargate_service = f'{config_loader.app_prefix}-{resources.FARGATE_SERVICE}'
+    print(
+        AwsCli(config_loader).get_url_of_fargate_tasks(
+            config_loader.app_prefix, fargate_service))
 
 
 if __name__ == "__main__":

--- a/cloud/aws/templates/aws_oidc/bin/aws_cli.py
+++ b/cloud/aws/templates/aws_oidc/bin/aws_cli.py
@@ -53,8 +53,17 @@ class AwsCli:
                 f'--service={service_name}', f'--cluster={cluster}'
             ])
 
+    def get_load_balancer_dns(self, name: str) -> str:
+        res = self._call_cli(
+            ['elbv2', 'describe-load-balancers', f'--names={name}'])
+        load_balancer = res['LoadBalancers'][0]
+        return load_balancer['DNSName']
+
     def get_url_of_secret(self, secret_name: str) -> str:
         return f'https://{self.config.aws_region}.console.aws.amazon.com/secretsmanager/secret?name={secret_name}'
+
+    def get_url_of_fargate_tasks(self, cluster: str, service_name: str) -> str:
+        return f'https://{self.config.aws_region}.console.aws.amazon.com/ecs/v2/clusters/{cluster}/services/{service_name}/configuration'
 
     def _call_cli(self, args: List[str]) -> Dict:
         args = [

--- a/cloud/aws/templates/aws_oidc/bin/resources.py
+++ b/cloud/aws/templates/aws_oidc/bin/resources.py
@@ -20,3 +20,4 @@ DATABASE = 'civiform-db'
 
 # Defined by fargate modules file cloud/aws/templates/aws_oidc/app.tf
 FARGATE_SERVICE = 'service'
+LOAD_BALANCER = 'lb'

--- a/cloud/aws/templates/aws_oidc/bin/setup.py
+++ b/cloud/aws/templates/aws_oidc/bin/setup.py
@@ -57,6 +57,7 @@ class Setup(AwsSetupTemplate):
             self._maybe_set_secret_value(
                 f'{self.config.app_prefix}-{name}', doc)
         self._maybe_change_default_db_password()
+        self._print_final_message()
 
     def _maybe_set_secret_value(self, secret_name: str, documentation: str):
         """
@@ -113,4 +114,24 @@ class Setup(AwsSetupTemplate):
             print('Password has already been changed. Not touching it.')
         print(
             f'You can see the password here: {self._aws_cli.get_url_of_secret(secret_name)}'
+        )
+
+    def _print_final_message(self):
+        app = self.config.app_prefix
+
+        # Print link to ECS tasks.
+        print()
+        fargate_service = f'{app}-{resources.FARGATE_SERVICE}'
+        tasks_url = self._aws_cli.get_url_of_fargate_tasks(app, fargate_service)
+        print('Setup finished. You can monitor civiform tasks status here:')
+        print(tasks_url)
+
+        # Print info about load balancer url.
+        print()
+        lb_dns = self._aws_cli.get_load_balancer_dns(
+            f'{app}-{resources.LOAD_BALANCER}')
+        print(f'Server is available on url: {lb_dns}')
+        base_url = self.config.get_config_variables()['BASE_URL']
+        print(
+            f'In your domain registrar create a CNAME record for {base_url} to point to the url above.'
         )

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -3,6 +3,7 @@
 import subprocess
 import tempfile
 
+from cloud.shared.bin.lib import terraform
 from cloud.shared.bin.lib.setup_template import SetupTemplate
 """
 Template Setup
@@ -56,6 +57,8 @@ class Setup(SetupTemplate):
     def post_terraform_setup(self):
         self._get_adfs_user_inputs()
         self._configure_slot_settings()
+        # Why are running terraform again for azure?
+        terraform.perform_apply(self.config_loader)
 
     def cleanup(self):
         self._upload_log_file()

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -57,7 +57,7 @@ class Setup(SetupTemplate):
     def post_terraform_setup(self):
         self._get_adfs_user_inputs()
         self._configure_slot_settings()
-        # Why are running terraform again for azure?
+        # Run terraform again as get_adfs_user_inputs updated secret variables.
         terraform.perform_apply(self.config_loader)
 
     def cleanup(self):

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -74,12 +74,6 @@ def main():
             print("Starting port-terraform setup")
             template_setup.post_terraform_setup()
 
-            subprocess.check_call(
-                [
-                    "terraform", f"-chdir={terraform_template_dir}", "apply",
-                    "-input=false", f"-var-file={config_loader.tfvars_filename}"
-                ])
-
         subprocess.run(
             [
                 "/bin/bash", "-c",
@@ -94,7 +88,8 @@ def main():
             ],
             check=True)
         print("Deployment Failed :(", file=sys.stderr)
-        print("error:", err)
+        # rethrow error so that full stack trace is printed
+        raise err
 
     finally:
         template_setup.cleanup()


### PR DESCRIPTION
### Description

1. The links should help deployer verify whether deployment was successful or not. 
2. At the end of setup we remind to update domain CNAME record to point to the freshly created load balancer url where civiform app is running.
3. Move second run of `terraform apply` to azure-specific post-terraform step. It's not needed by AWS and messes up "print final message" code which is done in post-terraform setup. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
