### PR TITLE
Fix deploy staging actions broken by moving configs around

### DIFF
--- a/.github/workflows/aws-oidc-deploy-test.yaml
+++ b/.github/workflows/aws-oidc-deploy-test.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/staging-aws-deploy/main/civiform_config.sh > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/aws_staging_civiform_config.sh > civiform_config.sh
 
       - name: Source config, set CIVIFORM_MODE to be "test", Run setup with latest tag
         run: |

--- a/.github/workflows/azure-saml-ses-deploy-test.yaml
+++ b/.github/workflows/azure-saml-ses-deploy-test.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           #  Grab the config from the staging deploy repo to confirm
           #  the changes work with actual data
-          curl https://raw.githubusercontent.com/civiform/staging-azure-deploy/main/civiform_config.sh > civiform_config.sh
+          curl https://raw.githubusercontent.com/civiform/civiform-staging-deploy/main/azure_staging_civiform_config.sh > civiform_config.sh
 
       - name: Source config, set CIVIFORM_MODE to be "test" and deploy with latest snapshot tag
         run: |


### PR DESCRIPTION
### Description

They got broken by https://github.com/civiform/civiform-staging-deploy/pull/7


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
