### PR TITLE
Change data privacy settings option text and add link to documentation

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -222,7 +222,8 @@ describe('normal question lifecycle', () => {
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)
 
-    // Navigate to the new question page and ensure that "No export" is pre-selected.
+    // Navigate to the new question page and ensure that "Don't allow answers to be exported"
+    // is pre-selected.
     await adminQuestions.gotoAdminQuestionsPage()
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -40,9 +40,9 @@ export class AdminQuestions {
 
   static readonly DOES_NOT_REPEAT_OPTION = 'does not repeat'
 
-  public static readonly NO_EXPORT_OPTION = 'No export'
-  public static readonly EXPORT_VALUE_OPTION = 'Export Value'
-  public static readonly EXPORT_OBFUSCATED_OPTION = 'Export Obfuscated'
+  public static readonly NO_EXPORT_OPTION = "Don't allow answers to be exported"
+  public static readonly EXPORT_VALUE_OPTION = 'Export exact answers'
+  public static readonly EXPORT_OBFUSCATED_OPTION = 'Export obfuscated answers'
 
   constructor(page: Page) {
     this.page = page
@@ -72,7 +72,9 @@ export class AdminQuestions {
   }
 
   async expectViewOnlyQuestion(questionName: string) {
-    expect(await this.page.isDisabled('text=No Export')).toEqual(true)
+    expect(
+      await this.page.isDisabled(`text=${AdminQuestions.NO_EXPORT_OPTION}`),
+    ).toEqual(true)
     expect(
       await this.page.isDisabled(`input[value="${questionName}"]`),
     ).toEqual(true)
@@ -373,7 +375,7 @@ export class AdminQuestions {
 
   async exportQuestion(questionName: string) {
     await this.gotoQuestionEditPage(questionName)
-    await this.page.click('text="Export Value"')
+    await this.page.click(`text="${AdminQuestions.EXPORT_VALUE_OPTION}"`)
     await this.clickSubmitButtonAndNavigate('Update')
     await this.expectAdminQuestionsPageWithUpdateSuccessToast()
     await this.expectDraftQuestionExist(questionName)
@@ -381,7 +383,7 @@ export class AdminQuestions {
 
   async exportQuestionOpaque(questionName: string) {
     await this.gotoQuestionEditPage(questionName)
-    await this.page.click('text="Export Obfuscated"')
+    await this.page.click(`text="${AdminQuestions.EXPORT_OBFUSCATED_OPTION}"`)
     await this.clickSubmitButtonAndNavigate('Update')
     await this.expectAdminQuestionsPageWithUpdateSuccessToast()
     await this.expectDraftQuestionExist(questionName)

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -379,7 +379,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setId("question-demographic-no-export")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
-                .setLabelText("No export")
+                .setLabelText("Don't allow answers to be exported")
                 .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
                 .setChecked(exportState == QuestionTag.NON_DEMOGRAPHIC)
                 .getRadioTag(),
@@ -387,7 +387,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setId("question-demographic-export-demographic")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
-                .setLabelText("Export Value")
+                .setLabelText("Export exact answers")
                 .setValue(QuestionTag.DEMOGRAPHIC.getValue())
                 .setChecked(exportState == QuestionTag.DEMOGRAPHIC)
                 .getRadioTag(),
@@ -395,7 +395,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setId("question-demographic-export-pii")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
-                .setLabelText("Export Obfuscated")
+                .setLabelText("Export obfuscated answers")
                 .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())
                 .setChecked(exportState == QuestionTag.DEMOGRAPHIC_PII)
                 .getRadioTag());

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -322,7 +322,6 @@ public final class QuestionEditView extends BaseHtmlView {
 
     formTag.with(
         FieldWithLabel.textArea()
-            .setId("question-description-textarea")
             .setFieldName("questionDescription")
             .setLabelText("Description")
             .setPlaceholderText("The description displayed in the question builder")
@@ -376,7 +375,6 @@ public final class QuestionEditView extends BaseHtmlView {
         .with(
             legend("Data privacy settings*").withClass(BaseStyles.INPUT_LABEL),
             FieldWithLabel.radio()
-                .setId("question-demographic-no-export")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
                 .setLabelText("Don't allow answers to be exported")
@@ -384,7 +382,6 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setChecked(exportState == QuestionTag.NON_DEMOGRAPHIC)
                 .getRadioTag(),
             FieldWithLabel.radio()
-                .setId("question-demographic-export-demographic")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
                 .setLabelText("Export exact answers")
@@ -392,7 +389,6 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setChecked(exportState == QuestionTag.DEMOGRAPHIC)
                 .getRadioTag(),
             FieldWithLabel.radio()
-                .setId("question-demographic-export-pii")
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")
                 .setLabelText("Export obfuscated answers")

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -8,6 +8,8 @@ import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.legend;
+import static j2html.TagCreator.p;
+import static j2html.TagCreator.span;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +40,7 @@ import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
 import views.components.FieldWithLabel;
+import views.components.LinkElement;
 import views.components.SelectWithLabel;
 import views.components.ToastMessage;
 import views.style.BaseStyles;
@@ -374,6 +377,16 @@ public final class QuestionEditView extends BaseHtmlView {
     return fieldset()
         .with(
             legend("Data privacy settings*").withClass(BaseStyles.INPUT_LABEL),
+            p().withClasses(Styles.PX_1, Styles.PB_2, Styles.TEXT_SM, Styles.TEXT_GRAY_600)
+                .with(
+                    span("Learn more about each of the data export settings in the "),
+                    new LinkElement()
+                        .setHref(
+                            "https://docs.civiform.us/user-manual/civiform-admin-guide/manage-questions#question-export-settings")
+                        .setText("documentation")
+                        .opensInNewTab()
+                        .asAnchorText(),
+                    span(".")),
             FieldWithLabel.radio()
                 .setDisabled(!submittable)
                 .setFieldName("questionExportState")


### PR DESCRIPTION
### Description

Updated the link text for these options per https://github.com/civiform/civiform/issues/1914#issuecomment-1220890859 and adding a link to the documentation that explains the options in further detail.

### Screenshots

Before:
![Screen Shot 2022-08-26 at 9 47 37 AM](https://user-images.githubusercontent.com/1870301/186968271-bf73aef5-2f90-40a3-b3e5-b1d039014ad0.png)

After:
![Screen Shot 2022-08-26 at 9 47 25 AM](https://user-images.githubusercontent.com/1870301/186968291-f1b57e2b-271c-4cda-bfd4-7f263f21c423.png)

## Release notes:

Change data privacy settings option text and add link to documentation.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #1914
