### PR TITLE
Upload videos on browser test failures when running on CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload test videos on failure
         uses: actions/upload-artifact@v3
         with:
-          name: test videos directory
+          name: tests videos
           path: browser-test/tmp
         if: failure()
       - name: Print logs on failure
@@ -127,7 +127,7 @@ jobs:
       - name: Upload test videos on failure
         uses: actions/upload-artifact@v3
         with:
-          name: test videos directory
+          name: tests videos
           path: browser-test/tmp
         if: failure()
       - name: Print logs on failure

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,6 +72,12 @@ jobs:
         with:
           name: image diff output directory
           path: browser-test/diff_output
+      - name: Upload test videos on failure
+        uses: actions/upload-artifact@v3
+        with:
+          name: test videos directory
+          path: browser-test/tmp
+        if: failure()
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs
@@ -118,6 +124,12 @@ jobs:
         with:
           name: image diff output directory
           path: browser-test/diff_output
+      - name: Upload test videos on failure
+        uses: actions/upload-artifact@v3
+        with:
+          name: test videos directory
+          path: browser-test/tmp
+        if: failure()
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -3,6 +3,9 @@
 # DOC: Run the browser tests in CI mode.
 
 export COMPOSE_INTERACTIVE_NO_CLI=1
+# Enable video recording on CI tests as it will be helpful to debug test
+# failures.
+export RECORD_VIDEO=1
 
 source bin/lib.sh
 docker::set_project_name_browser_tests


### PR DESCRIPTION
### Description

This way it can help us understand the root cause of intermittent azure failures.


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary