### PR TITLE
Preventing program admins from accessing applications that aren't part of the provided program

### DIFF
--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -1,0 +1,41 @@
+package services.applications;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.inject.Inject;
+import java.util.Optional;
+import models.Application;
+import repository.ApplicationRepository;
+import services.program.ProgramDefinition;
+
+/** The service responsible for mediating a program admin's access to the Application resource. */
+public final class ProgramAdminApplicationService {
+  private final ApplicationRepository applicationRepository;
+
+  @Inject
+  ProgramAdminApplicationService(ApplicationRepository applicationRepository) {
+    this.applicationRepository = checkNotNull(applicationRepository);
+  }
+
+  /**
+   * Retrieves the application with the given ID and validates that it is associated with the given
+   * program.
+   */
+  public Optional<Application> getApplication(long applicationId, ProgramDefinition program) {
+    Optional<Application> maybeApplication =
+        applicationRepository.getApplication(applicationId).toCompletableFuture().join();
+    if (!maybeApplication.isPresent()) {
+      return Optional.empty();
+    }
+    Application application = maybeApplication.get();
+    if (program.adminName().isEmpty()
+        || !application
+            .getProgram()
+            .getProgramDefinition()
+            .adminName()
+            .equals(program.adminName())) {
+      return Optional.empty();
+    }
+    return Optional.of(application);
+  }
+}

--- a/server/test/services/applications/ProgramAdminApplicationServiceTest.java
+++ b/server/test/services/applications/ProgramAdminApplicationServiceTest.java
@@ -1,0 +1,69 @@
+package services.applications;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import models.Applicant;
+import models.Application;
+import models.LifecycleStage;
+import org.junit.Before;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.program.ProgramDefinition;
+import support.ProgramBuilder;
+
+public class ProgramAdminApplicationServiceTest extends ResetPostgres {
+  private ProgramAdminApplicationService service;
+
+  @Before
+  public void setProgramServiceImpl() {
+    service = instanceOf(ProgramAdminApplicationService.class);
+  }
+
+  @Test
+  public void getApplication() {
+    ProgramDefinition program = ProgramBuilder.newActiveProgram("some-program").buildDefinition();
+
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application application =
+        Application.create(applicant, program.toProgram(), LifecycleStage.ACTIVE)
+            .setSubmitTimeToNow();
+
+    Optional<Application> result = service.getApplication(application.id, program);
+    assertThat(result).isPresent();
+    assertThat(result.get().id).isEqualTo(application.id);
+  }
+
+  @Test
+  public void getApplication_notFound() {
+    ProgramDefinition program = ProgramBuilder.newActiveProgram().buildDefinition();
+    assertThat(service.getApplication(Long.MAX_VALUE, program)).isEmpty();
+  }
+
+  @Test
+  public void getApplication_programMismatch() {
+    ProgramDefinition firstProgram =
+        ProgramBuilder.newActiveProgram("first-program").buildDefinition();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application firstProgramApplication =
+        Application.create(applicant, firstProgram.toProgram(), LifecycleStage.ACTIVE)
+            .setSubmitTimeToNow();
+
+    ProgramDefinition secondProgram =
+        ProgramBuilder.newActiveProgram("second-program").buildDefinition();
+
+    assertThat(service.getApplication(firstProgramApplication.id, secondProgram)).isEmpty();
+  }
+
+  @Test
+  public void getApplication_emptyAdminName() {
+    ProgramDefinition program = ProgramBuilder.newActiveProgram("").buildDefinition();
+
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application application =
+        Application.create(applicant, program.toProgram(), LifecycleStage.ACTIVE)
+            .setSubmitTimeToNow();
+
+    assertThat(service.getApplication(application.id, program)).isEmpty();
+  }
+}


### PR DESCRIPTION
### Description

Added further validation that the retrieved application's associated program name matches the one from the request. Introduced a new service for program admin access of applications to mediate access.

## Release notes:

Preventing program admins from accessing applications that aren't part of the provided program

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
