### PR TITLE
Moving getEncodedFileKey to common function and fixing unit tests

### DIFF
--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -53,6 +53,8 @@ public abstract class AnswerData {
   /** The identifier of the applicant's uploaded file if applicable. */
   public abstract Optional<String> fileKey();
 
+  public abstract Optional<String> encodedFileKey();
+
   /**
    * The original file name of the applicant's uploaded file, if applicable. For example, this is
    * needed for Azure blob storage, where the original file name is different from the file key.
@@ -94,6 +96,8 @@ public abstract class AnswerData {
     public abstract Builder setAnswerText(String answerText);
 
     public abstract Builder setFileKey(Optional<String> fileKey);
+
+    public abstract Builder setEncodedFileKey(Optional<String> encodedFileKey);
 
     public abstract Builder setOriginalFileName(Optional<String> originalFileName);
 

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -50,9 +50,7 @@ public abstract class AnswerData {
   /** The applicant's response to the question. */
   public abstract String answerText();
 
-  /** The identifier of the applicant's uploaded file if applicable. */
-  public abstract Optional<String> fileKey();
-
+  /** The identifier of the applicant's uploaded file after its UTF-8 encoded if applicable */
   public abstract Optional<String> encodedFileKey();
 
   /**
@@ -94,8 +92,6 @@ public abstract class AnswerData {
     public abstract Builder setIsAnswered(boolean isAnswered);
 
     public abstract Builder setAnswerText(String answerText);
-
-    public abstract Builder setFileKey(Optional<String> fileKey);
 
     public abstract Builder setEncodedFileKey(Optional<String> encodedFileKey);
 

--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -185,15 +185,14 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
         Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
         Optional<Long> updatedProgram = question.getUpdatedInProgramMetadata();
         Optional<String> originalFileName = Optional.empty();
-        Optional<String> fileKey = Optional.empty();
         Optional<String> encodedFileKey = Optional.empty();
         if (isAnswered && question.isFileUploadQuestion()) {
           FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
           originalFileName = fileUploadQuestion.getOriginalFileName();
-          fileKey = fileUploadQuestion.getFileKeyValue();
-          if (fileKey.isPresent()) {
-            encodedFileKey = Optional.of(URLEncoder.encode(fileKey.get(), StandardCharsets.UTF_8));
-          }
+          encodedFileKey =
+              fileUploadQuestion
+                  .getFileKeyValue()
+                  .map((fileKey) -> URLEncoder.encode(fileKey, StandardCharsets.UTF_8));
         }
         boolean isPreviousResponse =
             updatedProgram.isPresent() && updatedProgram.get() != programDefinition.id();
@@ -209,7 +208,6 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setQuestionText(questionText)
                 .setIsAnswered(isAnswered)
                 .setAnswerText(answerText)
-                .setFileKey(fileKey)
                 .setEncodedFileKey(encodedFileKey)
                 .setOriginalFileName(originalFileName)
                 .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))

--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -186,10 +186,14 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
         Optional<Long> updatedProgram = question.getUpdatedInProgramMetadata();
         Optional<String> originalFileName = Optional.empty();
         Optional<String> fileKey = Optional.empty();
+        Optional<String> encodedFileKey = Optional.empty();
         if (isAnswered && question.isFileUploadQuestion()) {
           FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
           originalFileName = fileUploadQuestion.getOriginalFileName();
           fileKey = fileUploadQuestion.getFileKeyValue();
+          if (fileKey.isPresent()) {
+            encodedFileKey = Optional.of(URLEncoder.encode(fileKey.get(), StandardCharsets.UTF_8));
+          }
         }
         boolean isPreviousResponse =
             updatedProgram.isPresent() && updatedProgram.get() != programDefinition.id();
@@ -206,6 +210,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setIsAnswered(isAnswered)
                 .setAnswerText(answerText)
                 .setFileKey(fileKey)
+                .setEncodedFileKey(encodedFileKey)
                 .setOriginalFileName(originalFileName)
                 .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))
                 .setIsPreviousResponse(isPreviousResponse)

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -97,7 +97,7 @@ public final class PdfExporter {
                 answerData.questionDefinition().getName(),
                 FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
         Paragraph answer = null;
-        if (answerData.fileKey().isPresent()) {
+        if (answerData.encodedFileKey().isPresent()) {
           String encodedFileKey = answerData.encodedFileKey().get();
           String fileLink =
               controllers.routes.FileController.adminShow(programId, encodedFileKey).url();

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -15,8 +15,6 @@ import com.itextpdf.text.pdf.PdfWriter;
 import com.typesafe.config.Config;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -100,8 +98,7 @@ public final class PdfExporter {
                 FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
         Paragraph answer = null;
         if (answerData.fileKey().isPresent()) {
-          String encodedFileKey =
-              URLEncoder.encode(answerData.fileKey().get(), StandardCharsets.UTF_8);
+          String encodedFileKey = answerData.encodedFileKey().get();
           String fileLink =
               controllers.routes.FileController.adminShow(programId, encodedFileKey).url();
           Anchor anchor = new Anchor(answerData.answerText());

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -197,7 +197,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
     LocalDate date =
         Instant.ofEpochMilli(answerData.timestamp()).atZone(ZoneId.systemDefault()).toLocalDate();
     DivTag answerContent;
-    if (answerData.fileKey().isPresent()) {
+    if (answerData.encodedFileKey().isPresent()) {
       String encodedFileKey = answerData.encodedFileKey().get();
       String fileLink =
           controllers.routes.FileController.adminShow(programId, encodedFileKey).url();

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -25,8 +25,6 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.SelectTag;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -200,7 +198,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
         Instant.ofEpochMilli(answerData.timestamp()).atZone(ZoneId.systemDefault()).toLocalDate();
     DivTag answerContent;
     if (answerData.fileKey().isPresent()) {
-      String encodedFileKey = URLEncoder.encode(answerData.fileKey().get(), StandardCharsets.UTF_8);
+      String encodedFileKey = answerData.encodedFileKey().get();
       String fileLink =
           controllers.routes.FileController.adminShow(programId, encodedFileKey).url();
       answerContent = div(a(answerData.answerText()).withHref(fileLink));

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -141,7 +141,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     // Add existing answer.
     if (data.isAnswered()) {
       final ContainerTag answerContent;
-      if (data.fileKey().isPresent()) {
+      if (data.encodedFileKey().isPresent()) {
         String encodedFileKey = data.encodedFileKey().get();
         String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
         answerContent = a().withHref(fileLink);

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -14,8 +14,6 @@ import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -144,7 +142,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     if (data.isAnswered()) {
       final ContainerTag answerContent;
       if (data.fileKey().isPresent()) {
-        String encodedFileKey = URLEncoder.encode(data.fileKey().get(), StandardCharsets.UTF_8);
+        String encodedFileKey = data.encodedFileKey().get();
         String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
         answerContent = a().withHref(fileLink);
       } else {

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -987,9 +987,9 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
 
     assertEquals(2, result.size());
     // Non-fileupload question does not have a file key
-    assertThat(result.get(0).fileKey()).isEmpty();
+    assertThat(result.get(0).encodedFileKey()).isEmpty();
     // Fileupload question has a file key
-    assertThat(result.get(1).fileKey()).isNotEmpty();
+    assertThat(result.get(1).encodedFileKey()).isNotEmpty();
   }
 
   @Test

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -26,8 +26,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
 
     assertThat(content.body())
-        .containsPattern(
-            "<link href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
+        .containsPattern("<link href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
     assertThat(content.body())
         .containsPattern(
             "<script src=\"/assets/javascripts/[a-z0-9]+-main.js\""
@@ -53,8 +52,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
     assertThat(content.body())
-        .containsPattern(
+        .contains(
             "<link href=\"moose.css\" rel=\"stylesheet\"><link"
-                + " href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
+                + " href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
   }
 }

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -26,7 +26,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
 
     assertThat(content.body())
-        .containsPattern("<link href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
+        .containsPattern(
+            "<link href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
     assertThat(content.body())
         .containsPattern(
             "<script src=\"/assets/javascripts/[a-z0-9]+-main.js\""
@@ -52,8 +53,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
     assertThat(content.body())
-        .contains(
+        .containsPattern(
             "<link href=\"moose.css\" rel=\"stylesheet\"><link"
-                + " href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
+                + " href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
   }
 }


### PR DESCRIPTION
### Description

Moved EncodedFileKet as a memeber of the AnswerData class. It will be a common field like the FileKey(). 

## Release notes:

EncodedFileKey is moved a universal location. So all file downloads should be using it.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3409 
