### PR TITLE
Clear database before running application_navigation screenshot tests

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -19,7 +19,8 @@ describe('Applicant navigation flow', () => {
 
   beforeAll(async () => {
     const {page} = await startSession()
-    await dropTables(page)
+    // Clear db to prevent screenshot test failures.
+    await resetSession(page, /* clearDb= */ true)
     pageObject = page
   })
 

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -11,6 +11,7 @@ import {
   resetSession,
   validateAccessibility,
   validateScreenshot,
+  dropTables,
 } from './support'
 
 describe('Applicant navigation flow', () => {
@@ -18,6 +19,7 @@ describe('Applicant navigation flow', () => {
 
   beforeAll(async () => {
     const {page} = await startSession()
+    await dropTables(page)
     pageObject = page
   })
 

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -11,7 +11,6 @@ import {
   resetSession,
   validateAccessibility,
   validateScreenshot,
-  dropTables,
 } from './support'
 
 describe('Applicant navigation flow', () => {


### PR DESCRIPTION
### Description

Browser tests are currently failing in CI due to interaction between tests. This clears the database before running the screenshot tests to fix the issue.

## Release notes:

N/A

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
