### PR TITLE
Automatically close modal after clicking download

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -552,7 +552,6 @@ export class AdminPrograms {
       this.page.waitForEvent('download'),
       this.page.click('text="Download JSON"'),
     ])
-    await dismissModal(this.page)
     const path = await downloadEvent.path()
     if (path === null) {
       throw new Error('download failed')
@@ -572,7 +571,6 @@ export class AdminPrograms {
       this.page.waitForEvent('download'),
       this.page.click('text="Download CSV"'),
     ])
-    await dismissModal(this.page)
     const path = await downloadEvent.path()
     if (path === null) {
       throw new Error('download failed')

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -211,6 +211,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                 TagCreator.button("Download CSV")
                                     .withClasses(
                                         ReferenceClasses.DOWNLOAD_ALL_BUTTON,
+                                        ReferenceClasses.MODAL_CLOSE,
                                         AdminStyles.PRIMARY_BUTTON_STYLES)
                                     .withFormaction(
                                         controllers.admin.routes.AdminApplicationController
@@ -225,6 +226,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                 TagCreator.button("Download JSON")
                                     .withClasses(
                                         ReferenceClasses.DOWNLOAD_ALL_BUTTON,
+                                        ReferenceClasses.MODAL_CLOSE,
                                         AdminStyles.PRIMARY_BUTTON_STYLES)
                                     .withFormaction(
                                         controllers.admin.routes.AdminApplicationController


### PR DESCRIPTION
### Description

On the admin program list view this makes the download modal automatically close after clicking the download button for csv or json.

## Release notes:

Automatically close Program Application List popup after clicking json or csv download button.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3095 
