### PR TITLE
cleanup browsertest-env volumes and add warmup loop

### DIFF
--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -137,6 +137,15 @@ if truth::is_enabled both_emulators; then
   "bin/localstack/wait" "http://localhost:6645"
 fi
 
+# Start a warmup request loop so that when the subsequent server startup is ready, we trigger lazy
+# loading its edit-refresh resources so save developer time.
+for i in {1..60}; do
+  sleep 5
+  if curl --output /dev/null --silent --fail http://localhost:9999/loginForm; then
+    break
+  fi
+done &
+
 # Start everything else.
 echo "Running docker compose to start the CiviForm environment:"
 if truth::is_enabled continuous_integration; then

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -10,11 +10,12 @@ export RECORD_VIDEO=1
 source bin/lib.sh
 docker::set_project_name_browser_tests
 
-docker volume create browser-tests-node-modules
-# The display name returned by test_oidc_provider.js is <username>@example.com.
+# Run browser tests from within the civiform-browser-test container. We map
+# full browser-test local directory to the container so that it uses local changes.
+# node_modules is already mapped to an anonymous volume so that it doesn't
+# conflict with node_modules created locally.
 docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
-  -v "browser-tests-node-modules:/usr/src/civiform-browser-tests/node_modules" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   -e TEST_USER_AUTH_STRATEGY="fake-oidc" \
   -e TEST_USER_LOGIN="testuser" \

--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -5,22 +5,9 @@ services:
   civiform:
     volumes:
       - ./server:/usr/src/server
-      - target:/usr/src/server/target
-      - node_modules-data:/usr/src/server/node_modules
-      - project-data:/usr/src/server/project/project
-      - project-target-data:/usr/src/server/project/target
     stdin_open: true # docker run -i
     tty: true # docker run -t
     ports:
-      - 9457:9457
-    command: -jvm-debug "*:9457" ~run -Dconfig.file=conf/application.dev-browser-tests.conf
-
-volumes:
-  node_modules-data:
-    driver: local
-  project-data:
-    driver: local
-  project-target-data:
-    driver: local
-  target:
-    driver: local
+      - 9100:9000
+      - 9457:8457
+    command: -jvm-debug "*:8457" ~run -Dconfig.file=conf/application.dev.conf

--- a/browser-test/playwright.Dockerfile.dockerignore
+++ b/browser-test/playwright.Dockerfile.dockerignore
@@ -4,8 +4,6 @@ node_modules
 browser-test-compose.yml
 playwright.Dockerfile
 playwright.Dockerfile.dockerignore
-
-
 .bsp/
 .Dockerfile.swp
 .dockerignore

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
       - 3390:3390
 
   civiform:
-    build: .
+    image: civiform-dev
     volumes: *sbt-volumes
     stdin_open: true # docker run -i
     tty: true # docker run -t

--- a/test-support/unit-test-docker-compose.dev.yml
+++ b/test-support/unit-test-docker-compose.dev.yml
@@ -4,17 +4,3 @@ services:
   civiform:
     volumes:
       - ../server:/usr/src/server
-      - target:/usr/src/server/target
-      - node_modules-data:/usr/src/server/node_modules
-      - project-data:/usr/src/server/project/project
-      - project-target-data:/usr/src/server/project/target
-
-volumes:
-  node_modules-data:
-    driver: local
-  project-data:
-    driver: local
-  project-target-data:
-    driver: local
-  target:
-    driver: local


### PR DESCRIPTION
### Description

The browsertest dev env docker-compose had extra unneeded volumes.  Remove them.
Also add a warmup loop so that sbt starts compilation.

## Release notes:

n/a

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
