### PR TITLE
Rename Manage Admin, Link to program website

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -135,7 +135,7 @@ export class AdminPrograms {
       this.withinProgramCardSelector(
         programName,
         'Draft',
-        ':text("Manage Admins")',
+        ':text("Manage Program Admins")',
       ),
     )
     await waitForPageJsLoad(this.page)

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -105,7 +105,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
         FieldWithLabel.input()
             .setId("program-external-link-input")
             .setFieldName("externalLink")
-            .setLabelText("Link for additional program information")
+            .setLabelText("Link to program website")
             .setValue(externalLink)
             .getInputTag(),
         submitButton("Save").withId("program-update-button"));

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -515,7 +515,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   private ButtonTag renderManageProgramAdminsLink(ProgramDefinition program) {
     String adminLink = routes.ProgramAdminManagementController.edit(program.id()).url();
     ButtonTag button =
-        makeSvgTextButton("Manage admins", Icons.GROUP)
+        makeSvgTextButton("Manage Program Admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
     return asRedirectButton(button, adminLink);


### PR DESCRIPTION
### Description

Change "Manage Admins" to "Manage Program Admins"
<img width="369" alt="image" src="https://user-images.githubusercontent.com/1741747/185000741-691bd843-e3dd-495d-82c9-ed7b6f8dcd68.png">

Change "Link for additional program information" to "Link to program website"

<img width="439" alt="image" src="https://user-images.githubusercontent.com/1741747/185000791-681c8627-87bd-4ab3-b173-df4fc1c1e101.png">


## Release notes:

Change "Manage Admins" to "Manage Program Admins"
Change "Link for additional program information" to "Link to program website"

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3034 Fixes #3082; 
