### PR TITLE
Adding warnings when no email will be sent as part of updating a program's status

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -1,4 +1,5 @@
 import {
+  dismissModal,
   startSession,
   logout,
   loginAsGuest,
@@ -114,12 +115,14 @@ describe('view program statuses', () => {
 
     describe('when a status is changed, a confirmation dialog is shown', () => {
       it('when rejecting, the selected status is not changed', async () => {
-        await adminPrograms.setStatusOptionAndDismissModal(statusName)
+        const modal = await adminPrograms.setStatusOptionAndAwaitModal(statusName)
+        await dismissModal(adminPrograms.applicationFrame())
         expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
       })
 
       it('when confirmed, the page is redirected with a success toast', async () => {
-        await adminPrograms.setStatusOptionAndConfirmModal(statusName)
+        const modal = await adminPrograms.setStatusOptionAndAwaitModal(statusName)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
         await adminPrograms.expectUpdateStatusToast()
         // TODO(#3020): Assert that the selected status has been updated.

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -503,7 +503,7 @@ export class AdminPrograms {
    * Clicks the confirm button in the status update confirmation dialog and waits until the IFrame
    * containing the modal has been refreshed.
    */
-   async confirmStatusUpdateModal(modal: ElementHandle<HTMLElement>) {
+  async confirmStatusUpdateModal(modal: ElementHandle<HTMLElement>) {
     // Confirming should cause the frame to redirect and waitForNavigation must be called prior
     // to taking the action that would trigger navigation.
     const confirmButton = (await modal.$('text=Confirm'))!

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1,4 +1,4 @@
-import {ElementHandle, Page} from 'playwright'
+import {ElementHandle, Frame, Page} from 'playwright'
 import {readFileSync} from 'fs'
 import {
   clickAndWaitForModal,
@@ -424,6 +424,10 @@ export class AdminPrograms {
 
   private static APPLICATION_DISPLAY_FRAME_NAME = 'application-display-frame'
 
+  applicationFrame(): Frame {
+    return this.page.frame(AdminPrograms.APPLICATION_DISPLAY_FRAME_NAME)!
+  }
+
   applicationFrameLocator() {
     return this.page.frameLocator(
       `iframe[name="${AdminPrograms.APPLICATION_DISPLAY_FRAME_NAME}"]`,
@@ -478,33 +482,9 @@ export class AdminPrograms {
   }
 
   /**
-   * Selects the provided status option and then clicks the confirm button on the resulting
-   * confirmation dialog.
+   * Selects the provided status option and then awaits the confirmation dialog.
    */
-  async setStatusOptionAndConfirmModal(status: string) {
-    const confirmationModal = await this.setStatusOptionAndAwaitModal(status)
-
-    // TODO(#2912): Add support for confirming that the email checkbox appears when an email is
-    // configured.
-
-    // Confirming should cause the frame to redirect and waitForNavigation must be called prior
-    // to taking the action that would trigger navigation.
-    const confirmButton = (await confirmationModal.$('text=Confirm'))!
-    await Promise.all([this.waitForApplicationFrame(), confirmButton.click()])
-  }
-
-  /**
-   * Selects the provided status option and then clicks the cancel button on the resulting
-   * dialog.
-   */
-  async setStatusOptionAndDismissModal(status: string) {
-    await this.setStatusOptionAndAwaitModal(status)
-    return dismissModal(
-      this.page.frame(AdminPrograms.APPLICATION_DISPLAY_FRAME_NAME)!,
-    )
-  }
-
-  private async setStatusOptionAndAwaitModal(
+  async setStatusOptionAndAwaitModal(
     status: string,
   ): Promise<ElementHandle<HTMLElement>> {
     await this.applicationFrameLocator()
@@ -517,6 +497,17 @@ export class AdminPrograms {
     }
 
     return waitForAnyModal(frame)
+  }
+
+  /**
+   * Clicks the confirm button in the status update confirmation dialog and waits until the IFrame
+   * containing the modal has been refreshed.
+   */
+   async confirmStatusUpdateModal(modal: ElementHandle<HTMLElement>) {
+    // Confirming should cause the frame to redirect and waitForNavigation must be called prior
+    // to taking the action that would trigger navigation.
+    const confirmButton = (await modal.$('text=Confirm'))!
+    await Promise.all([this.waitForApplicationFrame(), confirmButton.click()])
   }
 
   async expectUpdateStatusToast() {


### PR DESCRIPTION
### Description

### Screenshots

No email configured for the status:
![Screen Shot 2022-08-25 at 10 30 58 AM](https://user-images.githubusercontent.com/1870301/186731723-64b81380-e33a-4e11-9dc6-bd6bb333a80b.png)

No email provided by applicant: 
![Screen Shot 2022-08-25 at 10 34 07 AM](https://user-images.githubusercontent.com/1870301/186731932-42605f38-618f-4b52-a5da-23a62a4223db.png)

## Release notes:

Adding warnings when no email will be sent as part of updating a program's status

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
