### PR TITLE
Close warning message dialog when resetting context in browser tests

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -173,6 +173,7 @@ export const createTestContext = (clearDb = true): TestContext => {
     ctx.adminPredicates = new AdminPredicates(ctx.page)
     ctx.adminTranslations = new AdminTranslations(ctx.page)
     await ctx.page.goto(BASE_URL)
+    await closeWarningMessage(page)
   }
 
   beforeAll(async () => {

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -173,7 +173,7 @@ export const createTestContext = (clearDb = true): TestContext => {
     ctx.adminPredicates = new AdminPredicates(ctx.page)
     ctx.adminTranslations = new AdminTranslations(ctx.page)
     await ctx.page.goto(BASE_URL)
-    await closeWarningMessage(page)
+    await closeWarningMessage(ctx.page)
   }
 
   beforeAll(async () => {


### PR DESCRIPTION
### Description

Staging probers are failing ([sample link](https://github.com/civiform/civiform-staging-deploy/runs/8206635473?check_suite_focus=true)) due to an axe accessibility test failing on the "Do not enter actual or personal data in this demo site" pop up dialog. This dialog is never show in prod, so is not a real issue.

We don't show the warning pop up message when running the browser tests in non-staging environments ([code link](https://github.com/civiform/civiform/blob/7f88bb7fa2ae2c8a790c462d8983953ceb066c2f/server/app/views/BaseHtmlLayout.java#L79)), so this was failing on staging but passing everywhere else.

This PR should hopefully fix the staging failures.

## Release notes:

N/A

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

