### PR TITLE
Pass the UI select application status to the BE and save it.

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -1,6 +1,8 @@
 package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static views.admin.programs.ProgramApplicationView.NEW_STATUS;
+import static views.admin.programs.ProgramApplicationView.SEND_EMAIL;
 
 import annotations.BindingAnnotations.Now;
 import auth.Authorizers;
@@ -344,9 +346,9 @@ public final class AdminApplicationController extends CiviFormController {
     Application application = applicationMaybe.get();
 
     Map<String, String> formData = formFactory.form().bindFromRequest(request).rawData();
-    Optional<String> maybeNewStatus = Optional.ofNullable(formData.get("newStatus"));
-    Optional<String> maybeSendEmail = Optional.ofNullable(formData.get("sendEmail"));
-    // TODO(shanemc-goog): check that the previous status is the current previous status for
+    Optional<String> maybeNewStatus = Optional.ofNullable(formData.get(NEW_STATUS));
+    Optional<String> maybeSendEmail = Optional.ofNullable(formData.get(SEND_EMAIL));
+    // TODO(#3263): check that the previous status is the current previous status for
     // consistency.
     if (maybeNewStatus.isEmpty()) {
       return badRequest("A selected status is not present");
@@ -367,8 +369,7 @@ public final class AdminApplicationController extends CiviFormController {
             .setStatusText(newStatus)
             .setEmailSent(Boolean.parseBoolean(maybeSendEmail.get()))
             .build(),
-        profileUtils.currentUserProfile(request).get().getAccount().join(),
-        ApplicationEventDetails.Type.STATUS_CHANGE);
+        profileUtils.currentUserProfile(request).get().getAccount().join());
     return redirect(routes.AdminApplicationController.show(programId, application.id).url())
         .flashing("success", "Application status updated");
   }

--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -32,10 +32,6 @@ public class Application extends BaseModel {
 
   @ManyToOne private Program program;
 
-  public List<ApplicationEvent> getApplicationEvents() {
-    return applicationEvents;
-  }
-
   @OneToMany(mappedBy = "application")
   private List<ApplicationEvent> applicationEvents;
 
@@ -94,6 +90,10 @@ public class Application extends BaseModel {
         data.hasPreferredLocale() ? data.preferredLocale().toLanguageTag() : null;
     this.object = data.asJsonString();
     return this;
+  }
+
+  public List<ApplicationEvent> getApplicationEvents() {
+    return applicationEvents;
   }
 
   public LifecycleStage getLifecycleStage() {

--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -3,10 +3,12 @@ package models;
 import io.ebean.annotation.DbJson;
 import io.ebean.annotation.WhenCreated;
 import java.time.Instant;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
@@ -29,6 +31,13 @@ public class Application extends BaseModel {
   @ManyToOne private Applicant applicant;
 
   @ManyToOne private Program program;
+
+  public List<ApplicationEvent> getApplicationEvents() {
+    return applicationEvents;
+  }
+
+  @OneToMany(mappedBy = "application")
+  private List<ApplicationEvent> applicationEvents;
 
   @Constraints.Required private LifecycleStage lifecycleStage;
 

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -4,17 +4,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.Inject;
 import java.util.Optional;
+import models.Account;
 import models.Application;
+import models.ApplicationEvent;
+import repository.ApplicationEventRepository;
 import repository.ApplicationRepository;
+import services.application.ApplicationEventDetails;
+import services.application.ApplicationEventDetails.StatusEvent;
 import services.program.ProgramDefinition;
 
 /** The service responsible for mediating a program admin's access to the Application resource. */
 public final class ProgramAdminApplicationService {
   private final ApplicationRepository applicationRepository;
+  private final ApplicationEventRepository eventRepository;
 
   @Inject
-  ProgramAdminApplicationService(ApplicationRepository applicationRepository) {
+  ProgramAdminApplicationService(
+      ApplicationRepository applicationRepository, ApplicationEventRepository eventRepository) {
     this.applicationRepository = checkNotNull(applicationRepository);
+    this.eventRepository = checkNotNull(eventRepository);
   }
 
   /**
@@ -37,5 +45,16 @@ public final class ProgramAdminApplicationService {
       return Optional.empty();
     }
     return Optional.of(application);
+  }
+
+  public void setStatus(
+      Application application,
+      StatusEvent newStatus,
+      Account admin,
+      ApplicationEventDetails.Type type) {
+    ApplicationEventDetails details =
+        ApplicationEventDetails.builder().setEventType(type).setStatusEvent(newStatus).build();
+    ApplicationEvent event = new ApplicationEvent(application, admin, type, details);
+    eventRepository.insertSync(event);
   }
 }

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -47,14 +47,15 @@ public final class ProgramAdminApplicationService {
     return Optional.of(application);
   }
 
-  public void setStatus(
-      Application application,
-      StatusEvent newStatus,
-      Account admin,
-      ApplicationEventDetails.Type type) {
+  public void setStatus(Application application, StatusEvent newStatus, Account admin) {
     ApplicationEventDetails details =
-        ApplicationEventDetails.builder().setEventType(type).setStatusEvent(newStatus).build();
-    ApplicationEvent event = new ApplicationEvent(application, admin, type, details);
+        ApplicationEventDetails.builder()
+            .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+            .setStatusEvent(newStatus)
+            .build();
+    ApplicationEvent event =
+        new ApplicationEvent(
+            application, admin, ApplicationEventDetails.Type.STATUS_CHANGE, details);
     eventRepository.insertSync(event);
   }
 }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -23,6 +23,7 @@ import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
+import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.OptionTag;
 import j2html.tags.specialized.SelectTag;
 import java.net.URLEncoder;
@@ -322,6 +323,13 @@ public final class ProgramApplicationView extends BaseHtmlView {
                 p().with(span("Program: "), span(programName).withClass(Styles.FONT_SEMIBOLD)),
                 div()
                     .withClasses(Styles.MT_4)
+                    // Add the new status to the form hidden.
+                    .with(
+                        input()
+                            .isHidden()
+                            .withType("text")
+                            .withName("newStatus")
+                            .withValue(status.statusText()))
                     .with(
                         renderStatusUpdateConfirmationModalEmailSection(
                             applicantNameWithApplicationId, application, status)),
@@ -350,8 +358,11 @@ public final class ProgramApplicationView extends BaseHtmlView {
       StatusDefinitions.Status status) {
     Optional<String> maybeApplicantEmail =
         Optional.ofNullable(application.getApplicant().getAccount().getEmailAddress());
+    // Send an affirmative sendEmail = false if it's not valid for the Application.
+    InputTag hiddenDisabledEmail = input().withType("checkbox").isHidden().withName("sendEmail");
     if (!status.localizedEmailBodyText().isPresent()) {
       return p().with(
+              hiddenDisabledEmail,
               span(applicantNameWithApplicationId).withClass(Styles.FONT_SEMIBOLD),
               span(
                   " will not receive an email because there is no email content set for this"
@@ -359,6 +370,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                       + " status."));
     } else if (maybeApplicantEmail.isEmpty()) {
       return p().with(
+              hiddenDisabledEmail,
               span(applicantNameWithApplicationId).withClass(Styles.FONT_SEMIBOLD),
               span(
                   " will not receive an email for this change since they have not provided an"
@@ -366,12 +378,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
     }
     return label()
         .with(
-            // Add the new status to the form hidden.
-            input()
-                .isHidden()
-                .withType("text")
-                .withName("newStatus")
-                .withValue(status.statusText()),
             input()
                 .withType("checkbox")
                 .isChecked()

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -366,6 +366,12 @@ public final class ProgramApplicationView extends BaseHtmlView {
     }
     return label()
         .with(
+                    // Add the current and new status to the form hidden.
+                        input()
+                            .isHidden()
+                            .withType("text")
+                            .withName("newStatus")
+                            .withValue(status.statusText()),
             input()
                 .withType("checkbox")
                 .isChecked()

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -366,7 +366,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
     }
     return label()
         .with(
-            // Add the current and new status to the form hidden.
+            // Add the new status to the form hidden.
             input()
                 .isHidden()
                 .withType("text")

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -366,12 +366,12 @@ public final class ProgramApplicationView extends BaseHtmlView {
     }
     return label()
         .with(
-                    // Add the current and new status to the form hidden.
-                        input()
-                            .isHidden()
-                            .withType("text")
-                            .withName("newStatus")
-                            .withValue(status.statusText()),
+            // Add the current and new status to the form hidden.
+            input()
+                .isHidden()
+                .withType("text")
+                .withName("newStatus")
+                .withValue(status.statusText()),
             input()
                 .withType("checkbox")
                 .isChecked()

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -60,6 +60,9 @@ import views.style.Styles;
 
 /** Renders a page for a program admin to view a single submitted application. */
 public final class ProgramApplicationView extends BaseHtmlView {
+
+  public static final String SEND_EMAIL = "sendEmail";
+  public static final String NEW_STATUS = "newStatus";
   private final BaseHtmlLayout layout;
   private final Messages enUsMessages;
 
@@ -328,7 +331,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                         input()
                             .isHidden()
                             .withType("text")
-                            .withName("newStatus")
+                            .withName(NEW_STATUS)
                             .withValue(status.statusText()))
                     .with(
                         renderStatusUpdateConfirmationModalEmailSection(
@@ -359,7 +362,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
     Optional<String> maybeApplicantEmail =
         Optional.ofNullable(application.getApplicant().getAccount().getEmailAddress());
     // Send an affirmative sendEmail = false if it's not valid for the Application.
-    InputTag hiddenDisabledEmail = input().withType("checkbox").isHidden().withName("sendEmail");
+    InputTag hiddenDisabledEmail = input().withType("checkbox").isHidden().withName(SEND_EMAIL);
     if (!status.localizedEmailBodyText().isPresent()) {
       return p().with(
               hiddenDisabledEmail,
@@ -381,7 +384,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
             input()
                 .withType("checkbox")
                 .isChecked()
-                .withName("sendEmail")
+                .withName(SEND_EMAIL)
                 .withClasses(BaseStyles.CHECKBOX),
             span("Notify "),
             span(applicantNameWithApplicationId).withClass(Styles.FONT_SEMIBOLD),

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -23,7 +23,6 @@ import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
-import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.OptionTag;
 import j2html.tags.specialized.SelectTag;
 import java.net.URLEncoder;
@@ -361,11 +360,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
       StatusDefinitions.Status status) {
     Optional<String> maybeApplicantEmail =
         Optional.ofNullable(application.getApplicant().getAccount().getEmailAddress());
-    // Send an affirmative sendEmail = false if it's not valid for the Application.
-    InputTag hiddenDisabledEmail = input().withType("checkbox").isHidden().withName(SEND_EMAIL);
     if (!status.localizedEmailBodyText().isPresent()) {
       return p().with(
-              hiddenDisabledEmail,
               span(applicantNameWithApplicationId).withClass(Styles.FONT_SEMIBOLD),
               span(
                   " will not receive an email because there is no email content set for this"
@@ -373,7 +369,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
                       + " status."));
     } else if (maybeApplicantEmail.isEmpty()) {
       return p().with(
-              hiddenDisabledEmail,
               span(applicantNameWithApplicationId).withClass(Styles.FONT_SEMIBOLD),
               span(
                   " will not receive an email for this change since they have not provided an"

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -210,7 +210,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.STATUS_CHANGE);
     assertThat(gotEvent.getDetails().statusEvent()).isPresent();
-    assertThat(gotEvent.getDetails().statusEvent().get().statusText()).isEqualTo(APPROVED_STATUS.statusText());
+    assertThat(gotEvent.getDetails().statusEvent().get().statusText())
+        .isEqualTo(APPROVED_STATUS.statusText());
     assertThat(gotEvent.getCreator()).isEqualTo(adminAccount);
     assertThat(gotEvent.getCreateTime()).isAfter(start);
   }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -195,9 +195,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
-                    .bodyForm(
-                        Map.of("newStatus", APPROVED_STATUS.statusText(), "sendEmail", "false")))
+                Helpers.fakeRequest().bodyForm(Map.of("newStatus", APPROVED_STATUS.statusText())))
             .build();
 
     // Execute

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -4,22 +4,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
+import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 
+import auth.CiviFormProfile;
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import auth.ProfileUtils;
+import com.google.inject.util.Providers;
 import featureflags.FeatureFlags;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
 import models.Applicant;
 import models.Application;
 import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.core.context.session.SessionStore;
+import play.i18n.MessagesApi;
+import play.libs.concurrent.HttpExecutionContext;
+import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.test.Helpers;
+import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import services.DateConverter;
+import services.applicant.ApplicantService;
+import services.applications.ProgramAdminApplicationService;
+import services.export.ExporterService;
+import services.export.JsonExporter;
+import services.export.PdfExporter;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import support.ProgramBuilder;
+import views.admin.programs.ProgramApplicationListView;
+import views.admin.programs.ProgramApplicationView;
 
 public class AdminApplicationControllerTest extends ResetPostgres {
   // NOTE: the controller asserts the user is valid on the program that applications are requested
@@ -45,6 +69,28 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             /* fromDate= */ Optional.empty(),
             /* untilDate= */ Optional.empty());
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void index() throws Exception {
+
+    controller = makeNoOpProfileController();
+    Program program = ProgramBuilder.newActiveProgram().build();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    applicant.refresh();
+    Application application =
+        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+    application.refresh();
+    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Result result =
+        controller.index(
+            request,
+            program.id,
+            /* search= */ Optional.empty(),
+            /* page= */ Optional.of(1), // Needed to skip redirect.
+            /* fromDate= */ Optional.empty(),
+            /* untilDate= */ Optional.empty());
+    assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test
@@ -125,5 +171,61 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     Result result = controller.updateNote(request, program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  // Returns a controller with a faked ProfileUtils to bypass acl checks.
+  AdminApplicationController makeNoOpProfileController() {
+    return new AdminApplicationController(
+        instanceOf(ProgramService.class),
+        instanceOf(ApplicantService.class),
+        instanceOf(ExporterService.class),
+        instanceOf(JsonExporter.class),
+        instanceOf(PdfExporter.class),
+        instanceOf(ProgramApplicationListView.class),
+        instanceOf(ProgramApplicationView.class),
+        instanceOf(ProgramAdminApplicationService.class),
+        instanceOf(ProfileUtilsNoOpTester.class),
+        instanceOf(MessagesApi.class),
+        instanceOf(DateConverter.class),
+        Providers.of(LocalDateTime.now(ZoneId.systemDefault())),
+        instanceOf(FeatureFlags.class));
+  }
+
+  // A test version of ProfileUtils that disable functionality that is hard
+  // to otherwise test around.
+  static class ProfileUtilsNoOpTester extends ProfileUtils {
+    private final ProfileTester profileTester;
+
+    @Inject
+    public ProfileUtilsNoOpTester(
+        SessionStore sessionStore, ProfileFactory profileFactory, ProfileTester profileTester) {
+      super(sessionStore, profileFactory);
+      this.profileTester = profileTester;
+    }
+
+    // Returns a Profile that will never fail auth checks.
+    @Override
+    public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
+      return Optional.of(profileTester);
+    }
+
+    // A test version of CiviFormProfile that disable functionality that is hard
+    // to otherwise test around.
+    static class ProfileTester extends CiviFormProfile {
+
+      @Inject
+      public ProfileTester(
+          DatabaseExecutionContext dbContext,
+          HttpExecutionContext httpContext,
+          CiviFormProfileData profileData) {
+        super(dbContext, httpContext, profileData);
+      }
+
+      // Always passes and does no checks.
+      @Override
+      public CompletableFuture<Void> checkProgramAuthorization(String programName) {
+        return CompletableFuture.completedFuture(null);
+      }
+    }
   }
 }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -177,6 +177,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
+  // TODO(shanemc-goog): Add invalid data tests.
+  // TODO(shanemc-goog): Add email set tests.
   @Test
   public void updateStatus() throws Exception {
     // Setup

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -177,8 +177,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
-  // TODO(shanemc-goog): Add invalid data tests.
-  // TODO(shanemc-goog): Add email set tests.
+  // TODO(#3263): Add invalid data tests.
+  // TODO(#3263): Add email set tests.
   @Test
   public void updateStatus() throws Exception {
     // Setup

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -93,9 +93,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
   private static final ImmutableList<Status> ORIGINAL_STATUSES =
       ImmutableList.of(APPROVED_STATUS, REJECTED_STATUS, WITH_STATUS_TRANSLATIONS);
-  // NOTE: the controller asserts the user is valid on the program that applications are requested
-  // for. However, we currently have no pattern for setting a profile in a test request, so we can't
-  // make affirmative tests.
   private AdminApplicationController controller;
 
   @Before


### PR DESCRIPTION
### Description

Pipe the UI selected status to the BE and into the DB.

## Release notes:

UI selection of a status by a Project Admin is now saved into the database.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3263