### PR TITLE
Fix CI breakage where unit test assertion doesn't match the updated OIDC image from #3334

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,10 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
+      - name: Build dev-oidc
+        env:
+          DOCKER_BUILDKIT: 1
+        run: bin/build-dev-oidc
       - name: Run tests
         run: bin/run-test-ci
       - name: Upload coverage to Codecov

--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -37,6 +37,8 @@ public class SecurityBrowserTest extends BaseBrowserTest {
     // If we are not cookied, enter a username and password.
     // Otherwise, since the fake provider uses the "web" flow, we're automatically sent to the
     // redirect URI to merge logins.
+    // TODO(#1770): Once the user is logged out from the fake OIDC provider, the below conditional
+    // can likely be removed entirely.
     if (browser.pageSource().contains("Enter any login")) {
       browser.$("[name='login']").click();
       browser.keyboard().sendKeys("username");

--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -32,9 +32,11 @@ public class SecurityBrowserTest extends BaseBrowserTest {
     userRepository = app.injector().instanceOf(UserRepository.class);
   }
 
-  protected void loginWithSimulatedIdcs() {
+  private void loginWithSimulatedIdcs() {
     goTo(routes.LoginController.applicantLogin(Optional.empty()));
     // If we are not cookied, enter a username and password.
+    // Otherwise, since the fake provider uses the "web" flow, we're automatically sent to the
+    // redirect URI to merge logins.
     if (browser.pageSource().contains("Enter any login")) {
       browser.$("[name='login']").click();
       browser.keyboard().sendKeys("username");
@@ -43,8 +45,6 @@ public class SecurityBrowserTest extends BaseBrowserTest {
       // Log in.
       browser.$(".login-submit").click();
       // Bypass consent screen.
-      browser.$(".login-submit").click();
-    } else {
       browser.$(".login-submit").click();
     }
   }

--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -37,8 +37,8 @@ public class SecurityBrowserTest extends BaseBrowserTest {
     // If we are not cookied, enter a username and password.
     // Otherwise, since the fake provider uses the "web" flow, we're automatically sent to the
     // redirect URI to merge logins.
-    // TODO(#1770): Once the user is logged out from the fake OIDC provider, the below conditional
-    // can likely be removed entirely.
+    // TODO(#1770): Consider removing the below conditional entirely once full logout from the
+    // fake OIDC provider is supported.
     if (browser.pageSource().contains("Enter any login")) {
       browser.$("[name='login']").click();
       browser.keyboard().sendKeys("username");

--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -101,7 +101,7 @@ public class SecurityBrowserTest extends BaseBrowserTest {
     Optional<String> applicantName =
         applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_FIRST_NAME);
     assertThat(applicantName).isPresent();
-    assertThat(applicantName.get()).isEqualTo("first");
+    assertThat(applicantName.get()).isEqualTo("username@example.com");
 
     applicantName = applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_MIDDLE_NAME);
     assertThat(applicantName).isPresent();

--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -103,13 +103,10 @@ public class SecurityBrowserTest extends BaseBrowserTest {
     assertThat(applicantName).isPresent();
     assertThat(applicantName.get()).isEqualTo("username@example.com");
 
-    applicantName = applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_MIDDLE_NAME);
-    assertThat(applicantName).isPresent();
-    assertThat(applicantName.get()).isEqualTo("middle");
-
-    applicantName = applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_LAST_NAME);
-    assertThat(applicantName).isPresent();
-    assertThat(applicantName.get()).isEqualTo("last");
+    assertThat(applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_MIDDLE_NAME))
+        .isEmpty();
+    assertThat(applicant.getApplicantData().readString(WellKnownPaths.APPLICANT_LAST_NAME))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixing CI breakage described in https://github.com/civiform/civiform/issues/3326#issuecomment-1239971757.

In addition to fixing the test assertions, I also updated CI to build the test OIDC container (similar to browser-tests below) prior to running unit tests so that the version used matches the test code.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3326