### PR TITLE
Fixing incorrect URL assumption for AWS staging prober login (not yet used)

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -303,7 +303,7 @@ async function loginAsTestUserSeattleStaging(page: Page) {
 
 async function loginAsTestUserAwsStaging(page: Page) {
   await Promise.all([
-    page.waitForURL('**/u/login/*', {waitUntil: 'networkidle'}),
+    page.waitForURL('**/u/login*', {waitUntil: 'networkidle'}),
     page.click('button:has-text("Log in")'),
   ])
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -285,6 +285,9 @@ export const loginAsTestUser = async (page: Page) => {
       }
   }
   await waitForPageJsLoad(page)
+  await page.waitForSelector(
+    `:has-text("Logged in as ${testUserDisplayName()}")`,
+  )
 }
 
 async function loginAsTestUserSeattleStaging(page: Page) {


### PR DESCRIPTION
### Description

Noticed when starting to manually test using a new test user with AWS staging (https://github.com/civiform/civiform/issues/3326#issuecomment-1244021249).

Auth0's login URL is of the form `.../u/login?state=<elided>`, whereas the test assertion was assuming that there'd be a trailing slash in the URL (e.g. `.../u/login/?state=<elided>`). This fixes that assumption and also adds a positive assertion that a successful login flow indicates it in the UI as well.

### Tested

Manually tested by running `bin/build-browser-tests` then running:

```
 docker run \
  -e TEST_USER_AUTH_STRATEGY="aws-staging" \
  -e TEST_USER_LOGIN="<elided>" \
  -e TEST_USER_PASSWORD='<elided>' \
  -e TEST_USER_DISPLAY_NAME="<elided>" \
  -e BASE_URL="https://staging-aws.civiform.dev" \
  -e DISABLE_SCREENSHOTS=true civiform/civiform-browser-test:latest \
  -c "yarn install && yarn probe application_previous_version.test.ts"
```

Before the change, this failed with:
```
 page.waitForURL: Timeout 5000ms exceeded.
    =========================== logs ===========================
    waiting for navigation to "**/u/login/*" until "networkidle"
      navigated to "https://civiform-staging.us.auth0.com/u/login?state=<elided>
```

After, it made it past login and failed due to an issue between test expectations and the staging environment (e.g. browser test was running at head whereas staging environment was deployed multiple hours ago).

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3326