### PR TITLE
Instrument server for Prometheus metrics

### DIFF
--- a/cloud/aws/templates/aws_oidc/app.tf
+++ b/cloud/aws/templates/aws_oidc/app.tf
@@ -170,6 +170,7 @@ module "td" {
 
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled
     CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET          = var.civiform_api_keys_ban_global_subnet
+    CIVIFORM_SERVER_METRICS_ENABLED              = var.civiform_server_metrics_enabled
   }
   log_configuration = {
     logDriver = "awslogs"

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -266,6 +266,6 @@ variable "civiform_api_keys_ban_global_subnet" {
 
 variable "civiform_server_metrics_enabled" {
   type        = bool
-  description = "Whether enable exporting server metrics on the /metrics route."
+  description = "Whether to enable exporting server metrics on the /metrics route."
   default     = false
 }

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -263,3 +263,9 @@ variable "civiform_api_keys_ban_global_subnet" {
   description = "Whether to allow 0.0.0.0/0 subnet for API key access."
   default     = true
 }
+
+variable "civiform_server_metrics_enabled" {
+  type        = bool
+  description = "Whether enable exporting server metrics on the /metrics route."
+  default     = false
+}

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -77,6 +77,7 @@ locals {
 
     CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED = var.feature_flag_status_tracking_enabled
     CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET          = var.civiform_api_keys_ban_global_subnet
+    CIVIFORM_SERVER_METRICS_ENABLED              = var.civiform_server_metrics_enabled
   }
   adfs_client_id     = "adfs-client-id"
   adfs_discovery_uri = "adfs-discovery-uri"

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -268,3 +268,9 @@ variable "civiform_api_keys_ban_global_subnet" {
   description = "Whether to allow 0.0.0.0/0 subnet for API key access."
   default     = true
 }
+
+variable "civiform_server_metrics_enabled" {
+  type        = bool
+  description = "Whether enable exporting server metrics on the /metrics route."
+  default     = false
+}

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -271,6 +271,6 @@ variable "civiform_api_keys_ban_global_subnet" {
 
 variable "civiform_server_metrics_enabled" {
   type        = bool
-  description = "Whether enable exporting server metrics on the /metrics route."
+  description = "Whether to enable exporting server metrics on the /metrics route."
   default     = false
 }

--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -62,6 +62,7 @@ module "app" {
 
   feature_flag_status_tracking_enabled = var.feature_flag_status_tracking_enabled
   civiform_api_keys_ban_global_subnet  = var.civiform_api_keys_ban_global_subnet
+  civiform_server_metrics_enabled      = var.civiform_server_metrics_enabled
 }
 
 module "custom_hostname" {

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -153,6 +153,6 @@ variable "civiform_api_keys_ban_global_subnet" {
 
 variable "civiform_server_metrics_enabled" {
   type        = bool
-  description = "Whether enable exporting server metrics on the /metrics route."
+  description = "Whether to enable exporting server metrics on the /metrics route."
   default     = false
 }

--- a/cloud/azure/templates/azure_saml_ses/variables.tf
+++ b/cloud/azure/templates/azure_saml_ses/variables.tf
@@ -150,3 +150,9 @@ variable "civiform_api_keys_ban_global_subnet" {
   description = "Whether to allow 0.0.0.0/0 subnet for API key access."
   default     = true
 }
+
+variable "civiform_server_metrics_enabled" {
+  type        = bool
+  description = "Whether enable exporting server metrics on the /metrics route."
+  default     = false
+}

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -121,5 +121,11 @@
     "secret": false,
     "tfvar": true,
     "type": "bool"
+  },
+  "CIVIFORM_SERVER_METRICS_ENABLED": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "bool"
   }
 }

--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -8,6 +8,7 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import javax.inject.Inject;
 import play.mvc.Result;
 
@@ -27,6 +28,10 @@ public final class MetricsController extends CiviFormController {
     this.metricsEnabled = checkNotNull(config).getBoolean("server_metrics.enabled");
   }
 
+  /**
+   * Exports server metrics in Prometheus 0.0.4 text format
+   * (https://github.com/Showmax/prometheus-docs/blob/master/content/docs/instrumenting/exposition_formats.md#format-version-004).
+   */
   public Result getMetrics() {
     if (!metricsEnabled) {
       return notFound();
@@ -37,7 +42,7 @@ public final class MetricsController extends CiviFormController {
     try {
       TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
 
     return ok(writer.toString()).as(TextFormat.CONTENT_TYPE_004);

--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -1,0 +1,45 @@
+package controllers.monitoring;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.typesafe.config.Config;
+import controllers.CiviFormController;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import java.io.IOException;
+import java.io.StringWriter;
+import javax.inject.Inject;
+import play.mvc.Result;
+
+/**
+ * Controller for exporting Prometheus server metrics via HTTP. Based on the implementation found in
+ * {@link com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController} and
+ * customized to allow disabling via configuration flag.
+ */
+public final class MetricsController extends CiviFormController {
+
+  private final boolean metricsEnabled;
+  private final CollectorRegistry collectorRegistry;
+
+  @Inject
+  public MetricsController(CollectorRegistry collectorRegistry, Config config) {
+    this.collectorRegistry = checkNotNull(collectorRegistry);
+    this.metricsEnabled = checkNotNull(config).getBoolean("server_metrics.enabled");
+  }
+
+  public Result getMetrics() {
+    if (!metricsEnabled) {
+      return notFound();
+    }
+
+    var writer = new StringWriter();
+
+    try {
+      TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return ok(writer.toString()).as(TextFormat.CONTENT_TYPE_004);
+  }
+}

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -42,6 +42,9 @@ lazy val root = (project in file("."))
       "org.postgresql" % "postgresql" % "42.4.2",
       "com.h2database" % "h2" % "2.1.214" % Test,
 
+      // Metrics collection and export for Prometheus
+      "io.github.jyllands-posten" %% "play-prometheus-filters" % "0.6.1",
+
       // Parameterized testing
       "pl.pragmatists" % "JUnitParams" % "1.1.1" % Test,
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -340,6 +340,14 @@ pac4j.security.rules = [
   }
 ]
 
+# If enabled, allows Prometheus server metrics to be retrieved via the "/metrics" URL path.
+# If "/metrics" disabled, returns a 404.
+server_metrics.enabled = false
+server_metrics.enabled = ${?SERVER_METRICS_ENABLED}
+# Configuration for monitoring library https://github.com/Jyllands-Posten/play-prometheus-filters
+# The Prometheus Hotspot library provides some default collectors for garbage collection, memory pool, etc
+play-prometheus-filters.register-default-hotspot-collectors = true
+
 ## Filter Configuration
 # https://www.playframework.com/documentation/latest/Filters
 # ~~~~~
@@ -347,6 +355,7 @@ pac4j.security.rules = [
 # to give Play greater security.
 #
 play.filters {
+  enabled += com.github.stijndehaes.playprometheusfilters.filters.StatusAndRouteLatencyAndCounterFilter
   enabled += filters.DisableCachingFilter
   enabled += filters.HSTSFilter
   enabled += filters.LoggingFilter
@@ -372,7 +381,7 @@ play.filters {
   # on the security logic setting ApiKey ID as the profile ID on the request object.
   enabled += filters.ApiKeyUsageFilter
 
-## CORS filter configuration
+  ## CORS filter configuration
   # https://www.playframework.com/documentation/latest/CorsFilter
   # ~~~~~
   # CORS is a protocol that allows web applications to make requests from the browser

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -341,7 +341,7 @@ pac4j.security.rules = [
 ]
 
 # If enabled, allows Prometheus server metrics to be retrieved via the "/metrics" URL path.
-# If "/metrics" disabled, returns a 404.
+# If "/metrics" is disabled, returns a 404.
 server_metrics.enabled = false
 server_metrics.enabled = ${?CIVIFORM_SERVER_METRICS_ENABLED}
 # Configuration for monitoring library https://github.com/Jyllands-Posten/play-prometheus-filters

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -343,7 +343,7 @@ pac4j.security.rules = [
 # If enabled, allows Prometheus server metrics to be retrieved via the "/metrics" URL path.
 # If "/metrics" disabled, returns a 404.
 server_metrics.enabled = false
-server_metrics.enabled = ${?SERVER_METRICS_ENABLED}
+server_metrics.enabled = ${?CIVIFORM_SERVER_METRICS_ENABLED}
 # Configuration for monitoring library https://github.com/Jyllands-Posten/play-prometheus-filters
 # The Prometheus Hotspot library provides some default collectors for garbage collection, memory pool, etc
 play-prometheus-filters.register-default-hotspot-collectors = true

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -191,3 +191,5 @@ POST    /dev/seed/clear                  controllers.dev.DatabaseSeedController.
 GET     /dev/feature/:flag/disable     controllers.dev.FeatureFlagOverrideController.disable(request: Request, flag: String)
 GET     /dev/feature/:flag/enable      controllers.dev.FeatureFlagOverrideController.enable(request: Request, flag: String)
 
+## Prometheus metrics export
+GET         /metrics          controllers.monitoring.MetricsController.getMetrics()


### PR DESCRIPTION
### Description

Allows exporting of Prometheus metrics from the CiviForm server, must be enabled with the `CIVIFORM_SERVER_METRICS_ENABLED` environment variable.

## Release notes:

Allows exporting of Prometheus metrics from the CiviForm server, must be enabled with the `CIVIFORM_SERVER_METRICS_ENABLED` environment variable.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
