### PR TITLE
Update warning text shown when email body for a status is cleared.

### DIFF
--- a/browser-test/src/support/admin_program_statuses.ts
+++ b/browser-test/src/support/admin_program_statuses.ts
@@ -153,7 +153,9 @@ export class AdminProgramStatuses {
     // Close the modal prior to any assertions to avoid affecting subsequent tests.
     await dismissModal(this.page)
 
-    return innerText.includes('This status has an email configured')
+    return innerText.includes(
+      'clearing the email body will also clear any associated translations',
+    )
   }
 
   async expectProgramManageStatusesPage(programName: string) {

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -392,8 +392,8 @@ public final class ProgramStatusesView extends BaseHtmlView {
   }
 
   private PTag renderEmailTranslationWarning() {
-    return p("This status has an email configured. Clearing this value will also remove any"
-            + " associated translated content.")
+    return p("Please be aware that clearing the email body will also clear any associated"
+                 + " translations")
         .withClasses(
             Styles.M_2,
             Styles.P_2,

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -393,7 +393,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
 
   private PTag renderEmailTranslationWarning() {
     return p("Please be aware that clearing the email body will also clear any associated"
-                 + " translations")
+            + " translations")
         .withClasses(
             Styles.M_2,
             Styles.P_2,


### PR DESCRIPTION
### Description

This is post-merge feedback from https://github.com/civiform/civiform/pull/3150.

![Screen Shot 2022-08-15 at 1 57 41 PM](https://user-images.githubusercontent.com/1870301/184717147-4db91e5c-96e0-405a-84e0-cc2147f3d75a.png)

## Release notes:

N/A.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2752