### PR TITLE
Pass the Application Note to the BE and save to the DB

### DIFF
--- a/server/app/models/ApplicationEvent.java
+++ b/server/app/models/ApplicationEvent.java
@@ -34,14 +34,11 @@ public final class ApplicationEvent extends BaseModel {
    * @param creator the Account that created the event.
    */
   public ApplicationEvent(
-      Application application,
-      Account creator,
-      ApplicationEventDetails.Type eventType,
-      ApplicationEventDetails details) {
+      Application application, Account creator, ApplicationEventDetails details) {
     this.application = checkNotNull(application);
     this.creator = checkNotNull(creator);
-    this.eventType = checkNotNull(eventType);
     this.details = checkNotNull(details);
+    this.eventType = details.eventType();
   }
 
   public Application getApplication() {

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -59,9 +59,7 @@ public final class ProgramAdminApplicationService {
             .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
             .setStatusEvent(newStatus)
             .build();
-    ApplicationEvent event =
-        new ApplicationEvent(
-            application, admin, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    ApplicationEvent event = new ApplicationEvent(application, admin, details);
     eventRepository.insertSync(event);
   }
 
@@ -76,8 +74,7 @@ public final class ProgramAdminApplicationService {
             .setEventType(ApplicationEventDetails.Type.NOTE_CHANGE)
             .setNoteEvent(note)
             .build();
-    ApplicationEvent event =
-        new ApplicationEvent(application, admin, ApplicationEventDetails.Type.NOTE_CHANGE, details);
+    ApplicationEvent event = new ApplicationEvent(application, admin, details);
     eventRepository.insertSync(event);
   }
 }

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -49,7 +49,7 @@ public final class ProgramAdminApplicationService {
   }
 
   /**
-   * Saves a new {@link ApplicationEventDetails.Type.STATUS_CHANGE} event.
+   * Sets the status on the {@code Application}.
    *
    * @param admin The Account that instigated the change.
    */
@@ -66,7 +66,7 @@ public final class ProgramAdminApplicationService {
   }
 
   /**
-   * Saves a new {@link ApplicationEventDetails.Type.NOTE_CHANGE} event.
+   * Sets the note on the {@code Application}.
    *
    * @param admin The Account that instigated the change.
    */

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -10,6 +10,7 @@ import models.ApplicationEvent;
 import repository.ApplicationEventRepository;
 import repository.ApplicationRepository;
 import services.application.ApplicationEventDetails;
+import services.application.ApplicationEventDetails.NoteEvent;
 import services.application.ApplicationEventDetails.StatusEvent;
 import services.program.ProgramDefinition;
 
@@ -47,6 +48,11 @@ public final class ProgramAdminApplicationService {
     return Optional.of(application);
   }
 
+  /**
+   * Saves a new {@link ApplicationEventDetails.Type.STATUS_CHANGE} event.
+   *
+   * @param admin The Account that instigated the change.
+   */
   public void setStatus(Application application, StatusEvent newStatus, Account admin) {
     ApplicationEventDetails details =
         ApplicationEventDetails.builder()
@@ -56,6 +62,22 @@ public final class ProgramAdminApplicationService {
     ApplicationEvent event =
         new ApplicationEvent(
             application, admin, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    eventRepository.insertSync(event);
+  }
+
+  /**
+   * Saves a new {@link ApplicationEventDetails.Type.NOTE_CHANGE} event.
+   *
+   * @param admin The Account that instigated the change.
+   */
+  public void setNote(Application application, NoteEvent note, Account admin) {
+    ApplicationEventDetails details =
+        ApplicationEventDetails.builder()
+            .setEventType(ApplicationEventDetails.Type.NOTE_CHANGE)
+            .setNoteEvent(note)
+            .build();
+    ApplicationEvent event =
+        new ApplicationEvent(application, admin, ApplicationEventDetails.Type.NOTE_CHANGE, details);
     eventRepository.insertSync(event);
   }
 }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -62,6 +62,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
 
   public static final String SEND_EMAIL = "sendEmail";
   public static final String NEW_STATUS = "newStatus";
+  public static final String NOTE = "note";
   private final BaseHtmlLayout layout;
   private final Messages enUsMessages;
 
@@ -269,17 +270,24 @@ public final class ProgramApplicationView extends BaseHtmlView {
       long programId, Application application, Http.Request request) {
     ButtonTag triggerButton =
         makeSvgTextButton("Edit note", Icons.EDIT).withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
+    // Give each form a unique id based on the application.
+    String formId = String.format("note-form-%d", application.id);
     FormTag modalContent =
         form()
             .withAction(
                 controllers.admin.routes.AdminApplicationController.updateNote(
                         programId, application.id)
                     .url())
+            .withId(formId)
             .withMethod("POST")
             .withClasses(Styles.PX_6, Styles.PY_2)
             .with(makeCsrfTokenInputTag(request));
     modalContent.with(
-        FieldWithLabel.textArea().setRows(OptionalLong.of(8)).getTextareaTag(),
+        FieldWithLabel.textArea()
+            .setFormId(formId)
+            .setFieldName(NOTE)
+            .setRows(OptionalLong.of(8))
+            .getTextareaTag(),
         div()
             .withClasses(Styles.FLEX, Styles.MT_5, Styles.SPACE_X_2)
             .with(

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -32,7 +32,6 @@ import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.UUID;
 import models.Application;
 import org.apache.commons.lang3.RandomStringUtils;
 import play.i18n.Messages;
@@ -272,8 +271,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
       long programId, Application application, Http.Request request) {
     ButtonTag triggerButton =
         makeSvgTextButton("Edit note", Icons.EDIT).withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
-    // Give each form a unique id based on the application.
-    String formId = UUID.randomUUID().toString();
+    String formId = Modal.randomModalId();
     FormTag modalContent =
         form()
             .withAction(

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.UUID;
 import models.Application;
 import org.apache.commons.lang3.RandomStringUtils;
 import play.i18n.Messages;
@@ -271,7 +272,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
     ButtonTag triggerButton =
         makeSvgTextButton("Edit note", Icons.EDIT).withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
     // Give each form a unique id based on the application.
-    String formId = String.format("note-form-%d", application.id);
+    String formId = UUID.randomUUID().toString();
     FormTag modalContent =
         form()
             .withAction(

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -363,6 +363,55 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
+  @Test
+  public void updateNote_noNote_fails() throws Exception {
+    // Setup.
+    Account adminAccount = resourceCreator.insertAccount();
+    controller = makeNoOpProfileController(Optional.of(adminAccount));
+    Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application application =
+        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+
+    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    // Execute.
+    Result result = controller.updateNote(request, program.id, application.id);
+
+    // Verify.
+    assertThat(result.status()).isEqualTo(BAD_REQUEST);
+    assertThat(contentAsString(result)).contains("A note is not present");
+  }
+
+  @Test
+  public void updateNote_succeeds() throws Exception {
+    // Setup.
+    Instant start = Instant.now();
+    String noteText = "Test note content.";
+    Account adminAccount = resourceCreator.insertAccount();
+    controller = makeNoOpProfileController(Optional.of(adminAccount));
+    Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application application =
+        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+
+    Request request =
+        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("note", noteText))).build();
+
+    // Execute.
+    Result result = controller.updateNote(request, program.id, application.id);
+
+    // Verify.
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    application.refresh();
+    assertThat(application.getApplicationEvents()).hasSize(1);
+    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.NOTE_CHANGE);
+    assertThat(gotEvent.getDetails().noteEvent()).isPresent();
+    assertThat(gotEvent.getDetails().noteEvent().get().note()).isEqualTo(noteText);
+    assertThat(gotEvent.getCreator()).isEqualTo(adminAccount);
+    assertThat(gotEvent.getCreateTime()).isAfter(start);
+  }
+
   // Returns a controller with a faked ProfileUtils to bypass acl checks.
   AdminApplicationController makeNoOpProfileController(Optional<Account> adminAccount) {
     ProfileTester profileTester =

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -412,6 +412,33 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(gotEvent.getCreateTime()).isAfter(start);
   }
 
+  @Test
+  public void updateNote_emptyNote_succeeds() throws Exception {
+    // Setup.
+    Instant start = Instant.now();
+    String noteText = "";
+    Account adminAccount = resourceCreator.insertAccount();
+    controller = makeNoOpProfileController(Optional.of(adminAccount));
+    Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
+    Applicant applicant = resourceCreator.insertApplicantWithAccount();
+    Application application =
+        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+
+    Request request =
+        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("note", noteText))).build();
+
+    // Execute.
+    Result result = controller.updateNote(request, program.id, application.id);
+
+    // Verify.
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    application.refresh();
+    assertThat(application.getApplicationEvents()).hasSize(1);
+    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    assertThat(gotEvent.getDetails().noteEvent()).isPresent();
+    assertThat(gotEvent.getDetails().noteEvent().get().note()).isEqualTo(noteText);
+  }
+
   // Returns a controller with a faked ProfileUtils to bypass acl checks.
   AdminApplicationController makeNoOpProfileController(Optional<Account> adminAccount) {
     ProfileTester profileTester =

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -415,7 +415,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
   @Test
   public void updateNote_emptyNote_succeeds() throws Exception {
     // Setup.
-    Instant start = Instant.now();
     String noteText = "";
     Account adminAccount = resourceCreator.insertAccount();
     controller = makeNoOpProfileController(Optional.of(adminAccount));

--- a/server/test/models/ApplicationEventTest.java
+++ b/server/test/models/ApplicationEventTest.java
@@ -24,7 +24,6 @@ public class ApplicationEventTest extends ResetPostgres {
         new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.NOTE_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.NOTE_CHANGE)
                 .setNoteEvent(NoteEvent.create("some note"))
@@ -47,7 +46,6 @@ public class ApplicationEventTest extends ResetPostgres {
     new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.STATUS_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
                 .setStatusEvent(
@@ -62,7 +60,6 @@ public class ApplicationEventTest extends ResetPostgres {
     new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.STATUS_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
                 .setStatusEvent(StatusEvent.builder().setStatusText("").setEmailSent(false).build())
@@ -86,7 +83,6 @@ public class ApplicationEventTest extends ResetPostgres {
         new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.STATUS_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
                 .setStatusEvent(
@@ -105,7 +101,6 @@ public class ApplicationEventTest extends ResetPostgres {
         new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.STATUS_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
                 .setStatusEvent(

--- a/server/test/models/ApplicationTest.java
+++ b/server/test/models/ApplicationTest.java
@@ -39,7 +39,6 @@ public class ApplicationTest extends ResetPostgres {
         new ApplicationEvent(
             application,
             adminAccount,
-            ApplicationEventDetails.Type.STATUS_CHANGE,
             ApplicationEventDetails.builder()
                 .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
                 .setStatusEvent(

--- a/server/test/repository/ApplicationEventRepositoryTest.java
+++ b/server/test/repository/ApplicationEventRepositoryTest.java
@@ -37,9 +37,7 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
             .setStatusEvent(
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
-    ApplicationEvent event =
-        new ApplicationEvent(
-            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    ApplicationEvent event = new ApplicationEvent(application, actor, details);
     ApplicationEvent insertedEvent = repo.insertSync(event);
     // Generated values.
     assertThat(insertedEvent.id).isNotNull();
@@ -66,14 +64,10 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
 
-    ApplicationEvent event1 =
-        new ApplicationEvent(
-            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    ApplicationEvent event1 = new ApplicationEvent(application, actor, details);
     ApplicationEvent insertedEvent1 = repo.insertSync(event1);
 
-    ApplicationEvent event2 =
-        new ApplicationEvent(
-            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    ApplicationEvent event2 = new ApplicationEvent(application, actor, details);
 
     ApplicationEvent insertedEvent2 = repo.insertSync(event2);
 
@@ -104,9 +98,7 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
             .setStatusEvent(
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
-    ApplicationEvent event =
-        new ApplicationEvent(
-            application, actor, ApplicationEventDetails.Type.STATUS_CHANGE, details);
+    ApplicationEvent event = new ApplicationEvent(application, actor, details);
     repo.insertSync(event);
 
     // Execute


### PR DESCRIPTION
### Description

Save the Application Note into the database.

Add an Id and name to the existing UI elements and have the Controller/Service save it as an ApplicationEvent.

## Release notes:

Program Application Notes are now saved into the database. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Addresses #3020 #3264