### PR TITLE
Prototype of sequence of changes to have login provider work in browser tests rather than falling back on guest

### DIFF
--- a/bin/pull-image
+++ b/bin/pull-image
@@ -26,7 +26,7 @@ function pull_all() {
   docker pull civiform/civiform-dev:latest
 
   # Explicitly pull dev dependencies. (in parallel)
-  docker pull docker.io/civiform/oidc-provider:latest &
+  # docker pull docker.io/civiform/oidc-provider:latest &
   docker pull mcr.microsoft.com/azure-storage/azurite &
   docker pull localstack/localstack &
 
@@ -76,7 +76,7 @@ while [ "${1:-}" != "" ]; do
 
     "--oidc-provider")
       echo "Pull oidc-provider docker image"
-      docker pull docker.io/civiform/oidc-provider:latest
+      # docker pull docker.io/civiform/oidc-provider:latest
       ;;
 
     "--browser-tests")

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -26,7 +26,7 @@ function pull_all() {
   docker pull civiform/civiform-dev:latest
 
   # Explicitly pull dev dependencies. (in parallel)
-  # docker pull docker.io/civiform/oidc-provider:latest &
+  docker pull docker.io/civiform/oidc-provider:latest &
   docker pull mcr.microsoft.com/azure-storage/azurite &
   docker pull localstack/localstack &
 
@@ -76,7 +76,7 @@ while [ "${1:-}" != "" ]; do
 
     "--oidc-provider")
       echo "Pull oidc-provider docker image"
-      # docker pull docker.io/civiform/oidc-provider:latest
+      docker pull docker.io/civiform/oidc-provider:latest
       ;;
 
     "--browser-tests")

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -14,6 +14,10 @@ bin/pull-image
 docker run --rm -it \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
+  -e TEST_USER_AUTH_STRATEGY='fake-oidc' \
+  -e TEST_USER_LOGIN="testuser@example.com" \
+  -e TEST_USER_PASSWORD="anotsecretpassword" \
+  -e TEST_USER_DISPLAY_NAME="User, Test" \
   --network "${DOCKER_NETWORK_NAME}" \
   --init \
   civiform/civiform-browser-test:latest \

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -15,6 +15,10 @@ docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -v "browser-tests-node-modules:/usr/src/civiform-browser-tests/node_modules" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
+  -e TEST_USER_AUTH_STRATEGY='fake-oidc' \
+  -e TEST_USER_LOGIN="testuser@example.com" \
+  -e TEST_USER_PASSWORD="anotsecretpassword" \
+  -e TEST_USER_DISPLAY_NAME="User, Test" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -5,6 +5,10 @@
 source bin/lib.sh
 export BASE_URL=http://localhost:9999
 export DISABLE_SCREENSHOTS=true
+export TEST_USER_AUTH_STRATEGY=fake-oidc
+export TEST_USER_LOGIN=testuser@example.com
+export TEST_USER_PASSWORD=anotsecretpassword
+export TEST_USER_DISPLAY_NAME="User, Test"
 
 START_TIME=$(date +%s)
 DEADLINE=$(($START_TIME + 500))

--- a/bin/run-prober
+++ b/bin/run-prober
@@ -9,9 +9,9 @@ docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   -e BASE_URL="https://staging.seattle.civiform.com" \
-  -e TEST_USER_AUTH_STRATEGY="${TEST_USER_AUTH_STRATEGY}" \
+  -e TEST_USER_AUTH_STRATEGY="seattle-staging" \
   -e TEST_USER_LOGIN="${TEST_USER_LOGIN}" \
   -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD}" \
-  -e TEST_USER_DISPLAY_NAME="${TEST_USER_DISPLAY_NAME}" \
+  -e TEST_USER_DISPLAY_NAME="TEST, UATAPP" \
   civiform-browser-test:latest \
   /bin/bash -c "yarn install && yarn probe"

--- a/bin/run-prober
+++ b/bin/run-prober
@@ -9,7 +9,9 @@ docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   -e BASE_URL="https://staging.seattle.civiform.com" \
+  -e TEST_USER_AUTH_STRATEGY="${TEST_USER_AUTH_STRATEGY}" \
   -e TEST_USER_LOGIN="${TEST_USER_LOGIN}" \
   -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD}" \
+  -e TEST_USER_DISPLAY_NAME="${TEST_USER_DISPLAY_NAME}" \
   civiform-browser-test:latest \
   /bin/bash -c "yarn install && yarn probe"

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -11,6 +11,7 @@ import {
   AdminProgramStatuses,
   enableFeatureFlag,
   loginAsTestUser,
+  testUserDisplayName,
 } from './support'
 import {Page} from 'playwright'
 
@@ -171,8 +172,20 @@ describe('view program statuses', () => {
         await dismissModal(adminPrograms.applicationFrame())
       })
 
-      // TODO(#3297): Add a test that the send email checkbox is shown when an applicant has logged
-      // in and an email is configured for the status.
+      it('when email is configured for the status and applicant, a checkbox is shown to notify the applicant', async () => {
+        await adminPrograms.viewApplications(programWithStatusesName)
+        await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
+        const modal = await adminPrograms.setStatusOptionAndAwaitModal(
+          emailStatusName,
+        )
+        const notifyCheckbox = await modal.$('input[type=checkbox]')
+        if (!notifyCheckbox) {
+          throw new Error('Expected a checkbox input')
+        }
+        expect(await notifyCheckbox.isChecked()).toBe(true)
+        expect(await modal.innerText()).toContain(' of this change at ')
+        await dismissModal(adminPrograms.applicationFrame())
+      })
     })
 
     it('allows editing a note', async () => {

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -10,7 +10,7 @@ import {
   logout,
   selectApplicantLanguage,
   startSession,
-  userDisplayName,
+  testUserDisplayName,
 } from './support'
 
 describe('create and edit predicates', () => {
@@ -90,7 +90,7 @@ describe('create and edit predicates', () => {
     await logout(page)
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
 
     const applicationText = await adminPrograms
       .applicationFrameLocator()
@@ -182,7 +182,7 @@ describe('create and edit predicates', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
 
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     expect(
       await adminPrograms
         .applicationFrameLocator()

--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -9,7 +9,7 @@ import {
   loginAsTestUser,
   selectApplicantLanguage,
   ApplicantQuestions,
-  userDisplayName,
+  testUserDisplayName,
 } from './support'
 
 describe('view an application in an older version', () => {
@@ -47,7 +47,7 @@ describe('view an application in an older version', () => {
 
     // See the application in admin page
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,
@@ -66,7 +66,7 @@ describe('view an application in an older version', () => {
 
     // See the application in admin page in the old version
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -10,7 +10,7 @@ import {
   logout,
   selectApplicantLanguage,
   ApplicantQuestions,
-  userDisplayName,
+  testUserDisplayName,
 } from './support'
 
 describe('Program admin review of submitted applications', () => {
@@ -193,7 +193,7 @@ describe('Program admin review of submitted applications', () => {
     await loginAsProgramAdmin(page)
 
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       'address-q',
@@ -242,7 +242,7 @@ describe('Program admin review of submitted applications', () => {
     await loginAsProgramAdmin(page)
 
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(userDisplayName())
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 2',
       'favorite-trees-q',

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -6,6 +6,7 @@ import {
   waitForAnyModal,
   waitForPageJsLoad,
 } from './wait'
+import {BASE_URL} from './config'
 import {AdminProgramStatuses} from './admin_program_statuses'
 
 export class AdminPrograms {
@@ -372,6 +373,10 @@ export class AdminPrograms {
   }
 
   async viewApplications(programName: string) {
+    // Navigate back to the main page for the program admin.
+    await this.page.goto(BASE_URL)
+    await waitForPageJsLoad(this.page)
+
     // TODO(#1238): Consolidate the program admin and civiform admin views
     // and use the updated selector for this that clicks a button rather
     // than a link.

--- a/browser-test/src/support/config.ts
+++ b/browser-test/src/support/config.ts
@@ -1,6 +1,8 @@
 export const {
   BASE_URL = 'http://civiform:9000',
+  TEST_USER_AUTH_STRATEGY = 'fake-oidc',
   TEST_USER_LOGIN = '',
   TEST_USER_PASSWORD = '',
+  TEST_USER_DISPLAY_NAME = '',
   DISABLE_SCREENSHOTS = false,
 } = process.env

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -149,16 +149,17 @@ export const loginAsTestUser = async (page: Page) => {
       await loginAsTestUserFakeOidc(page)
       break
     case 'aws-staging':
-      // TODO(clouser): Remove this once a strategy for AWS staging is in place.
-      await loginAsGuest(page)
+      await loginAsTestUserAwsStaging(page)
       break
     case 'seattle-staging':
       await loginAsTestUserSeattleStaging(page)
       break
     default:
-      throw new Error(
-        `unrecognized TEST_USER_AUTH_STRATEGY "${TEST_USER_AUTH_STRATEGY}"`,
-      )
+      // TODO(clouser): Throw an error for an unrecognized strategy.
+      // throw new Error(
+      //   `unrecognized TEST_USER_AUTH_STRATEGY "${TEST_USER_AUTH_STRATEGY}"`,
+      // )
+      await loginAsGuest(page)
   }
   await waitForPageJsLoad(page)
 }
@@ -175,6 +176,20 @@ async function loginAsTestUserSeattleStaging(page: Page) {
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await page.click('button:has-text("Login"):not([disabled])')
   await page.waitForNavigation({waitUntil: 'networkidle'})
+}
+
+async function loginAsTestUserAwsStaging(page: Page) {
+  await Promise.all([
+    page.waitForURL('**/u/login/*', {waitUntil: 'networkidle'}),
+    page.click('button:has-text("Log in")'),
+  ])
+
+  await page.fill('input[name=username]', TEST_USER_LOGIN)
+  await page.fill('input[name=password]', TEST_USER_PASSWORD)
+  await Promise.all([
+    page.waitForURL('**/applicants/**', {waitUntil: 'networkidle'}),
+    page.click('button:has-text("Continue")'),
+  ])
 }
 
 async function loginAsTestUserFakeOidc(page: Page) {
@@ -216,8 +231,8 @@ async function loginAsTestUserFakeOidc(page: Page) {
 export const testUserDisplayName = () => {
   if (!TEST_USER_DISPLAY_NAME) {
     // TODO(clouser): Throw an error once this is in place.
-    return 'Guest'
     // throw new Error('TEST_USER_DISPLAY_NAME environment variable must be set')
+    return 'Guest'
   }
   return TEST_USER_DISPLAY_NAME
 }

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -148,6 +148,10 @@ export const loginAsTestUser = async (page: Page) => {
     case 'fake-oidc':
       await loginAsTestUserFakeOidc(page)
       break
+    case 'aws-staging':
+      // TODO(clouser): Remove this once a strategy for AWS staging is in place.
+      await loginAsGuest(page)
+      break
     case 'seattle-staging':
       await loginAsTestUserSeattleStaging(page)
       break
@@ -211,7 +215,9 @@ async function loginAsTestUserFakeOidc(page: Page) {
 
 export const testUserDisplayName = () => {
   if (!TEST_USER_DISPLAY_NAME) {
-    throw new Error('TEST_USER_DISPLAY_NAME environment variable must be set')
+    // TODO(clouser): Throw an error once this is in place.
+    return 'Guest'
+    // throw new Error('TEST_USER_DISPLAY_NAME environment variable must be set')
   }
   return TEST_USER_DISPLAY_NAME
 }

--- a/server/app/auth/oidc/applicant/IdcsProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsProvider.java
@@ -72,7 +72,7 @@ public final class IdcsProvider extends OidcProvider {
     // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#responsetypes
     // TODO: turn this into it's own fake provider or make the local provider allow
     // 'token'.
-    if (baseUrl.contains("localhost:")) {
+    if (baseUrl.contains("localhost:") || baseUrl.startsWith("http://civiform:")) {
       return "id_token";
     }
     return "id_token token";

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -7,14 +7,15 @@ const configuration = {
       response_types: ['id_token'],
       response_mode: ['form_post'],
       grant_types: ['implicit'],
-      // "native" because we're on localhost.
-      application_type: 'native',
+      application_type: 'web',
       scopes: ['openid', 'profile'],
       redirect_uris: [
         'http://localhost:9000/callback/OidcClient',
         'http://localhost:9000/callback/AdClient',
         'http://localhost:19001/callback/OidcClient',
         'http://localhost:19001/callback/AdClient',
+        'http://civiform:9000/callback/OidcClient',
+        'http://civiform:9000/callback/AdClient',
       ],
     },
   ],
@@ -30,7 +31,7 @@ const configuration = {
           user_emailid: id + '@example.com',
           // lie about verification for tests.
           email_verified: true,
-          user_displayname: 'first middle last',
+          user_displayname: 'Test middlename User',
         }
       },
     }
@@ -43,6 +44,20 @@ const configuration = {
 
 const oidcPort = process.env.OIDC_PORT || 3380
 const oidc = new Provider('http://localhost:' + oidcPort, configuration)
+
+const {invalidate: orig} = oidc.Client.Schema.prototype
+
+// By default, redirect URLs must be https and cannot refer to localhost. While these are correct
+// for production implementations, this is intended to be used ONLY for testing. For browser tests,
+// internal Docker networking is used, which uses HTTP. For running the server locally, redirects
+// are pointed towards localhost.
+// From https://github.com/panva/node-oidc-provider/blob/0fcc112e0a95b3b2dae4eba6da812253277567c9/recipes/implicit_http_localhost.md
+oidc.Client.Schema.prototype.invalidate = function invalidate(message, code) {
+  if (code === 'implicit-force-https' || code === 'implicit-forbid-localhost') {
+    return
+  }
+  orig.call(this, message)
+}
 
 process.on('SIGINT', () => {
   console.info('Interrupted')


### PR DESCRIPTION
### Description

Still TODO:
  * Test that Seattle's invocation of this works as expected
  * Add an adapter for AWS staging
  * Create test accounts in Auth0 and add data to GitHub secrets. Plumb this through in the AWS prober invocation.

Note: The change to oidc_provider will need to be run separately since we don't build the OIDC provider as part of our GitHub actions.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
