### PR TITLE
Enable asset caching on browser tests

### DIFF
--- a/server/app/filters/DisableCachingFilter.java
+++ b/server/app/filters/DisableCachingFilter.java
@@ -41,9 +41,8 @@ public class DisableCachingFilter extends EssentialFilter {
                       final Integer status = result.status();
                       final String path = request.uri().toLowerCase();
 
-
                       if ((!environment.isDev() // Must revalidate assets in dev mode
-                         || this.enableCacheForBrowserTests)
+                              || this.enableCacheForBrowserTests)
                           && ASSET_PATH_PREFIXES.stream().anyMatch(path::startsWith)
                           && OK_STATUS_CODES.contains(status)) {
                         // In prod/staging, static assets are fingerprinted,

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -613,3 +613,8 @@ application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_EN
 # work as expected in production if there are multiple servers.
 feature_flag_overrides_enabled = false
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
+
+# If enabled, all assets (JS, CSS files) will be returned with long caching.
+# This setting should be used only by browser tests. Note that it is used
+# in dev mode where normally files served with caching disabled.
+enable_asset_caching_for_browser_tests = false

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -7,3 +7,6 @@ include "application.dev.conf"
 # they should enable them via the Feature Flags HTTP
 # handler as needed.
 application_status_tracking_enabled = false
+
+# Enable caching of JS/CSS resources to speed up tests.
+enable_asset_caching_for_browser_tests = true


### PR DESCRIPTION
### Description

This improves speed of browser tests. For `quesiton_lifecycle.test.ts` duration goes from 250s to 140s. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

