### PR TITLE
Cleanup calls that pass icon size explicitly

### DIFF
--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -77,7 +77,7 @@ public abstract class BaseHtmlView {
   protected static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {
     return TagCreator.button()
         .with(
-            Icons.svg(icon, 20)
+            Icons.svg(icon)
                 .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0)
                 // Can't set 18px using Tailwind CSS classes.
                 .withStyle("width: 18px; height: 18px;"),

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -417,7 +417,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
                 StyleUtils.hover(Styles.TEXT_GRAY_800, Styles.BG_GRAY_100));
 
     SvgTag icon =
-        Icons.questionTypeSvg(questionDefinition.getQuestionType(), 24)
+        Icons.questionTypeSvg(questionDefinition.getQuestionType())
             .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_6);
     DivTag content =
         div()
@@ -487,7 +487,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
       boolean isInvisible) {
     ButtonTag button =
         submitButton("")
-            .with(Icons.svg(icon, 48).withClasses(Styles.W_6, Styles.H_6))
+            .with(Icons.svg(icon).withClasses(Styles.W_6, Styles.H_6))
             .withClasses(AdminStyles.MOVE_BLOCK_BUTTON)
             .attr("aria-label", label);
     String moveAction =

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -190,7 +190,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                 div()
                     .withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.GAP_4)
                     .with(
-                        Icons.questionTypeSvg(questionDefinition.getQuestionType(), 24)
+                        Icons.questionTypeSvg(questionDefinition.getQuestionType())
                             .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_6))
                     .with(
                         div()
@@ -258,7 +258,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
             Styles.BORDER,
             Styles.BORDER_GRAY_200)
         .with(
-            Icons.questionTypeSvg(questionDefinition.getQuestionType(), 24)
+            Icons.questionTypeSvg(questionDefinition.getQuestionType())
                 .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_6))
         .with(
             div()

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -275,7 +275,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                     Styles.JUSTIFY_CENTER)
                 .withStyle("min-width:90px")
                 .with(
-                    Icons.svg(Icons.NOISE_CONTROL_OFF, 20)
+                    Icons.svg(Icons.NOISE_CONTROL_OFF)
                         .withClasses(Styles.INLINE_BLOCK, Styles.ML_3_5),
                     span(badgeText).withClass(Styles.MR_4)),
             div()

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -264,11 +264,10 @@ public final class ProgramStatusesView extends BaseHtmlView {
                         p().withClasses(
                                 Styles.MT_1, Styles.TEXT_XS, Styles.FLEX, Styles.ITEMS_CENTER)
                             .with(
-                                Icons.svg(Icons.EMAIL, 24)
-                                    // TODO(#3148): Once SVG icon sizes are consistent, just set
-                                    // size to 18.
-                                    .withWidth("18")
-                                    .withHeight("18")
+                                Icons.svg(Icons.EMAIL)
+                                    // Tailwind doesn't have classes for 18px so use inline
+                                    // style.
+                                    .withStyle("width: 18px; height: 18px;")
                                     .withClasses(Styles.MR_2, Styles.INLINE_BLOCK),
                                 span("Applicant notification email added"))),
                 div().withClass(Styles.FLEX_GROW),

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -129,7 +129,7 @@ public final class QuestionsListView extends BaseHtmlView {
                   Styles.TEXT_GRAY_600,
                   StyleUtils.hover(Styles.BG_GRAY_100, Styles.TEXT_GRAY_800))
               .with(
-                  Icons.questionTypeSvg(type, 24)
+                  Icons.questionTypeSvg(type)
                       .withClasses(
                           Styles.INLINE_BLOCK, Styles.H_6, Styles.W_6, Styles.MR_1, Styles.TEXT_SM))
               .with(

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -288,7 +288,7 @@ public class ProgramIndexView extends BaseHtmlView {
               .opensInNewTab()
               .asAnchorText()
               .with(
-                  Icons.svg(Icons.OPEN_IN_NEW, 24)
+                  Icons.svg(Icons.OPEN_IN_NEW)
                       .withClasses(
                           Styles.FLEX_SHRINK_0,
                           Styles.H_5,

--- a/server/app/views/components/Accordion.java
+++ b/server/app/views/components/Accordion.java
@@ -45,7 +45,7 @@ public class Accordion {
     DivTag titleDiv = div(this.title).withClasses(Styles.TEXT_XL, Styles.FONT_LIGHT);
 
     SvgTag accordionSvg =
-        Icons.svg(Icons.ACCORDION_BUTTON, 24)
+        Icons.svg(Icons.ACCORDION_BUTTON)
             .withClasses(Styles.H_6, Styles.W_6)
             .attr("fill", "none")
             .attr("stroke-width", "2")

--- a/server/app/views/components/Icons.java
+++ b/server/app/views/components/Icons.java
@@ -300,23 +300,10 @@ public enum Icons {
   }
 
   /**
-   * Returns SVG element for given icon. Note that callers need to size this element using Tailwind
-   * classes like any other element.
-   */
-  public static SvgTag svg(Icons icon) {
-    return svg(icon, icon.size);
-  }
-
-  /**
    * Returns SVG element for given question. Note that callers need to size this element using
    * Tailwind classes like any other element.
    */
   public static SvgTag questionTypeSvg(QuestionType type) {
-    return questionTypeSvg(type, 24);
-  }
-
-  /** Don't use it. Use {@link #questionTypeSvg(QuestionType type) instead} */
-  public static SvgTag questionTypeSvg(QuestionType type, int size) {
     Icons icon;
     switch (type) {
       case ADDRESS:
@@ -326,7 +313,7 @@ public enum Icons {
         icon = Icons.CHECKBOX;
         break;
       case CURRENCY:
-        return svg(Icons.CURRENCY, size)
+        return svg(Icons.CURRENCY)
             .attr("fill", "none")
             .attr("stroke-linecap", "round")
             .attr("stroke-linejoin", "round")
@@ -359,7 +346,7 @@ public enum Icons {
         icon = Icons.ENUMERATOR;
         break;
       case STATIC:
-        return svg(Icons.ANNOTATION, size)
+        return svg(Icons.ANNOTATION)
             .attr("fill", "none")
             .attr("stroke-linecap", "round")
             .attr("stroke-linejoin", "round")
@@ -370,31 +357,25 @@ public enum Icons {
       default:
         icon = Icons.UNKNOWN;
     }
-    return svg(icon, size);
+    return svg(icon);
   }
 
-  /** Don't use it. Use {@link #questionTypeSvg(QuestionType type) instead} */
-  public static SvgTag svg(Icons icon, int size) {
-    if (icon.size != size) {
-      logger.error(
-          "Trying override size of icon {} to be {} while its actual size{}. Don't pass"
-              + " explicit size to svg(). See"
-              + " https://github.com/civiform/civiform/issues/3148",
-          icon,
-          size,
-          icon.size);
-    }
+  /**
+   * Returns SVG element for given icon. Note that callers need to size this element using Tailwind
+   * classes like any other element.
+   */
+  public static SvgTag svg(Icons icon) {
     // Setting the viewBox to a specific height/width is insufficient to
     // actually cause the SVG's bounds to match. Here, the width / height
     // of the SVG element are explicitly set, which is more consistent
     // with what one would expect given the method signature.
     return svg()
         .with(path(icon.path))
-        .attr("viewBox", String.format("0 0 %1$d %2$d", size, size))
+        .attr("viewBox", String.format("0 0 %1$d %2$d", icon.size, icon.size))
         // TODO(#3148): don't set width/height on the element. Callers should
         // style element themselves using tailwind's classes.
-        .withWidth(String.valueOf(size))
-        .withHeight(String.valueOf(size));
+        .withWidth(String.valueOf(icon.size))
+        .withHeight(String.valueOf(icon.size));
   }
 
   private static SvgTag svg() {

--- a/server/app/views/components/Icons.java
+++ b/server/app/views/components/Icons.java
@@ -1,7 +1,5 @@
 package views.components;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import services.question.types.QuestionType;
 
 /**
@@ -288,8 +286,6 @@ public enum Icons {
   ACCORDION_BUTTON(24, "M19 9l-7 7-7-7"),
   ARROW_UPWARD(48, "M22.5 40V13.7L10.1 26.1 8 24 24 8l16 16-2.1 2.1-12.4-12.4V40Z"),
   ARROW_DOWNWARD(48, "M24 40 8 24l2.1-2.1 12.4 12.4V8h3v26.3l12.4-12.4L40 24Z");
-
-  private static final Logger logger = LoggerFactory.getLogger(Icons.class);
 
   public final String path;
   private final int size;

--- a/server/app/views/components/QuestionBank.java
+++ b/server/app/views/components/QuestionBank.java
@@ -31,7 +31,7 @@ import views.style.Styles;
 /** Contains methods for rendering question bank for an admin to add questions to a program. */
 public class QuestionBank {
   private static final SvgTag PLUS_ICON =
-      Icons.svg(Icons.PLUS, 20)
+      Icons.svg(Icons.PLUS)
           .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_5)
           .attr("fill", "currentColor")
           .attr("stroke-width", "2")
@@ -105,7 +105,7 @@ public class QuestionBank {
                 Styles.SHADOW,
                 StyleUtils.focus(Styles.OUTLINE_NONE));
 
-    SvgTag filterIcon = Icons.svg(Icons.SEARCH, 56).withClasses(Styles.H_4, Styles.W_4);
+    SvgTag filterIcon = Icons.svg(Icons.SEARCH).withClasses(Styles.H_4, Styles.W_4);
     DivTag filterIconDiv =
         div().withClasses(Styles.ABSOLUTE, Styles.ML_4, Styles.MT_3, Styles.MR_4).with(filterIcon);
     DivTag filterDiv = div().withClasses(Styles.RELATIVE).with(filterIconDiv).with(filterInput);
@@ -151,7 +151,7 @@ public class QuestionBank {
             .withClasses(ReferenceClasses.ADD_QUESTION_BUTTON, AdminStyles.CLICK_TARGET_BUTTON);
 
     SvgTag icon =
-        Icons.questionTypeSvg(definition.getQuestionType(), 24)
+        Icons.questionTypeSvg(definition.getQuestionType())
             .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_6);
     DivTag content =
         div()

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -92,7 +92,7 @@ public class TextFormatter {
         urlTag
             .withTarget("_blank")
             .with(
-                Icons.svg(Icons.OPEN_IN_NEW, 24)
+                Icons.svg(Icons.OPEN_IN_NEW)
                     .withClasses(
                         Styles.FLEX_SHRINK_0,
                         Styles.H_5,


### PR DESCRIPTION
### Description

Original icon size is part of the icon definition enum now so passing it explicitly is unnecessary. I manually checked that size that passed explicitly matches icon size so this is a no-op.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3148
