### PR TITLE
Convert SelectWithLabel to take a list of options rather than a map.

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -15,7 +15,6 @@ import static j2html.TagCreator.span;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import controllers.admin.routes;
 import j2html.TagCreator;
@@ -25,7 +24,6 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.SpanTag;
 import java.util.Optional;
-import java.util.function.Function;
 import models.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,21 +183,28 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                 .setLabelText("Application status")
                 .setValue(filterParams.selectedApplicationStatus().orElse(""))
                 // TODO(#3269): Consider adding support for passing <optgroups> and divide the
-                // static options from the application statuses with a "-----" section. Also
-                // update options to take an ordered collection rather than an unordered
-                // collection in order to create more determinism in the order that options are
-                // rendered.
+                // static options from the application statuses with a "-----" section.
                 .setOptions(
-                    ImmutableMap.<String, String>builder()
-                        .put("Any application status", "")
-                        .put(
-                            "Only applications without a status",
-                            SubmittedApplicationFilter.NO_STATUS_FILTERS_OPTION_UUID)
-                        .putAll(
+                    ImmutableList.<SelectWithLabel.OptionValue>builder()
+                        .add(
+                            SelectWithLabel.OptionValue.builder()
+                                .setLabel("Any application status")
+                                .setValue("")
+                                .build())
+                        .add(
+                            SelectWithLabel.OptionValue.builder()
+                                .setLabel("Only applications without a status")
+                                .setValue(SubmittedApplicationFilter.NO_STATUS_FILTERS_OPTION_UUID)
+                                .build())
+                        .addAll(
                             allPossibleProgramApplicationStatuses.stream()
-                                .collect(
-                                    ImmutableMap.toImmutableMap(
-                                        Function.identity(), Function.identity())))
+                                .map(
+                                    status ->
+                                        SelectWithLabel.OptionValue.builder()
+                                            .setLabel(status)
+                                            .setValue(status)
+                                            .build())
+                                .collect(ImmutableList.toImmutableList()))
                         .build())
                 .getSelectTag())
         .with(

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -2,7 +2,6 @@ package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
@@ -14,7 +13,6 @@ import static j2html.TagCreator.text;
 import static play.mvc.Http.HttpVerbs.POST;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.admin.routes;
 import j2html.TagCreator;
@@ -269,9 +267,15 @@ public final class ProgramBlockPredicatesEditView extends ProgramBlockView {
   }
 
   private DivTag createActionDropdown(String blockName) {
-    ImmutableMap<String, String> actionOptions =
+    ImmutableList<SelectWithLabel.OptionValue> actionOptions =
         Arrays.stream(PredicateAction.values())
-            .collect(toImmutableMap(PredicateAction::toDisplayString, PredicateAction::name));
+            .map(
+                action ->
+                    SelectWithLabel.OptionValue.builder()
+                        .setLabel(action.toDisplayString())
+                        .setValue(action.name())
+                        .build())
+            .collect(ImmutableList.toImmutableList());
     return new SelectWithLabel()
         .setFieldName("predicateAction")
         .setLabelText(String.format("%s should be", blockName))

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.div;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import forms.AddressQuestionForm;
 import forms.EnumeratorQuestionForm;
@@ -292,7 +291,9 @@ public final class QuestionConfig {
    * I don't feel like hard-coding a list of states here, so this will do until we can think up a
    * better approach.
    */
-  private static ImmutableMap<String, String> stateOptions() {
-    return ImmutableMap.of("-- Leave blank --", "-", "Washington", "WA");
+  private static ImmutableList<SelectWithLabel.OptionValue> stateOptions() {
+    return ImmutableList.of(
+        SelectWithLabel.OptionValue.builder().setLabel("-- Leave blank --").setValue("-").build(),
+        SelectWithLabel.OptionValue.builder().setLabel("Washington").setValue("WA").build());
   }
 }

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -1,7 +1,6 @@
 package views.admin.questions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
@@ -13,7 +12,6 @@ import static j2html.TagCreator.span;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import forms.MultiOptionQuestionForm;
 import forms.QuestionForm;
@@ -438,13 +436,25 @@ public final class QuestionEditView extends BaseHtmlView {
   private SelectWithLabel enumeratorOptionsFromEnumerationQuestionDefinitions(
       QuestionForm questionForm,
       ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions) {
-    ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.builder();
-    optionsBuilder.put(NO_ENUMERATOR_DISPLAY_STRING, NO_ENUMERATOR_ID_STRING);
-    optionsBuilder.putAll(
-        enumeratorQuestionDefinitions.stream()
-            .collect(toImmutableMap(QuestionDefinition::getName, q -> String.valueOf(q.getId()))));
+    ImmutableList<SelectWithLabel.OptionValue> options =
+        ImmutableList.<SelectWithLabel.OptionValue>builder()
+            .add(
+                SelectWithLabel.OptionValue.builder()
+                    .setLabel(NO_ENUMERATOR_DISPLAY_STRING)
+                    .setValue(NO_ENUMERATOR_ID_STRING)
+                    .build())
+            .addAll(
+                enumeratorQuestionDefinitions.stream()
+                    .map(
+                        q ->
+                            SelectWithLabel.OptionValue.builder()
+                                .setLabel(q.getName())
+                                .setValue(String.valueOf(q.getId()))
+                                .build())
+                    .collect(ImmutableList.toImmutableList()))
+            .build();
     return enumeratorOptions(
-        optionsBuilder.build(),
+        options,
         questionForm.getEnumeratorId().map(String::valueOf).orElse(NO_ENUMERATOR_ID_STRING));
   }
 
@@ -462,10 +472,17 @@ public final class QuestionEditView extends BaseHtmlView {
         maybeEnumerationQuestionDefinition
             .map(q -> String.valueOf(q.getId()))
             .orElse(NO_ENUMERATOR_ID_STRING);
-    return enumeratorOptions(ImmutableMap.of(enumeratorName, enumeratorId), enumeratorId);
+    return enumeratorOptions(
+        ImmutableList.of(
+            SelectWithLabel.OptionValue.builder()
+                .setLabel(enumeratorName)
+                .setValue(enumeratorId)
+                .build()),
+        enumeratorId);
   }
 
-  private SelectWithLabel enumeratorOptions(ImmutableMap<String, String> options, String selected) {
+  private SelectWithLabel enumeratorOptions(
+      ImmutableList<SelectWithLabel.OptionValue> options, String selected) {
     return new SelectWithLabel()
         .setId("question-enumerator-select")
         .setFieldName(QUESTION_ENUMERATOR_FIELD)

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -1,8 +1,8 @@
 package views.questiontypes;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
@@ -43,10 +43,14 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
             .setOptions(
                 singleSelectQuestion.getOptions().stream()
                     .sorted(Comparator.comparing(LocalizedQuestionOption::order))
-                    .collect(
-                        toImmutableMap(
-                            LocalizedQuestionOption::optionText,
-                            option -> String.valueOf(option.id()))));
+                    .map(
+                        option ->
+                            SelectWithLabel.OptionValue.builder()
+                                .setLabel(option.optionText())
+                                .setValue(String.valueOf(option.id()))
+                                .build())
+                    .collect(ImmutableList.toImmutableList()));
+
     select.setScreenReaderText(question.getQuestionText());
 
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {

--- a/server/test/views/components/SelectWithLabelTest.java
+++ b/server/test/views/components/SelectWithLabelTest.java
@@ -2,7 +2,7 @@ package views.components;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 public class SelectWithLabelTest {
@@ -15,9 +15,12 @@ public class SelectWithLabelTest {
 
   @Test
   public void createSelect_rendersOptions() {
-    SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
-    ImmutableMap<String, String> options = ImmutableMap.of("a", "b");
-    selectWithLabel.setOptions(options);
+    SelectWithLabel selectWithLabel =
+        new SelectWithLabel()
+            .setId("id")
+            .setOptions(
+                ImmutableList.of(
+                    SelectWithLabel.OptionValue.builder().setLabel("a").setValue("b").build()));
     assertThat(selectWithLabel.getSelectTag().render()).contains("<option");
   }
 
@@ -32,10 +35,13 @@ public class SelectWithLabelTest {
 
   @Test
   public void createSelect_rendersSelectedOption() {
-    SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
-    ImmutableMap<String, String> options = ImmutableMap.of("a", "b");
-    selectWithLabel.setOptions(options);
-    selectWithLabel.setValue("b");
+    SelectWithLabel selectWithLabel =
+        new SelectWithLabel()
+            .setId("id")
+            .setValue("b")
+            .setOptions(
+                ImmutableList.of(
+                    SelectWithLabel.OptionValue.builder().setLabel("a").setValue("b").build()));
     assertThat(selectWithLabel.getSelectTag().render()).contains("<select");
     assertThat(selectWithLabel.getSelectTag().render()).contains("value=\"b\" selected");
     assertThat(selectWithLabel.getSelectTag().render()).doesNotContain("hidden selected");


### PR DESCRIPTION
### Description

Previously, an ImmutableMap<String, String> was passed in. Enumeration order isn't guaranteed for maps and relying on the implementation isn't scalable. Additionally, having an autovalue type improves readability of what each string value means and leaves us open to add more functionality in the future (e.g. a "disabled" selection option that we can use for grouping options).

This was noticed as part of #3320.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3269