### PR TITLE
Add separate optgroups for application status filtering for program admin.

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -183,43 +183,37 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                 .setLabelText("Application status")
                 .setValue(filterParams.selectedApplicationStatus().orElse(""))
                 .setOptionGroups(
-                    ImmutableList.<SelectWithLabel.OptionGroup>builder()
-                        .add(
-                            SelectWithLabel.OptionGroup.builder()
-                                .setLabel("General")
-                                .setOptions(
-                                    ImmutableList.<SelectWithLabel.OptionValue>builder()
-                                        .add(
-                                            SelectWithLabel.OptionValue.builder()
-                                                .setLabel("Any application status")
-                                                .setValue("")
-                                                .build())
-                                        .add(
-                                            SelectWithLabel.OptionValue.builder()
-                                                .setLabel("Only applications without a status")
-                                                .setValue(
-                                                    SubmittedApplicationFilter
-                                                        .NO_STATUS_FILTERS_OPTION_UUID)
-                                                .build())
-                                        .build())
-                                .build())
-                        .add(
-                            SelectWithLabel.OptionGroup.builder()
-                                .setLabel("Application statuses")
-                                .setOptions(
-                                    ImmutableList.<SelectWithLabel.OptionValue>builder()
-                                        .addAll(
-                                            allPossibleProgramApplicationStatuses.stream()
-                                                .map(
-                                                    status ->
-                                                        SelectWithLabel.OptionValue.builder()
-                                                            .setLabel(status)
-                                                            .setValue(status)
-                                                            .build())
-                                                .collect(ImmutableList.toImmutableList()))
-                                        .build())
-                                .build())
-                        .build())
+                    ImmutableList.of(
+                        SelectWithLabel.OptionGroup.builder()
+                            .setLabel("General")
+                            .setOptions(
+                                ImmutableList.of(
+                                    SelectWithLabel.OptionValue.builder()
+                                        .setLabel("Any application status")
+                                        .setValue("")
+                                        .build(),
+                                    SelectWithLabel.OptionValue.builder()
+                                        .setLabel("Only applications without a status")
+                                        .setValue(
+                                            SubmittedApplicationFilter
+                                                .NO_STATUS_FILTERS_OPTION_UUID)
+                                        .build()))
+                            .build(),
+                        SelectWithLabel.OptionGroup.builder()
+                            .setLabel("Application statuses")
+                            .setOptions(
+                                ImmutableList.<SelectWithLabel.OptionValue>builder()
+                                    .addAll(
+                                        allPossibleProgramApplicationStatuses.stream()
+                                            .map(
+                                                status ->
+                                                    SelectWithLabel.OptionValue.builder()
+                                                        .setLabel(status)
+                                                        .setValue(status)
+                                                        .build())
+                                            .collect(ImmutableList.toImmutableList()))
+                                    .build())
+                            .build()))
                 .getSelectTag())
         .with(
             div()

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -182,29 +182,43 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                 .setFieldName(APPLICATION_STATUS_PARAM)
                 .setLabelText("Application status")
                 .setValue(filterParams.selectedApplicationStatus().orElse(""))
-                // TODO(#3269): Consider adding support for passing <optgroups> and divide the
-                // static options from the application statuses with a "-----" section.
-                .setOptions(
-                    ImmutableList.<SelectWithLabel.OptionValue>builder()
+                .setOptionGroups(
+                    ImmutableList.<SelectWithLabel.OptionGroup>builder()
                         .add(
-                            SelectWithLabel.OptionValue.builder()
-                                .setLabel("Any application status")
-                                .setValue("")
+                            SelectWithLabel.OptionGroup.builder()
+                                .setLabel("General")
+                                .setOptions(
+                                    ImmutableList.<SelectWithLabel.OptionValue>builder()
+                                        .add(
+                                            SelectWithLabel.OptionValue.builder()
+                                                .setLabel("Any application status")
+                                                .setValue("")
+                                                .build())
+                                        .add(
+                                            SelectWithLabel.OptionValue.builder()
+                                                .setLabel("Only applications without a status")
+                                                .setValue(
+                                                    SubmittedApplicationFilter
+                                                        .NO_STATUS_FILTERS_OPTION_UUID)
+                                                .build())
+                                        .build())
                                 .build())
                         .add(
-                            SelectWithLabel.OptionValue.builder()
-                                .setLabel("Only applications without a status")
-                                .setValue(SubmittedApplicationFilter.NO_STATUS_FILTERS_OPTION_UUID)
+                            SelectWithLabel.OptionGroup.builder()
+                                .setLabel("Application statuses")
+                                .setOptions(
+                                    ImmutableList.<SelectWithLabel.OptionValue>builder()
+                                        .addAll(
+                                            allPossibleProgramApplicationStatuses.stream()
+                                                .map(
+                                                    status ->
+                                                        SelectWithLabel.OptionValue.builder()
+                                                            .setLabel(status)
+                                                            .setValue(status)
+                                                            .build())
+                                                .collect(ImmutableList.toImmutableList()))
+                                        .build())
                                 .build())
-                        .addAll(
-                            allPossibleProgramApplicationStatuses.stream()
-                                .map(
-                                    status ->
-                                        SelectWithLabel.OptionValue.builder()
-                                            .setLabel(status)
-                                            .setValue(status)
-                                            .build())
-                                .collect(ImmutableList.toImmutableList()))
                         .build())
                 .getSelectTag())
         .with(

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -1,5 +1,7 @@
 package views.components;
 
+import static j2html.TagCreator.each;
+import static j2html.TagCreator.optgroup;
 import static j2html.TagCreator.option;
 
 import com.google.auto.value.AutoValue;
@@ -13,7 +15,7 @@ import views.style.ReferenceClasses;
 /** Utility class for rendering a select input field with an optional label. */
 public final class SelectWithLabel extends FieldWithLabel {
 
-  private ImmutableList<OptionValue> options = ImmutableList.of();
+  private ImmutableList<OptionGroup> optionGroups = ImmutableList.of();
   private ImmutableList<OptionTag> customOptions = ImmutableList.of();
 
   @Override
@@ -22,9 +24,16 @@ public final class SelectWithLabel extends FieldWithLabel {
     return this;
   }
 
+  /** Sets the option groups associated with the select element. */
+  public SelectWithLabel setOptionGroups(ImmutableList<OptionGroup> optionGroups) {
+    this.optionGroups = optionGroups;
+    return this;
+  }
+
   /** Sets the options associated with the select element. */
   public SelectWithLabel setOptions(ImmutableList<OptionValue> options) {
-    this.options = options;
+    this.optionGroups =
+        ImmutableList.of(OptionGroup.builder().setLabel("").setOptions(options).build());
     return this;
   }
 
@@ -93,19 +102,47 @@ public final class SelectWithLabel extends FieldWithLabel {
       customOptions.forEach(option -> fieldTag.with(option));
     } else {
       fieldTag.with(
-          options.stream()
+          optionGroups.stream()
               .map(
-                  optionData -> {
-                    return option(optionData.label())
-                        .withClasses(
-                            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-                            ReferenceClasses.MULTI_OPTION_VALUE)
-                        .withValue(optionData.value())
-                        .withCondSelected(optionData.value().equals(fieldValue));
+                  optionGroup -> {
+                    return optgroup()
+                        .withLabel(optionGroup.label())
+                        .with(
+                            each(
+                                optionGroup.options(),
+                                optionData -> {
+                                  return option(optionData.label())
+                                      .withClasses(
+                                          ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
+                                          ReferenceClasses.MULTI_OPTION_VALUE)
+                                      .withValue(optionData.value())
+                                      .withCondSelected(optionData.value().equals(fieldValue));
+                                }));
                   }));
     }
 
     return applyAttrsAndGenLabel(fieldTag);
+  }
+
+  @AutoValue
+  public abstract static class OptionGroup {
+    /** The user-visible option group text. */
+    public abstract String label();
+
+    public abstract ImmutableList<OptionValue> options();
+
+    public static Builder builder() {
+      return new AutoValue_SelectWithLabel_OptionGroup.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setLabel(String v);
+
+      public abstract Builder setOptions(ImmutableList<OptionValue> v);
+
+      public abstract OptionGroup build();
+    }
   }
 
   @AutoValue

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -1,6 +1,5 @@
 package views.components;
 
-import static j2html.TagCreator.each;
 import static j2html.TagCreator.optgroup;
 import static j2html.TagCreator.option;
 
@@ -8,6 +7,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import j2html.TagCreator;
 import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.OptgroupTag;
 import j2html.tags.specialized.OptionTag;
 import j2html.tags.specialized.SelectTag;
 import views.style.ReferenceClasses;
@@ -101,27 +101,24 @@ public final class SelectWithLabel extends FieldWithLabel {
     if (!customOptions.isEmpty()) {
       customOptions.forEach(option -> fieldTag.with(option));
     } else {
-      fieldTag.with(
-          optionGroups.stream()
-              .map(
-                  optionGroup -> {
-                    return optgroup()
-                        .withLabel(optionGroup.label())
-                        .with(
-                            each(
-                                optionGroup.options(),
-                                optionData -> {
-                                  return option(optionData.label())
-                                      .withClasses(
-                                          ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-                                          ReferenceClasses.MULTI_OPTION_VALUE)
-                                      .withValue(optionData.value())
-                                      .withCondSelected(optionData.value().equals(fieldValue));
-                                }));
-                  }));
+      fieldTag.with(optionGroups.stream().map(this::renderOptionGroup));
     }
 
     return applyAttrsAndGenLabel(fieldTag);
+  }
+
+  private OptgroupTag renderOptionGroup(OptionGroup optionGroup) {
+    return optgroup()
+        .withLabel(optionGroup.label())
+        .with(optionGroup.options().stream().map(this::renderOption));
+  }
+
+  private OptionTag renderOption(OptionValue optionData) {
+    return option(optionData.label())
+        .withClasses(
+            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION, ReferenceClasses.MULTI_OPTION_VALUE)
+        .withValue(optionData.value())
+        .withCondSelected(optionData.value().equals(fieldValue));
   }
 
   @AutoValue

--- a/server/test/views/components/SelectWithLabelTest.java
+++ b/server/test/views/components/SelectWithLabelTest.java
@@ -65,7 +65,7 @@ public class SelectWithLabelTest {
                                     .build()))
                         .build(),
                     SelectWithLabel.OptionGroup.builder()
-                        .setLabel("First group label")
+                        .setLabel("Second group label")
                         .setOptions(
                             ImmutableList.of(
                                 SelectWithLabel.OptionValue.builder()

--- a/server/test/views/components/SelectWithLabelTest.java
+++ b/server/test/views/components/SelectWithLabelTest.java
@@ -56,16 +56,28 @@ public class SelectWithLabelTest {
             .setOptionGroups(
                 ImmutableList.of(
                     SelectWithLabel.OptionGroup.builder()
-                        .setLabel("A label")
+                        .setLabel("First group label")
                         .setOptions(
                             ImmutableList.of(
                                 SelectWithLabel.OptionValue.builder()
                                     .setLabel("a")
                                     .setValue("b")
                                     .build()))
+                        .build(),
+                    SelectWithLabel.OptionGroup.builder()
+                        .setLabel("First group label")
+                        .setOptions(
+                            ImmutableList.of(
+                                SelectWithLabel.OptionValue.builder()
+                                    .setLabel("c")
+                                    .setValue("d")
+                                    .build()))
                         .build()));
     assertThat(selectWithLabel.getSelectTag().render()).contains("<select");
-    assertThat(selectWithLabel.getSelectTag().render()).contains("<optgroup label=\"A label\">");
+    assertThat(selectWithLabel.getSelectTag().render())
+        .contains("<optgroup label=\"First group label\">");
+    assertThat(selectWithLabel.getSelectTag().render())
+        .contains("<optgroup label=\"Second group label\">");
     assertThat(selectWithLabel.getSelectTag().render()).contains("<option");
   }
 }

--- a/server/test/views/components/SelectWithLabelTest.java
+++ b/server/test/views/components/SelectWithLabelTest.java
@@ -45,5 +45,27 @@ public class SelectWithLabelTest {
     assertThat(selectWithLabel.getSelectTag().render()).contains("<select");
     assertThat(selectWithLabel.getSelectTag().render()).contains("value=\"b\" selected");
     assertThat(selectWithLabel.getSelectTag().render()).doesNotContain("hidden selected");
+    assertThat(selectWithLabel.getSelectTag().render()).doesNotContain("<optgroup>");
+  }
+
+  @Test
+  public void createSelect_withOptGroups() {
+    SelectWithLabel selectWithLabel =
+        new SelectWithLabel()
+            .setId("id")
+            .setOptionGroups(
+                ImmutableList.of(
+                    SelectWithLabel.OptionGroup.builder()
+                        .setLabel("A label")
+                        .setOptions(
+                            ImmutableList.of(
+                                SelectWithLabel.OptionValue.builder()
+                                    .setLabel("a")
+                                    .setValue("b")
+                                    .build()))
+                        .build()));
+    assertThat(selectWithLabel.getSelectTag().render()).contains("<select");
+    assertThat(selectWithLabel.getSelectTag().render()).contains("<optgroup label=\"A label\">");
+    assertThat(selectWithLabel.getSelectTag().render()).contains("<option");
   }
 }


### PR DESCRIPTION
### Description

This allows for visual separation of different application status filters (e.g. "General" filters such as all applications) vs for a specific status.

## Release notes:

Better organize application status filter options within the program admin view.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3269
