### PR TITLE
Updating assertions to expect 'Guest', since we log in as guest when completing applications

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -8,7 +8,6 @@ import {
   selectApplicantLanguage,
   ApplicantQuestions,
   AdminPrograms,
-  userDisplayName,
   AdminProgramStatuses,
   enableFeatureFlag,
 } from './support'
@@ -53,7 +52,7 @@ describe('view program statuses', () => {
       // Navigate to the submitted application as the program admin.
       await loginAsProgramAdmin(pageObject)
       await adminPrograms.viewApplications(programWithoutStatusesName)
-      await adminPrograms.viewApplicationForApplicant(userDisplayName())
+      await adminPrograms.viewApplicationForApplicant('Guest')
     })
 
     afterAll(async () => {
@@ -102,7 +101,7 @@ describe('view program statuses', () => {
       await enableFeatureFlag(pageObject, 'application_status_tracking_enabled')
 
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.viewApplicationForApplicant(userDisplayName())
+      await adminPrograms.viewApplicationForApplicant('Guest')
     })
 
     afterAll(async () => {


### PR DESCRIPTION
### Description

Fixes failing Seattle staging prober runs ([example](https://github.com/seattle-civiform/civiform-deploy/runs/8135343650?check_suite_focus=true)). This was due to the fact that we use `userDisplayName`, which returns "Guest" for non-prober runs and the test account's name when running against Seattle staging.

The test code had copied this from elsewhere, which meant that it was expecting the test user when run as a prober, even though it had completed the application as a guest.

## Release notes:

N/A.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

