### PR TITLE
Surface latest status within the UI, backed by a DB trigger to populate the value

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -128,18 +128,16 @@ describe('view program statuses', () => {
         const modal = await adminPrograms.setStatusOptionAndAwaitModal(
           noEmailStatusName,
         )
+        expect(await modal.innerText()).toContain(
+          `Status Change: Unset -> ${noEmailStatusName}`,
+        )
         await adminPrograms.confirmStatusUpdateModal(modal)
         expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
 
       it('when no email is configured for the status, a warning is shown', async () => {
-        const modal = await adminPrograms.setStatusOptionAndAwaitModal(
-          noEmailStatusName,
-        )
-        expect(await modal.innerText()).toContain(
-          'will not receive an email because there is no email content set for this status.',
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await dismissModal(adminPrograms.applicationFrame())
       })
 
@@ -153,6 +151,17 @@ describe('view program statuses', () => {
         await dismissModal(adminPrograms.applicationFrame())
       })
 
+      it('when changing status, the previous status is shown', async () => {
+        expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
+        const modal = await adminPrograms.setStatusOptionAndAwaitModal(
+          emailStatusName,
+        )
+        expect(await modal.innerText()).toContain(
+          `Status Change: ${noEmailStatusName} -> ${emailStatusName}`,
+        )
+        await dismissModal(adminPrograms.applicationFrame())
+      })
+
       // TODO(#3297): Add a test that the send email checkbox is shown when an applicant has logged
       // in and an email is configured for the status.
     })
@@ -160,7 +169,7 @@ describe('view program statuses', () => {
     it('allows editing a note', async () => {
       await adminPrograms.editNote('Some note content')
       await adminPrograms.expectNoteUpdatedToast()
-      // TODO(#3020): Assert that the note has been updated.
+      // TODO(#3264): Assert that the note has been updated.
     })
   })
 })

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -129,9 +129,8 @@ describe('view program statuses', () => {
           noEmailStatusName,
         )
         await adminPrograms.confirmStatusUpdateModal(modal)
-        expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
+        expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         await adminPrograms.expectUpdateStatusToast()
-        // TODO(#3020): Assert that the selected status has been updated.
       })
 
       it('when no email is configured for the status, a warning is shown', async () => {

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -404,7 +404,7 @@ public final class AdminApplicationController extends CiviFormController {
       return notFound(String.format("Application %d does not exist.", applicationId));
     }
 
-    // TODO(#3020): Actually edit the note rather than unconditionally returning success.
+    // TODO(#3264): Actually edit the note rather than unconditionally returning success.
     return redirect(
             routes.AdminApplicationController.show(programId, applicationMaybe.get().id).url())
         .flashing("success", "Application note updated");

--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -120,7 +120,14 @@ public class Application extends BaseModel {
     return this;
   }
 
-  /** Returns the latest application status value associated with the applicaton. */
+  /**
+   * Returns the latest application status value associated with the application.
+   *
+   * <p>This value is updated by DB triggers defined in conf/evolutions/default/44.sql which set the
+   * status to the latest ApplicationEventDetails event for the application with a type of
+   * "status_change". Attempts to update the status manually will be overridden by the trigger (and
+   * has associated tests confirming this).
+   */
   public Optional<String> getLatestStatus() {
     return Optional.ofNullable(latestStatus);
   }

--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -121,12 +121,15 @@ public class Application extends BaseModel {
   }
 
   /**
-   * Returns the latest application status value associated with the application.
+   * Returns the latest application status text value associated with the application.
    *
    * <p>This value is updated by DB triggers defined in conf/evolutions/default/44.sql which set the
    * status to the latest ApplicationEventDetails event for the application with a type of
    * "status_change". Attempts to update the status manually will be overridden by the trigger (and
    * has associated tests confirming this).
+   *
+   * <p>If information about the actual event that set this status is desired, make use of
+   * getApplicationEvents instead.
    */
   public Optional<String> getLatestStatus() {
     return Optional.ofNullable(latestStatus);

--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -1,5 +1,6 @@
 package models;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.ebean.annotation.DbJson;
 import io.ebean.annotation.WhenCreated;
 import java.time.Instant;
@@ -44,6 +45,7 @@ public class Application extends BaseModel {
   private Instant submitTime;
   private String preferredLocale;
   private String submitterEmail;
+  private String latestStatus;
 
   public Application(Applicant applicant, Program program, LifecycleStage lifecycleStage) {
     this.applicant = applicant;
@@ -116,5 +118,19 @@ public class Application extends BaseModel {
   public Application setSubmitTimeToNow() {
     this.submitTime = Instant.now();
     return this;
+  }
+
+  /** Returns the latest application status value associated with the applicaton. */
+  public Optional<String> getLatestStatus() {
+    return Optional.ofNullable(latestStatus);
+  }
+
+  /**
+   * This is visible only for tests to manipulate the latest status directly in order to ensure that
+   * updates to it are overridden by the configured database trigger.
+   */
+  @VisibleForTesting
+  void setLatestStatusForTest(String latestStatus) {
+    this.latestStatus = latestStatus;
   }
 }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -301,8 +301,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
       String applicantNameWithApplicationId,
       StatusDefinitions.Status status,
       Http.Request request) {
-    // TODO(#3020): Populate the modal content with the previous configured status.
-    String previousStatus = "Unset";
+    String previousStatus = application.getLatestStatus().orElse("Unset");
     FormTag modalContent =
         form()
             .withAction(

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -23,7 +23,6 @@ import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
-import j2html.tags.specialized.OptionTag;
 import j2html.tags.specialized.SelectTag;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -126,7 +125,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                         div()
                             .withClasses(Styles.FLEX, Styles.MR_4, Styles.SPACE_X_2)
                             .with(
-                                renderStatusOptionsSelector(statusDefinitions),
+                                renderStatusOptionsSelector(application, statusDefinitions),
                                 updateNoteModal.getButton()))
                     .with(renderDownloadButton(programId, application.id)))
             .with(
@@ -222,7 +221,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     Styles.FLEX_AUTO, Styles.TEXT_RIGHT, Styles.FONT_LIGHT, Styles.TEXT_XS));
   }
 
-  private DivTag renderStatusOptionsSelector(StatusDefinitions statusDefinitions) {
+  private DivTag renderStatusOptionsSelector(
+      Application application, StatusDefinitions statusDefinitions) {
     final String SELECTOR_ID = RandomStringUtils.randomAlphabetic(8);
     DivTag container =
         div()
@@ -251,16 +251,16 @@ public final class ProgramApplicationView extends BaseHtmlView {
     dropdownTag.with(
         option(enUsMessages.at(MessageKey.DROPDOWN_PLACEHOLDER.getKeyName()))
             .isDisabled()
-            .isSelected());
+            .withCondSelected(!application.getLatestStatus().isPresent()));
 
     // Add statuses in the order they're provided.
-    statusDefinitions
-        .getStatuses()
+    statusDefinitions.getStatuses().stream()
+        .map(StatusDefinitions.Status::statusText)
         .forEach(
-            status -> {
-              String value = status.statusText();
-              OptionTag optionTag = option(value).withValue(value);
-              dropdownTag.with(optionTag);
+            statusText -> {
+              boolean isCurrentStatus = statusText.equals(application.getLatestStatus().orElse(""));
+              dropdownTag.with(
+                  option(statusText).withValue(statusText).withCondSelected(isCurrentStatus));
             });
     return container.with(dropdownTag);
   }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -258,7 +258,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
         .map(StatusDefinitions.Status::statusText)
         .forEach(
             statusText -> {
-              boolean isCurrentStatus = statusText.equals(application.getLatestStatus().orElse(""));
+              String latestStatusText = application.getLatestStatus().orElse("");
+              boolean isCurrentStatus = statusText.equals(latestStatusText);
               dropdownTag.with(
                   option(statusText).withValue(statusText).withCondSelected(isCurrentStatus));
             });

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -254,11 +254,11 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .withCondSelected(!application.getLatestStatus().isPresent()));
 
     // Add statuses in the order they're provided.
+    String latestStatusText = application.getLatestStatus().orElse("");
     statusDefinitions.getStatuses().stream()
         .map(StatusDefinitions.Status::statusText)
         .forEach(
             statusText -> {
-              String latestStatusText = application.getLatestStatus().orElse("");
               boolean isCurrentStatus = statusText.equals(latestStatusText);
               dropdownTag.with(
                   option(statusText).withValue(statusText).withCondSelected(isCurrentStatus));

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -12,7 +12,7 @@ alter table applications add column if not exists latest_status varchar;
 
 -- The latest status associated with an application is set to NULL if no application event entries
 -- exist. Otherwise, the text from the latest event corresponding to a status change is used.
-CREATE OR REPLACE FUNCTION retrieve_latest_status(app_id applications.id%TYPE) RETURNS text AS $$
+CREATE OR REPLACE FUNCTION retrieve_latest_application_status(app_id applications.id%TYPE) RETURNS text AS $$
   SELECT
       (CASE WHEN details->'status_event'->>'status_text' = ''
         THEN NULL
@@ -28,39 +28,46 @@ $$ LANGUAGE SQL;
 
 -- A function that sets the "latest_status" column anytime an application is updated.
 -- Note: The "NEW" variable corresponds to the application record to be inserted / updated.
-CREATE OR REPLACE FUNCTION process_application_change() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION process_latest_status_on_application_change() RETURNS TRIGGER AS $$
   BEGIN
-    NEW.latest_status := retrieve_latest_status(NEW.id);;
+    NEW.latest_status := retrieve_latest_application_status(NEW.id);;
     RETURN NEW;;
   END;;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
-    FOR EACH ROW EXECUTE FUNCTION process_application_change();
-
 -- A function that sets the "latest_status" column on the referenced application record anytime
 -- an event record is updated.
 -- Note: The "NEW" variable corresponds to the application event record to be inserted / updated.
-CREATE OR REPLACE FUNCTION process_application_event_change() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION process_latest_status_on_application_event_change() RETURNS TRIGGER AS $$
   BEGIN
     IF ((NEW.details->>'event_type') = 'STATUS_CHANGE') THEN
       UPDATE applications
-        SET latest_status = retrieve_latest_status(NEW.application_id)
+        -- Don't always use the status event being modified since we care only about setting the
+        -- latest_status column based on the most recent application event, which isn't necessarily
+        -- the event being modified.
+        SET latest_status = retrieve_latest_application_status(NEW.application_id)
       WHERE id = NEW.application_id;;
     END IF;;
     RETURN NULL;; -- result is ignored for triggers that execute after an insert
   END;;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER application_event_change
-AFTER INSERT OR UPDATE ON application_events
-  FOR EACH ROW EXECUTE FUNCTION process_application_event_change();
+-- Triggers are set for any insert/updates to the applications / application_events tables. The
+-- application_events trigger is necessary in order to ensure the latest_status field is kept up to
+-- date on the application. The application trigger provides defense against application code
+-- attempting to explicitly set / modify the latest_status column. This column is intended to be
+-- readonly and the trigger enforces that even if application code attempts otherwise. There are
+-- unit tests to assert this in ApplicationTest.java.
+CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
+    FOR EACH ROW EXECUTE FUNCTION process_latest_status_on_application_change();
+CREATE TRIGGER application_event_change BEFORE INSERT OR UPDATE ON application_events
+    FOR EACH ROW EXECUTE FUNCTION process_latest_status_on_application_event_change();
 
 # --- !Downs
 
 DROP TRIGGER application_event_change ON application_events;
 DROP TRIGGER application_change ON applications;
-DROP FUNCTION IF EXISTS process_application_event_change;
-DROP FUNCTION IF EXISTS process_application_change;
-DROP FUNCTION IF EXISTS retrieve_latest_status;
+DROP FUNCTION IF EXISTS process_latest_status_on_application_event_change;
+DROP FUNCTION IF EXISTS process_latest_status_on_application_change;
+DROP FUNCTION IF EXISTS retrieve_latest_application_status;
 alter table applications drop column if exists latest_status;

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -1,10 +1,15 @@
 # --- Add database triggers to set the latest_status column on creating an application_event or
 # --- updating an application.
+# --- Relevant documentation:
+# --- Trigger functions: https://www.postgresql.org/docs/current/sql-createtrigger.html
+# --- Create trigger statement: https://www.postgresql.org/docs/current/sql-createtrigger.html
 
 # --- !Ups
 
 alter table applications add column if not exists latest_status varchar;
 
+-- The latest status associated with an application is set to NULL if no application event entries
+-- exist. Otherwise, the text from the latest event corresponding to a status change is used.
 CREATE OR REPLACE FUNCTION retrieve_latest_status(app_id applications.id%TYPE) RETURNS text AS $$
   SELECT
       (CASE WHEN details->'status_event'->>'status_text' = ''
@@ -19,6 +24,8 @@ CREATE OR REPLACE FUNCTION retrieve_latest_status(app_id applications.id%TYPE) R
       LIMIT 1
 $$ LANGUAGE SQL;
 
+-- A function that sets the "latest_status" column anytime an application is updated.
+-- Note: The "NEW" variable corresponds to the application record to be inserted / updated.
 CREATE OR REPLACE FUNCTION process_application_change() RETURNS TRIGGER AS $$
   BEGIN
     NEW.latest_status := retrieve_latest_status(NEW.id);;
@@ -26,6 +33,12 @@ CREATE OR REPLACE FUNCTION process_application_change() RETURNS TRIGGER AS $$
   END;;
 $$ LANGUAGE plpgsql;
 
+CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
+    FOR EACH ROW EXECUTE FUNCTION process_application_change();
+
+-- A function that sets the "latest_status" column on the referenced application record anytime
+-- an event record is updated.
+-- Note: The "NEW" variable corresponds to the application event record to be inserted / updated.
 CREATE OR REPLACE FUNCTION process_application_event_change() RETURNS TRIGGER AS $$
   BEGIN
     IF ((NEW.details->>'event_type') = 'STATUS_CHANGE') THEN
@@ -33,7 +46,7 @@ CREATE OR REPLACE FUNCTION process_application_event_change() RETURNS TRIGGER AS
         SET latest_status = retrieve_latest_status(NEW.application_id)
       WHERE id = NEW.application_id;;
     END IF;;
-    RETURN NULL;; -- result is ignored since this is an AFTER
+    RETURN NULL;; -- result is ignored for triggers that execute after an insert
   END;;
 $$ LANGUAGE plpgsql;
 
@@ -41,13 +54,10 @@ CREATE TRIGGER application_event_change
 AFTER INSERT OR UPDATE ON application_events
   FOR EACH ROW EXECUTE FUNCTION process_application_event_change();
 
-CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
-    FOR EACH ROW EXECUTE FUNCTION process_application_change();
-
 # --- !Downs
 
-DROP TRIGGER application_change ON applications;
 DROP TRIGGER application_event_change ON application_events;
+DROP TRIGGER application_change ON applications;
 DROP FUNCTION IF EXISTS process_application_event_change;
 DROP FUNCTION IF EXISTS process_application_change;
 DROP FUNCTION IF EXISTS retrieve_latest_status;

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION process_application_change() RETURNS TRIGGER AS $$
   END;;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION process_status_change() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION process_application_event_change() RETURNS TRIGGER AS $$
   BEGIN
     IF ((NEW.details->>'event_type') = 'STATUS_CHANGE') THEN
       UPDATE applications
@@ -37,13 +37,18 @@ CREATE OR REPLACE FUNCTION process_status_change() RETURNS TRIGGER AS $$
   END;;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER status_change
+CREATE TRIGGER application_event_change
 AFTER INSERT OR UPDATE ON application_events
-  FOR EACH ROW EXECUTE FUNCTION process_status_change();
+  FOR EACH ROW EXECUTE FUNCTION process_application_event_change();
 
 CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
     FOR EACH ROW EXECUTE FUNCTION process_application_change();
 
 # --- !Downs
 
+DROP TRIGGER application_change ON applications;
+DROP TRIGGER application_event_change ON application_events;
+DROP FUNCTION IF EXISTS process_application_event_change;
+DROP FUNCTION IF EXISTS process_application_change;
+DROP FUNCTION IF EXISTS retrieve_latest_status;
 alter table applications drop column if exists latest_status;

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -1,5 +1,7 @@
 # --- Add database triggers to set the latest_status column on creating an application_event or
 # --- updating an application.
+# --- For rationale behind choosing database triggers, see:
+# ---   https://github.com/civiform/civiform/issues/3269#issuecomment-1232193163
 # --- Relevant documentation:
 # --- Trigger functions: https://www.postgresql.org/docs/current/sql-createtrigger.html
 # --- Create trigger statement: https://www.postgresql.org/docs/current/sql-createtrigger.html

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -60,7 +60,7 @@ $$ LANGUAGE plpgsql;
 -- unit tests to assert this in ApplicationTest.java.
 CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
     FOR EACH ROW EXECUTE FUNCTION process_latest_status_on_application_change();
-CREATE TRIGGER application_event_change BEFORE INSERT OR UPDATE ON application_events
+CREATE TRIGGER application_event_change AFTER INSERT OR UPDATE ON application_events
     FOR EACH ROW EXECUTE FUNCTION process_latest_status_on_application_event_change();
 
 # --- !Downs

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -10,8 +10,8 @@
 
 alter table applications add column if not exists latest_status varchar;
 
--- The latest status associated with an application is set to NULL if no application event entries
--- exist. Otherwise, the text from the latest event corresponding to a status change is used.
+-- Retrieves the status text from the latest event corresponding to a status change. If no
+-- application event entries exist, the column is set to NULL.
 CREATE OR REPLACE FUNCTION retrieve_latest_application_status(app_id applications.id%TYPE) RETURNS text AS $$
   SELECT
       (CASE WHEN details->'status_event'->>'status_text' = ''

--- a/server/conf/evolutions/default/44.sql
+++ b/server/conf/evolutions/default/44.sql
@@ -1,0 +1,49 @@
+# --- Add database triggers to set the latest_status column on creating an application_event or
+# --- updating an application.
+
+# --- !Ups
+
+alter table applications add column if not exists latest_status varchar;
+
+CREATE OR REPLACE FUNCTION retrieve_latest_status(app_id applications.id%TYPE) RETURNS text AS $$
+  SELECT
+      (CASE WHEN details->'status_event'->>'status_text' = ''
+        THEN NULL
+        ELSE details->'status_event'->>'status_text'
+       END) AS latest_status
+      FROM application_events
+      WHERE
+        application_id = app_id AND
+        details->>'event_type' = 'STATUS_CHANGE'
+      ORDER BY create_time DESC
+      LIMIT 1
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION process_application_change() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.latest_status := retrieve_latest_status(NEW.id);;
+    RETURN NEW;;
+  END;;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION process_status_change() RETURNS TRIGGER AS $$
+  BEGIN
+    IF ((NEW.details->>'event_type') = 'STATUS_CHANGE') THEN
+      UPDATE applications
+        SET latest_status = retrieve_latest_status(NEW.application_id)
+      WHERE id = NEW.application_id;;
+    END IF;;
+    RETURN NULL;; -- result is ignored since this is an AFTER
+  END;;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER status_change
+AFTER INSERT OR UPDATE ON application_events
+  FOR EACH ROW EXECUTE FUNCTION process_status_change();
+
+CREATE TRIGGER application_change BEFORE INSERT OR UPDATE ON applications
+    FOR EACH ROW EXECUTE FUNCTION process_application_change();
+
+# --- !Downs
+
+alter table applications drop column if exists latest_status;

--- a/server/test/models/ApplicationEventTest.java
+++ b/server/test/models/ApplicationEventTest.java
@@ -1,0 +1,127 @@
+package models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.application.ApplicationEventDetails;
+import services.application.ApplicationEventDetails.NoteEvent;
+import services.application.ApplicationEventDetails.StatusEvent;
+
+public class ApplicationEventTest extends ResetPostgres {
+  @Test
+  public void createNonStatusEventDoesNothing() {
+    Program program = resourceCreator.insertActiveProgram("test program");
+
+    Account adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
+    Application application =
+        resourceCreator.insertActiveApplication(resourceCreator.insertApplicant(), program);
+    assertThat(application.getLatestStatus()).isEmpty();
+
+    ApplicationEvent event =
+        new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.NOTE_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.NOTE_CHANGE)
+                .setNoteEvent(NoteEvent.create("some note"))
+                .build());
+    event.save();
+
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEmpty();
+  }
+
+  @Test
+  public void createStatusEventUpdatesApplicationLatestStatus() {
+    Program program = resourceCreator.insertActiveProgram("test program");
+
+    Account adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
+    Application application =
+        resourceCreator.insertActiveApplication(resourceCreator.insertApplicant(), program);
+    assertThat(application.getLatestStatus()).isEmpty();
+
+    new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.STATUS_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+                .setStatusEvent(
+                    StatusEvent.builder().setStatusText("approved").setEmailSent(false).build())
+                .build())
+        .save();
+
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEqualTo(Optional.of("approved"));
+
+    // Create another event transitioning to empty and ensure that the result is empty.
+    new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.STATUS_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+                .setStatusEvent(StatusEvent.builder().setStatusText("").setEmailSent(false).build())
+                .build())
+        .save();
+
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEmpty();
+  }
+
+  @Test
+  public void eventTriggerUsesLatestStatusEvent() throws Exception {
+    Program program = resourceCreator.insertActiveProgram("test program");
+
+    Account adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
+    Application application =
+        resourceCreator.insertActiveApplication(resourceCreator.insertApplicant(), program);
+    assertThat(application.getLatestStatus()).isEmpty();
+
+    ApplicationEvent firstEvent =
+        new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.STATUS_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+                .setStatusEvent(
+                    StatusEvent.builder().setStatusText("approved").setEmailSent(false).build())
+                .build());
+    firstEvent.save();
+
+    // When persisting models with @WhenModified fields, EBean
+    // truncates the persisted timestamp to milliseconds:
+    // https://github.com/seattle-uat/civiform/pull/2499#issuecomment-1133325484.
+    // Sleep for a few milliseconds to ensure that a subsequent
+    // update would have a distinct timestamp.
+    TimeUnit.MILLISECONDS.sleep(5);
+
+    ApplicationEvent secondEvent =
+        new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.STATUS_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+                .setStatusEvent(
+                    StatusEvent.builder().setStatusText("rejected").setEmailSent(false).build())
+                .build());
+    secondEvent.save();
+
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEqualTo(Optional.of("rejected"));
+
+    // Update the first event to have a new creator and ensure that we still use the most recently
+    // created event to update latest_status.
+    firstEvent.setCreator(resourceCreator.insertAccountWithEmail("someotheraccount@example.com"));
+    firstEvent.save();
+
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEqualTo(Optional.of("rejected"));
+  }
+}

--- a/server/test/models/ApplicationTest.java
+++ b/server/test/models/ApplicationTest.java
@@ -1,0 +1,77 @@
+package models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.LocalizedStrings;
+import services.application.ApplicationEventDetails;
+import services.application.ApplicationEventDetails.StatusEvent;
+import services.program.StatusDefinitions;
+import support.ProgramBuilder;
+
+public class ApplicationTest extends ResetPostgres {
+
+  private static final StatusDefinitions.Status APPROVED_STATUS =
+      StatusDefinitions.Status.builder()
+          .setStatusText("Approved")
+          .setLocalizedStatusText(LocalizedStrings.withDefaultValue("Approved"))
+          .build();
+
+  @Test
+  public void staleLatestStatusIsNotPersisted() {
+    // Tests a case where an Application (and its associated latest_status value has been loaded
+    // in-memory, a new ApplicationEventDetails is added (causing the trigger to execute), and the
+    // Application is persisted.
+    Program program =
+        ProgramBuilder.newActiveProgram("test program", "description")
+            .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
+            .build();
+
+    Account adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
+    Application application =
+        resourceCreator.insertActiveApplication(resourceCreator.insertApplicant(), program);
+    assertThat(application.getLatestStatus()).isEmpty();
+
+    ApplicationEvent event =
+        new ApplicationEvent(
+            application,
+            adminAccount,
+            ApplicationEventDetails.Type.STATUS_CHANGE,
+            ApplicationEventDetails.builder()
+                .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
+                .setStatusEvent(
+                    StatusEvent.builder()
+                        .setStatusText(APPROVED_STATUS.statusText())
+                        .setEmailSent(false)
+                        .build())
+                .build());
+    event.save();
+
+    // Trigger an update in the application.
+    application.setSubmitTimeToNow();
+    application.setLatestStatusForTest("some-status-value");
+    application.save();
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEqualTo(Optional.of(APPROVED_STATUS.statusText()));
+  }
+
+  @Test
+  public void latestStatusIsNotPersistedEvenWithNoApplicationEvents() {
+    Program program =
+        ProgramBuilder.newActiveProgram("test program", "description")
+            .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
+            .build();
+
+    Application application =
+        resourceCreator.insertActiveApplication(resourceCreator.insertApplicant(), program);
+    assertThat(application.getLatestStatus()).isEmpty();
+
+    application.setLatestStatusForTest("some-status-value");
+    application.save();
+    application.refresh();
+    assertThat(application.getLatestStatus()).isEmpty();
+  }
+}


### PR DESCRIPTION
### Description

Adds a `Application.latest_status` column corresponding to the most recent `ApplicationEvent` with type `status_change`. This value is precomputed via a database trigger.

The rationale for using a database trigger is documented [here](https://github.com/civiform/civiform/issues/3269#issuecomment-1232193163) (also linked in the database evolution).

This value is then consumed to populate the selected status value when the program admin is viewing an application. It is additionally used to in the status change confirmation dialog as the "previous status value".

This value will also be used in a subsequent PR to add filtering of applications via relevant statuses.

## Release notes:

Adds a column indicating the application's current status that has been set by a program admin. 

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #3020; Fixes #3267; #3264; #3269