### PR TITLE
Enable fingerpriting and caching for static files even on dev mode

### DIFF
--- a/server/app/filters/DisableCachingFilter.java
+++ b/server/app/filters/DisableCachingFilter.java
@@ -19,13 +19,10 @@ public class DisableCachingFilter extends EssentialFilter {
   // Only cache when Status is OK. https://web.dev/uses-long-cache-ttl/
   private static final ImmutableSet<Integer> OK_STATUS_CODES = ImmutableSet.of(200, 203, 206);
 
-  private final play.Environment environment;
-
   @Inject
-  public DisableCachingFilter(Executor exec, play.Environment environment) {
+  public DisableCachingFilter(Executor exec) {
     super();
     this.exec = checkNotNull(exec);
-    this.environment = checkNotNull(environment);
   }
 
   @Override
@@ -38,8 +35,7 @@ public class DisableCachingFilter extends EssentialFilter {
                       final Integer status = result.status();
                       final String path = request.uri().toLowerCase();
 
-                      if (!environment.isDev() // Must revalidate assets in dev mode
-                          && ASSET_PATH_PREFIXES.stream().anyMatch(path::startsWith)
+                      if (ASSET_PATH_PREFIXES.stream().anyMatch(path::startsWith)
                           && OK_STATUS_CODES.contains(status)) {
                         // In prod/staging, static assets are fingerprinted,
                         // so we can cache for a longer time.

--- a/server/app/filters/DisableCachingFilter.java
+++ b/server/app/filters/DisableCachingFilter.java
@@ -37,9 +37,10 @@ public class DisableCachingFilter extends EssentialFilter {
 
                       if (ASSET_PATH_PREFIXES.stream().anyMatch(path::startsWith)
                           && OK_STATUS_CODES.contains(status)) {
-                        // In prod/staging, static assets are fingerprinted,
-                        // so we can cache for a longer time.
-                        // Cache for 2 weeks.
+                        // Static assets are fingerprinted so we can cache them for 2 weeks.
+                        // Even in dev mode where static files also don't change that often
+                        // it can add some performance improvement. Improves speed of
+                        // browser tests significantly.
                         return result.withHeader(
                             "Cache-Control", "public, max-age=1209600, immutable");
                       }

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -120,8 +120,9 @@ lazy val root = (project in file("."))
     // https://github.com/sbt/zinc/issues/911
     incOptions := incOptions.value.withTransitiveStep(2),
     pipelineStages := Seq(digest, gzip), // plugins to use for assets
-    // Uncomment to test the sbt-web asset pipeline locally.
-    // Assets / pipelineStages  := Seq(digest, gzip), // Test the sbt-web pipeline locally.
+    // Enable digest for local dev so that files can be served çached improving
+    // page speed and also browser tests speed.
+    Assets / pipelineStages  := Seq(digest, gzip),
 
     // Make verbose tests
     Test / testOptions := Seq(

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -122,7 +122,7 @@ lazy val root = (project in file("."))
     pipelineStages := Seq(digest, gzip), // plugins to use for assets
     // Enable digest for local dev so that files can be served çached improving
     // page speed and also browser tests speed.
-    Assets / pipelineStages  := Seq(digest, gzip),
+    Assets / pipelineStages := Seq(digest, gzip),
 
     // Make verbose tests
     Test / testOptions := Seq(

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -26,12 +26,15 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
 
     assertThat(content.body())
-        .contains("<link href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
+        .containsPattern("<link href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
     assertThat(content.body())
-        .contains("<script src=\"/assets/javascripts/main.js\" type=\"text/javascript\"></script>");
+        .containsPattern(
+            "<script src=\"/assets/javascripts/[a-z0-9]+-main.js\""
+                + " type=\"text/javascript\"></script>");
     assertThat(content.body())
-        .contains(
-            "<script src=\"/assets/javascripts/radio.js\" type=\"text/javascript\"></script>");
+        .containsPattern(
+            "<script src=\"/assets/javascripts/[a-z0-9]+-radio.js\""
+                + " type=\"text/javascript\"></script>");
 
     assertThat(content.body()).contains("<main></main>");
   }


### PR DESCRIPTION
### Description

This improves speed of browser tests. For quesiton_lifecycle.test.ts duration goes from 250s to 140s. Fingerprinting guarantees that when while changes - a new version will be requested. The downside of that approach is that it adds an extra step (fingerprinting) into incremental rebuild of static assets (TS files). But that adds only around 1-2s so it's practically unnoticeable. It might become an issue in future if we have bigger static files, but with current guidelines (minimum JS) that unlikely to happen soon.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
