### PR TITLE
Set browser test timeout to 5 sec for all tests

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -10,7 +10,6 @@ describe('program creation', () => {
   const ctx = createTestContext()
   it('create program with enumerator and repeated questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 
@@ -74,7 +73,6 @@ describe('program creation', () => {
 
   it('change questions order within block', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 

--- a/browser-test/src/admin_program_hidden.test.ts
+++ b/browser-test/src/admin_program_hidden.test.ts
@@ -11,7 +11,6 @@ describe('Hide a program that should not be public yet', () => {
   const ctx = createTestContext()
   it('Create a new hidden program, verify applicants cannot see it on the home page', async () => {
     const {page, adminPrograms} = ctx
-    page.setDefaultTimeout(5000)
 
     await loginAsAdmin(page)
 
@@ -36,8 +35,6 @@ describe('Hide a program that should not be public yet', () => {
 
   it('create a public program, verify applicants can see it on the home page', async () => {
     const {page, adminPrograms} = ctx
-
-    page.setDefaultTimeout(5000)
 
     await loginAsAdmin(page)
 

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -22,12 +22,6 @@ describe('normal application flow', () => {
 
   it('all major steps', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
-    // Timeout for clicks and element fills. If your selector fails to locate
-    // the HTML element, the test hangs. If you find the tests time out, you
-    // want to verify that your selectors are working as expected first.
-    // Because all tests are run concurrently, it could be that your selector
-    // selects a different entity from another test.
-    page.setDefaultTimeout(4000)
 
     const noApplyFilters = false
     const applyFilters = true

--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -14,8 +14,6 @@ describe('view an application in an older version', () => {
 
   it('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
-    page.setDefaultTimeout(5000)
-
     await loginAsAdmin(page)
 
     // Create a program with one question

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -14,7 +14,6 @@ describe('Program admin review of submitted applications', () => {
 
   it('all major steps', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
-    page.setDefaultTimeout(5000)
 
     await loginAsAdmin(page)
 
@@ -247,7 +246,6 @@ describe('Program admin review of submitted applications', () => {
 
   it('program applications listed most recent first', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
-    page.setDefaultTimeout(5000)
 
     // Create a simple one question program application.
     await loginAsAdmin(page)

--- a/browser-test/src/error_pages.test.ts
+++ b/browser-test/src/error_pages.test.ts
@@ -10,7 +10,6 @@ describe('error pages', () => {
   const ctx = createTestContext()
   it('test 404 page', async () => {
     const {page} = ctx
-    page.setDefaultTimeout(4000)
 
     const notFound = new NotFoundPage(page)
 

--- a/browser-test/src/question_delete.test.ts
+++ b/browser-test/src/question_delete.test.ts
@@ -6,7 +6,6 @@ describe('deleting question lifecycle', () => {
 
   it('create, publish, delete unused questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
     const programName = 'deleting program'

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -31,7 +31,6 @@ describe('normal question lifecycle', () => {
   for (const type of Object.values(QuestionType)) {
     it(`${type} question: create, update, publish, create a new version, and update`, async () => {
       const {page, adminQuestions, adminPrograms} = ctx
-      page.setDefaultTimeout(4000)
 
       await loginAsAdmin(page)
 
@@ -103,7 +102,6 @@ describe('normal question lifecycle', () => {
 
   it('shows error when creating a dropdown question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 
@@ -126,7 +124,6 @@ describe('normal question lifecycle', () => {
 
   it('shows error when creating a radio question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 
@@ -149,7 +146,6 @@ describe('normal question lifecycle', () => {
 
   it('shows error when updating a dropdown question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 
@@ -177,7 +173,6 @@ describe('normal question lifecycle', () => {
 
   it('shows error when updating a radio question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 
@@ -207,7 +202,6 @@ describe('normal question lifecycle', () => {
 
   it('persists export state', async () => {
     const {page, adminQuestions} = ctx
-    page.setDefaultTimeout(4000)
 
     await loginAsAdmin(page)
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -171,6 +171,10 @@ export const createTestContext = (clearDb = true): TestContext => {
     }
     browserContext = await makeBrowserContext(browser)
     ctx.page = await browserContext.newPage()
+    // Default timeout is 30s. It's too long given that civiform is not JS
+    // heavy and all elements render quite quickly. Setting it to 5 sec so that
+    // tests fail fast.
+    ctx.page.setDefaultTimeout(5000)
     ctx.adminQuestions = new AdminQuestions(ctx.page)
     ctx.adminPrograms = new AdminPrograms(ctx.page)
     ctx.adminApiKeys = new AdminApiKeys(ctx.page)


### PR DESCRIPTION
### Description

This will help with local test development as today we often wait for 30sec before test times out and fails. We shouldn't places where we wait for more than 5 sec for some elements to render/become visible. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
