### PR TITLE
Program admin list view reuses the card styling that the CiviForm admin sees

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -372,14 +372,11 @@ export class AdminPrograms {
   }
 
   async viewApplications(programName: string) {
-    // TODO(#1238): Consolidate the program admin and civiform admin views
-    // and use the updated selector for this that clicks a button rather
-    // than a link.
     await this.page.click(
       this.withinProgramCardSelector(
         programName,
         'ACTIVE',
-        'a:text("Applications")',
+        ':text("Applications")',
       ),
     )
     await waitForPageJsLoad(this.page)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -376,7 +376,7 @@ export class AdminPrograms {
       this.withinProgramCardSelector(
         programName,
         'ACTIVE',
-        ':text("Applications")',
+        'button :text("Applications")',
       ),
     )
     await waitForPageJsLoad(this.page)

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -7,7 +7,27 @@ class AdminPrograms {
   private static LAST_UPDATED_MILLIS = 'data-last-updated-millis'
   private static PROGRAM_LINK_ATTRIBUTE = 'data-copyable-program-link'
 
-  constructor() {
+  static attachCopyProgramLinkListeners() {
+    const withCopyableProgramLink = Array.from(
+      document.querySelectorAll(
+        `${AdminPrograms.PROGRAM_CARDS_SELECTOR} [${AdminPrograms.PROGRAM_LINK_ATTRIBUTE}]`,
+      ),
+    )
+    withCopyableProgramLink.forEach((el) => {
+      const programLink = el.getAttribute(AdminPrograms.PROGRAM_LINK_ATTRIBUTE)
+      if (!programLink) {
+        console.warn(
+          `Empty ${AdminPrograms.PROGRAM_LINK_ATTRIBUTE} for element`,
+        )
+        return
+      }
+      el.addEventListener('click', () => {
+        AdminPrograms.copyProgramLinkToClipboard(programLink)
+      })
+    })
+  }
+
+  static sortCardsOnLoad() {
     const cardsParent = document.querySelector(
       AdminPrograms.PROGRAM_ADIN_LIST_SELECTOR,
     )
@@ -27,31 +47,15 @@ class AdminPrograms {
         cardsPlaceholder.classList.add('hidden')
       }
     }
-
-    const withCopyableProgramLink = Array.from(
-      cardsParent.querySelectorAll(`[${AdminPrograms.PROGRAM_LINK_ATTRIBUTE}]`),
-    )
-    withCopyableProgramLink.forEach((el) => {
-      const programLink = el.getAttribute(AdminPrograms.PROGRAM_LINK_ATTRIBUTE)
-      if (!programLink) {
-        console.warn(
-          `Empty ${AdminPrograms.PROGRAM_LINK_ATTRIBUTE} for element`,
-        )
-        return
-      }
-      el.addEventListener('click', () => {
-        AdminPrograms.copyProgramLinkToClipboard(programLink)
-      })
-    })
   }
 
-  sortCards(cardsParent: HTMLElement) {
+  static sortCards(cardsParent: HTMLElement) {
     const cards = Array.from(
       cardsParent.querySelectorAll(AdminPrograms.PROGRAM_CARDS_SELECTOR),
     )
     cards.sort((first, second) => {
-      const firstComparator = this.comparatorObject(first)
-      const secondComparator = this.comparatorObject(second)
+      const firstComparator = AdminPrograms.comparatorObject(first)
+      const secondComparator = AdminPrograms.comparatorObject(second)
 
       return (
         secondComparator.lastUpdatedMillis -
@@ -67,7 +71,7 @@ class AdminPrograms {
     })
   }
 
-  comparatorObject(el: Element) {
+  static comparatorObject(el: Element) {
     const lastUpdatedMillisString =
       el.getAttribute(AdminPrograms.LAST_UPDATED_MILLIS) || ''
     const lastUpdatedMillis = Number(lastUpdatedMillisString)
@@ -120,4 +124,7 @@ class AdminPrograms {
   }
 }
 
-window.addEventListener('load', () => new AdminPrograms())
+window.addEventListener('load', () => {
+  AdminPrograms.sortCardsOnLoad()
+  AdminPrograms.attachCopyProgramLinkListeners()
+})

--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -77,13 +77,7 @@ public abstract class BaseHtmlView {
   }
 
   protected static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {
-    return TagCreator.button()
-        .with(
-            Icons.svg(icon)
-                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0)
-                // Can't set 18px using Tailwind CSS classes.
-                .withStyle("width: 18px; height: 18px;"),
-            span(buttonText).withClass(Styles.TEXT_LEFT));
+    return ViewUtils.makeSvgTextButton(buttonText, icon);
   }
 
   protected static SpanTag spanNowrap(String tag) {

--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -1,15 +1,20 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.button;
 import static j2html.TagCreator.img;
 import static j2html.TagCreator.link;
 import static j2html.TagCreator.script;
+import static j2html.TagCreator.span;
 
 import controllers.AssetsFinder;
+import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.ImgTag;
 import j2html.tags.specialized.LinkTag;
 import j2html.tags.specialized.ScriptTag;
 import javax.inject.Inject;
+import views.components.Icons;
+import views.style.Styles;
 
 /** Utility class for accessing stateful view dependencies. */
 public final class ViewUtils {
@@ -61,5 +66,15 @@ public final class ViewUtils {
 
   public ImgTag makeLocalImageTag(String filename) {
     return img().withSrc(assetsFinder.path("Images/" + filename + ".png"));
+  }
+
+  public static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {
+    return button()
+        .with(
+            Icons.svg(icon)
+                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0)
+                // Can't set 18px using Tailwind CSS classes.
+                .withStyle("width: 18px; height: 18px;"),
+            span(buttonText).withClass(Styles.TEXT_LEFT));
   }
 }

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -24,6 +24,7 @@ import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
 import views.components.Icons;
 import views.components.ProgramCardFactory;
+import views.components.ProgramCardFactory.ProgramCardData;
 import views.style.AdminStyles;
 import views.style.Styles;
 
@@ -75,14 +76,17 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
 
   private DivTag renderProgramListItem(ProgramDefinition activeProgram) {
     return programCardFactory.renderCard(
-        ProgramCardFactory.ProgramCardParams.builder()
-            .setActiveProgram(Optional.of(activeProgram))
-            .setActiveRowActions(
-                ImmutableList.of(
-                    renderShareLink(activeProgram), renderViewApplicationsLink(activeProgram)))
-            .setActiveRowExtraActions(ImmutableList.of())
-            .setDraftRowActions(ImmutableList.of())
-            .setDraftRowExtraActions(ImmutableList.of())
+        ProgramCardFactory.ProgramCardData.builder()
+            .setActiveProgram(
+                Optional.of(
+                    ProgramCardData.ProgramRow.builder()
+                        .setProgram(activeProgram)
+                        .setRowActions(
+                            ImmutableList.of(
+                                renderShareLink(activeProgram),
+                                renderViewApplicationsLink(activeProgram)))
+                        .setExtraRowActions(ImmutableList.of())
+                        .build()))
             .build());
   }
 

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -4,21 +4,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.h1;
-import static j2html.TagCreator.input;
-import static j2html.TagCreator.label;
-import static j2html.TagCreator.p;
 
 import auth.CiviFormProfile;
+import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import controllers.admin.routes;
-import j2html.tags.Tag;
+import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
-import j2html.tags.specialized.LabelTag;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.twirl.api.Content;
-import services.DateConverter;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramDefinition;
 import views.BaseHtmlView;
@@ -26,24 +22,24 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
-import views.components.LinkElement;
-import views.style.ReferenceClasses;
-import views.style.StyleUtils;
+import views.components.Icons;
+import views.components.ProgramCardFactory;
+import views.style.AdminStyles;
 import views.style.Styles;
 
 /** Renders a page for program admins to view programs they administer. */
-public class ProgramAdministratorProgramListView extends BaseHtmlView {
+public final class ProgramAdministratorProgramListView extends BaseHtmlView {
 
   private final AdminLayout layout;
   private final String baseUrl;
-  private final DateConverter dateConverter;
+  private final ProgramCardFactory programCardFactory;
 
   @Inject
   public ProgramAdministratorProgramListView(
-      AdminLayoutFactory layoutFactory, Config config, DateConverter dateConverter) {
+      AdminLayoutFactory layoutFactory, Config config, ProgramCardFactory programCardFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
-    this.dateConverter = checkNotNull(dateConverter);
+    this.programCardFactory = checkNotNull(programCardFactory);
   }
 
   public Content render(
@@ -56,9 +52,6 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
       layout.setOnlyProgramAdminType();
     }
 
-    // TODO(#1238): Create a "Program Card" UI component that encapsulates
-    // the styling of the CiviForm Admin equivalent of this view and reuse
-    // it here.
     String title = "Your programs";
     DivTag contentDiv =
         div()
@@ -66,128 +59,54 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
             .with(
                 h1(title).withClasses(Styles.MY_4),
                 each(
-                    programs.getProgramNames().stream()
-                        .filter(programName -> authorizedPrograms.contains(programName))
-                        .map(
-                            name ->
-                                this.renderProgramListItem(
-                                    programs.getActiveProgramDefinition(name),
-                                    programs.getDraftProgramDefinition(name)))));
+                    programs.getActivePrograms().stream()
+                        .filter(program -> authorizedPrograms.contains(program.adminName()))
+                        .map(this::renderProgramListItem)));
 
-    HtmlBundle htmlBundle = layout.getBundle().setTitle(title).addMainContent(contentDiv);
+    HtmlBundle htmlBundle =
+        layout
+            .getBundle()
+            .setTitle(title)
+            .addMainContent(contentDiv)
+            .addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
 
     return layout.renderCentered(htmlBundle);
   }
 
-  public ProgramDefinition getDisplayProgram(
-      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
-    if (draftProgram.isPresent()) {
-      return draftProgram.get();
-    }
-    return activeProgram.get();
+  private DivTag renderProgramListItem(ProgramDefinition activeProgram) {
+    return programCardFactory.renderCard(
+        ProgramCardFactory.ProgramCardParams.builder()
+            .setActiveProgram(Optional.of(activeProgram))
+            .setActiveRowActions(
+                ImmutableList.of(
+                    renderShareLink(activeProgram), renderViewApplicationsLink(activeProgram)))
+            .setActiveRowExtraActions(ImmutableList.of())
+            .setDraftRowActions(ImmutableList.of())
+            .setDraftRowExtraActions(ImmutableList.of())
+            .build());
   }
 
-  public DivTag renderProgramListItem(
-      Optional<ProgramDefinition> activeProgram, Optional<ProgramDefinition> draftProgram) {
-    String programStatusText = extractProgramStatusText(draftProgram, activeProgram);
-    String viewApplicationsLinkText = "Applications →";
-
-    ProgramDefinition displayProgram = getDisplayProgram(draftProgram, activeProgram);
-
-    String lastEditText =
-        displayProgram.lastModifiedTime().isPresent()
-            ? "Last updated: "
-                + dateConverter.renderDateTime(displayProgram.lastModifiedTime().get())
-            : "Could not find latest update time";
-    String programTitleText = displayProgram.adminName();
-    String programDescriptionText = displayProgram.adminDescription();
-    String blockCountText = "Screens: " + displayProgram.getBlockCount();
-    String questionCountText = "Questions: " + displayProgram.getQuestionCount();
-
-    DivTag topContent =
-        div(
-                div(
-                    p(programStatusText).withClasses(Styles.TEXT_SM, Styles.TEXT_GRAY_700),
-                    div(programTitleText)
-                        .withClasses(
-                            Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL, Styles.MB_2)),
-                p().withClasses(Styles.FLEX_GROW),
-                div(p(blockCountText), p(questionCountText))
-                    .withClasses(
-                        Styles.TEXT_RIGHT,
-                        Styles.TEXT_XS,
-                        Styles.TEXT_GRAY_700,
-                        Styles.MR_2,
-                        StyleUtils.applyUtilityClass(StyleUtils.RESPONSIVE_MD, Styles.MR_4)))
-            .withClasses(Styles.FLEX);
-
-    DivTag midContent =
-        div(programDescriptionText)
-            .withClasses(Styles.TEXT_GRAY_700, Styles.TEXT_BASE, Styles.MB_8, Styles.LINE_CLAMP_3);
-
-    DivTag bottomContent =
-        div(
-                p(lastEditText).withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
-                p().withClasses(Styles.FLEX_GROW),
-                maybeRenderViewApplicationsLink(viewApplicationsLinkText, activeProgram))
-            .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL);
-
-    LabelTag programDeepLink =
-        label("Deep link, use this URL to link to this program from outside of CiviForm:")
-            .withClasses(Styles.W_FULL)
-            .with(
-                input()
-                    .withValue(
-                        baseUrl
-                            + controllers.applicant.routes.RedirectController.programBySlug(
-                                    displayProgram.slug())
-                                .url())
-                    .isDisabled()
-                    .isReadonly()
-                    .withClasses(Styles.W_FULL, Styles.MB_2)
-                    .withType("text"));
-
-    DivTag innerDiv =
-        div(topContent, midContent, programDeepLink, bottomContent)
-            .withClasses(
-                Styles.BORDER, Styles.BORDER_GRAY_300, Styles.BG_WHITE, Styles.ROUNDED, Styles.P_4);
-
-    return div(innerDiv)
-        .withClasses(
-            ReferenceClasses.ADMIN_PROGRAM_CARD, Styles.W_FULL, Styles.SHADOW_LG, Styles.MB_4);
+  private ButtonTag renderViewApplicationsLink(ProgramDefinition activeProgram) {
+    String viewApplicationsLink =
+        routes.AdminApplicationController.index(
+                activeProgram.id(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty())
+            .url();
+    ButtonTag button =
+        makeSvgTextButton("Applications", Icons.TEXT_SNIPPET)
+            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+    return asRedirectButton(button, viewApplicationsLink);
   }
 
-  private String extractProgramStatusText(
-      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
-    if (draftProgram.isPresent() && activeProgram.isPresent()) {
-      return "Active, with draft";
-    } else if (draftProgram.isPresent()) {
-      return "Draft";
-    } else if (activeProgram.isPresent()) {
-      return "Active";
-    }
-    throw new IllegalArgumentException("Program neither active nor draft.");
-  }
-
-  Tag<?> maybeRenderViewApplicationsLink(String text, Optional<ProgramDefinition> activeProgram) {
-    if (activeProgram.isPresent()) {
-      String viewApplicationsLink =
-          routes.AdminApplicationController.index(
-                  activeProgram.get().id(),
-                  Optional.empty(),
-                  Optional.empty(),
-                  Optional.empty(),
-                  Optional.empty())
-              .url();
-
-      return new LinkElement()
-          .setId("program-view-apps-link-" + activeProgram.get().id())
-          .setHref(viewApplicationsLink)
-          .setText(text)
-          .setStyles(Styles.MR_2)
-          .asAnchorText();
-    } else {
-      return div();
-    }
+  private ButtonTag renderShareLink(ProgramDefinition program) {
+    String programLink =
+        baseUrl
+            + controllers.applicant.routes.RedirectController.programBySlug(program.slug()).url();
+    return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
+        .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
+        .withData("copyable-program-link", programLink);
   }
 }

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -210,11 +210,9 @@ public final class ProgramIndexView extends BaseHtmlView {
       Optional<ProgramDefinition> draftProgram,
       Http.Request request,
       Optional<CiviFormProfile> profile) {
-    ProgramCardFactory.ProgramCardParams.Builder cardBuilder =
-        ProgramCardFactory.ProgramCardParams.builder()
-            .setActiveProgram(activeProgram)
-            .setDraftProgram(draftProgram);
 
+    Optional<ProgramCardFactory.ProgramCardData.ProgramRow> draftRow = Optional.empty();
+    Optional<ProgramCardFactory.ProgramCardData.ProgramRow> activeRow = Optional.empty();
     if (draftProgram.isPresent()) {
       List<ButtonTag> draftRowActions = Lists.newArrayList();
       List<ButtonTag> draftRowExtraActions = Lists.newArrayList();
@@ -228,10 +226,13 @@ public final class ProgramIndexView extends BaseHtmlView {
       if (featureFlags.isStatusTrackingEnabled(request)) {
         draftRowExtraActions.add(renderEditStatusesLink(draftProgram.get()));
       }
-      cardBuilder =
-          cardBuilder
-              .setDraftRowActions(ImmutableList.copyOf(draftRowActions))
-              .setDraftRowExtraActions(ImmutableList.copyOf(draftRowExtraActions));
+      draftRow =
+          Optional.of(
+              ProgramCardFactory.ProgramCardData.ProgramRow.builder()
+                  .setProgram(draftProgram.get())
+                  .setRowActions(ImmutableList.copyOf(draftRowActions))
+                  .setExtraRowActions(ImmutableList.copyOf(draftRowExtraActions))
+                  .build());
     }
 
     if (activeProgram.isPresent()) {
@@ -245,13 +246,20 @@ public final class ProgramIndexView extends BaseHtmlView {
         activeRowExtraActions.add(renderManageProgramAdminsLink(activeProgram.get()));
       }
       activeRowActions.add(renderShareLink(activeProgram.get()));
-      cardBuilder =
-          cardBuilder
-              .setActiveRowActions(ImmutableList.copyOf(activeRowActions))
-              .setActiveRowExtraActions(ImmutableList.copyOf(activeRowExtraActions));
+      activeRow =
+          Optional.of(
+              ProgramCardFactory.ProgramCardData.ProgramRow.builder()
+                  .setProgram(activeProgram.get())
+                  .setRowActions(ImmutableList.copyOf(activeRowActions))
+                  .setExtraRowActions(ImmutableList.copyOf(activeRowExtraActions))
+                  .build());
     }
 
-    return programCardFactory.renderCard(cardBuilder.build());
+    return programCardFactory.renderCard(
+        ProgramCardFactory.ProgramCardData.builder()
+            .setActiveProgram(activeRow)
+            .setDraftProgram(draftRow)
+            .build());
   }
 
   ButtonTag renderShareLink(ProgramDefinition program) {

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -8,9 +8,9 @@ import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.legend;
 import static j2html.TagCreator.p;
-import static j2html.TagCreator.span;
 
 import auth.CiviFormProfile;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
@@ -18,13 +18,11 @@ import controllers.admin.routes;
 import featureflags.FeatureFlags;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import play.mvc.Http;
 import play.twirl.api.Content;
-import services.DateConverter;
 import services.TranslationLocales;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramDefinition;
@@ -36,32 +34,31 @@ import views.admin.AdminLayoutFactory;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
+import views.components.ProgramCardFactory;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
-import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders a page so the admin can view all active programs and draft programs. */
 public final class ProgramIndexView extends BaseHtmlView {
   private final AdminLayout layout;
   private final String baseUrl;
-  private final DateConverter dateConverter;
   private final TranslationLocales translationLocales;
+  private final ProgramCardFactory programCardFactory;
   private final FeatureFlags featureFlags;
 
   @Inject
   public ProgramIndexView(
       AdminLayoutFactory layoutFactory,
       Config config,
-      DateConverter dateConverter,
       TranslationLocales translationLocales,
+      ProgramCardFactory programCardFactory,
       FeatureFlags featureFlags) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
-    this.dateConverter = checkNotNull(dateConverter);
     this.translationLocales = checkNotNull(translationLocales);
+    this.programCardFactory = checkNotNull(programCardFactory);
     this.featureFlags = checkNotNull(featureFlags);
   }
 
@@ -208,130 +205,16 @@ public final class ProgramIndexView extends BaseHtmlView {
     return asRedirectButton(button, link);
   }
 
-  public ProgramDefinition getDisplayProgram(
-      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
-    if (draftProgram.isPresent()) {
-      return draftProgram.get();
-    }
-    return activeProgram.get();
-  }
-
-  private DivTag renderProgramRow(
-      boolean isActive,
-      ProgramDefinition program,
-      List<ButtonTag> actions,
-      List<ButtonTag> extraActions,
-      String... extraStyles) {
-    String badgeText = "Draft";
-    String badgeBGColor = BaseStyles.BG_CIVIFORM_PURPLE_LIGHT;
-    String badgeFillColor = BaseStyles.TEXT_CIVIFORM_PURPLE;
-    String updatedPrefix = "Edited on ";
-    Optional<Instant> updatedTime = program.lastModifiedTime();
-    if (isActive) {
-      badgeText = "Active";
-      badgeBGColor = BaseStyles.BG_CIVIFORM_GREEN_LIGHT;
-      badgeFillColor = BaseStyles.TEXT_CIVIFORM_GREEN;
-      updatedPrefix = "Published on ";
-    }
-
-    String formattedUpdateTime =
-        updatedTime.map(t -> dateConverter.renderDateTime(t)).orElse("unknown");
-    String formattedUpdateDate =
-        updatedTime.map(t -> dateConverter.renderDate(t)).orElse("unknown");
-
-    int blockCount = program.getBlockCount();
-    int questionCount = program.getQuestionCount();
-
-    String extraActionsButtonId = "extra-actions-" + program.id();
-    ButtonTag extraActionsButton =
-        makeSvgTextButton("", Icons.MORE_VERT)
-            .withId(extraActionsButtonId)
-            .withClasses(
-                AdminStyles.TERTIARY_BUTTON_STYLES,
-                ReferenceClasses.WITH_DROPDOWN,
-                Styles.H_12,
-                extraActions.size() == 0 ? Styles.INVISIBLE : "");
-
-    return div()
-        .withClasses(
-            Styles.PY_7,
-            Styles.FLEX,
-            Styles.FLEX_ROW,
-            StyleUtils.hover(Styles.BG_GRAY_100),
-            StyleUtils.joinStyles(extraStyles))
-        .with(
-            p().withClasses(
-                    badgeBGColor,
-                    badgeFillColor,
-                    Styles.ML_2,
-                    StyleUtils.responsiveXLarge(Styles.ML_8),
-                    Styles.FONT_MEDIUM,
-                    Styles.ROUNDED_FULL,
-                    Styles.FLEX,
-                    Styles.FLEX_ROW,
-                    Styles.GAP_X_2,
-                    Styles.PLACE_ITEMS_CENTER,
-                    Styles.JUSTIFY_CENTER)
-                .withStyle("min-width:90px")
-                .with(
-                    Icons.svg(Icons.NOISE_CONTROL_OFF)
-                        .withClasses(Styles.INLINE_BLOCK, Styles.ML_3_5),
-                    span(badgeText).withClass(Styles.MR_4)),
-            div()
-                .withClasses(Styles.ML_4, StyleUtils.responsiveXLarge(Styles.ML_10))
-                .with(
-                    p().with(
-                            span(updatedPrefix),
-                            span(formattedUpdateTime)
-                                .withClasses(
-                                    Styles.FONT_SEMIBOLD,
-                                    Styles.HIDDEN,
-                                    StyleUtils.responsiveLarge(Styles.INLINE)),
-                            span(formattedUpdateDate)
-                                .withClasses(
-                                    Styles.FONT_SEMIBOLD,
-                                    StyleUtils.responsiveLarge(Styles.HIDDEN))),
-                    p().with(
-                            span(String.format("%d", blockCount)).withClass(Styles.FONT_SEMIBOLD),
-                            span(blockCount == 1 ? " screen, " : " screens, "),
-                            span(String.format("%d", questionCount))
-                                .withClass(Styles.FONT_SEMIBOLD),
-                            span(questionCount == 1 ? " question" : " questions"))),
-            div().withClass(Styles.FLEX_GROW),
-            div()
-                .withClasses(Styles.FLEX, Styles.SPACE_X_2, Styles.PR_6, Styles.FONT_MEDIUM)
-                .with(actions)
-                .with(
-                    div()
-                        .withClass(Styles.RELATIVE)
-                        .with(
-                            extraActionsButton,
-                            div()
-                                .withId(extraActionsButtonId + "-dropdown")
-                                .withClasses(
-                                    Styles.HIDDEN,
-                                    Styles.FLEX,
-                                    Styles.FLEX_COL,
-                                    Styles.BORDER,
-                                    Styles.BG_WHITE,
-                                    Styles.ABSOLUTE,
-                                    Styles.RIGHT_0,
-                                    Styles.W_56,
-                                    Styles.Z_50)
-                                .with(extraActions))));
-  }
-
-  public DivTag renderProgramListItem(
+  private DivTag renderProgramListItem(
       Optional<ProgramDefinition> activeProgram,
       Optional<ProgramDefinition> draftProgram,
       Http.Request request,
       Optional<CiviFormProfile> profile) {
-    ProgramDefinition displayProgram = getDisplayProgram(draftProgram, activeProgram);
+    ProgramCardFactory.ProgramCardParams.Builder cardBuilder =
+        ProgramCardFactory.ProgramCardParams.builder()
+            .setActiveProgram(activeProgram)
+            .setDraftProgram(draftProgram);
 
-    String programTitleText = displayProgram.adminName();
-    String programDescriptionText = displayProgram.adminDescription();
-
-    DivTag statusDiv = div();
     if (draftProgram.isPresent()) {
       List<ButtonTag> draftRowActions = Lists.newArrayList();
       List<ButtonTag> draftRowExtraActions = Lists.newArrayList();
@@ -345,13 +228,10 @@ public final class ProgramIndexView extends BaseHtmlView {
       if (featureFlags.isStatusTrackingEnabled(request)) {
         draftRowExtraActions.add(renderEditStatusesLink(draftProgram.get()));
       }
-      statusDiv =
-          statusDiv.with(
-              renderProgramRow(
-                  /* isActive = */ false,
-                  draftProgram.get(),
-                  draftRowActions,
-                  draftRowExtraActions));
+      cardBuilder =
+          cardBuilder
+              .setDraftRowActions(ImmutableList.copyOf(draftRowActions))
+              .setDraftRowExtraActions(ImmutableList.copyOf(draftRowExtraActions));
     }
 
     if (activeProgram.isPresent()) {
@@ -365,69 +245,13 @@ public final class ProgramIndexView extends BaseHtmlView {
         activeRowExtraActions.add(renderManageProgramAdminsLink(activeProgram.get()));
       }
       activeRowActions.add(renderShareLink(activeProgram.get()));
-      statusDiv =
-          statusDiv.with(
-              renderProgramRow(
-                  /* isActive = */ true,
-                  activeProgram.get(),
-                  activeRowActions,
-                  activeRowExtraActions,
-                  draftProgram.isPresent() ? Styles.BORDER_T : ""));
+      cardBuilder =
+          cardBuilder
+              .setActiveRowActions(ImmutableList.copyOf(activeRowActions))
+              .setActiveRowExtraActions(ImmutableList.copyOf(activeRowExtraActions));
     }
 
-    DivTag titleAndStatus =
-        div()
-            .withClass(Styles.FLEX)
-            .with(
-                p(programTitleText)
-                    .withClasses(
-                        ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE,
-                        Styles.W_1_4,
-                        Styles.PY_7,
-                        Styles.TEXT_BLACK,
-                        Styles.FONT_BOLD,
-                        Styles.TEXT_XL),
-                statusDiv.withClasses(
-                    Styles.FLEX_GROW,
-                    Styles.TEXT_SM,
-                    StyleUtils.responsiveLarge(Styles.TEXT_BASE)));
-
-    return div()
-        .withClasses(
-            ReferenceClasses.ADMIN_PROGRAM_CARD,
-            Styles.W_FULL,
-            Styles.MY_4,
-            Styles.PL_6,
-            Styles.BORDER,
-            Styles.BORDER_GRAY_300,
-            Styles.ROUNDED_LG)
-        .with(
-            titleAndStatus,
-            p(programDescriptionText)
-                .withClasses(
-                    Styles.W_3_4,
-                    Styles.MB_8,
-                    Styles.PT_4,
-                    Styles.LINE_CLAMP_3,
-                    Styles.TEXT_GRAY_700,
-                    Styles.TEXT_BASE))
-        // Add data attributes used for client-side sorting.
-        .withData(
-            "last-updated-millis",
-            Long.toString(extractLastUpdated(draftProgram, activeProgram).toEpochMilli()))
-        .withData("name", programTitleText);
-  }
-
-  private static Instant extractLastUpdated(
-      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
-    // Prefer when the draft was last updated, since active versions should be immutable after
-    // being published.
-    if (draftProgram.isEmpty() && activeProgram.isEmpty()) {
-      throw new IllegalArgumentException("Program neither active nor draft.");
-    }
-
-    ProgramDefinition program = draftProgram.isPresent() ? draftProgram.get() : activeProgram.get();
-    return program.lastModifiedTime().orElse(Instant.EPOCH);
+    return programCardFactory.renderCard(cardBuilder.build());
   }
 
   ButtonTag renderShareLink(ProgramDefinition program) {
@@ -504,7 +328,6 @@ public final class ProgramIndexView extends BaseHtmlView {
 
       ButtonTag button =
           makeSvgTextButton("Applications", Icons.TEXT_SNIPPET)
-              .withId("program-view-apps-link-" + activeProgram.id())
               .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
       return Optional.of(asRedirectButton(button, editLink));
     }

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -21,6 +21,9 @@ import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 import views.style.Styles;
 
+/**
+ * Responsible for generating a program card for view by CiviForm admins / program admins.
+ */
 public final class ProgramCardFactory {
 
   private final DateConverter dateConverter;
@@ -30,25 +33,25 @@ public final class ProgramCardFactory {
     this.dateConverter = checkNotNull(dateConverter);
   }
 
-  public DivTag renderCard(ProgramCardData params) {
-    ProgramDefinition displayProgram = getDisplayProgram(params);
+  public DivTag renderCard(ProgramCardData cardData) {
+    ProgramDefinition displayProgram = getDisplayProgram(cardData);
 
     String programTitleText = displayProgram.adminName();
     String programDescriptionText = displayProgram.adminDescription();
 
     DivTag statusDiv = div();
-    if (params.draftProgram().isPresent()) {
+    if (cardData.draftProgram().isPresent()) {
       statusDiv =
-          statusDiv.with(renderProgramRow(/* isActive = */ false, params.draftProgram().get()));
+          statusDiv.with(renderProgramRow(/* isActive = */ false, cardData.draftProgram().get()));
     }
 
-    if (params.activeProgram().isPresent()) {
+    if (cardData.activeProgram().isPresent()) {
       statusDiv =
           statusDiv.with(
               renderProgramRow(
                   /* isActive = */ true,
-                  params.activeProgram().get(),
-                  params.draftProgram().isPresent() ? Styles.BORDER_T : ""));
+                  cardData.activeProgram().get(),
+                  cardData.draftProgram().isPresent() ? Styles.BORDER_T : ""));
     }
 
     DivTag titleAndStatus =
@@ -88,7 +91,7 @@ public final class ProgramCardFactory {
                     Styles.TEXT_GRAY_700,
                     Styles.TEXT_BASE))
         // Add data attributes used for client-side sorting.
-        .withData("last-updated-millis", Long.toString(extractLastUpdated(params).toEpochMilli()))
+        .withData("last-updated-millis", Long.toString(extractLastUpdated(cardData).toEpochMilli()))
         .withData("name", programTitleText);
   }
 

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -1,7 +1,6 @@
 package views.components;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
@@ -15,15 +14,14 @@ import java.util.Optional;
 import javax.inject.Inject;
 import services.DateConverter;
 import services.program.ProgramDefinition;
+import views.ViewUtils;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-/**
- * Responsible for generating a program card for view by CiviForm admins / program admins.
- */
+/** Responsible for generating a program card for view by CiviForm admins / program admins. */
 public final class ProgramCardFactory {
 
   private final DateConverter dateConverter;
@@ -120,7 +118,7 @@ public final class ProgramCardFactory {
 
     String extraActionsButtonId = "extra-actions-" + program.id();
     ButtonTag extraActionsButton =
-        makeSvgTextButton("", Icons.MORE_VERT)
+        ViewUtils.makeSvgTextButton("", Icons.MORE_VERT)
             .withId(extraActionsButtonId)
             .withClasses(
                 AdminStyles.TERTIARY_BUTTON_STYLES,
@@ -216,17 +214,6 @@ public final class ProgramCardFactory {
             ? cardData.draftProgram().get().program()
             : cardData.activeProgram().get().program();
     return program.lastModifiedTime().orElse(Instant.EPOCH);
-  }
-
-  // TODO(clouser): Helper.
-  private static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {
-    return button()
-        .with(
-            Icons.svg(icon)
-                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0)
-                // Can't set 18px using Tailwind CSS classes.
-                .withStyle("width: 18px; height: 18px;"),
-            span(buttonText).withClass(Styles.TEXT_LEFT));
   }
 
   @AutoValue

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -1,0 +1,278 @@
+package views.components;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.button;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.p;
+import static j2html.TagCreator.span;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import j2html.tags.specialized.ButtonTag;
+import j2html.tags.specialized.DivTag;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import services.DateConverter;
+import services.program.ProgramDefinition;
+import views.style.AdminStyles;
+import views.style.BaseStyles;
+import views.style.ReferenceClasses;
+import views.style.StyleUtils;
+import views.style.Styles;
+
+public final class ProgramCardFactory {
+
+  private final DateConverter dateConverter;
+
+  @Inject
+  public ProgramCardFactory(DateConverter dateConverter) {
+    this.dateConverter = checkNotNull(dateConverter);
+  }
+
+  public DivTag renderCard(ProgramCardParams params) {
+    ProgramDefinition displayProgram =
+        getDisplayProgram(params.draftProgram(), params.activeProgram());
+
+    String programTitleText = displayProgram.adminName();
+    String programDescriptionText = displayProgram.adminDescription();
+
+    DivTag statusDiv = div();
+    if (params.draftProgram().isPresent()) {
+      statusDiv =
+          statusDiv.with(
+              renderProgramRow(
+                  /* isActive = */ false,
+                  params.draftProgram().get(),
+                  params.draftRowActions(),
+                  params.draftRowExtraActions()));
+    }
+
+    if (params.activeProgram().isPresent()) {
+      statusDiv =
+          statusDiv.with(
+              renderProgramRow(
+                  /* isActive = */ true,
+                  params.activeProgram().get(),
+                  params.activeRowActions(),
+                  params.activeRowExtraActions(),
+                  params.draftProgram().isPresent() ? Styles.BORDER_T : ""));
+    }
+
+    DivTag titleAndStatus =
+        div()
+            .withClass(Styles.FLEX)
+            .with(
+                p(programTitleText)
+                    .withClasses(
+                        ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE,
+                        Styles.W_1_4,
+                        Styles.PY_7,
+                        Styles.TEXT_BLACK,
+                        Styles.FONT_BOLD,
+                        Styles.TEXT_XL),
+                statusDiv.withClasses(
+                    Styles.FLEX_GROW,
+                    Styles.TEXT_SM,
+                    StyleUtils.responsiveLarge(Styles.TEXT_BASE)));
+
+    return div()
+        .withClasses(
+            ReferenceClasses.ADMIN_PROGRAM_CARD,
+            Styles.W_FULL,
+            Styles.MY_4,
+            Styles.PL_6,
+            Styles.BORDER,
+            Styles.BORDER_GRAY_300,
+            Styles.ROUNDED_LG)
+        .with(
+            titleAndStatus,
+            p(programDescriptionText)
+                .withClasses(
+                    Styles.W_3_4,
+                    Styles.MB_8,
+                    Styles.PT_4,
+                    Styles.LINE_CLAMP_3,
+                    Styles.TEXT_GRAY_700,
+                    Styles.TEXT_BASE))
+        // Add data attributes used for client-side sorting.
+        .withData(
+            "last-updated-millis",
+            Long.toString(
+                extractLastUpdated(params.draftProgram(), params.activeProgram()).toEpochMilli()))
+        .withData("name", programTitleText);
+  }
+
+  private DivTag renderProgramRow(
+      boolean isActive,
+      ProgramDefinition program,
+      List<ButtonTag> actions,
+      List<ButtonTag> extraActions,
+      String... extraStyles) {
+    String badgeText = "Draft";
+    String badgeBGColor = BaseStyles.BG_CIVIFORM_PURPLE_LIGHT;
+    String badgeFillColor = BaseStyles.TEXT_CIVIFORM_PURPLE;
+    String updatedPrefix = "Edited on ";
+    Optional<Instant> updatedTime = program.lastModifiedTime();
+    if (isActive) {
+      badgeText = "Active";
+      badgeBGColor = BaseStyles.BG_CIVIFORM_GREEN_LIGHT;
+      badgeFillColor = BaseStyles.TEXT_CIVIFORM_GREEN;
+      updatedPrefix = "Published on ";
+    }
+
+    String formattedUpdateTime =
+        updatedTime.map(t -> dateConverter.renderDateTime(t)).orElse("unknown");
+    String formattedUpdateDate =
+        updatedTime.map(t -> dateConverter.renderDate(t)).orElse("unknown");
+
+    int blockCount = program.getBlockCount();
+    int questionCount = program.getQuestionCount();
+
+    String extraActionsButtonId = "extra-actions-" + program.id();
+    ButtonTag extraActionsButton =
+        makeSvgTextButton("", Icons.MORE_VERT)
+            .withId(extraActionsButtonId)
+            .withClasses(
+                AdminStyles.TERTIARY_BUTTON_STYLES,
+                ReferenceClasses.WITH_DROPDOWN,
+                Styles.H_12,
+                extraActions.size() == 0 ? Styles.INVISIBLE : "");
+
+    return div()
+        .withClasses(
+            Styles.PY_7,
+            Styles.FLEX,
+            Styles.FLEX_ROW,
+            StyleUtils.hover(Styles.BG_GRAY_100),
+            StyleUtils.joinStyles(extraStyles))
+        .with(
+            p().withClasses(
+                    badgeBGColor,
+                    badgeFillColor,
+                    Styles.ML_2,
+                    StyleUtils.responsiveXLarge(Styles.ML_8),
+                    Styles.FONT_MEDIUM,
+                    Styles.ROUNDED_FULL,
+                    Styles.FLEX,
+                    Styles.FLEX_ROW,
+                    Styles.GAP_X_2,
+                    Styles.PLACE_ITEMS_CENTER,
+                    Styles.JUSTIFY_CENTER)
+                .withStyle("min-width:90px")
+                .with(
+                    Icons.svg(Icons.NOISE_CONTROL_OFF)
+                        .withClasses(Styles.INLINE_BLOCK, Styles.ML_3_5),
+                    span(badgeText).withClass(Styles.MR_4)),
+            div()
+                .withClasses(Styles.ML_4, StyleUtils.responsiveXLarge(Styles.ML_10))
+                .with(
+                    p().with(
+                            span(updatedPrefix),
+                            span(formattedUpdateTime)
+                                .withClasses(
+                                    Styles.FONT_SEMIBOLD,
+                                    Styles.HIDDEN,
+                                    StyleUtils.responsiveLarge(Styles.INLINE)),
+                            span(formattedUpdateDate)
+                                .withClasses(
+                                    Styles.FONT_SEMIBOLD,
+                                    StyleUtils.responsiveLarge(Styles.HIDDEN))),
+                    p().with(
+                            span(String.format("%d", blockCount)).withClass(Styles.FONT_SEMIBOLD),
+                            span(blockCount == 1 ? " screen, " : " screens, "),
+                            span(String.format("%d", questionCount))
+                                .withClass(Styles.FONT_SEMIBOLD),
+                            span(questionCount == 1 ? " question" : " questions"))),
+            div().withClass(Styles.FLEX_GROW),
+            div()
+                .withClasses(Styles.FLEX, Styles.SPACE_X_2, Styles.PR_6, Styles.FONT_MEDIUM)
+                .with(actions)
+                .with(
+                    div()
+                        .withClass(Styles.RELATIVE)
+                        .with(
+                            extraActionsButton,
+                            div()
+                                .withId(extraActionsButtonId + "-dropdown")
+                                .withClasses(
+                                    Styles.HIDDEN,
+                                    Styles.FLEX,
+                                    Styles.FLEX_COL,
+                                    Styles.BORDER,
+                                    Styles.BG_WHITE,
+                                    Styles.ABSOLUTE,
+                                    Styles.RIGHT_0,
+                                    Styles.W_56,
+                                    Styles.Z_50)
+                                .with(extraActions))));
+  }
+
+  private ProgramDefinition getDisplayProgram(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    if (draftProgram.isPresent()) {
+      return draftProgram.get();
+    }
+    return activeProgram.get();
+  }
+
+  private static Instant extractLastUpdated(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    // Prefer when the draft was last updated, since active versions should be immutable after
+    // being published.
+    if (draftProgram.isEmpty() && activeProgram.isEmpty()) {
+      throw new IllegalArgumentException("Program neither active nor draft.");
+    }
+
+    ProgramDefinition program = draftProgram.isPresent() ? draftProgram.get() : activeProgram.get();
+    return program.lastModifiedTime().orElse(Instant.EPOCH);
+  }
+
+  // TODO(clouser): Helper.
+  private static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {
+    return button()
+        .with(
+            Icons.svg(icon)
+                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0)
+                // Can't set 18px using Tailwind CSS classes.
+                .withStyle("width: 18px; height: 18px;"),
+            span(buttonText).withClass(Styles.TEXT_LEFT));
+  }
+
+  @AutoValue
+  public abstract static class ProgramCardParams {
+    abstract Optional<ProgramDefinition> activeProgram();
+
+    abstract ImmutableList<ButtonTag> activeRowActions();
+
+    abstract ImmutableList<ButtonTag> activeRowExtraActions();
+
+    abstract Optional<ProgramDefinition> draftProgram();
+
+    abstract ImmutableList<ButtonTag> draftRowActions();
+
+    abstract ImmutableList<ButtonTag> draftRowExtraActions();
+
+    public static Builder builder() {
+      return new AutoValue_ProgramCardFactory_ProgramCardParams.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setActiveProgram(Optional<ProgramDefinition> v);
+
+      public abstract Builder setActiveRowActions(ImmutableList<ButtonTag> v);
+
+      public abstract Builder setActiveRowExtraActions(ImmutableList<ButtonTag> v);
+
+      public abstract Builder setDraftProgram(Optional<ProgramDefinition> v);
+
+      public abstract Builder setDraftRowActions(ImmutableList<ButtonTag> v);
+
+      public abstract Builder setDraftRowExtraActions(ImmutableList<ButtonTag> v);
+
+      public abstract ProgramCardParams build();
+    }
+  }
+}

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -255,7 +255,11 @@ public final class ProgramCardFactory {
     abstract ImmutableList<ButtonTag> draftRowExtraActions();
 
     public static Builder builder() {
-      return new AutoValue_ProgramCardFactory_ProgramCardParams.Builder();
+      return new AutoValue_ProgramCardFactory_ProgramCardParams.Builder()
+          .setActiveRowActions(ImmutableList.of())
+          .setActiveRowExtraActions(ImmutableList.of())
+          .setDraftRowActions(ImmutableList.of())
+          .setDraftRowExtraActions(ImmutableList.of());
     }
 
     @AutoValue.Builder


### PR DESCRIPTION
### Description

Program admins also see a program list with distinct options from a CiviForm admin. That said, the styling is largely the same. This PR factors out the "render a program with a set of actions" logic from the CiviForm admin view into `ProgramCardFactory`. It is then reused by the program admin view to display program cards containing actions for 1) viewing applications and 2) making a shareable program link.

While here, I also adapted the TS code to attach the copy to clipboard behavior to any elements with the specified data attribute rather than just those inside of a program card list.

The only visual change was that we would previously show program admins data that a draft existed, which doesn't seem pertinent since program admins have no ability to affect a draft version.

### Screenshots
Before:
![Screen Shot 2022-08-31 at 10 42 19 AM](https://user-images.githubusercontent.com/1870301/187745313-73d6c539-f56b-4d63-972c-de571cec73cd.png)

After:
![Screen Shot 2022-08-31 at 10 49 17 AM](https://user-images.githubusercontent.com/1870301/187745668-14f83409-ca1e-495e-81a4-ff8d595bcedc.png)

## Release notes:

Updates the list of programs shown to a program admin to be consistent with the new visual styling shown to the CiviForm admin.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #1238