### PR TITLE
Run eslint on browser tests

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -14,6 +14,7 @@ bin/pull-image
 # The display name returned by test_oidc_provider.js is <username>@example.com.
 docker run --rm -it \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
+  -v "$(pwd)/formatter:/usr/src/formatter" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   -e TEST_USER_AUTH_STRATEGY="fake-oidc" \
   -e TEST_USER_LOGIN="testuser" \

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -3,7 +3,7 @@
 # DOC: Run the browser tests locally. Requires browser test env already running.
 
 source bin/lib.sh
-export BASE_URL=http://localhost:9999
+export BASE_URL="https://staging-mikita.civiform.dev"
 export DISABLE_SCREENSHOTS=true
 export TEST_USER_AUTH_STRATEGY=fake-oidc
 export TEST_USER_LOGIN=testuser
@@ -34,7 +34,9 @@ done
 
 echo "Detected server start"
 
-npm test "$@"
+# If test fails - don't abort script. Allow eslint below to run in case it can
+# provide useful findings about code.
+npm test "$@" || true
 
 echo -e "\nRunning eslint..."
 npx eslint --cache "src/**/*.ts"

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -20,7 +20,8 @@ if ! output="$(node -v)"; then
   exit 1
 fi
 
-npm install --force --prefix browser-test --quiet
+cd browser-test
+npm install --force --quiet
 
 echo "Polling to check server start"
 
@@ -33,4 +34,8 @@ done
 
 echo "Detected server start"
 
-npm test --prefix browser-test "$@"
+npm test "$@"
+
+echo -e "\nRunning eslint..."
+npx eslint --cache "src/**/*.ts"
+echo "Done!"

--- a/browser-test/.gitignore
+++ b/browser-test/.gitignore
@@ -2,3 +2,4 @@
 .idea
 *.log
 tmp/
+.eslintcache

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -29,10 +29,12 @@ for arg; do
   set -- "$@" "$arg"
 done
 
+  # If test fails - don't abort script. Allow eslint below to run in case it can
+  # provide useful findings about code.
 if (($debug == 1)); then
-  DEBUG="pw:api" BASE_URL="${SERVER_URL}" npm test "$@"
+  DEBUG="pw:api" BASE_URL="${SERVER_URL}" npm test "$@" || true
 else
-  BASE_URL="${SERVER_URL}" npm test "$@"
+  BASE_URL="${SERVER_URL}" npm test "$@"  || true
 fi
 
 echo -e "\nRunning eslint..."

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -34,3 +34,7 @@ if (($debug == 1)); then
 else
   BASE_URL="${SERVER_URL}" npm test "$@"
 fi
+
+echo -e "\nRunning eslint..."
+npx eslint --cache "src/**/*.ts"
+echo "Done!"

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -11,7 +11,7 @@ describe('applicant security', () => {
   it('applicant cannot access another applicant data', async () => {
     const {page} = ctx
     await loginAsGuest(page)
-    const response = await gotoEndpoint(page, '/applicants/1234/programs')
+    const response = await gotoEndpoint(page, '/applicantsss/1234/programs')
     expect(response!.status()).toBe(401)
   })
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -527,10 +527,11 @@ export const extractEmailsForRecipient = async function (
   }
   const originalPageUrl = page.url()
   await page.goto(`${LOCALSTACK_URL}/_localstack/ses`)
-  const responseJson = JSON.parse(await page.innerText('body')) as any
+  const response = JSON.parse(await page.innerText('body')) as {
+    messages: LocalstackSesEmail[]
+  }
 
-  const allEmails = responseJson.messages as LocalstackSesEmail[]
-  const filteredEmails = allEmails.filter((email) => {
+  const filteredEmails = response.messages.filter((email) => {
     return email.Destination.ToAddresses.includes(recipientEmail)
   })
 


### PR DESCRIPTION
### Description

Eslint is run after browser test finishes (successfully or unsuccessfully). This way it doesn't block engineers if they don't find ESlint useful: they get test results and can immediately act on them. At the same time if eslint fails - eng might see it and look into it. It can help detect issues like non-awaited promises that can lead to test failures or flakiness.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
