### PR TITLE
Switching to use external name / description for the program card in the program list view

### DIFF
--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -34,8 +34,8 @@ public final class ProgramCardFactory {
   public DivTag renderCard(ProgramCardData cardData) {
     ProgramDefinition displayProgram = getDisplayProgram(cardData);
 
-    String programTitleText = displayProgram.adminName();
-    String programDescriptionText = displayProgram.adminDescription();
+    String programTitleText = displayProgram.localizedName().getDefault();
+    String programDescriptionText = displayProgram.localizedDescription().getDefault();
 
     DivTag statusDiv = div();
     if (cardData.draftProgram().isPresent()) {

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -36,6 +36,7 @@ public final class ProgramCardFactory {
 
     String programTitleText = displayProgram.localizedName().getDefault();
     String programDescriptionText = displayProgram.localizedDescription().getDefault();
+    String adminNoteText = displayProgram.adminDescription();
 
     DivTag statusDiv = div();
     if (cardData.draftProgram().isPresent()) {
@@ -56,14 +57,15 @@ public final class ProgramCardFactory {
         div()
             .withClass(Styles.FLEX)
             .with(
-                p(programTitleText)
+                div()
                     .withClasses(
-                        ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE,
-                        Styles.W_1_4,
-                        Styles.PY_7,
-                        Styles.TEXT_BLACK,
-                        Styles.FONT_BOLD,
-                        Styles.TEXT_XL),
+                        ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE, Styles.W_1_3, Styles.PY_7)
+                    .with(
+                        p(programTitleText)
+                            .withClasses(Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL),
+                        p(programDescriptionText)
+                            .withClasses(
+                                Styles.LINE_CLAMP_2, Styles.TEXT_GRAY_700, Styles.TEXT_BASE)),
                 statusDiv.withClasses(
                     Styles.FLEX_GROW,
                     Styles.TEXT_SM,
@@ -78,16 +80,17 @@ public final class ProgramCardFactory {
             Styles.BORDER,
             Styles.BORDER_GRAY_300,
             Styles.ROUNDED_LG)
-        .with(
-            titleAndStatus,
-            p(programDescriptionText)
-                .withClasses(
+        .with(titleAndStatus)
+        .condWith(
+            !adminNoteText.isBlank(),
+            p().withClasses(
                     Styles.W_3_4,
                     Styles.MB_8,
                     Styles.PT_4,
                     Styles.LINE_CLAMP_3,
                     Styles.TEXT_GRAY_700,
-                    Styles.TEXT_BASE))
+                    Styles.TEXT_BASE)
+                .with(span("Admin note: ").withClasses(Styles.FONT_SEMIBOLD), span(adminNoteText)))
         // Add data attributes used for client-side sorting.
         .withData("last-updated-millis", Long.toString(extractLastUpdated(cardData).toEpochMilli()))
         .withData("name", programTitleText);

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -58,11 +58,14 @@ public final class ProgramCardFactory {
             .withClass(Styles.FLEX)
             .with(
                 div()
-                    .withClasses(
-                        ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE, Styles.W_1_3, Styles.PY_7)
+                    .withClasses(Styles.W_1_3, Styles.PY_7)
                     .with(
                         p(programTitleText)
-                            .withClasses(Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL),
+                            .withClasses(
+                                ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE,
+                                Styles.TEXT_BLACK,
+                                Styles.FONT_BOLD,
+                                Styles.TEXT_XL),
                         p(programDescriptionText)
                             .withClasses(
                                 Styles.LINE_CLAMP_2, Styles.TEXT_GRAY_700, Styles.TEXT_BASE)),

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -100,13 +100,13 @@ public class AdminProgramControllerTest extends ResetPostgres {
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
-                        "New Program",
+                        "Internal program name",
                         "adminDescription",
-                        "This is a new program",
+                        "Internal program description",
                         "localizedDisplayName",
-                        "display name",
+                        "External program name",
                         "localizedDisplayDescription",
-                        "display description",
+                        "External program description",
                         "displayMode",
                         DisplayMode.PUBLIC.getValue())));
 
@@ -116,8 +116,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
     Result redirectResult = controller.index(addCSRFToken(Helpers.fakeRequest()).build());
-    assertThat(contentAsString(redirectResult)).contains("New Program");
-    assertThat(contentAsString(redirectResult)).contains("This is a new program");
+    assertThat(contentAsString(redirectResult)).contains("External program name");
+    assertThat(contentAsString(redirectResult)).contains("External program description");
   }
 
   @Test
@@ -129,13 +129,13 @@ public class AdminProgramControllerTest extends ResetPostgres {
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
-                        "New Program",
+                        "Internal program name",
                         "adminDescription",
-                        "This is a new program",
+                        "Internal program description",
                         "localizedDisplayName",
-                        "display name",
+                        "External program name",
                         "localizedDisplayDescription",
-                        "display description",
+                        "External program description",
                         "displayMode",
                         DisplayMode.PUBLIC.getValue())));
 
@@ -146,8 +146,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Result redirectResult = controller.index(addCSRFToken(Helpers.fakeRequest()).build());
     assertThat(contentAsString(redirectResult)).contains("Existing One");
-    assertThat(contentAsString(redirectResult)).contains("New Program");
-    assertThat(contentAsString(redirectResult)).contains("This is a new program");
+    assertThat(contentAsString(redirectResult)).contains("External program name");
+    assertThat(contentAsString(redirectResult)).contains("External program description");
   }
 
   @Test
@@ -251,11 +251,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "new description",
+                    "New internal program description",
                     "localizedDisplayName",
-                    "test",
+                    "New external program name",
                     "localizedDisplayDescription",
-                    "test",
+                    "New external program description",
                     "displayMode",
                     DisplayMode.PUBLIC.getValue()));
 
@@ -266,7 +266,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Result redirectResult = controller.index(addCSRFToken(Helpers.fakeRequest()).build());
     assertThat(contentAsString(redirectResult))
-        .contains("Create new program", "Existing One", "new description");
+        .contains(
+            "Create new program",
+            "Existing One",
+            "New external program name",
+            "New external program description");
     assertThat(contentAsString(redirectResult)).doesNotContain("old description");
   }
 }


### PR DESCRIPTION
### Description

The name associated with the draft version of the program is preferred over the name associated with the active version of the program.

This is the first step in de-emphasing the internal-facing name / description described in https://github.com/civiform/civiform/issues/3085#issuecomment-1246008757.

The "internal description" has been relabeled as "Admin note", similar to what we now do on the question list page.

![Screen Shot 2022-09-14 at 11 29 17 AM](https://user-images.githubusercontent.com/1870301/190234008-ac926926-94bf-4856-a859-d6189552a303.png)


## Release notes:

CiviForm admin / program admin program list now displays the "Display name / description" for a program rather than the internal admin name / description.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3085