### PR TITLE
Run fmt test when formatters change

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -62,6 +62,13 @@ jobs:
       - name: show diff
         run: git add .; git diff --exit-code HEAD
 
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: terraform fmt
+        id: tf_fmt
+        run: terraform fmt -check -recursive -diff cloud
+
       - name: Check bin scripts have docstrings.
         if: contains(toJSON(steps.file_changes.outputs.files), 'bin/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
         id: check_bin_script_docs
@@ -89,7 +96,7 @@ jobs:
           cache-from: |
             civiform/formatter:latest
       - name: Run Browsertest formatter
-        if: contains(toJSON(steps.file_changes.outputs.files), 'browser-test/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
+        if: contains(toJSON(steps.file_changes.outputs.files), 'browser-test/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.files), 'formatter')
         run: browser-test/bin/fmt
       - name: show Browsertest diff
         run: git add .; git diff --exit-code HEAD
@@ -113,7 +120,7 @@ jobs:
       - name: Run bin/fmt-sbt
         env:
           DOCKER_BUILDKIT: 1
-        if: contains(toJSON(steps.file_changes.outputs.files), '.sbt') || contains(toJSON(steps.file_changes.outputs.files), '.scala')|| contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
+        if: contains(toJSON(steps.file_changes.outputs.files), '.sbt') || contains(toJSON(steps.file_changes.outputs.files), '.scala') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.files), 'fmt-sbt')
         run: bin/fmt-sbt
       - name: show bin/fmt-sbt diff
         run: git add .; git diff --exit-code HEAD
@@ -132,6 +139,7 @@ jobs:
             # -i 2   indent 2 spaces
             # -bn    binary ops like && and | may start a line
             # -ci    switch cases will be indented
+
   python-formatting:
     name: Formatting Check
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -62,13 +62,6 @@ jobs:
       - name: show diff
         run: git add .; git diff --exit-code HEAD
 
-      - name: setup terraform
-        uses: hashicorp/setup-terraform@v2
-
-      - name: terraform fmt
-        id: tf_fmt
-        run: terraform fmt -check -recursive -diff cloud
-
       - name: Check bin scripts have docstrings.
         if: contains(toJSON(steps.file_changes.outputs.files), 'bin/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
         id: check_bin_script_docs

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -63,3 +63,7 @@ echo 'Start format shell'
 shfmt -bn -ci -i 2 -w -l \
   $(shfmt -f . | grep -v -e /node_modules)
 echo 'Done formatting shell'
+
+echo 'Start format terraform'
+terraform fmt -recursive cloud
+echo 'Done format terraform'

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -63,7 +63,3 @@ echo 'Start format shell'
 shfmt -bn -ci -i 2 -w -l \
   $(shfmt -f . | grep -v -e /node_modules)
 echo 'Done formatting shell'
-
-echo 'Start format terraform'
-terraform fmt -recursive cloud
-echo 'Done format terraform'

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/do
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
 
 RUN apk update && apk add --no-cache --update \
-  openjdk11 bash wget npm shfmt git py3-pip
+  openjdk11 bash wget npm shfmt git py3-pip terraform
 
 RUN pip install yapf
 RUN npm install --global yarn


### PR DESCRIPTION
### Description

Have the tests run when their formatter changes.
Include the terraform package in the formatter dockerfile for use in the cloud-deploy-infra repo.

## Release notes:

n/a

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

