### PR TITLE
Add display of Feature Flag overriding allowance configuration.

### DIFF
--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -18,9 +18,23 @@ import play.mvc.Result;
  */
 public final class FeatureFlagOverrideController extends DevController {
 
+  private final FeatureFlags featureFlags;
+
   @Inject
-  public FeatureFlagOverrideController(Environment environment, Config configuration) {
+  public FeatureFlagOverrideController(
+      Environment environment, Config configuration, FeatureFlags featureFlags) {
     super(environment, configuration);
+    this.featureFlags = featureFlags;
+  }
+
+  @Secure(authorizers = Labels.CIVIFORM_ADMIN)
+  public Result index(Request request) {
+    return ok(
+        String.format(
+            "Overrides are allowed if all are true:\n"
+                + "Server environment: %s\n"
+                + "Configuration: %s",
+            isDevOrStagingEnvironment(), featureFlags.areOverridesEnabled()));
   }
 
   @Secure(authorizers = Labels.ANY_ADMIN)

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -27,7 +27,7 @@ public final class FeatureFlags {
     this.config = checkNotNull(config);
   }
 
-  private boolean areOverridesEnabled() {
+  public boolean areOverridesEnabled() {
     return config.hasPath(FEATURE_FLAG_OVERRIDES_ENABLED)
         && config.getBoolean(FEATURE_FLAG_OVERRIDES_ENABLED);
   }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -187,6 +187,7 @@ GET     /dev/icons                       controllers.dev.IconsController.index()
 POST    /dev/seed                        controllers.dev.DatabaseSeedController.seed()
 POST    /dev/seed/clear                  controllers.dev.DatabaseSeedController.clear()
 # Change feature flags.
+GET     /dev/feature                  controllers.dev.FeatureFlagOverrideController.index(request: Request)
 GET     /dev/feature/:flag/disable     controllers.dev.FeatureFlagOverrideController.disable(request: Request, flag: String)
 GET     /dev/feature/:flag/enable      controllers.dev.FeatureFlagOverrideController.enable(request: Request, flag: String)
 


### PR DESCRIPTION
### Description
Adds a simple view to understand if feature flag overriding is enabled.

Display is of the form

```
Overrides are allowed if all are true:
Server environment: true
Configuration: true
```

## Release notes:

Add a way for Admins to understand if feature flag overriding is configured.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
