### PR TITLE
Enable tailwind css building for unit tests

### DIFF
--- a/server/tailwindbuilder.sbt
+++ b/server/tailwindbuilder.sbt
@@ -18,3 +18,6 @@ tailwindCli := {
 dist := (dist dependsOn tailwindCli).value
 stage := (stage dependsOn tailwindCli).value
 test := (Test / test dependsOn tailwindCli).value
+testOnly := (Test / testOnly dependsOn tailwindCli).evaluated
+testQuick := (Test / testQuick dependsOn tailwindCli).evaluated
+jacoco := (Test / jacoco dependsOn tailwindCli).value

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -26,7 +26,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
 
     assertThat(content.body())
-        .containsPattern("<link href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
+        .containsPattern(
+            "<link href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
     assertThat(content.body())
         .containsPattern(
             "<script src=\"/assets/javascripts/[a-z0-9]+-main.js\""
@@ -52,8 +53,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
     assertThat(content.body())
-        .contains(
+        .containsPattern(
             "<link href=\"moose.css\" rel=\"stylesheet\"><link"
-                + " href=\"/assets/stylesheets/tailwind.css\" rel=\"stylesheet\">");
+                + " href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
   }
 }


### PR DESCRIPTION
### Description

Previously it was enabled only when developer runs all java unit tests locally. This PR adds tailwind building hook to the following test commands: `jococo` - used to run tests on CI, `testOnly`/`testQuick` - used to iteratively run individual tests locally.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

