### PR TITLE
Fix TS style warnings and add few missing checks in assertions

### DIFF
--- a/browser-test/.eslintrc.json
+++ b/browser-test/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "guard-for-in": "off",
     "valid-jsdoc": "off",
     "@typescript-eslint/no-non-null-assertion": "off" // this is test code.
   }

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -45,7 +45,7 @@ describe.skip('view program statuses', () => {
       await applicantQuestions.clickApplyProgramButton(
         programWithoutStatusesName,
       )
-      await applicantQuestions.submitFromPreviewPage(programWithoutStatusesName)
+      await applicantQuestions.submitFromPreviewPage()
 
       await logout(pageObject)
     })
@@ -86,7 +86,7 @@ describe.skip('view program statuses', () => {
 
       // Submit an application.
       await applicantQuestions.clickApplyProgramButton(programWithStatusesName)
-      await applicantQuestions.submitFromPreviewPage(programWithStatusesName)
+      await applicantQuestions.submitFromPreviewPage()
 
       await logout(pageObject)
       await loginAsProgramAdmin(pageObject)

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -114,7 +114,7 @@ describe('normal application flow', () => {
 
     // Apply to the program again as the same user
     await applicantQuestions.clickApplyProgramButton(programName)
-    await applicantQuestions.submitFromPreviewPage(programName)
+    await applicantQuestions.submitFromPreviewPage()
     await logout(page)
 
     // #######################################

--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -37,8 +37,8 @@ export class AdminPredicates {
     } else {
       // We have a checkbox for the value.
       const valueArray = value.split(',')
-      for (const index in valueArray) {
-        await this.page.check(`label:has-text("${valueArray[index]}")`)
+      for (const value of valueArray) {
+        await this.page.check(`label:has-text("${value}")`)
       }
     }
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -33,9 +33,11 @@ export class AdminQuestions {
     await this.expectAdminQuestionsPage()
   }
 
-  async goToViewQuestionPage(_questionName: string) {
+  async goToViewQuestionPage(questionName: string) {
     await this.gotoAdminQuestionsPage()
-    await this.page.click('text=View')
+    await this.page.click(
+      this.selectWithinQuestionTableRow(questionName, 'a:has-text("View")'),
+    )
     await waitForPageJsLoad(this.page)
   }
 
@@ -48,10 +50,11 @@ export class AdminQuestions {
     expect(await this.page.innerText('h1')).toEqual('All Questions')
   }
 
-  async expectViewOnlyQuestion(_questionName: string) {
+  async expectViewOnlyQuestion(questionName: string) {
     expect(await this.page.isDisabled('text=No Export')).toEqual(true)
-    // TODO(sgoldblatt): This test does not find any questions need to look into
-    // expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
+    expect(
+      await this.page.isDisabled(`input[value="${questionName}"]`),
+    ).toEqual(true)
   }
 
   selectorForExportOption(exportOption: string) {
@@ -402,26 +405,26 @@ export class AdminQuestions {
   }
 
   async updateAllQuestions(questions: string[]) {
-    for (const i in questions) {
-      await this.updateQuestion(questions[i])
+    for (const question of questions) {
+      await this.updateQuestion(question)
     }
   }
 
   async createNewVersionForQuestions(questions: string[]) {
-    for (const i in questions) {
-      await this.createNewVersion(questions[i])
+    for (const question of questions) {
+      await this.createNewVersion(question)
     }
   }
 
   async expectDraftQuestions(questions: string[]) {
-    for (const i in questions) {
-      await this.expectDraftQuestionExist(questions[i])
+    for (const question of questions) {
+      await this.expectDraftQuestionExist(question)
     }
   }
 
   async expectActiveQuestions(questions: string[]) {
-    for (const i in questions) {
-      await this.expectActiveQuestionExist(questions[i])
+    for (const question of questions) {
+      await this.expectActiveQuestionExist(question)
     }
   }
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -73,9 +73,9 @@ export class ApplicantQuestions {
     await this.validateInputValue(lastName, '.cf-name-last input')
   }
 
-  async answerCheckboxQuestion(checked: Array<string>) {
-    for (const index in checked) {
-      await this.page.check(`label:has-text("${checked[index]}")`)
+  async answerCheckboxQuestion(options: Array<string>) {
+    for (const option of options) {
+      await this.page.check(`label:has-text("${option}")`)
     }
   }
 
@@ -283,7 +283,7 @@ export class ApplicantQuestions {
     await waitForPageJsLoad(this.page)
   }
 
-  async submitFromPreviewPage(_programName: string) {
+  async submitFromPreviewPage() {
     // Assert that we're on the preview page.
     expect(await this.page.innerText('h1')).toContain(
       'Program application preview',


### PR DESCRIPTION
### Description

1. Use for-of instead of for-in.
2. Remove unused function arguments. Either delete them if they are not needed or add missing code that uses them.


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
