### PR TITLE
fixing Create-new-question dropdown (as the scroll bar isn't working)

### DIFF
--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -35,7 +35,7 @@ public final class CreateQuestionButton {
                 Styles.BG_WHITE,
                 Styles.TEXT_GRAY_600,
                 Styles.SHADOW_LG,
-                Styles.OVERFLOW_AUTO,
+                Styles.ABSOLUTE,
                 Styles.ML_3,
                 Styles.MT_1,
                 Styles.HIDDEN);

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -35,7 +35,7 @@ public final class CreateQuestionButton {
                 Styles.BG_WHITE,
                 Styles.TEXT_GRAY_600,
                 Styles.SHADOW_LG,
-                Styles.ABSOLUTE,
+                Styles.OVERFLOW_AUTO,
                 Styles.ML_3,
                 Styles.MT_1,
                 Styles.HIDDEN);

--- a/server/app/views/components/QuestionBank.java
+++ b/server/app/views/components/QuestionBank.java
@@ -58,7 +58,7 @@ public final class QuestionBank {
             .withAction(params.questionAction())
             .with(params.csrfTag());
 
-    DivTag innerDiv = div().withClasses(Styles.SHADOW_LG, Styles.OVERFLOW_HIDDEN, Styles.H_FULL);
+    DivTag innerDiv = div().withClasses(Styles.SHADOW_LG, Styles.H_FULL);
     questionForm.with(innerDiv);
     DivTag contentDiv =
         div().withClasses(Styles.RELATIVE, Styles.GRID, Styles.GAP_6, Styles.PX_5, Styles.PY_6);


### PR DESCRIPTION
### Description

Dropdown for "create-new-question" doesn't have a scroll option. So Admins cannot choose other options.

## Release notes:

Dropdown for "create-new-question" doesn't have a scroll option. So Admins cannot choose other options.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3365 ; 

Screenshots
Before:
![image](https://user-images.githubusercontent.com/101214724/188991943-07f63b39-991d-4282-91b4-b0f442d5440a.png)

After:
![image](https://user-images.githubusercontent.com/101214724/188993160-ccfed428-683a-496a-bc6e-19f1f3c81cf5.png)


