### PR TITLE
give access permissions to filestorage key

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -66,9 +66,10 @@ module "td" {
               "kms:Decrypt",
               "kms:ReEncrypt*",
               "kms:GenerateDataKey*",
-              "kms:DescribeKey"
+              "kms:DescribeKey",
+              "kms:GenerateDataKey"
             ],
-            "Resource" : [aws_kms_key.civiform_kms_key.arn]
+            "Resource" : [aws_kms_key.civiform_kms_key.arn, aws_kms_key.file_storage_key.arn]
           },
           {
             "Effect" : "Allow",


### PR DESCRIPTION
### Description

Instance role for the Civiform needs access to s3 encryption key.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
