### PR TITLE
Introduce createTestContext() function

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -1,37 +1,25 @@
 import {
-  startSession,
   loginAsAdmin,
   AdminQuestions,
-  AdminPrograms,
   seedCanonicalQuestions,
   waitForPageJsLoad,
   validateScreenshot,
-  resetSession,
   dropTables,
+  createTestContext,
 } from './support'
 import {QuestionType} from './support/admin_questions'
 import {BASE_URL} from './support/config'
-import {Page} from 'playwright'
 
 describe('normal question lifecycle', () => {
-  let page: Page
-
-  beforeAll(async () => {
-    const obj = await startSession()
-    page = obj.page
-  })
-
-  afterEach(async () => {
-    await resetSession(page, /* clearDb= */ true)
-  })
+  const ctx = createTestContext()
 
   it('canonical question seeding works', async () => {
+    const {page, adminQuestions} = ctx
     await dropTables(page)
     await seedCanonicalQuestions(page)
 
     await page.goto(BASE_URL)
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     await adminQuestions.gotoAdminQuestionsPage()
     await adminQuestions.expectDraftQuestionExist('Name')
@@ -42,11 +30,10 @@ describe('normal question lifecycle', () => {
   // test duration reasonable.
   for (const type of Object.values(QuestionType)) {
     it(`${type} question: create, update, publish, create a new version, and update`, async () => {
+      const {page, adminQuestions, adminPrograms} = ctx
       page.setDefaultTimeout(4000)
 
       await loginAsAdmin(page)
-      const adminQuestions = new AdminQuestions(page)
-      const adminPrograms = new AdminPrograms(page)
 
       const questionName = `qlc-${type}`
       // for most question types there will be only 1 question. But for
@@ -115,10 +102,10 @@ describe('normal question lifecycle', () => {
   }
 
   it('shows error when creating a dropdown question and admin left an option field blank', async () => {
+    const {page, adminQuestions} = ctx
     page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     const options = ['option1', 'option2', '']
 
@@ -138,10 +125,10 @@ describe('normal question lifecycle', () => {
   })
 
   it('shows error when creating a radio question and admin left an option field blank', async () => {
+    const {page, adminQuestions} = ctx
     page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     const options = ['option1', 'option2', '']
 
@@ -161,10 +148,10 @@ describe('normal question lifecycle', () => {
   })
 
   it('shows error when updating a dropdown question and admin left an option field blank', async () => {
+    const {page, adminQuestions} = ctx
     page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     const options = ['option1', 'option2']
     const questionName = 'updateEmptyDropdown'
@@ -189,10 +176,10 @@ describe('normal question lifecycle', () => {
   })
 
   it('shows error when updating a radio question and admin left an option field blank', async () => {
+    const {page, adminQuestions} = ctx
     page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     const options = ['option1', 'option2']
     const questionName = 'updateEmptyRadio'
@@ -219,10 +206,10 @@ describe('normal question lifecycle', () => {
   })
 
   it('persists export state', async () => {
+    const {page, adminQuestions} = ctx
     page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
-    const adminQuestions = new AdminQuestions(page)
 
     // Navigate to the new question page and ensure that "Don't allow answers to be exported"
     // is pre-selected.
@@ -267,10 +254,8 @@ describe('normal question lifecycle', () => {
   })
 
   it('redirects to draft question when trying to edit original question', async () => {
+    const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
-
-    const adminQuestions = new AdminQuestions(page)
-    const adminPrograms = new AdminPrograms(page)
 
     await adminQuestions.gotoAdminQuestionsPage()
     await adminQuestions.addNameQuestion({questionName: 'name-q'})

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -91,7 +91,7 @@ export const startSession = async (
 
 /**
  * Object containing properties and methods for interacting with browser and
- * app. See docs for createBrowserContext() method for more info.
+ * app. See docs for createTestContext() method for more info.
  */
 export interface TestContext {
   /**
@@ -107,15 +107,19 @@ export interface TestContext {
 
 /**
  * Launches a browser and returns context that contains objects needed to
- * interact with the browser. Example usage:
+ * interact with the browser. It should be called at the very beginning of the
+ * top-most describe() and reused across all other describe/it functions.
+ * Example usage:
  *
+ * ```
  * describe('some test', () => {
- *   const ctx = createBrowserContext()
+ *   const ctx = createTestContext()
  *
  *   it('should do foo', async () => {
  *     await ctx.page.click('#some-button')
  *   })
  * })
+ * ```
  *
  * Browser session is reset between tests and database is cleared by default.
  * Each test starts on the login page.
@@ -140,8 +144,8 @@ export const createTestContext = (clearDb = true): TestContext => {
 
   // We create new browser context and session before each test. It's
   // important to get fresh browser context so that each test gets its own
-  // videos. If we reuse same browser context - we'll get one huge video for
-  // all tests.
+  // video file. If we reuse same browser context across multiple test cases -
+  // we'll get one huge video for all tests.
   async function resetContext() {
     if (browserContext != null) {
       await browserContext.close()

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -83,7 +83,6 @@ export const startSession = async (
   const context = await makeBrowserContext(browser)
   const page = await context.newPage()
 
-  await dropTables(page)
   await page.goto(BASE_URL)
   await closeWarningMessage(page)
 

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -469,9 +469,9 @@ function attachFormDebouncers() {
 /**
  * Adds event listener to all elements on a page that match given selector.
  * This function doesn't handle elements added dynamically after the function was invoked.
- * @param selector CSS selector that will be used to retrieve list of elements.
- * @param event Browser event. For example 'click'
- * @param listener Listener that will be registered on all matching elements.
+ * @param {string} selector CSS selector that will be used to retrieve list of elements.
+ * @param {string} event Browser event. For example 'click'
+ * @param {Function} listener Listener that will be registered on all matching elements.
  */
 function addEventListenerToElements(
   selector: string,


### PR DESCRIPTION
### Description

The function simplifies managing browser-related, session stuff: it resets session between tests and launches/shutdowns browser once per test file. Using this function test writers don't need to worry about initialization of browser. Example usage:

```ts
describe('some test', () => {
  const ctx = createTestContext();

  it('does something', async () => {
    // do something with ctx.page
  })
})
```

By default it clears database between tests. Many tests rely on database not being cleared so for those tests I disable DB clearing. In future we should rework them so that each re-creates data from scratch. Doing it now will increase test runtime significantly. Once we have some batch approach to create data we can revisit it.


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Issue #3323
