### PR TITLE
Improve typing of TS browser tests

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -261,9 +261,7 @@ describe('view program statuses', () => {
         applyFilters,
       )
       expect(noStatusFilteredCsvContent).toContain(favoriteColorAnswer)
-      const noStatusFilteredJsonContent = JSON.parse(
-        await adminPrograms.getJson(applyFilters),
-      )
+      const noStatusFilteredJsonContent = await adminPrograms.getJson(applyFilters)
       expect(noStatusFilteredJsonContent.length).toEqual(1)
       expect(
         noStatusFilteredJsonContent[0].application.statusesfavecolorq.text,
@@ -280,9 +278,7 @@ describe('view program statuses', () => {
       expect(approvedStatusFilteredCsvContent).not.toContain(
         favoriteColorAnswer,
       )
-      const approvedStatusFilteredJsonContent = JSON.parse(
-        await adminPrograms.getJson(applyFilters),
-      )
+      const approvedStatusFilteredJsonContent = await adminPrograms.getJson(applyFilters)
       expect(approvedStatusFilteredJsonContent.length).toEqual(0)
     })
 

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -261,7 +261,9 @@ describe('view program statuses', () => {
         applyFilters,
       )
       expect(noStatusFilteredCsvContent).toContain(favoriteColorAnswer)
-      const noStatusFilteredJsonContent = await adminPrograms.getJson(applyFilters)
+      const noStatusFilteredJsonContent = await adminPrograms.getJson(
+        applyFilters,
+      )
       expect(noStatusFilteredJsonContent.length).toEqual(1)
       expect(
         noStatusFilteredJsonContent[0].application.statusesfavecolorq.text,
@@ -278,7 +280,9 @@ describe('view program statuses', () => {
       expect(approvedStatusFilteredCsvContent).not.toContain(
         favoriteColorAnswer,
       )
-      const approvedStatusFilteredJsonContent = await adminPrograms.getJson(applyFilters)
+      const approvedStatusFilteredJsonContent = await adminPrograms.getJson(
+        applyFilters,
+      )
       expect(approvedStatusFilteredJsonContent.length).toEqual(0)
     })
 

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -125,9 +125,7 @@ describe('normal application flow', () => {
       postEditCsvContent.split('Gus,,Guest,op2,01/01/1990,2000.00').length - 1
     expect(numberOfGusEntries).toEqual(2)
 
-    const postEditJsonContent = JSON.parse(
-      await adminPrograms.getJson(noApplyFilters),
-    )
+    const postEditJsonContent = await adminPrograms.getJson(noApplyFilters)
     expect(postEditJsonContent.length).toEqual(3)
     expect(postEditJsonContent[0].program_name).toEqual(programName)
     expect(postEditJsonContent[0].language).toEqual('en-US')
@@ -154,9 +152,7 @@ describe('normal application flow', () => {
     expect(filteredCsvContent).not.toContain(
       'Gus,,Guest,op2,01/01/1990,2000.00',
     )
-    const filteredJsonContent = JSON.parse(
-      await adminPrograms.getJson(applyFilters),
-    )
+    const filteredJsonContent = await adminPrograms.getJson(applyFilters)
     expect(filteredJsonContent.length).toEqual(1)
     expect(filteredJsonContent[0].application.name.first_name).toEqual('sarah')
     // Ensures that choosing not to apply filters continues to return all
@@ -164,9 +160,7 @@ describe('normal application flow', () => {
     const allCsvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(allCsvContent).toContain('sarah,,smith,op2,05/10/2021,1000.00')
     expect(allCsvContent).toContain('Gus,,Guest,op2,01/01/1990,2000.00')
-    const allJsonContent = JSON.parse(
-      await adminPrograms.getJson(noApplyFilters),
-    )
+    const allJsonContent = await adminPrograms.getJson(noApplyFilters)
     expect(allJsonContent.length).toEqual(3)
     expect(allJsonContent[0].application.name.first_name).toEqual('Gus')
     expect(allJsonContent[1].application.name.first_name).toEqual('Gus')

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -12,13 +12,13 @@ describe('applicant security', () => {
     const {page} = ctx
     await loginAsGuest(page)
     const response = await gotoEndpoint(page, '/applicants/1234/programs')
-    expect(response!.status()).toBe(401)
+    expect(response.status()).toBe(401)
   })
 
   it('admin cannot access applicant pages', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
     const response = await gotoEndpoint(page, '/applicants/1234567/programs')
-    expect(response!.status()).toBe(401)
+    expect(response.status()).toBe(401)
   })
 })

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -12,13 +12,13 @@ describe('applicant security', () => {
     const {page} = ctx
     await loginAsGuest(page)
     const response = await gotoEndpoint(page, '/applicants/1234/programs')
-    expect(response.status()).toBe(401)
+    expect(response!.status()).toBe(401)
   })
 
   it('admin cannot access applicant pages', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
     const response = await gotoEndpoint(page, '/applicants/1234567/programs')
-    expect(response.status()).toBe(401)
+    expect(response!.status()).toBe(401)
   })
 })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -9,6 +9,28 @@ import {
 import {BASE_URL} from './config'
 import {AdminProgramStatuses} from './admin_program_statuses'
 
+/**
+ * JSON object representing downloaded application. It can be retrieved by
+ * program admins. To see all fields check buildJsonApplication() method in
+ * JsonExporter.java.
+ */
+export interface DownloadedApplication {
+  program_name: string,
+  program_version_id: number,
+  applicant_id: number,
+  application_id: number,
+  language: string,
+  create_time: string,
+  submitter_email: string,
+  submit_time: string,
+  // Applicant answers as a map of question name to answer data.
+  application: {
+    [questionName: string]: {
+      [questionField: string]: unknown
+    }
+  }
+}
+
 export class AdminPrograms {
   public page!: Page
 
@@ -642,7 +664,7 @@ export class AdminPrograms {
     expect(toastMessages).toContain('Application note updated')
   }
 
-  async getJson(applyFilters: boolean) {
+  async getJson(applyFilters: boolean): Promise<DownloadedApplication[]> {
     await clickAndWaitForModal(this.page, 'download-program-applications-modal')
     if (applyFilters) {
       await this.page.check('text="Current results"')
@@ -658,7 +680,7 @@ export class AdminPrograms {
       throw new Error('download failed')
     }
 
-    return readFileSync(path, 'utf8')
+    return JSON.parse(readFileSync(path, 'utf8'))
   }
 
   async getCsv(applyFilters: boolean) {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -15,14 +15,14 @@ import {AdminProgramStatuses} from './admin_program_statuses'
  * JsonExporter.java.
  */
 export interface DownloadedApplication {
-  program_name: string,
-  program_version_id: number,
-  applicant_id: number,
-  application_id: number,
-  language: string,
-  create_time: string,
-  submitter_email: string,
-  submit_time: string,
+  program_name: string
+  program_version_id: number
+  applicant_id: number
+  application_id: number
+  language: string
+  create_time: string
+  submitter_email: string
+  submit_time: string
   // Applicant answers as a map of question name to answer data.
   application: {
     [questionName: string]: {


### PR DESCRIPTION
### Description

Add type definition for the application JSON object that can be downloaded by program admins. It doesn't guarantee that type definition doesn't become stale but at least it provides TS code with better centralized type checking. Needed for #3361

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
