### PR TITLE
Creating evolution that drops programs.export_definitions, removed in #2814.

### DIFF
--- a/server/app/services/export/CsvExporter.java
+++ b/server/app/services/export/CsvExporter.java
@@ -17,9 +17,6 @@ import services.Path;
 import services.applicant.ReadOnlyApplicantProgramService;
 import services.program.Column;
 
-// TODO(#2821): Create a DB evolution to remove the programs.export_definitions
-// column.
-
 /**
  * CsvExporter takes a list of {@link Column}s and exports the data specified. A column contains a
  * {@link Path} indexing into an applicant's data, and CsvExporter takes the path and reads the

--- a/server/conf/evolutions/default/45.sql
+++ b/server/conf/evolutions/default/45.sql
@@ -1,0 +1,10 @@
+# --- Drops export definitions
+
+# --- !Ups
+
+alter table programs drop column if exists export_definitions;
+
+# --- !Downs
+alter table programs add export_definitions jsonb;
+
+update programs set export_definitions = '[]' where export_definitions is null;

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -67,9 +67,9 @@ public class ProgramRepositoryTest extends ResetPostgres {
   @Test
   public void loadLegacy() {
     DB.sqlUpdate(
-            "insert into programs (name, description, block_definitions, export_definitions,"
+            "insert into programs (name, description, block_definitions,"
                 + " legacy_localized_name, legacy_localized_description) values ('Old Schema"
-                + " Entry', 'Description', '[]', '[]', '{\"en_us\": \"name\"}', '{\"en_us\":"
+                + " Entry', 'Description', '[]', '{\"en_us\": \"name\"}', '{\"en_us\":"
                 + " \"description\"}');")
         .execute();
     DB.sqlUpdate(
@@ -97,9 +97,9 @@ public class ProgramRepositoryTest extends ResetPostgres {
   @Test
   public void loadStatusDefinitionsEvolution() {
     DB.sqlUpdate(
-            "insert into programs (name, description, block_definitions, export_definitions,"
+            "insert into programs (name, description, block_definitions,"
                 + " legacy_localized_name, legacy_localized_description, status_definitions)"
-                + " values ('Status Default', 'Description', '[]', '[]', '{\"en_us\": \"name\"}',"
+                + " values ('Status Default', 'Description', '[]', '{\"en_us\": \"name\"}',"
                 + "'{\"en_us\": \"description\"}', '{\"statuses\": []}');")
         .execute();
     DB.sqlUpdate(
@@ -121,9 +121,9 @@ public class ProgramRepositoryTest extends ResetPostgres {
   @Test
   public void getForSlug_withOldSchema() {
     DB.sqlUpdate(
-            "insert into programs (name, description, block_definitions, export_definitions,"
+            "insert into programs (name, description, block_definitions,"
                 + " legacy_localized_name, legacy_localized_description) values ('Old Schema"
-                + " Entry', 'Description', '[]', '[]', '{\"en_us\": \"a\"}', '{\"en_us\":"
+                + " Entry', 'Description', '[]', '{\"en_us\": \"a\"}', '{\"en_us\":"
                 + " \"b\"}');")
         .execute();
     DB.sqlUpdate(


### PR DESCRIPTION
### Description

Confirmed with deployers that this is now safe to remove in https://github.com/civiform/civiform/issues/2821#issuecomment-1238321345.

Corresponding docs change is https://github.com/civiform/docs/pull/122.

## Release notes:

Dropping a no-longer used database column for custom export code.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2821