### PR TITLE
Add field requiredness indicators to program/question UIs.

### DIFF
--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -30,7 +30,7 @@ describe('create dropdown question with options', () => {
 
     // Fill in basic info
     const questionName = 'favorite ice cream'
-    await page.fill('text="Name *"', questionName)
+    await page.fill('text="Name*"', questionName)
     await page.fill('text=Description', 'description')
     await page.fill('text=Question Text', 'questionText')
     await page.fill('text=Question help text', 'helpText')

--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -30,7 +30,7 @@ describe('create dropdown question with options', () => {
 
     // Fill in basic info
     const questionName = 'favorite ice cream'
-    await page.fill('text="Name"', questionName)
+    await page.fill('text=Name', questionName)
     await page.fill('text=Description', 'description')
     await page.fill('text=Question Text', 'questionText')
     await page.fill('text=Question help text', 'helpText')

--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -30,7 +30,7 @@ describe('create dropdown question with options', () => {
 
     // Fill in basic info
     const questionName = 'favorite ice cream'
-    await page.fill('text=Name', questionName)
+    await page.fill('text="Name *"', questionName)
     await page.fill('text=Description', 'description')
     await page.fill('text=Question Text', 'questionText')
     await page.fill('text=Question help text', 'helpText')

--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.input;
+import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 
@@ -16,6 +17,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.H1Tag;
 import j2html.tags.specialized.InputTag;
+import j2html.tags.specialized.PTag;
 import java.util.function.Function;
 import org.apache.commons.lang3.RandomStringUtils;
 import play.i18n.Messages;
@@ -127,5 +129,10 @@ public abstract class BaseHtmlView {
             .with(input().isHidden().withValue(getCsrfToken(request)).withName("csrfToken"));
 
     return buttonEl.withForm(formId).with(hiddenForm);
+  }
+
+  protected static final PTag requiredFieldsExplanationContent() {
+    return p("Note: Fields marked with a * are required.")
+        .withClasses(Styles.TEXT_SM, Styles.TEXT_GRAY_600, Styles.MB_2);
   }
 }

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -1,8 +1,10 @@
 package views.admin.programs;
 
+import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.h3;
+import static j2html.TagCreator.legend;
 
 import forms.ProgramForm;
 import j2html.tags.specialized.FormTag;
@@ -10,6 +12,7 @@ import models.DisplayMode;
 import services.program.ProgramDefinition;
 import views.BaseHtmlView;
 import views.components.FieldWithLabel;
+import views.style.BaseStyles;
 
 /**
  * Builds a program form for rendering. If the program was previously created, the {@code adminName}
@@ -51,47 +54,52 @@ public class ProgramFormBuilder extends BaseHtmlView {
       boolean editExistingProgram) {
     FormTag formTag = form().withMethod("POST");
     formTag.with(
+        requiredFieldsExplanationContent(),
         h2("Internal program information"),
         h3("This will only be visible to administrators"),
         FieldWithLabel.input()
             .setId("program-name-input")
             .setFieldName("adminName")
-            .setLabelText("Enter internal name or nickname of this program")
+            .setLabelText("Enter internal name or nickname of this program *")
             .setValue(adminName)
             .setDisabled(editExistingProgram)
             .getInputTag(),
         FieldWithLabel.textArea()
             .setId("program-description-textarea")
             .setFieldName("adminDescription")
-            .setLabelText("Describe this program for administrative use")
+            .setLabelText("Describe this program for administrative use *")
             .setValue(adminDescription)
             .getTextareaTag(),
-        FieldWithLabel.radio()
-            .setId("program-display-mode-public")
-            .setFieldName("displayMode")
-            .setLabelText("Public")
-            .setValue(DisplayMode.PUBLIC.getValue())
-            .setChecked(displayMode.equals(DisplayMode.PUBLIC.getValue()))
-            .getRadioTag(),
-        FieldWithLabel.radio()
-            .setId("program-display-mode-hidden")
-            .setFieldName("displayMode")
-            .setLabelText("Hidden in Index")
-            .setValue(DisplayMode.HIDDEN_IN_INDEX.getValue())
-            .setChecked(displayMode.equals(DisplayMode.HIDDEN_IN_INDEX.getValue()))
-            .getRadioTag(),
+        // TODO(#2618): Consider using helpers for grouping related radio controls.
+        fieldset()
+            .with(
+                legend("Program visibility *").withClass(BaseStyles.INPUT_LABEL),
+                FieldWithLabel.radio()
+                    .setId("program-display-mode-public")
+                    .setFieldName("displayMode")
+                    .setLabelText("Public")
+                    .setValue(DisplayMode.PUBLIC.getValue())
+                    .setChecked(displayMode.equals(DisplayMode.PUBLIC.getValue()))
+                    .getRadioTag(),
+                FieldWithLabel.radio()
+                    .setId("program-display-mode-hidden")
+                    .setFieldName("displayMode")
+                    .setLabelText("Hidden in Index")
+                    .setValue(DisplayMode.HIDDEN_IN_INDEX.getValue())
+                    .setChecked(displayMode.equals(DisplayMode.HIDDEN_IN_INDEX.getValue()))
+                    .getRadioTag()),
         h2("Public program information"),
         h3("This will be visible to the public"),
         FieldWithLabel.input()
             .setId("program-display-name-input")
             .setFieldName("localizedDisplayName")
-            .setLabelText("Enter the publicly displayed name for this program")
+            .setLabelText("Enter the publicly displayed name for this program *")
             .setValue(displayName)
             .getInputTag(),
         FieldWithLabel.textArea()
             .setId("program-display-description-textarea")
             .setFieldName("localizedDisplayDescription")
-            .setLabelText("Describe this program for the public")
+            .setLabelText("Describe this program for the public *")
             .setValue(displayDescription)
             .getTextareaTag(),
         FieldWithLabel.input()

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -60,20 +60,20 @@ public class ProgramFormBuilder extends BaseHtmlView {
         FieldWithLabel.input()
             .setId("program-name-input")
             .setFieldName("adminName")
-            .setLabelText("Enter internal name or nickname of this program *")
+            .setLabelText("Enter internal name or nickname of this program*")
             .setValue(adminName)
             .setDisabled(editExistingProgram)
             .getInputTag(),
         FieldWithLabel.textArea()
             .setId("program-description-textarea")
             .setFieldName("adminDescription")
-            .setLabelText("Describe this program for administrative use *")
+            .setLabelText("Describe this program for administrative use*")
             .setValue(adminDescription)
             .getTextareaTag(),
         // TODO(#2618): Consider using helpers for grouping related radio controls.
         fieldset()
             .with(
-                legend("Program visibility *").withClass(BaseStyles.INPUT_LABEL),
+                legend("Program visibility*").withClass(BaseStyles.INPUT_LABEL),
                 FieldWithLabel.radio()
                     .setId("program-display-mode-public")
                     .setFieldName("displayMode")
@@ -93,13 +93,13 @@ public class ProgramFormBuilder extends BaseHtmlView {
         FieldWithLabel.input()
             .setId("program-display-name-input")
             .setFieldName("localizedDisplayName")
-            .setLabelText("Enter the publicly displayed name for this program *")
+            .setLabelText("Enter the publicly displayed name for this program*")
             .setValue(displayName)
             .getInputTag(),
         FieldWithLabel.textArea()
             .setId("program-display-description-textarea")
             .setFieldName("localizedDisplayDescription")
-            .setLabelText("Describe this program for the public *")
+            .setLabelText("Describe this program for the public*")
             .setValue(displayDescription)
             .getTextareaTag(),
         FieldWithLabel.input()

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -178,7 +178,7 @@ public class QuestionConfig {
         FieldWithLabel.input()
             .setId("enumerator-question-entity-type-input")
             .setFieldName("entityType")
-            .setLabelText("Repeated entity type")
+            .setLabelText("Repeated entity type *")
             .setPlaceholderText("What are we enumerating?")
             .setValue(enumeratorQuestionForm.getEntityType())
             .getInputTag());
@@ -202,7 +202,7 @@ public class QuestionConfig {
     DivTag optionInput =
         FieldWithLabel.input()
             .setFieldName(isForNewOption ? "newOptions[]" : "options[]")
-            .setLabelText("Question option")
+            .setLabelText("Question option *")
             .addReferenceClass(ReferenceClasses.MULTI_OPTION_INPUT)
             .setValue(existingOption.map(LocalizedQuestionOption::optionText))
             .setFieldErrors(

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -178,7 +178,7 @@ public class QuestionConfig {
         FieldWithLabel.input()
             .setId("enumerator-question-entity-type-input")
             .setFieldName("entityType")
-            .setLabelText("Repeated entity type *")
+            .setLabelText("Repeated entity type*")
             .setPlaceholderText("What are we enumerating?")
             .setValue(enumeratorQuestionForm.getEntityType())
             .getInputTag());
@@ -202,7 +202,7 @@ public class QuestionConfig {
     DivTag optionInput =
         FieldWithLabel.input()
             .setFieldName(isForNewOption ? "newOptions[]" : "options[]")
-            .setLabelText("Question option *")
+            .setLabelText("Question option*")
             .addReferenceClass(ReferenceClasses.MULTI_OPTION_INPUT)
             .setValue(existingOption.map(LocalizedQuestionOption::optionText))
             .setFieldErrors(

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -299,7 +299,7 @@ public final class QuestionEditView extends BaseHtmlView {
         FieldWithLabel.input()
             .setId("question-name-input")
             .setFieldName(QUESTION_NAME_FIELD)
-            .setLabelText("Name *")
+            .setLabelText("Name*")
             .setDisabled(!submittable)
             .setPlaceholderText("The name displayed in the question builder")
             .setValue(questionForm.getQuestionName());
@@ -346,7 +346,7 @@ public final class QuestionEditView extends BaseHtmlView {
             FieldWithLabel.textArea()
                 .setId("question-text-textarea")
                 .setFieldName("questionText")
-                .setLabelText("Question text *")
+                .setLabelText("Question text*")
                 .setPlaceholderText("The question text displayed to the applicant")
                 .setDisabled(!submittable)
                 .setValue(questionForm.getQuestionText())
@@ -370,7 +370,7 @@ public final class QuestionEditView extends BaseHtmlView {
     return fieldset()
         .withId("demographic-field-content")
         .with(
-            legend("Export options *").withClass(BaseStyles.INPUT_LABEL),
+            legend("Export options*").withClass(BaseStyles.INPUT_LABEL),
             FieldWithLabel.radio()
                 .setId("question-demographic-no-export")
                 .setDisabled(!submittable)
@@ -449,7 +449,7 @@ public final class QuestionEditView extends BaseHtmlView {
     return new SelectWithLabel()
         .setId("question-enumerator-select")
         .setFieldName(QUESTION_ENUMERATOR_FIELD)
-        .setLabelText("Question enumerator *")
+        .setLabelText("Question enumerator*")
         .setOptions(options)
         .setValue(selected);
   }

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -3,8 +3,10 @@ package views.admin.questions;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.input;
+import static j2html.TagCreator.legend;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +40,7 @@ import views.admin.AdminLayoutFactory;
 import views.components.FieldWithLabel;
 import views.components.SelectWithLabel;
 import views.components.ToastMessage;
+import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.Styles;
 
@@ -284,7 +287,7 @@ public final class QuestionEditView extends BaseHtmlView {
       boolean submittable,
       boolean forCreate) {
     QuestionType questionType = questionForm.getQuestionType();
-    FormTag formTag = form().withMethod("POST");
+    FormTag formTag = form().withMethod("POST").with(requiredFieldsExplanationContent());
 
     // The question enumerator and name fields should not be changed after the question is created.
     // If this form is not for creation, the fields are disabled, and hidden fields to pass
@@ -296,7 +299,7 @@ public final class QuestionEditView extends BaseHtmlView {
         FieldWithLabel.input()
             .setId("question-name-input")
             .setFieldName(QUESTION_NAME_FIELD)
-            .setLabelText("Name")
+            .setLabelText("Name *")
             .setDisabled(!submittable)
             .setPlaceholderText("The name displayed in the question builder")
             .setValue(questionForm.getQuestionName());
@@ -343,7 +346,7 @@ public final class QuestionEditView extends BaseHtmlView {
             FieldWithLabel.textArea()
                 .setId("question-text-textarea")
                 .setFieldName("questionText")
-                .setLabelText("Question text")
+                .setLabelText("Question text *")
                 .setPlaceholderText("The question text displayed to the applicant")
                 .setDisabled(!submittable)
                 .setValue(questionForm.getQuestionText())
@@ -354,44 +357,44 @@ public final class QuestionEditView extends BaseHtmlView {
     formTag.with(QuestionConfig.buildQuestionConfig(questionForm, messages));
 
     if (!ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(questionType)) {
-      formTag.with(
-          div()
-              .withId("demographic-field-content")
-              .with(buildDemographicFields(questionForm, submittable)));
+      formTag.with(buildDemographicFields(questionForm, submittable));
     }
 
     return formTag;
   }
 
-  private ImmutableList<DomContent> buildDemographicFields(
-      QuestionForm questionForm, boolean submittable) {
+  private DomContent buildDemographicFields(QuestionForm questionForm, boolean submittable) {
 
     QuestionTag exportState = questionForm.getQuestionExportStateTag();
-    return ImmutableList.of(
-        FieldWithLabel.radio()
-            .setId("question-demographic-no-export")
-            .setDisabled(!submittable)
-            .setFieldName("questionExportState")
-            .setLabelText("No export")
-            .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
-            .setChecked(exportState == QuestionTag.NON_DEMOGRAPHIC)
-            .getRadioTag(),
-        FieldWithLabel.radio()
-            .setId("question-demographic-export-demographic")
-            .setDisabled(!submittable)
-            .setFieldName("questionExportState")
-            .setLabelText("Export Value")
-            .setValue(QuestionTag.DEMOGRAPHIC.getValue())
-            .setChecked(exportState == QuestionTag.DEMOGRAPHIC)
-            .getRadioTag(),
-        FieldWithLabel.radio()
-            .setId("question-demographic-export-pii")
-            .setDisabled(!submittable)
-            .setFieldName("questionExportState")
-            .setLabelText("Export Obfuscated")
-            .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())
-            .setChecked(exportState == QuestionTag.DEMOGRAPHIC_PII)
-            .getRadioTag());
+    // TODO(#2618): Consider using helpers for grouping related radio controls.
+    return fieldset()
+        .withId("demographic-field-content")
+        .with(
+            legend("Export options *").withClass(BaseStyles.INPUT_LABEL),
+            FieldWithLabel.radio()
+                .setId("question-demographic-no-export")
+                .setDisabled(!submittable)
+                .setFieldName("questionExportState")
+                .setLabelText("No export")
+                .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
+                .setChecked(exportState == QuestionTag.NON_DEMOGRAPHIC)
+                .getRadioTag(),
+            FieldWithLabel.radio()
+                .setId("question-demographic-export-demographic")
+                .setDisabled(!submittable)
+                .setFieldName("questionExportState")
+                .setLabelText("Export Value")
+                .setValue(QuestionTag.DEMOGRAPHIC.getValue())
+                .setChecked(exportState == QuestionTag.DEMOGRAPHIC)
+                .getRadioTag(),
+            FieldWithLabel.radio()
+                .setId("question-demographic-export-pii")
+                .setDisabled(!submittable)
+                .setFieldName("questionExportState")
+                .setLabelText("Export Obfuscated")
+                .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())
+                .setChecked(exportState == QuestionTag.DEMOGRAPHIC_PII)
+                .getRadioTag());
   }
 
   private DomContent formQuestionTypeSelect(QuestionType selectedType) {
@@ -446,7 +449,7 @@ public final class QuestionEditView extends BaseHtmlView {
     return new SelectWithLabel()
         .setId("question-enumerator-select")
         .setFieldName(QUESTION_ENUMERATOR_FIELD)
-        .setLabelText("Question enumerator")
+        .setLabelText("Question enumerator *")
         .setOptions(options)
         .setValue(selected);
   }


### PR DESCRIPTION
### Description

While here, I put the program visibility mode / question export mode options inside a fieldset for better grouping (and a place to put field requiredness).

### Screenshots

Program creation:
![Screen Shot 2022-08-15 at 1 44 17 PM](https://user-images.githubusercontent.com/1870301/184715165-4703a97b-1a35-4061-98de-7848bf3fb2c9.png)

Question creation:
![Screen Shot 2022-08-15 at 1 45 12 PM](https://user-images.githubusercontent.com/1870301/184715258-49494726-6060-4e3d-94de-b7c02346ce0e.png)

## Release notes:

Add indicators for which fields are required when editing/creating questions and programs.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3023