### PR TITLE
Removing hover state from application status row.

### DIFF
--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -42,7 +42,6 @@ import views.components.Modal.Width;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.ReferenceClasses;
-import views.style.StyleUtils;
 import views.style.Styles;
 
 public final class ProgramStatusesView extends BaseHtmlView {
@@ -252,8 +251,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
                 Styles.FONT_NORMAL,
                 Styles.SPACE_X_2,
                 Styles.FLEX,
-                Styles.ITEMS_CENTER,
-                StyleUtils.hover(Styles.BG_GRAY_100))
+                Styles.ITEMS_CENTER)
             .with(
                 div()
                     .withClass(Styles.W_1_4)


### PR DESCRIPTION
### Description

Per feedback from @rahaghas, there's no reason to change the background color when hovering over an application status row since clicking it wouldn't do anything.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2752