### PR TITLE
Update code naming for TI notification in the submit flow

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -63,23 +63,23 @@ public class ApplicationRepository {
    * and create a new application in the active state.
    */
   public CompletionStage<Application> submitApplication(
-      Applicant applicant, Program program, Optional<String> submitterEmail) {
+      Applicant applicant, Program program, Optional<String> tiSubmitterEmail) {
     return supplyAsync(
-        () -> submitApplicationInternal(applicant, program, submitterEmail),
+        () -> submitApplicationInternal(applicant, program, tiSubmitterEmail),
         executionContext.current());
   }
 
   public CompletionStage<Optional<Application>> submitApplication(
-      long applicantId, long programId, Optional<String> submitterEmail) {
+      long applicantId, long programId, Optional<String> tiSubmitterEmail) {
     return this.perform(
         applicantId,
         programId,
         (ApplicationArguments appArgs) ->
-            submitApplicationInternal(appArgs.applicant, appArgs.program, submitterEmail));
+            submitApplicationInternal(appArgs.applicant, appArgs.program, tiSubmitterEmail));
   }
 
   private Application submitApplicationInternal(
-      Applicant applicant, Program program, Optional<String> submitterEmail) {
+      Applicant applicant, Program program, Optional<String> tiSubmitterEmail) {
     database.beginTransaction();
     try {
       List<Application> oldApplications =
@@ -106,8 +106,8 @@ public class ApplicationRepository {
               : drafts.get(0);
       application.setLifecycleStage(LifecycleStage.ACTIVE);
       application.setSubmitTimeToNow();
-      if (submitterEmail.isPresent()) {
-        application.setSubmitterEmail(submitterEmail.get());
+      if (tiSubmitterEmail.isPresent()) {
+        application.setSubmitterEmail(tiSubmitterEmail.get());
       }
       application.save();
 

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -264,6 +264,8 @@ public final class ApplicantService {
    * <p>An application is a snapshot of all the answers the applicant has filled in so far, along
    * with association with the applicant and a program that the applicant is applying to.
    *
+   * @param submitterProfile the user that submitted the application, iff it is a TI the application
+   *     is associated with this profile too.
    * @return the saved {@link Application}. If the submission failed, a {@link
    *     ApplicationSubmissionException} is thrown and wrapped in a `CompletionException`.
    */
@@ -274,17 +276,20 @@ public final class ApplicantService {
           .getAccount()
           .thenComposeAsync(
               account ->
-                  submitApplication(applicantId, programId, Optional.of(account.getEmailAddress())),
+                  submitApplication(
+                      applicantId,
+                      programId,
+                      /* tiSubmitterEmail= */ Optional.of(account.getEmailAddress())),
               httpExecutionContext.current());
     }
 
-    return submitApplication(applicantId, programId, Optional.empty());
+    return submitApplication(applicantId, programId, /* tiSubmitterEmail= */ Optional.empty());
   }
 
   private CompletionStage<Application> submitApplication(
-      long applicantId, long programId, Optional<String> submitterEmail) {
+      long applicantId, long programId, Optional<String> tiSubmitterEmail) {
     return applicationRepository
-        .submitApplication(applicantId, programId, submitterEmail)
+        .submitApplication(applicantId, programId, tiSubmitterEmail)
         .thenComposeAsync(
             (Optional<Application> applicationMaybe) -> {
               if (applicationMaybe.isEmpty()) {
@@ -296,8 +301,8 @@ public final class ApplicantService {
               String programName = application.getProgram().getProgramDefinition().adminName();
               notifyProgramAdmins(applicantId, programId, application.id, programName);
 
-              if (submitterEmail.isPresent()) {
-                notifySubmitter(submitterEmail.get(), applicantId, application.id, programName);
+              if (tiSubmitterEmail.isPresent()) {
+                notifyTiSubmitter(tiSubmitterEmail.get(), applicantId, application.id, programName);
               }
 
               maybeNotifyApplicant(applicantId, application.id, programName);
@@ -373,8 +378,8 @@ public final class ApplicantService {
     }
   }
 
-  private void notifySubmitter(
-      String submitter, long applicantId, long applicationId, String programName) {
+  private void notifyTiSubmitter(
+      String tiEmail, long applicantId, long applicationId, String programName) {
     String tiDashLink =
         baseUrl
             + controllers.ti.routes.TrustedIntermediaryController.dashboard(
@@ -395,7 +400,7 @@ public final class ApplicantService {
     if (isStaging) {
       amazonSESClient.send(stagingTiNotificationMailingList, subject, message);
     } else {
-      amazonSESClient.send(submitter, subject, message);
+      amazonSESClient.send(tiEmail, subject, message);
     }
   }
 


### PR DESCRIPTION
### Description

We have generic naming in our notification flow for what is in effect a TI flow; which is confusing and errorprone.

Also the current naming of "submitter" is ambiguous as the code flows explicitly mean "not the applicant", but applicants most often are the ones submitting applications. 

The code flows _could_ work if the submitter was a program admin, but the product does not allow for that, so I didn't aim to find a term that encompassed "not an applicant" and went with TI specifically.

The effective code flow root of the changes is [ApplicationService.submitApplication](https://github.com/civiform/civiform/pull/3329/files#diff-163cd8467b46ba09a916370044f5c51a2955bc56c2ee4650fb62ca66ccdd0d26R274)

## Release notes:

NA, just code renaming.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
