### PR TITLE
Throwing errors when test user environment variables aren't set instead of silently falling back on previous behaviors.

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -275,14 +275,9 @@ export const loginAsTestUser = async (page: Page) => {
       await loginAsTestUserSeattleStaging(page)
       break
     default:
-      // TODO(#3326): Throw an error for an unrecognized strategy rather than falling back on
-      // logging in as a guest. Handling this case is presently in place to support AWS staging
-      // and Seattle staging prober runs.
-      if (TEST_USER_LOGIN) {
-        await loginAsTestUserSeattleStaging(page)
-      } else {
-        await loginAsGuest(page)
-      }
+      throw new Error(
+        `Unrecognized or unset TEST_USER_AUTH_STRATEGY environment variable of '${TEST_USER_AUTH_STRATEGY}'`,
+      )
   }
   await waitForPageJsLoad(page)
   await page.waitForSelector(
@@ -356,15 +351,9 @@ async function loginAsTestUserFakeOidc(page: Page) {
 
 export const testUserDisplayName = () => {
   if (!TEST_USER_DISPLAY_NAME) {
-    // TODO(#3326): Throw an error if the environment variable isn't provided rather than falling
-    // back on Guest. This is presently in place to support AWS staging and Seattle staging prober
-    // runs.
-    if (TEST_USER_LOGIN) {
-      // Seattle staging.
-      return 'TEST, UATAPP'
-    }
-    // AWS staging.
-    return 'Guest'
+    throw new Error(
+      'Empty or unset TEST_USER_DISPLAY_NAME environment variable',
+    )
   }
   return TEST_USER_DISPLAY_NAME
 }


### PR DESCRIPTION
### Description

Removing fallback code in place for probers now that we set the appropriate environment variables for all environments ([AWS staging](https://github.com/civiform/civiform/issues/3326#issuecomment-1245809004) / [Seattle staging](https://github.com/civiform/civiform/issues/3326#issuecomment-1247203184)).

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3326