### PR TITLE
No longer trimming configuredStatusText since it corresponds directly to what is in the DB

### DIFF
--- a/server/app/controllers/admin/AdminProgramStatusesController.java
+++ b/server/app/controllers/admin/AdminProgramStatusesController.java
@@ -183,9 +183,7 @@ public final class AdminProgramStatusesController extends CiviFormController {
 
     DynamicForm requestData = formFactory.form().bindFromRequest(request);
     String rawDeleteStatusText = requestData.get(ProgramStatusesView.DELETE_STATUS_TEXT_NAME);
-    // TODO(#2752): Consider only trimming the user-provided data before serializing
-    // to a program's statuses here and when editing a status.
-    final String deleteStatusText = rawDeleteStatusText != null ? rawDeleteStatusText.trim() : "";
+    final String deleteStatusText = rawDeleteStatusText != null ? rawDeleteStatusText : "";
     if (deleteStatusText.isBlank()) {
       return badRequest("missing or empty status text");
     }

--- a/server/app/forms/admin/ProgramStatusesForm.java
+++ b/server/app/forms/admin/ProgramStatusesForm.java
@@ -53,7 +53,7 @@ public final class ProgramStatusesForm implements Validatable<List<ValidationErr
   }
 
   public void setConfiguredStatusText(String value) {
-    configuredStatusText = checkNotNull(value).trim();
+    configuredStatusText = checkNotNull(value);
   }
 
   public String getStatusText() {


### PR DESCRIPTION
### Description

It makes sense to trim the text from user-provided status texts and emails. However, the `configuredStatusText` field used to identify the original status when editing / deleting is essentially a key into what is in the DB directly. Additionally, it's populated based on the DB value. Performing a trim here will cause issues if a status makes it's way into a program that hasn't been trimmed.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2752