### PR TITLE
Add ProfileUtils tester to unlock testing being an admin/program ACL.

### DIFF
--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -77,10 +77,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     controller = makeNoOpProfileController();
     Program program = ProgramBuilder.newActiveProgram().build();
     Applicant applicant = resourceCreator.insertApplicantWithAccount();
-    applicant.refresh();
-    Application application =
-        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
-    application.refresh();
+    Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     Result result =
         controller.index(

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -4,22 +4,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
+import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 
+import auth.CiviFormProfile;
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import auth.ProfileUtils;
+import com.google.inject.util.Providers;
 import featureflags.FeatureFlags;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
 import models.Applicant;
 import models.Application;
 import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.core.context.session.SessionStore;
+import play.i18n.MessagesApi;
+import play.libs.concurrent.HttpExecutionContext;
+import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.test.Helpers;
+import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import services.DateConverter;
+import services.applicant.ApplicantService;
+import services.applications.ProgramAdminApplicationService;
+import services.export.ExporterService;
+import services.export.JsonExporter;
+import services.export.PdfExporter;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import support.ProgramBuilder;
+import views.admin.programs.ProgramApplicationListView;
+import views.admin.programs.ProgramApplicationView;
 
 public class AdminApplicationControllerTest extends ResetPostgres {
   // NOTE: the controller asserts the user is valid on the program that applications are requested
@@ -45,6 +69,28 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             /* fromDate= */ Optional.empty(),
             /* untilDate= */ Optional.empty());
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void index() throws Exception {
+
+    controller = makeNoOpProfileController();
+    Program program = ProgramBuilder.newActiveProgram().build();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    applicant.refresh();
+    Application application =
+        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+    application.refresh();
+    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Result result =
+        controller.index(
+            request,
+            program.id,
+            /* search= */ Optional.empty(),
+            /* page= */ Optional.of(1), // Needed to skip redirect.
+            /* fromDate= */ Optional.empty(),
+            /* untilDate= */ Optional.empty());
+    assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test
@@ -125,5 +171,61 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     Result result = controller.updateNote(request, program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  // Returns a controller with a faked ProfileUtils to bypass acl checks.
+  AdminApplicationController makeNoOpProfileController() {
+    return new AdminApplicationController(
+        instanceOf(ProgramService.class),
+        instanceOf(ApplicantService.class),
+        instanceOf(ExporterService.class),
+        instanceOf(JsonExporter.class),
+        instanceOf(PdfExporter.class),
+        instanceOf(ProgramApplicationListView.class),
+        instanceOf(ProgramApplicationView.class),
+        instanceOf(ProgramAdminApplicationService.class),
+        instanceOf(ProfileUtilsNoOpTester.class),
+        instanceOf(MessagesApi.class),
+        instanceOf(DateConverter.class),
+        Providers.of(LocalDateTime.now(ZoneId.systemDefault())),
+        instanceOf(FeatureFlags.class));
+  }
+
+  // A test version of ProfileUtils that disable functionality that is hard
+  // to otherwise test around.
+  static class ProfileUtilsNoOpTester extends ProfileUtils {
+    private final ProfileTester profileTester;
+
+    @Inject
+    public ProfileUtilsNoOpTester(
+        SessionStore sessionStore, ProfileFactory profileFactory, ProfileTester profileTester) {
+      super(sessionStore, profileFactory);
+      this.profileTester = profileTester;
+    }
+
+    // Returns a Profile that will never fail auth checks.
+    @Override
+    public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
+      return Optional.of(profileTester);
+    }
+
+    // A test version of CiviFormProfile that disable functionality that is hard
+    // to otherwise test around.
+    static class ProfileTester extends CiviFormProfile {
+
+      @Inject
+      public ProfileTester(
+          DatabaseExecutionContext dbContext,
+          HttpExecutionContext httpContext,
+          CiviFormProfileData profileData) {
+        super(dbContext, httpContext, profileData);
+      }
+
+      // Always passes and does no checks.
+      @Override
+      public CompletableFuture<Void> checkProgramAuthorization(String programName) {
+        return CompletableFuture.completedFuture(null);
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

Created a ProfileUtils fake for testing.  Admin Application features are guarded behind ACLs that we currently don't have a pattern for creating the data or faking otherwise.  This utility just bypasses all checks so subsequent code can be tested.

## Release notes:

NA/ testing only

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
