### PR TITLE
Override the feature_flag_overrides_enabled in application.conf

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -612,3 +612,4 @@ application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_EN
 # development and pre-release evaluation of features. In fact it is unlikely to
 # work as expected in production if there are multiple servers.
 feature_flag_overrides_enabled = false
+feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}


### PR DESCRIPTION
### Description

Adding the option to override the feature_flag_overrides_enabled via environment variable in Staging file. Adding this since the container uses application.conf only.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

