### PR TITLE
Always present the "archive" option and show a modal if the operation can't be performed

### DIFF
--- a/browser-test/src/question_delete.test.ts
+++ b/browser-test/src/question_delete.test.ts
@@ -28,6 +28,12 @@ describe('deleting question lifecycle', () => {
     await adminPrograms.publishProgram(programName)
     await adminQuestions.expectActiveQuestionExist(onlyUsedQuestion)
 
+    // Confirm the archive option is still available and displays a dialog.
+    await adminQuestions.archiveQuestion({
+      questionName: onlyUsedQuestion,
+      expectModal: true,
+    })
+
     // Make a Draft then discard it.
     await adminQuestions.createNewVersion(unreferencedQuestions[0])
     await adminQuestions.expectDraftQuestionExist(unreferencedQuestions[0])
@@ -43,17 +49,23 @@ describe('deleting question lifecycle', () => {
     // Archive, unarchive, archive all unreferenced questions.
     for (const questionName of unreferencedQuestions) {
       await adminQuestions.expectActiveQuestionExist(questionName)
-      await adminQuestions.archiveQuestion(questionName)
+      await adminQuestions.archiveQuestion({questionName, expectModal: false})
       await adminQuestions.undeleteQuestion(questionName)
       await adminQuestions.expectActiveQuestionExist(questionName)
-      await adminQuestions.archiveQuestion(questionName)
+      await adminQuestions.archiveQuestion({questionName, expectModal: false})
     }
     // Archive, unarchive, archive an unreferenced draft question.
     await adminQuestions.expectDraftQuestionExist(draftOnlyQuestionName)
-    await adminQuestions.archiveQuestion(draftOnlyQuestionName)
+    await adminQuestions.archiveQuestion({
+      questionName: draftOnlyQuestionName,
+      expectModal: false,
+    })
     await adminQuestions.undeleteQuestion(draftOnlyQuestionName)
     await adminQuestions.expectDraftQuestionExist(draftOnlyQuestionName)
-    await adminQuestions.archiveQuestion(draftOnlyQuestionName)
+    await adminQuestions.archiveQuestion({
+      questionName: draftOnlyQuestionName,
+      expectModal: false,
+    })
 
     // Publish all the above changes.
     await adminPrograms.createNewVersion(programName)

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -378,7 +378,6 @@ public final class QuestionsListView extends BaseHtmlView {
   private ATag renderQuestionEditLink(QuestionDefinition definition, String linkText) {
     String link = controllers.admin.routes.AdminQuestionController.edit(definition.getId()).url();
     return new LinkElement()
-        .setId("edit-question-link-" + definition.getId())
         .setHref(link)
         .setText(linkText)
         .setStyles(Styles.MR_2)
@@ -396,7 +395,6 @@ public final class QuestionsListView extends BaseHtmlView {
             .url();
     return Optional.of(
         new LinkElement()
-            .setId("translate-question-link-" + definition.getId())
             .setHref(link)
             .setText(linkText)
             .setStyles(Styles.MR_2)
@@ -406,7 +404,6 @@ public final class QuestionsListView extends BaseHtmlView {
   private ATag renderQuestionViewLink(QuestionDefinition definition, String linkText) {
     String link = controllers.admin.routes.AdminQuestionController.show(definition.getId()).url();
     return new LinkElement()
-        .setId("view-question-link-" + definition.getId())
         .setHref(link)
         .setText(linkText)
         .setStyles(Styles.MR_2)
@@ -468,7 +465,6 @@ public final class QuestionsListView extends BaseHtmlView {
     String link =
         controllers.admin.routes.AdminQuestionController.discardDraft(definition.getId()).url();
     return new LinkElement()
-        .setId("discard-question-link-" + definition.getId())
         .setHref(link)
         .setText(linkText)
         .setStyles(Styles.MR_2)
@@ -480,7 +476,6 @@ public final class QuestionsListView extends BaseHtmlView {
     String link =
         controllers.admin.routes.AdminQuestionController.restore(definition.getId()).url();
     return new LinkElement()
-        .setId("restore-question-link-" + definition.getId())
         .setHref(link)
         .setText(linkText)
         .setStyles(Styles.MR_2)
@@ -498,7 +493,6 @@ public final class QuestionsListView extends BaseHtmlView {
           controllers.admin.routes.AdminQuestionController.archive(definition.getId()).url();
       return Pair.of(
           new LinkElement()
-              .setId("archive-question-link-" + definition.getId())
               .setHref(link)
               .setText(linkText)
               .setStyles(Styles.MR_2)


### PR DESCRIPTION
### Description

To aid in discoverability of the "Archive" feature, we always present the option in the action list. If there are still programs referencing the question, clicking "Archive" causes the referenced program modal to be popped up with a warning indicating that the question can't be archived. This implements the proposal in https://github.com/civiform/civiform/issues/2788#issuecomment-1184751742.

![Screen Shot 2022-08-12 at 2 04 28 PM](https://user-images.githubusercontent.com/1870301/184445002-8ec715ba-ac1e-4556-b6c5-ed32cb7dcf5a.png)


## Release notes:

Always surface the "archive question" option. When the operation can't be performed, show a a modal explaining why.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2788