### PR TITLE
Change asRedirectButton to asRedirectElement (due to the rename from #3311)

### DIFF
--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -102,7 +102,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Applications", Icons.TEXT_SNIPPET)
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
-    return asRedirectButton(button, viewApplicationsLink);
+    return asRedirectElement(button, viewApplicationsLink);
   }
 
   private ButtonTag renderShareLink(ProgramDefinition program) {


### PR DESCRIPTION
### Description

This was a conflict where #3311 renamed `asRedirectButton` to `asRedirectElement`. A new reference was added in #3310 and was merged to main without merging in the changes from #3311.

## Release notes:

Fixing build breakage due to merge conflict.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#1238