### PR TITLE
Refactors templates handling in python deploy script

### DIFF
--- a/cloud/shared/bin/lib/destroy.py
+++ b/cloud/shared/bin/lib/destroy.py
@@ -2,7 +2,7 @@
 
 from config_loader import ConfigLoader
 from cloud.shared.bin.lib import terraform
-from setup_class_loader import load_destroy_class
+from setup_class_loader import get_config_specific_destroy
 """
 Destroy.py destroys Civiform deployment.
 """
@@ -33,10 +33,7 @@ def main():
     # Load Setup Class for the specific template directory
     ###############################################################################
 
-    template_dir = config_loader.get_template_dir()
-    Destroy = load_destroy_class(template_dir)
-
-    template_destroy = Destroy(config_loader)
+    template_destroy = get_config_specific_destroy(config_loader)
     template_destroy.pre_terraform_destroy()
     terraform.perform_apply(config_loader, is_destroy=True)
     template_destroy.post_terraform_destroy()

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -6,7 +6,7 @@ import sys
 
 from cloud.shared.bin.lib.config_loader import ConfigLoader
 from cloud.shared.bin.lib.write_tfvars import TfVarWriter
-from setup_class_loader import load_setup_class
+from setup_class_loader import get_config_specific_setup
 from cloud.shared.bin.lib import terraform
 """
 Setup.py sets up and runs the initial terraform deployment. It's broken into
@@ -39,9 +39,8 @@ def main():
     ###############################################################################
 
     terraform_template_dir = config_loader.get_template_dir()
-    Setup = load_setup_class(terraform_template_dir)
+    template_setup = get_config_specific_setup(config_loader)
 
-    template_setup = Setup(config_loader)
     template_setup.setup_log_file()
     current_user = template_setup.get_current_user()
 

--- a/cloud/shared/bin/lib/setup_class_loader.py
+++ b/cloud/shared/bin/lib/setup_class_loader.py
@@ -1,22 +1,26 @@
-import importlib.util
-import os
 """
-load_class takes in a template dir and uses that to load the 
+load_class takes in a template dir and uses that to load the
 setup module which knows how to setup the template
 """
 
+import importlib.util
+import os
 
-def load_setup_class(template_dir):
+from cloud.shared.bin.lib.config_loader import ConfigLoader
+from cloud.shared.bin.lib.setup_template import SetupTemplate
+
+
+def get_config_specific_setup(config: ConfigLoader) -> SetupTemplate:
     spec = importlib.util.spec_from_file_location(
-        "setup", f"{os.getcwd()}/{template_dir}/bin/setup.py")
+        "setup", f"{os.getcwd()}/{config.get_template_dir()}/bin/setup.py")
     loaded_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(loaded_module)
-    return loaded_module.Setup
+    return loaded_module.Setup(config)
 
 
-def load_destroy_class(template_dir):
+def get_config_specific_destroy(config: ConfigLoader) -> SetupTemplate:
     spec = importlib.util.spec_from_file_location(
-        "destroy", f"{os.getcwd()}/{template_dir}/bin/destroy.py")
+        "destroy", f"{os.getcwd()}/{config.get_template_dir()}/bin/destroy.py")
     loaded_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(loaded_module)
-    return loaded_module.Destroy
+    return loaded_module.Destroy(config)

--- a/cloud/shared/bin/lib/setup_template.py
+++ b/cloud/shared/bin/lib/setup_template.py
@@ -1,14 +1,13 @@
-#! /usr/bin/env python3
-import shutil
-import tempfile
-import shutil
-
-from cloud.shared.bin.lib.config_loader import ConfigLoader
 """
 Template Setup
 
 These functions need to be defined for every template.
 """
+
+import tempfile
+import shutil
+
+from cloud.shared.bin.lib.config_loader import ConfigLoader
 
 
 class SetupTemplate:
@@ -34,12 +33,6 @@ class SetupTemplate:
         _, self.log_file_path = tempfile.mkstemp()
         print(" - TODO: Setup log file here.")
 
-    def _make_backend_override(self):
-        current_directory = self.config.get_template_dir()
-        shutil.copy2(
-            f'{current_directory}/backend_override',
-            f'{current_directory}/backend_override.tf')
-
     def requires_post_terraform_setup(self):
         return False
 
@@ -50,3 +43,9 @@ class SetupTemplate:
 
     def cleanup(self):
         print(" - TODO: cleanup. Upload log files.")
+
+    def pre_terraform_destroy(self):
+        pass
+
+    def post_terraform_destroy(self):
+        pass


### PR DESCRIPTION
### Description

There are changes in this PR. 

1. Make `SetupTemplate` class to be explicit base class for Setup and Destroy AWS/Azure classed by adding `pre_terraform_destroy` and `post_terraform_destroy` methods there. Both AWS Destroy and Azure Destroy classes inherit from `SetupTemplate`. Maybe we should redo inheritance in this case. For example have single AWS and single Azure classes which encapsulate both setup and destroy logic.

2. Create instances of AWS/Azure Setup/Destroy classes in setup_class_loaders instead of returning class objects. That allows to specify return type and improve type inference for IDEs. And generally hides that non-standard reflection logic within that file.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

