### PR TITLE
Refactor asRedirectButton method

### DIFF
--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -466,6 +466,34 @@ function attachFormDebouncers() {
   )
 }
 
+/**
+ * Adds event listener to all elements on a page that match given selector.
+ * This function doesn't handle elements added dynamically after the function was invoked.
+ * @param selector CSS selector that will be used to retrieve list of elements.
+ * @param event Browser event. For example 'click'
+ * @param listener Listener that will be registered on all matching elements.
+ */
+function addEventListenerToElements(
+  selector: string,
+  event: string,
+  listener: (e: Event) => void,
+) {
+  Array.from(document.querySelectorAll(selector)).forEach((el) =>
+    el.addEventListener(event, listener),
+  )
+}
+
+/**
+ * Adds listeners to all elements that have `data-redirect-to="..."` attribute.
+ * All such elements act as links taking user to another page.
+ */
+function attachRedirectToPageListeners() {
+  addEventListenerToElements('[data-redirect-to]', 'click', (e: Event) => {
+    e.stopPropagation()
+    window.location.href = (e.currentTarget as HTMLElement).dataset.redirectTo
+  })
+}
+
 window.addEventListener('load', () => {
   attachDropdown('create-question-button')
   Array.from(document.querySelectorAll('.cf-with-dropdown')).forEach((el) => {
@@ -476,12 +504,16 @@ window.addEventListener('load', () => {
 
   // Configure the admin predicate builder to show the appropriate options based on
   // the type of scalar selected.
-  Array.from(document.querySelectorAll('.cf-scalar-select')).forEach((el) =>
-    el.addEventListener('input', configurePredicateFormOnScalarChange),
+  addEventListenerToElements(
+    '.cf-scalar-select',
+    'input',
+    configurePredicateFormOnScalarChange,
   )
 
-  Array.from(document.querySelectorAll('.cf-operator-select')).forEach((el) =>
-    el.addEventListener('input', configurePredicateFormOnOperatorChange),
+  addEventListenerToElements(
+    '.cf-operator-select',
+    'input',
+    configurePredicateFormOnOperatorChange,
   )
 
   // Submit button is disabled by default until program block edit form is changed
@@ -503,9 +535,11 @@ window.addEventListener('load', () => {
   }
 
   // Bind click handler for remove options in multi-option edit view
-  Array.from(
-    document.querySelectorAll('.multi-option-question-field-remove-button'),
-  ).forEach((el) => el.addEventListener('click', removeInput))
+  addEventListenerToElements(
+    '.multi-option-question-field-remove-button',
+    'click',
+    removeInput,
+  )
 
   // Configure the button on the manage program admins form to add more email inputs
   const adminEmailButton = document.getElementById('add-program-admin-button')
@@ -520,9 +554,11 @@ window.addEventListener('load', () => {
   }
 
   // Bind click handler for removing program admins in the program admin management view
-  Array.from(
-    document.querySelectorAll('.cf-program-admin-remove-button'),
-  ).forEach((el) => el.addEventListener('click', hideInput))
+  addEventListenerToElements(
+    '.cf-program-admin-remove-button',
+    'click',
+    hideInput,
+  )
 
   // Configure the button on the enumerator question form to add more enumerator field options
   const enumeratorOptionButton = document.getElementById(
@@ -533,12 +569,16 @@ window.addEventListener('load', () => {
   }
 
   // Configure existing enumerator entity remove buttons
-  Array.from(document.querySelectorAll('.cf-enumerator-delete-button')).forEach(
-    (el) => el.addEventListener('click', removeExistingEnumeratorField),
+  addEventListenerToElements(
+    '.cf-enumerator-delete-button',
+    'click',
+    removeExistingEnumeratorField,
   )
   addEnumeratorListeners()
 
   attachFormDebouncers()
+
+  attachRedirectToPageListeners()
 
   // Advertise (e.g., for browser tests) that main.ts initialization is done
   document.body.dataset.loadMain = 'true'

--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -68,12 +68,21 @@ public abstract class BaseHtmlView {
   }
 
   protected static ButtonTag redirectButton(String id, String text, String redirectUrl) {
-    return asRedirectButton(
+    return asRedirectElement(
         TagCreator.button(text).withId(id).withClasses(Styles.M_2), redirectUrl);
   }
 
-  protected static ButtonTag asRedirectButton(ButtonTag buttonEl, String redirectUrl) {
-    return buttonEl.attr("onclick", String.format("window.location = '%s';", redirectUrl));
+  /**
+   * Turns provided element into a clickable element. Upon click the user will be redirected to the
+   * provided url. It's up to caller of this method to style element appropriately to make it clear
+   * that the element is clickable. For example add hover effect and change cursor style.
+   *
+   * @return The element itself.
+   */
+  protected static <T extends Tag> T asRedirectElement(T element, String redirectUrl) {
+    // Attribute `data-redirect-to` is handled in JS by main.ts file.
+    element.attr("data-redirect-to", redirectUrl);
+    return element;
   }
 
   protected static ButtonTag makeSvgTextButton(String buttonText, Icons icon) {

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -205,7 +205,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         makeSvgTextButton("Create new program", Icons.ADD)
             .withId("new-program-button")
             .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, Styles.MY_2);
-    return asRedirectButton(button, link);
+    return asRedirectElement(button, link);
   }
 
   public ProgramDefinition getDisplayProgram(
@@ -453,7 +453,7 @@ public final class ProgramIndexView extends BaseHtmlView {
             .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
     return isActive
         ? toLinkButtonForPost(button, editLink, request)
-        : asRedirectButton(button, editLink);
+        : asRedirectElement(button, editLink);
   }
 
   private Optional<ButtonTag> renderManageTranslationsLink(ProgramDefinition program) {
@@ -466,7 +466,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withId("program-translations-link-" + program.id())
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
-    return Optional.of(asRedirectButton(button, linkDestination));
+    return Optional.of(asRedirectElement(button, linkDestination));
   }
 
   private ButtonTag renderEditStatusesLink(ProgramDefinition program) {
@@ -474,7 +474,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage application statuses", Icons.FLAKY)
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
-    return asRedirectButton(button, linkDestination);
+    return asRedirectElement(button, linkDestination);
   }
 
   private Optional<ButtonTag> maybeRenderViewApplicationsLink(
@@ -506,7 +506,7 @@ public final class ProgramIndexView extends BaseHtmlView {
           makeSvgTextButton("Applications", Icons.TEXT_SNIPPET)
               .withId("program-view-apps-link-" + activeProgram.id())
               .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
-      return Optional.of(asRedirectButton(button, editLink));
+      return Optional.of(asRedirectElement(button, editLink));
     }
     return Optional.empty();
   }
@@ -517,6 +517,6 @@ public final class ProgramIndexView extends BaseHtmlView {
         makeSvgTextButton("Manage Program Admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
-    return asRedirectButton(button, adminLink);
+    return asRedirectElement(button, adminLink);
   }
 }

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -146,7 +146,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withClass(AdminStyles.SECONDARY_BUTTON_STYLES);
-    return Optional.of(asRedirectButton(button, linkDestination));
+    return Optional.of(asRedirectElement(button, linkDestination));
   }
 
   /**

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -272,7 +272,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .withClasses(Styles.FLEX, Styles.SPACE_X_2, Styles.MT_3)
                 .with(
                     div().withClasses(Styles.FLEX_GROW),
-                    asRedirectButton(button("Cancel"), questionForm.getRedirectUrl())
+                    asRedirectElement(button("Cancel"), questionForm.getRedirectUrl())
                         .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES),
                     submitButton("Create")
                         .withClass(Styles.M_4)

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -321,7 +321,7 @@ public final class QuestionsListView extends BaseHtmlView {
 
   private ButtonTag renderQuestionEditLink(QuestionDefinition definition, String linkText) {
     String link = controllers.admin.routes.AdminQuestionController.edit(definition.getId()).url();
-    return asRedirectButton(
+    return asRedirectElement(
         makeSvgTextButton(linkText, Icons.EDIT).withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
         link);
   }
@@ -336,7 +336,7 @@ public final class QuestionsListView extends BaseHtmlView {
             .url();
 
     ButtonTag button =
-        asRedirectButton(
+        asRedirectElement(
             makeSvgTextButton("Manage Translations", Icons.TRANSLATE)
                 .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
             link);
@@ -345,7 +345,7 @@ public final class QuestionsListView extends BaseHtmlView {
 
   private ButtonTag renderQuestionViewLink(QuestionDefinition definition, String linkText) {
     String link = controllers.admin.routes.AdminQuestionController.show(definition.getId()).url();
-    return asRedirectButton(
+    return asRedirectElement(
         makeSvgTextButton(linkText, Icons.VISIBILITY)
             .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
         link);


### PR DESCRIPTION
### Description

1. Rename it to `asRedirectElement` and update types to take any element. This is needed as we are planning to make some other elements, for example divs that act as rows, clickable.

2. Handle clicks using JS instead of inline `onclick` attribute. That gives us more flexibility in future as we can add extra JS in listener, for example call to `e.stopPropagation()`


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Issue #3033
