### PR TITLE
Remove uniqueness from application_events indexes

### DIFF
--- a/server/conf/evolutions/default/43.sql
+++ b/server/conf/evolutions/default/43.sql
@@ -1,0 +1,15 @@
+# --- Fix indexes made in evolution 42 to not be unique
+
+# --- !Ups
+
+DROP INDEX IF EXISTS index_application_events_by_application;
+DROP INDEX IF EXISTS index_application_events_by_creator;
+CREATE INDEX index_application_events_by_application ON application_events (application_id);
+CREATE INDEX index_application_events_by_creator ON application_events (creator_id);
+
+# --- !Downs
+
+--- Note we're not recreating the previous indexes as evolution 42 didn't remove
+--- them as it should have, so we're doing the next best thing.
+DROP INDEX IF EXISTS index_application_events_by_application;
+DROP INDEX IF EXISTS index_application_events_by_creator;

--- a/server/test/repository/ApplicationEventRepositoryTest.java
+++ b/server/test/repository/ApplicationEventRepositoryTest.java
@@ -52,7 +52,48 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void getEvents() {
+  public void insertMultipleEventsOnApplication() {
+    Instant startInstant = Instant.now();
+    Program program = resourceCreator.insertActiveProgram("Program");
+    Account actor = resourceCreator.insertAccount();
+    Applicant applicant = resourceCreator.insertApplicant();
+    Application application = resourceCreator.insertActiveApplication(applicant,
+      program);
+
+    ApplicationEventDetails details =
+      ApplicationEventDetails.builder()
+        .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+        .setStatusEvent(
+          StatusEvent.builder().setStatusText("Status").setEmailSent(true)
+            .build()).build();
+
+    ApplicationEvent event1 =
+      new ApplicationEvent(
+        application, actor, ApplicationEventDetails.Type.STATUS_CHANGE,
+        details);
+    ApplicationEvent insertedEvent1 = repo.insertSync(event1);
+
+    ApplicationEvent event2 =
+      new ApplicationEvent(
+        application, actor, ApplicationEventDetails.Type.STATUS_CHANGE,
+        details);
+
+    ApplicationEvent insertedEvent2 = repo.insertSync(event2);
+
+    // Evaluate.
+    assertThat(insertedEvent1.id).isNotEqualTo(insertedEvent2.id);
+    // Generated values.
+    assertThat(insertedEvent2.id).isNotNull();
+    assertThat(insertedEvent2.getCreateTime()).isAfter(startInstant);
+    // Pass through values.
+    assertThat(insertedEvent2.getApplication()).isEqualTo(application);
+    assertThat(insertedEvent2.getCreator()).isEqualTo(actor);
+    assertThat(insertedEvent2.getDetails()).isEqualTo(details);
+    assertThat(insertedEvent2.getEventType()).isEqualTo(
+      ApplicationEventDetails.Type.STATUS_CHANGE);
+  }
+    @Test
+    public void getEvents() {
     // Setup
     Instant startInstant = Instant.now();
     Program program = resourceCreator.insertActiveProgram("Program");

--- a/server/test/repository/ApplicationEventRepositoryTest.java
+++ b/server/test/repository/ApplicationEventRepositoryTest.java
@@ -57,26 +57,23 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
     Program program = resourceCreator.insertActiveProgram("Program");
     Account actor = resourceCreator.insertAccount();
     Applicant applicant = resourceCreator.insertApplicant();
-    Application application = resourceCreator.insertActiveApplication(applicant,
-      program);
+    Application application = resourceCreator.insertActiveApplication(applicant, program);
 
     ApplicationEventDetails details =
-      ApplicationEventDetails.builder()
-        .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
-        .setStatusEvent(
-          StatusEvent.builder().setStatusText("Status").setEmailSent(true)
-            .build()).build();
+        ApplicationEventDetails.builder()
+            .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+            .setStatusEvent(
+                StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
+            .build();
 
     ApplicationEvent event1 =
-      new ApplicationEvent(
-        application, actor, ApplicationEventDetails.Type.STATUS_CHANGE,
-        details);
+        new ApplicationEvent(
+            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
     ApplicationEvent insertedEvent1 = repo.insertSync(event1);
 
     ApplicationEvent event2 =
-      new ApplicationEvent(
-        application, actor, ApplicationEventDetails.Type.STATUS_CHANGE,
-        details);
+        new ApplicationEvent(
+            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
 
     ApplicationEvent insertedEvent2 = repo.insertSync(event2);
 
@@ -89,11 +86,11 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
     assertThat(insertedEvent2.getApplication()).isEqualTo(application);
     assertThat(insertedEvent2.getCreator()).isEqualTo(actor);
     assertThat(insertedEvent2.getDetails()).isEqualTo(details);
-    assertThat(insertedEvent2.getEventType()).isEqualTo(
-      ApplicationEventDetails.Type.STATUS_CHANGE);
+    assertThat(insertedEvent2.getEventType()).isEqualTo(ApplicationEventDetails.Type.STATUS_CHANGE);
   }
-    @Test
-    public void getEvents() {
+
+  @Test
+  public void getEvents() {
     // Setup
     Instant startInstant = Instant.now();
     Program program = resourceCreator.insertActiveProgram("Program");


### PR DESCRIPTION
### Description

Fix issue in #3020 where the foreign key indexes were unique when they should not be.  Added a test to verify multiple events can be saved for the same Application and Account.

## Release notes:

Remove and Recreate indexes on the new application_events table.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
