### PR TITLE
Removing overflow-hidden that prevented application viewing from being scrollable.

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -142,7 +142,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .addMainContent(contentDiv)
             // The body and main styles are necessary for modals to appear since they use fixed
             // sizing.
-            .addBodyStyles(Styles.OVERFLOW_HIDDEN, Styles.FLEX)
+            .addBodyStyles(Styles.FLEX)
             .addMainStyles(Styles.W_SCREEN)
             .addModals(updateNoteModal)
             .addModals(statusUpdateConfirmationModals)


### PR DESCRIPTION
### Description

This is a regression from https://github.com/civiform/civiform/pull/3191 where we incorrectly added the overflow-hidden class to the application content (thus disabling scrolling).

### Screenshots

Before (not scrollable):
![Screen Shot 2022-09-07 at 2 01 51 PM](https://user-images.githubusercontent.com/1870301/188978672-244088e6-e69c-4f6e-bf5d-f9be0a8319f5.png)

After (scrollable):
![Screen Shot 2022-09-07 at 1 59 13 PM](https://user-images.githubusercontent.com/1870301/188978705-81b071c3-fbb7-44ee-9bac-fa8d66237397.png)

## Release notes:

Fix issue where program admins viewing an application could not scroll through all of the content.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3362