### PR TITLE
Factor out SubmittedApplicationFilter type to allow more options to be added without updating all callsites

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -30,6 +30,7 @@ import play.i18n.MessagesApi;
 import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.SubmittedApplicationFilter;
 import repository.TimeFilter;
 import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
@@ -124,23 +125,23 @@ public final class AdminApplicationController extends CiviFormController {
     }
 
     boolean shouldApplyFilters = ignoreFilters.orElse("").isEmpty();
-    TimeFilter submitTimeFilter =
-        shouldApplyFilters
-            ? TimeFilter.builder()
-                .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-                .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
-                .build()
-            : TimeFilter.EMPTY;
-    Optional<String> searchFragment = shouldApplyFilters ? search : Optional.empty();
+    SubmittedApplicationFilter filters = SubmittedApplicationFilter.EMPTY;
+    if (shouldApplyFilters) {
+      filters =
+          SubmittedApplicationFilter.builder()
+              .setSearchNameFragment(search)
+              .setSubmitTimeFilter(
+                  TimeFilter.builder()
+                      .setFromTime(parseDateFromQuery(dateConverter, fromDate))
+                      .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                      .build())
+              .build();
+    }
 
     String filename = String.format("%s-%s.json", program.adminName(), nowProvider.get());
     String json =
         jsonExporter
-            .export(
-                program,
-                IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
-                searchFragment,
-                submitTimeFilter)
+            .export(program, IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG, filters)
             .getLeft();
 
     return ok(json)
@@ -160,19 +161,22 @@ public final class AdminApplicationController extends CiviFormController {
       throws ProgramNotFoundException {
     boolean shouldApplyFilters = ignoreFilters.orElse("").isEmpty();
     try {
-      TimeFilter submitTimeFilter =
-          shouldApplyFilters
-              ? TimeFilter.builder()
-                  .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-                  .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
-                  .build()
-              : TimeFilter.EMPTY;
-      Optional<String> searchFragment = shouldApplyFilters ? search : Optional.empty();
+      SubmittedApplicationFilter filters = SubmittedApplicationFilter.EMPTY;
+      if (shouldApplyFilters) {
+        filters =
+            SubmittedApplicationFilter.builder()
+                .setSearchNameFragment(search)
+                .setSubmitTimeFilter(
+                    TimeFilter.builder()
+                        .setFromTime(parseDateFromQuery(dateConverter, fromDate))
+                        .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                        .build())
+                .build();
+      }
       ProgramDefinition program = programService.getProgramDefinition(programId);
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
-      String csv =
-          exporterService.getProgramAllVersionsCsv(programId, searchFragment, submitTimeFilter);
+      String csv = exporterService.getProgramAllVersionsCsv(programId, filters);
       return ok(csv)
           .as(Http.MimeTypes.BINARY)
           .withHeader(
@@ -426,10 +430,14 @@ public final class AdminApplicationController extends CiviFormController {
               programId, search, Optional.of(1), fromDate, untilDate));
     }
 
-    TimeFilter submitTimeFilter =
-        TimeFilter.builder()
-            .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-            .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+    SubmittedApplicationFilter filters =
+        SubmittedApplicationFilter.builder()
+            .setSearchNameFragment(search)
+            .setSubmitTimeFilter(
+                TimeFilter.builder()
+                    .setFromTime(parseDateFromQuery(dateConverter, fromDate))
+                    .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                    .build())
             .build();
 
     final ProgramDefinition program;
@@ -443,7 +451,7 @@ public final class AdminApplicationController extends CiviFormController {
     var paginationSpec = new PageNumberBasedPaginationSpec(PAGE_SIZE, page.orElse(1));
     PaginationResult<Application> applications =
         programService.getSubmittedProgramApplicationsAllVersions(
-            programId, F.Either.Right(paginationSpec), search, submitTimeFilter);
+            programId, F.Either.Right(paginationSpec), filters);
 
     return ok(
         applicationListView.render(

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -40,7 +40,7 @@ import services.program.ProgramNotFoundException;
  * ProgramRepository performs complicated operations on {@link Program} that often involve other
  * EBean models or asynchronous handling.
  */
-public class ProgramRepository {
+public final class ProgramRepository {
   private static final Logger logger = LoggerFactory.getLogger(ProgramRepository.class);
 
   private final Database database;
@@ -209,16 +209,8 @@ public class ProgramRepository {
 
   /**
    * Get all submitted applications for this program and all other previous and future versions of
-   * it where the applicant's name, email, or application ID contains the search query. Does not
-   * include drafts or deleted applications. Results returned in reverse order that the applications
-   * were created. Results are optionally limited to applications submitted after {@code
-   * submitTimeFrom} and/or before {@code submitTimeTo}, inclusive of both values.
-   *
-   * <p>If searchNameFragment is not an unsigned integer, the query will filter to applications with
-   * email, first name, or last name that contain it.
-   *
-   * <p>If searchNameFragment is an unsigned integer, the query will filter to applications with an
-   * application ID matching it.
+   * it where the application matches the specified filters. Does not include drafts or deleted
+   * applications. Results returned in reverse order that the applications were created.
    *
    * <p>Both offset-based and page number-based pagination are supported. For paginationSpecEither
    * the caller may pass either a {@link IdentifierBasedPaginationSpec <Long>} or {@link
@@ -228,8 +220,7 @@ public class ProgramRepository {
       long programId,
       F.Either<IdentifierBasedPaginationSpec<Long>, PageNumberBasedPaginationSpec>
           paginationSpecEither,
-      Optional<String> searchNameFragment,
-      TimeFilter submitTimeFilter) {
+      SubmittedApplicationFilter filters) {
     ExpressionList<Application> query =
         database
             .find(Application.class)
@@ -241,16 +232,16 @@ public class ProgramRepository {
                 "lifecycle_stage",
                 ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE));
 
-    if (submitTimeFilter.fromTime().isPresent()) {
-      query = query.where().ge("submit_time", submitTimeFilter.fromTime().get());
+    if (filters.submitTimeFilter().fromTime().isPresent()) {
+      query = query.where().ge("submit_time", filters.submitTimeFilter().fromTime().get());
     }
 
-    if (submitTimeFilter.untilTime().isPresent()) {
-      query = query.where().lt("submit_time", submitTimeFilter.untilTime().get());
+    if (filters.submitTimeFilter().untilTime().isPresent()) {
+      query = query.where().lt("submit_time", filters.submitTimeFilter().untilTime().get());
     }
 
-    if (searchNameFragment.isPresent() && !searchNameFragment.get().isBlank()) {
-      String search = searchNameFragment.get().trim();
+    if (filters.searchNameFragment().isPresent() && !filters.searchNameFragment().get().isBlank()) {
+      String search = filters.searchNameFragment().get().trim();
 
       if (search.matches("^\\d+$")) {
         query = query.eq("id", Integer.parseInt(search));

--- a/server/app/repository/SubmittedApplicationFilter.java
+++ b/server/app/repository/SubmittedApplicationFilter.java
@@ -1,0 +1,38 @@
+package repository;
+
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
+
+/**
+ * Filters that can be applied to retrieve a list of applications matching all of the provided data.
+ */
+@AutoValue
+public abstract class SubmittedApplicationFilter {
+  public static final String NO_STATUS_FILTERS_OPTION_UUID = "ad80b347-5ae4-43c3-8578-e503b043be12";
+
+  public static final SubmittedApplicationFilter EMPTY =
+      SubmittedApplicationFilter.builder().setSubmitTimeFilter(TimeFilter.EMPTY).build();
+
+  /**
+   * If provided and is an unsigned integer, the query will filter to applications with an applicant
+   * ID matching it. If provided and is not an unsigned integer, the query will filter to
+   * applications with email, first name, or last name that contain it.
+   */
+  public abstract Optional<String> searchNameFragment();
+
+  /** Returns applications that were submitted within the provided date range. */
+  public abstract TimeFilter submitTimeFilter();
+
+  public static Builder builder() {
+    return new AutoValue_SubmittedApplicationFilter.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setSearchNameFragment(Optional<String> v);
+
+    public abstract Builder setSubmitTimeFilter(TimeFilter v);
+
+    public abstract SubmittedApplicationFilter build();
+  }
+}

--- a/server/app/repository/SubmittedApplicationFilter.java
+++ b/server/app/repository/SubmittedApplicationFilter.java
@@ -4,7 +4,8 @@ import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
 /**
- * Filters that can be applied to retrieve a list of applications matching all of the provided data.
+ * Filters that can be applied to retrieve a list of submitted applications matching all of the
+ * provided data. This does not include draft or deleted applications.
  */
 @AutoValue
 public abstract class SubmittedApplicationFilter {
@@ -20,7 +21,7 @@ public abstract class SubmittedApplicationFilter {
    */
   public abstract Optional<String> searchNameFragment();
 
-  /** Returns applications that were submitted within the provided date range. */
+  /** Filters to applications that were submitted within the provided date range. */
   public abstract TimeFilter submitTimeFilter();
 
   public static Builder builder() {

--- a/server/app/services/export/ExporterService.java
+++ b/server/app/services/export/ExporterService.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import models.Application;
 import models.QuestionTag;
 import play.libs.F;
+import repository.SubmittedApplicationFilter;
 import repository.TimeFilter;
 import services.IdentifierBasedPaginationSpec;
 import services.Path;
@@ -77,8 +78,7 @@ public final class ExporterService {
   }
 
   /** Return a string containing a CSV of all applications at all versions of particular program. */
-  public String getProgramAllVersionsCsv(
-      long programId, Optional<String> searchFragment, TimeFilter submitTimeFilter)
+  public String getProgramAllVersionsCsv(long programId, SubmittedApplicationFilter filters)
       throws ProgramNotFoundException {
     ImmutableList<ProgramDefinition> allProgramVersions =
         programService.getAllProgramDefinitionVersions(programId).stream()
@@ -90,8 +90,7 @@ public final class ExporterService {
             .getSubmittedProgramApplicationsAllVersions(
                 programId,
                 F.Either.Left(IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG),
-                searchFragment,
-                submitTimeFilter)
+                filters)
             .getPageContents();
 
     return exportCsv(exportConfig, applications);

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -7,12 +7,11 @@ import com.jayway.jsonpath.DocumentContext;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 import models.Application;
 import org.apache.commons.lang3.tuple.Pair;
 import play.libs.F;
-import repository.TimeFilter;
+import repository.SubmittedApplicationFilter;
 import services.CfJsonDocumentContext;
 import services.IdentifierBasedPaginationSpec;
 import services.PaginationResult;
@@ -45,16 +44,12 @@ public class JsonExporter {
   public Pair<String, PaginationResult<Application>> export(
       ProgramDefinition programDefinition,
       IdentifierBasedPaginationSpec<Long> paginationSpec,
-      Optional<String> searchFragment,
-      TimeFilter submitTimeFilter) {
+      SubmittedApplicationFilter filters) {
     PaginationResult<Application> paginationResult;
     try {
       paginationResult =
           programService.getSubmittedProgramApplicationsAllVersions(
-              programDefinition.id(),
-              F.Either.Left(paginationSpec),
-              searchFragment,
-              submitTimeFilter);
+              programDefinition.id(), F.Either.Left(paginationSpec), filters);
     } catch (ProgramNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -4,12 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import forms.BlockForm;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import models.Application;
 import play.libs.F;
-import repository.TimeFilter;
+import repository.SubmittedApplicationFilter;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.IdentifierBasedPaginationSpec;
@@ -343,27 +342,18 @@ public interface ProgramService {
 
   /**
    * Get all submitted applications for this program and all other previous and future versions of
-   * it where the applicant's name, email, or application ID contains the search query. Does not
-   * include drafts or deleted applications.
-   *
-   * <p>If searchNameFragment is not an unsigned integer, the query will filter to applications with
-   * email, first name, or last name that contain it.
-   *
-   * <p>If searchNameFragment is an unsigned integer, query will filter to applications with an
-   * applicant ID matching it.
+   * it matches the specified filters.
    *
    * @param paginationSpecEither the query supports two types of pagination, F.Either wraps the
    *     pagination spec to use for a given call.
-   * @param searchNameFragment a text fragment used for filtering the applications.
-   * @param submitTimeFilter specifies a filter for the submission time for returned results.
+   * @param filters a set of filters to apply to the examined applications.
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   PaginationResult<Application> getSubmittedProgramApplicationsAllVersions(
       long programId,
       F.Either<IdentifierBasedPaginationSpec<Long>, PageNumberBasedPaginationSpec>
           paginationSpecEither,
-      Optional<String> searchNameFragment,
-      TimeFilter submitTimeFilter)
+      SubmittedApplicationFilter filters)
       throws ProgramNotFoundException;
 
   /** Create a new draft starting from the program specified by `id`. */

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -31,7 +31,7 @@ import play.db.ebean.Transactional;
 import play.libs.F;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.ProgramRepository;
-import repository.TimeFilter;
+import repository.SubmittedApplicationFilter;
 import repository.UserRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
@@ -794,10 +794,9 @@ public final class ProgramServiceImpl implements ProgramService {
       long programId,
       F.Either<IdentifierBasedPaginationSpec<Long>, PageNumberBasedPaginationSpec>
           paginationSpecEither,
-      Optional<String> searchNameFragment,
-      TimeFilter submitTimeFilter) {
+      SubmittedApplicationFilter filters) {
     return programRepository.getApplicationsForAllProgramVersions(
-        programId, paginationSpecEither, searchNameFragment, submitTimeFilter);
+        programId, paginationSpecEither, filters);
   }
 
   @Override

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -216,8 +216,10 @@ public class ProgramRepositoryTest extends ResetPostgres {
         repo.getApplicationsForAllProgramVersions(
             program.id,
             F.Either.Left(IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG),
-            Optional.of(bobApp.id.toString()),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.builder()
+                .setSearchNameFragment(Optional.of(bobApp.id.toString()))
+                .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .build());
 
     assertThat(
             paginationResult.getPageContents().stream()
@@ -278,8 +280,10 @@ public class ProgramRepositoryTest extends ResetPostgres {
         repo.getApplicationsForAllProgramVersions(
             program.id,
             F.Either.Left(IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG),
-            Optional.of(searchFragment),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.builder()
+                .setSearchNameFragment(Optional.of(searchFragment))
+                .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .build());
 
     assertThat(
             paginationResult.getPageContents().stream()
@@ -340,11 +344,12 @@ public class ProgramRepositoryTest extends ResetPostgres {
         repo.getApplicationsForAllProgramVersions(
             program.id,
             F.Either.Right(new PageNumberBasedPaginationSpec(/* pageSize= */ 10)),
-            Optional.empty(),
-            TimeFilter.builder()
-                .setFromTime(Optional.of(Instant.parse("2022-01-25T00:00:00Z")))
-                .setUntilTime(Optional.of(Instant.parse("2022-02-10T00:00:00Z")))
-                .build());
+            SubmittedApplicationFilter.builder()
+                .setSubmitTimeFilter(
+                    TimeFilter.builder()
+                        .setFromTime(Optional.of(Instant.parse("2022-01-25T00:00:00Z")))
+                        .setUntilTime(Optional.of(Instant.parse("2022-02-10T00:00:00Z")))
+                        .build()));
 
     assertThat(paginationResult.hasMorePages()).isFalse();
     assertThat(
@@ -376,8 +381,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
         repo.getApplicationsForAllProgramVersions(
             nextVersion.id,
             F.Either.Right(new PageNumberBasedPaginationSpec(/* pageSize= */ 2)),
-            Optional.empty(),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.EMPTY);
 
     assertThat(paginationResult.getNumPages()).isEqualTo(2);
     assertThat(paginationResult.getPageContents().size()).isEqualTo(2);
@@ -390,8 +394,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             nextVersion.id,
             F.Either.Right(
                 new PageNumberBasedPaginationSpec(/* pageSize= */ 2, /* currentPage= */ 2)),
-            Optional.empty(),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.EMPTY);
 
     assertThat(paginationResult.getNumPages()).isEqualTo(2);
     assertThat(paginationResult.getPageContents().size()).isEqualTo(1);
@@ -421,8 +424,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
         repo.getApplicationsForAllProgramVersions(
             nextVersion.id,
             F.Either.Left(new IdentifierBasedPaginationSpec<>(2, Long.MAX_VALUE)),
-            Optional.empty(),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.EMPTY);
 
     assertThat(paginationResult.getNumPages()).isEqualTo(2);
     assertThat(paginationResult.getPageContents().size()).isEqualTo(2);
@@ -436,8 +438,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             F.Either.Left(
                 new IdentifierBasedPaginationSpec<>(
                     2, paginationResult.getPageContents().get(1).id)),
-            Optional.empty(),
-            TimeFilter.EMPTY);
+            SubmittedApplicationFilter.EMPTY);
 
     assertThat(paginationResult.getPageContents().size()).isEqualTo(1);
     assertThat(paginationResult.getPageContents().get(0).getApplicant()).isEqualTo(applicantOne);

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -349,7 +349,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
                     TimeFilter.builder()
                         .setFromTime(Optional.of(Instant.parse("2022-01-25T00:00:00Z")))
                         .setUntilTime(Optional.of(Instant.parse("2022-02-10T00:00:00Z")))
-                        .build()));
+                        .build())
+                .build());
 
     assertThat(paginationResult.hasMorePages()).isFalse();
     assertThat(

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import models.Application;
 import models.Program;
 import org.junit.Test;
-import repository.TimeFilter;
+import repository.SubmittedApplicationFilter;
 import services.CfJsonDocumentContext;
 import services.IdentifierBasedPaginationSpec;
 import services.Path;
@@ -26,8 +26,7 @@ public class JsonExporterTest extends AbstractExporterTest {
             .export(
                 fakeProgram.getProgramDefinition(),
                 IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
-                Optional.empty(),
-                TimeFilter.EMPTY)
+                SubmittedApplicationFilter.EMPTY)
             .getLeft();
     ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
 
@@ -96,8 +95,7 @@ public class JsonExporterTest extends AbstractExporterTest {
             .export(
                 fakeProgramWithEnumerator.getProgramDefinition(),
                 IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
-                Optional.empty(),
-                TimeFilter.EMPTY)
+                SubmittedApplicationFilter.EMPTY)
             .getLeft();
 
     ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);


### PR DESCRIPTION
### Description

As part of #3269, we'll be adding a new filter option for application status. Presently, we plumb both the search fragment and submit time filter through all code that filters applications. This change allows future changes to be made without plumbing the same values everywhere. Instead the filters are created at the top-level call site and consumed from the relevant ProgramRepository method.

## Release notes:

Internal code change to make adding more program admin application filtering options more maintainable.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
