### PR TITLE
Add config variable for global admin to get access to programs

### DIFF
--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -7,7 +7,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
-
 import java.util.Optional;
 import javax.inject.Inject;
 import models.Account;
@@ -25,10 +24,12 @@ public class RoleService {
   private final boolean allowGlobalAdminAccessPrograms;
 
   @Inject
-  public RoleService(ProgramService programRepository, UserRepository userRepository, Config config) {
+  public RoleService(
+      ProgramService programRepository, UserRepository userRepository, Config config) {
     this.programService = programRepository;
     this.userRepository = userRepository;
-    this.allowGlobalAdminAccessPrograms =  checkNotNull(config).getBoolean("allow_global_admin_acccess_programs");
+    this.allowGlobalAdminAccessPrograms =
+        checkNotNull(config).getBoolean("allow_global_admin_acccess_programs");
   }
 
   /**
@@ -42,12 +43,10 @@ public class RoleService {
 
   /**
    * Promotes the set of accounts (identified by email) to the role of {@link
-   * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. 
-   * When ALLOW_GLOBAL_ADMIN_ACCCESS_PROGRAMS = false: 
-   * If an account is currently a {@link
-   * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be
-   * program admins. Instead, we return a {@link CiviFormError} listing the admin accounts that
-   * could not be promoted to program admins.
+   * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. When ALLOW_GLOBAL_ADMIN_ACCCESS_PROGRAMS
+   * = false: If an account is currently a {@link auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be
+   * promoted, since CiviForm admins cannot be program admins. Instead, we return a {@link
+   * CiviFormError} listing the admin accounts that could not be promoted to program admins.
    *
    * @param programId the ID of the {@link models.Program} these accounts administer
    * @param accountEmails a {@link ImmutableSet} of account emails to make program admins
@@ -64,11 +63,13 @@ public class RoleService {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
     // admin.
-    ImmutableSet<String> globalAdminEmails = allowGlobalAdminAccessPrograms ? ImmutableSet.of() :
-        getGlobalAdmins().stream()
-            .map(Account::getEmailAddress)
-            .filter(address -> !Strings.isNullOrEmpty(address))
-            .collect(toImmutableSet());
+    ImmutableSet<String> globalAdminEmails =
+        allowGlobalAdminAccessPrograms
+            ? ImmutableSet.of()
+            : getGlobalAdmins().stream()
+                .map(Account::getEmailAddress)
+                .filter(address -> !Strings.isNullOrEmpty(address))
+                .collect(toImmutableSet());
     ImmutableSet.Builder<String> invalidEmailBuilder = ImmutableSet.builder();
     String errorMessageString = "";
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -598,11 +598,11 @@ api_keys_ban_global_subnet = ${?CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET}
 api_applications_list_max_page_size = 1000
 api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE_SIZE}
 
-# When set to true Global Admins can also be Program Admins.
-# It will enable Global Admin assign themselves as Program Admins, and get access to 
+# When set to true Civiform Admins can also be Program Admins.
+# It will enable Civiform Admin assign themselves as Program Admins, and get access to 
 # all Applications for that program.
-allow_global_admin_acccess_programs = false
-allow_global_admin_acccess_programs = ${?ALLOW_GLOBAL_ADMIN_ACCCESS_PROGRAMS}
+allow_civiform_admin_acccess_programs = false
+allow_civiform_admin_acccess_programs = ${?ALLOW_CIVIFORM_ADMIN_ACCCESS_PROGRAMS}
 ## Feature flag toggles.
 # Launched features.
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -598,6 +598,11 @@ api_keys_ban_global_subnet = ${?CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET}
 api_applications_list_max_page_size = 1000
 api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE_SIZE}
 
+# When set to true Global Admins can also be Program Admins.
+# It will enable Global Admin assign themselves as Program Admins, and get access to 
+# all Applications for that program.
+allow_global_admin_acccess_programs = false
+allow_global_admin_acccess_programs = ${?ALLOW_GLOBAL_ADMIN_ACCCESS_PROGRAMS}
 ## Feature flag toggles.
 # Launched features.
 

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -3,18 +3,15 @@ package services.role;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Optional;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
+import java.util.Optional;
 import models.Account;
 import models.Program;
+import org.junit.Before;
+import org.junit.Test;
 import repository.ResetPostgres;
 import repository.UserRepository;
 import services.CiviFormError;
@@ -25,231 +22,228 @@ import support.ProgramBuilder;
 
 public class RoleServiceTest extends ResetPostgres {
 
-    private UserRepository userRepository;
-    private RoleService service;
+  private UserRepository userRepository;
+  private RoleService service;
 
-    @Before
-    public void setup() {
-        userRepository = instanceOf(UserRepository.class);
-        service = instanceOf(RoleService.class);
-    }
+  @Before
+  public void setup() {
+    userRepository = instanceOf(UserRepository.class);
+    service = instanceOf(RoleService.class);
+  }
 
-    @Test
-    public void makeProgramAdmins_allPromoted() throws ProgramNotFoundException {
-        String email1 = "fake@email.com";
-        String email2 = "fake2.com";
-        Account account1 = new Account();
-        account1.setEmailAddress(email1);
-        account1.save();
-        Account account2 = new Account();
-        account2.setEmailAddress(email2);
-        account2.save();
+  @Test
+  public void makeProgramAdmins_allPromoted() throws ProgramNotFoundException {
+    String email1 = "fake@email.com";
+    String email2 = "fake2.com";
+    Account account1 = new Account();
+    account1.setEmailAddress(email1);
+    account1.save();
+    Account account2 = new Account();
+    account2.setEmailAddress(email2);
+    account2.save();
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        Optional<CiviFormError> result = service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
+    Optional<CiviFormError> result =
+        service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
 
-        assertThat(result).isEmpty();
+    assertThat(result).isEmpty();
 
-        account1 = userRepository.lookupAccountByEmail(email1).get();
-        account2 = userRepository.lookupAccountByEmail(email2).get();
+    account1 = userRepository.lookupAccountByEmail(email1).get();
+    account2 = userRepository.lookupAccountByEmail(email2).get();
 
-        assertThat(account1.getAdministeredProgramNames()).containsOnly(programName);
-        assertThat(account2.getAdministeredProgramNames()).containsOnly(programName);
-    }
+    assertThat(account1.getAdministeredProgramNames()).containsOnly(programName);
+    assertThat(account2.getAdministeredProgramNames()).containsOnly(programName);
+  }
 
-    @Test
-    public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
-        String emailUpperCase = "Fake.Person@email.com";
-        String emailLowerCase = "fake.person@email.com";
-        Account account = new Account();
-        account.setEmailAddress(emailUpperCase);
-        account.save();
+  @Test
+  public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
+    String emailUpperCase = "Fake.Person@email.com";
+    String emailLowerCase = "fake.person@email.com";
+    Account account = new Account();
+    account.setEmailAddress(emailUpperCase);
+    account.save();
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        // Make the lower case email a program admin.
-        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id,
-                ImmutableSet.of(emailLowerCase));
+    // Make the lower case email a program admin.
+    Optional<CiviFormError> lowerCaseResult =
+        service.makeProgramAdmins(program.id, ImmutableSet.of(emailLowerCase));
 
-        assertThat(lowerCaseResult)
-                .isEqualTo(
-                        Optional.of(
-                                CiviFormError.of(
-                                        String.format(
-                                                "%s does not have an admin account and cannot be added as a Program"
-                                                        + " Admin. ",
-                                                emailLowerCase))));
+    assertThat(lowerCaseResult)
+        .isEqualTo(
+            Optional.of(
+                CiviFormError.of(
+                    String.format(
+                        "%s does not have an admin account and cannot be added as a Program"
+                            + " Admin. ",
+                        emailLowerCase))));
 
-        // Lookup the upper case account. They do not have permission to any programs.
-        account = userRepository.lookupAccountByEmail(emailUpperCase).get();
-        assertThat(account.getAdministeredProgramNames()).isEmpty();
+    // Lookup the upper case account. They do not have permission to any programs.
+    account = userRepository.lookupAccountByEmail(emailUpperCase).get();
+    assertThat(account.getAdministeredProgramNames()).isEmpty();
 
-        // Now make the upper case Email a program admin.
-        Optional<CiviFormError> result = service.makeProgramAdmins(program.id, ImmutableSet.of(emailUpperCase));
-        assertThat(result).isEmpty();
+    // Now make the upper case Email a program admin.
+    Optional<CiviFormError> result =
+        service.makeProgramAdmins(program.id, ImmutableSet.of(emailUpperCase));
+    assertThat(result).isEmpty();
 
-        // Lookup the upper case account. They now have permissions to the program.
-        account = userRepository.lookupAccountByEmail(emailUpperCase).get();
-        assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
-    }
+    // Lookup the upper case account. They now have permissions to the program.
+    account = userRepository.lookupAccountByEmail(emailUpperCase).get();
+    assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
+  }
 
-    @Test
-    public void makeProgramAdmins_emptyList_returnsEmptyOptional() throws ProgramNotFoundException {
-        assertThat(service.makeProgramAdmins(1L, ImmutableSet.of())).isEmpty();
-    }
+  @Test
+  public void makeProgramAdmins_emptyList_returnsEmptyOptional() throws ProgramNotFoundException {
+    assertThat(service.makeProgramAdmins(1L, ImmutableSet.of())).isEmpty();
+  }
 
-    @Test
-    public void makeProgramAdmins_listOfBlankEmails_returnsEmptyOptional()
-            throws ProgramNotFoundException {
-        assertThat(service.makeProgramAdmins(1L, ImmutableSet.of(" ", "", "    "))).isEmpty();
-    }
+  @Test
+  public void makeProgramAdmins_listOfBlankEmails_returnsEmptyOptional()
+      throws ProgramNotFoundException {
+    assertThat(service.makeProgramAdmins(1L, ImmutableSet.of(" ", "", "    "))).isEmpty();
+  }
 
-    @Test
-    public void makeProgramAdmins_programNotFound_throwsException() {
-        assertThatThrownBy(() -> service.makeProgramAdmins(1234L, ImmutableSet.of("email@email.com")))
-                .isInstanceOf(ProgramNotFoundException.class);
-    }
+  @Test
+  public void makeProgramAdmins_programNotFound_throwsException() {
+    assertThatThrownBy(() -> service.makeProgramAdmins(1234L, ImmutableSet.of("email@email.com")))
+        .isInstanceOf(ProgramNotFoundException.class);
+  }
 
-    @Test
-    public void makeProgramAdmins_emailHasNoAccountReturnsError() throws ProgramNotFoundException {
-        String email = "admin_does_not_exist@email.com";
+  @Test
+  public void makeProgramAdmins_emailHasNoAccountReturnsError() throws ProgramNotFoundException {
+    String email = "admin_does_not_exist@email.com";
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id, ImmutableSet.of(email));
+    Optional<CiviFormError> lowerCaseResult =
+        service.makeProgramAdmins(program.id, ImmutableSet.of(email));
 
-        assertThat(lowerCaseResult)
-                .isEqualTo(
-                        Optional.of(
-                                CiviFormError.of(
-                                        String.format(
-                                                "%s does not have an admin account and cannot be added as a Program"
-                                                        + " Admin. ",
-                                                email))));
-    }
+    assertThat(lowerCaseResult)
+        .isEqualTo(
+            Optional.of(
+                CiviFormError.of(
+                    String.format(
+                        "%s does not have an admin account and cannot be added as a Program"
+                            + " Admin. ",
+                        email))));
+  }
 
-    @Test
-    public void makeProgramAdmins_manyEmailsHaveNoAccountReturnsError()
-            throws ProgramNotFoundException {
-        String email1 = "first_admin_does_not_exist@email.com";
-        String email2 = "second_admin_does_not_exist@email.com";
+  @Test
+  public void makeProgramAdmins_manyEmailsHaveNoAccountReturnsError()
+      throws ProgramNotFoundException {
+    String email1 = "first_admin_does_not_exist@email.com";
+    String email2 = "second_admin_does_not_exist@email.com";
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id,
-                ImmutableSet.of(email1, email2));
+    Optional<CiviFormError> lowerCaseResult =
+        service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
 
-        assertThat(lowerCaseResult)
-                .isEqualTo(
-                        Optional.of(
-                                CiviFormError.of(
-                                        String.format(
-                                                "%1$s does not have an admin account and cannot be added as a Program"
-                                                        + " Admin. %2$s does not have an admin account and cannot be added as"
-                                                        + " a Program Admin. ",
-                                                email1, email2))));
-    }
+    assertThat(lowerCaseResult)
+        .isEqualTo(
+            Optional.of(
+                CiviFormError.of(
+                    String.format(
+                        "%1$s does not have an admin account and cannot be added as a Program"
+                            + " Admin. %2$s does not have an admin account and cannot be added as"
+                            + " a Program Admin. ",
+                        email1, email2))));
+  }
 
-    @Test
-    public void removeProgramAdmins_succeeds() throws ProgramNotFoundException {
-        String programName = "to remove";
-        ProgramDefinition toRemove = ProgramBuilder.newDraftProgram(programName).buildDefinition();
-        String extraName = "extra";
-        ProgramDefinition extra = ProgramBuilder.newDraftProgram(extraName).buildDefinition();
+  @Test
+  public void removeProgramAdmins_succeeds() throws ProgramNotFoundException {
+    String programName = "to remove";
+    ProgramDefinition toRemove = ProgramBuilder.newDraftProgram(programName).buildDefinition();
+    String extraName = "extra";
+    ProgramDefinition extra = ProgramBuilder.newDraftProgram(extraName).buildDefinition();
 
-        Account one = new Account();
-        String emailOne = "one@test.com";
-        one.setEmailAddress(emailOne);
-        one.addAdministeredProgram(toRemove);
-        one.save();
+    Account one = new Account();
+    String emailOne = "one@test.com";
+    one.setEmailAddress(emailOne);
+    one.addAdministeredProgram(toRemove);
+    one.save();
 
-        Account two = new Account();
-        String emailTwo = "two@test.com";
-        two.setEmailAddress(emailTwo);
-        two.addAdministeredProgram(toRemove);
-        two.addAdministeredProgram(extra);
-        two.save();
+    Account two = new Account();
+    String emailTwo = "two@test.com";
+    two.setEmailAddress(emailTwo);
+    two.addAdministeredProgram(toRemove);
+    two.addAdministeredProgram(extra);
+    two.save();
 
-        assertThat(one.getAdministeredProgramNames()).containsOnly(programName);
-        assertThat(two.getAdministeredProgramNames()).containsOnly(programName, extraName);
+    assertThat(one.getAdministeredProgramNames()).containsOnly(programName);
+    assertThat(two.getAdministeredProgramNames()).containsOnly(programName, extraName);
 
-        service.removeProgramAdmins(toRemove.id(), ImmutableSet.of(emailOne, emailTwo));
+    service.removeProgramAdmins(toRemove.id(), ImmutableSet.of(emailOne, emailTwo));
 
-        assertThat(userRepository.lookupAccountByEmail(emailOne).get().getAdministeredProgramNames())
-                .isEmpty();
-        assertThat(userRepository.lookupAccountByEmail(emailTwo).get().getAdministeredProgramNames())
-                .containsOnly(extraName);
-    }
+    assertThat(userRepository.lookupAccountByEmail(emailOne).get().getAdministeredProgramNames())
+        .isEmpty();
+    assertThat(userRepository.lookupAccountByEmail(emailTwo).get().getAdministeredProgramNames())
+        .containsOnly(extraName);
+  }
 
-    @Test
-    public void removeProgramAdmins_noProgram_throwsProgramNotFoundException() {
-        assertThatThrownBy(() -> service.removeProgramAdmins(1234L, ImmutableSet.of("test")))
-                .isInstanceOf(ProgramNotFoundException.class);
-    }
+  @Test
+  public void removeProgramAdmins_noProgram_throwsProgramNotFoundException() {
+    assertThatThrownBy(() -> service.removeProgramAdmins(1234L, ImmutableSet.of("test")))
+        .isInstanceOf(ProgramNotFoundException.class);
+  }
 
-    @Test
-    public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
-        String globalAdminEmail = "global@admin";
-        Account globalAdmin = new Account();
-        globalAdmin.setEmailAddress(globalAdminEmail);
-        globalAdmin.setGlobalAdmin(true);
-        globalAdmin.save();
+  @Test
+  public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
+    String globalAdminEmail = "global@admin";
+    Account globalAdmin = new Account();
+    globalAdmin.setEmailAddress(globalAdminEmail);
+    globalAdmin.setGlobalAdmin(true);
+    globalAdmin.save();
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        Config config = ConfigFactory.parseMap(
-                ImmutableMap.of(
-                        "allow_global_admin_acccess_programs",
-                        "false"));
+    Config config =
+        ConfigFactory.parseMap(ImmutableMap.of("allow_global_admin_acccess_programs", "false"));
 
-        RoleService serviceWithGlobalAdminDisabled = new RoleService(
-                instanceOf(ProgramService.class),
-                instanceOf(UserRepository.class),
-                config);
+    RoleService serviceWithGlobalAdminDisabled =
+        new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), config);
 
-        assertThat(serviceWithGlobalAdminDisabled.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
-                .isEqualTo(
-                        Optional.of(
-                                CiviFormError.of(
-                                        String.format(
-                                                "The following are already CiviForm admins and could not be added as"
-                                                        + " program admins: %s",
-                                                globalAdminEmail))));
-    }
+    assertThat(
+            serviceWithGlobalAdminDisabled.makeProgramAdmins(
+                program.id, ImmutableSet.of(globalAdminEmail)))
+        .isEqualTo(
+            Optional.of(
+                CiviFormError.of(
+                    String.format(
+                        "The following are already CiviForm admins and could not be added as"
+                            + " program admins: %s",
+                        globalAdminEmail))));
+  }
 
-    @Test
-    public void makeProgramAdmins_allowGlobalAdmin() throws ProgramNotFoundException {
-        String globalAdminEmail = "global@admin";
-        Account globalAdmin = new Account();
-        globalAdmin.setEmailAddress(globalAdminEmail);
-        globalAdmin.setGlobalAdmin(true);
-        globalAdmin.save();
+  @Test
+  public void makeProgramAdmins_allowGlobalAdmin() throws ProgramNotFoundException {
+    String globalAdminEmail = "global@admin";
+    Account globalAdmin = new Account();
+    globalAdmin.setEmailAddress(globalAdminEmail);
+    globalAdmin.setGlobalAdmin(true);
+    globalAdmin.save();
 
-        String programName = "test program";
-        Program program = ProgramBuilder.newDraftProgram(programName).build();
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-        Config config = ConfigFactory.parseMap(
-                ImmutableMap.of(
-                        "allow_global_admin_acccess_programs",
-                        "true"));
+    Config config =
+        ConfigFactory.parseMap(ImmutableMap.of("allow_global_admin_acccess_programs", "true"));
 
-        RoleService serviceWithGlobalAdminEnabled = new RoleService(
-                instanceOf(ProgramService.class),
-                instanceOf(UserRepository.class),
-                config);
-        assertThat(
-                serviceWithGlobalAdminEnabled.makeProgramAdmins(
-                        program.id, ImmutableSet.of(globalAdminEmail)))
-                .isEmpty();
+    RoleService serviceWithGlobalAdminEnabled =
+        new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), config);
+    assertThat(
+            serviceWithGlobalAdminEnabled.makeProgramAdmins(
+                program.id, ImmutableSet.of(globalAdminEmail)))
+        .isEmpty();
 
-        globalAdmin = userRepository.lookupAccountByEmail(globalAdminEmail).get();
+    globalAdmin = userRepository.lookupAccountByEmail(globalAdminEmail).get();
 
-        assertThat(globalAdmin.getAdministeredProgramNames()).containsOnly(programName);
-    }
+    assertThat(globalAdmin.getAdministeredProgramNames()).containsOnly(programName);
+  }
 }

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -204,7 +204,7 @@ public class RoleServiceTest extends ResetPostgres {
     Program program = ProgramBuilder.newDraftProgram(programName).build();
 
     Config config =
-        ConfigFactory.parseMap(ImmutableMap.of("allow_global_admin_acccess_programs", "false"));
+        ConfigFactory.parseMap(ImmutableMap.of("allow_civiform_admin_acccess_programs", "false"));
 
     RoleService serviceWithGlobalAdminDisabled =
         new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), config);
@@ -233,7 +233,7 @@ public class RoleServiceTest extends ResetPostgres {
     Program program = ProgramBuilder.newDraftProgram(programName).build();
 
     Config config =
-        ConfigFactory.parseMap(ImmutableMap.of("allow_global_admin_acccess_programs", "true"));
+        ConfigFactory.parseMap(ImmutableMap.of("allow_civiform_admin_acccess_programs", "true"));
 
     RoleService serviceWithGlobalAdminEnabled =
         new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), config);

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -3,209 +3,253 @@ package services.role;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
-import models.Account;
-import models.Program;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import models.Account;
+import models.Program;
 import repository.ResetPostgres;
 import repository.UserRepository;
 import services.CiviFormError;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import support.ProgramBuilder;
 
 public class RoleServiceTest extends ResetPostgres {
 
-  private UserRepository userRepository;
-  private RoleService service;
+    private UserRepository userRepository;
+    private RoleService service;
 
-  @Before
-  public void setup() {
-    userRepository = instanceOf(UserRepository.class);
-    service = instanceOf(RoleService.class);
-  }
+    @Before
+    public void setup() {
+        userRepository = instanceOf(UserRepository.class);
+        service = instanceOf(RoleService.class);
+    }
 
-  @Test
-  public void makeProgramAdmins_allPromoted() throws ProgramNotFoundException {
-    String email1 = "fake@email.com";
-    String email2 = "fake2.com";
-    Account account1 = new Account();
-    account1.setEmailAddress(email1);
-    account1.save();
-    Account account2 = new Account();
-    account2.setEmailAddress(email2);
-    account2.save();
+    @Test
+    public void makeProgramAdmins_allPromoted() throws ProgramNotFoundException {
+        String email1 = "fake@email.com";
+        String email2 = "fake2.com";
+        Account account1 = new Account();
+        account1.setEmailAddress(email1);
+        account1.save();
+        Account account2 = new Account();
+        account2.setEmailAddress(email2);
+        account2.save();
 
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    Optional<CiviFormError> result =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
+        Optional<CiviFormError> result = service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
 
-    assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
 
-    account1 = userRepository.lookupAccountByEmail(email1).get();
-    account2 = userRepository.lookupAccountByEmail(email2).get();
+        account1 = userRepository.lookupAccountByEmail(email1).get();
+        account2 = userRepository.lookupAccountByEmail(email2).get();
 
-    assertThat(account1.getAdministeredProgramNames()).containsOnly(programName);
-    assertThat(account2.getAdministeredProgramNames()).containsOnly(programName);
-  }
+        assertThat(account1.getAdministeredProgramNames()).containsOnly(programName);
+        assertThat(account2.getAdministeredProgramNames()).containsOnly(programName);
+    }
 
-  @Test
-  public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
-    String emailUpperCase = "Fake.Person@email.com";
-    String emailLowerCase = "fake.person@email.com";
-    Account account = new Account();
-    account.setEmailAddress(emailUpperCase);
-    account.save();
+    @Test
+    public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
+        String emailUpperCase = "Fake.Person@email.com";
+        String emailLowerCase = "fake.person@email.com";
+        Account account = new Account();
+        account.setEmailAddress(emailUpperCase);
+        account.save();
 
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    // Make the lower case email a program admin.
-    Optional<CiviFormError> lowerCaseResult =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(emailLowerCase));
+        // Make the lower case email a program admin.
+        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id,
+                ImmutableSet.of(emailLowerCase));
 
-    assertThat(lowerCaseResult)
-        .isEqualTo(
-            Optional.of(
-                CiviFormError.of(
-                    String.format(
-                        "%s does not have an admin account and cannot be added as a Program"
-                            + " Admin. ",
-                        emailLowerCase))));
+        assertThat(lowerCaseResult)
+                .isEqualTo(
+                        Optional.of(
+                                CiviFormError.of(
+                                        String.format(
+                                                "%s does not have an admin account and cannot be added as a Program"
+                                                        + " Admin. ",
+                                                emailLowerCase))));
 
-    // Lookup the upper case account. They do not have permission to any programs.
-    account = userRepository.lookupAccountByEmail(emailUpperCase).get();
-    assertThat(account.getAdministeredProgramNames()).isEmpty();
+        // Lookup the upper case account. They do not have permission to any programs.
+        account = userRepository.lookupAccountByEmail(emailUpperCase).get();
+        assertThat(account.getAdministeredProgramNames()).isEmpty();
 
-    // Now make the upper case Email a program admin.
-    Optional<CiviFormError> result =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(emailUpperCase));
-    assertThat(result).isEmpty();
+        // Now make the upper case Email a program admin.
+        Optional<CiviFormError> result = service.makeProgramAdmins(program.id, ImmutableSet.of(emailUpperCase));
+        assertThat(result).isEmpty();
 
-    // Lookup the upper case account. They now have permissions to the program.
-    account = userRepository.lookupAccountByEmail(emailUpperCase).get();
-    assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
-  }
+        // Lookup the upper case account. They now have permissions to the program.
+        account = userRepository.lookupAccountByEmail(emailUpperCase).get();
+        assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
+    }
 
-  @Test
-  public void makeProgramAdmins_emptyList_returnsEmptyOptional() throws ProgramNotFoundException {
-    assertThat(service.makeProgramAdmins(1L, ImmutableSet.of())).isEmpty();
-  }
+    @Test
+    public void makeProgramAdmins_emptyList_returnsEmptyOptional() throws ProgramNotFoundException {
+        assertThat(service.makeProgramAdmins(1L, ImmutableSet.of())).isEmpty();
+    }
 
-  @Test
-  public void makeProgramAdmins_listOfBlankEmails_returnsEmptyOptional()
-      throws ProgramNotFoundException {
-    assertThat(service.makeProgramAdmins(1L, ImmutableSet.of(" ", "", "    "))).isEmpty();
-  }
+    @Test
+    public void makeProgramAdmins_listOfBlankEmails_returnsEmptyOptional()
+            throws ProgramNotFoundException {
+        assertThat(service.makeProgramAdmins(1L, ImmutableSet.of(" ", "", "    "))).isEmpty();
+    }
 
-  @Test
-  public void makeProgramAdmins_programNotFound_throwsException() {
-    assertThatThrownBy(() -> service.makeProgramAdmins(1234L, ImmutableSet.of("email@email.com")))
-        .isInstanceOf(ProgramNotFoundException.class);
-  }
+    @Test
+    public void makeProgramAdmins_programNotFound_throwsException() {
+        assertThatThrownBy(() -> service.makeProgramAdmins(1234L, ImmutableSet.of("email@email.com")))
+                .isInstanceOf(ProgramNotFoundException.class);
+    }
 
-  @Test
-  public void makeProgramAdmins_emailHasNoAccountReturnsError() throws ProgramNotFoundException {
-    String email = "admin_does_not_exist@email.com";
+    @Test
+    public void makeProgramAdmins_emailHasNoAccountReturnsError() throws ProgramNotFoundException {
+        String email = "admin_does_not_exist@email.com";
 
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    Optional<CiviFormError> lowerCaseResult =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(email));
+        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id, ImmutableSet.of(email));
 
-    assertThat(lowerCaseResult)
-        .isEqualTo(
-            Optional.of(
-                CiviFormError.of(
-                    String.format(
-                        "%s does not have an admin account and cannot be added as a Program"
-                            + " Admin. ",
-                        email))));
-  }
+        assertThat(lowerCaseResult)
+                .isEqualTo(
+                        Optional.of(
+                                CiviFormError.of(
+                                        String.format(
+                                                "%s does not have an admin account and cannot be added as a Program"
+                                                        + " Admin. ",
+                                                email))));
+    }
 
-  @Test
-  public void makeProgramAdmins_manyEmailsHaveNoAccountReturnsError()
-      throws ProgramNotFoundException {
-    String email1 = "first_admin_does_not_exist@email.com";
-    String email2 = "second_admin_does_not_exist@email.com";
+    @Test
+    public void makeProgramAdmins_manyEmailsHaveNoAccountReturnsError()
+            throws ProgramNotFoundException {
+        String email1 = "first_admin_does_not_exist@email.com";
+        String email2 = "second_admin_does_not_exist@email.com";
 
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    Optional<CiviFormError> lowerCaseResult =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(email1, email2));
+        Optional<CiviFormError> lowerCaseResult = service.makeProgramAdmins(program.id,
+                ImmutableSet.of(email1, email2));
 
-    assertThat(lowerCaseResult)
-        .isEqualTo(
-            Optional.of(
-                CiviFormError.of(
-                    String.format(
-                        "%1$s does not have an admin account and cannot be added as a Program"
-                            + " Admin. %2$s does not have an admin account and cannot be added as"
-                            + " a Program Admin. ",
-                        email1, email2))));
-  }
+        assertThat(lowerCaseResult)
+                .isEqualTo(
+                        Optional.of(
+                                CiviFormError.of(
+                                        String.format(
+                                                "%1$s does not have an admin account and cannot be added as a Program"
+                                                        + " Admin. %2$s does not have an admin account and cannot be added as"
+                                                        + " a Program Admin. ",
+                                                email1, email2))));
+    }
 
-  @Test
-  public void removeProgramAdmins_succeeds() throws ProgramNotFoundException {
-    String programName = "to remove";
-    ProgramDefinition toRemove = ProgramBuilder.newDraftProgram(programName).buildDefinition();
-    String extraName = "extra";
-    ProgramDefinition extra = ProgramBuilder.newDraftProgram(extraName).buildDefinition();
+    @Test
+    public void removeProgramAdmins_succeeds() throws ProgramNotFoundException {
+        String programName = "to remove";
+        ProgramDefinition toRemove = ProgramBuilder.newDraftProgram(programName).buildDefinition();
+        String extraName = "extra";
+        ProgramDefinition extra = ProgramBuilder.newDraftProgram(extraName).buildDefinition();
 
-    Account one = new Account();
-    String emailOne = "one@test.com";
-    one.setEmailAddress(emailOne);
-    one.addAdministeredProgram(toRemove);
-    one.save();
+        Account one = new Account();
+        String emailOne = "one@test.com";
+        one.setEmailAddress(emailOne);
+        one.addAdministeredProgram(toRemove);
+        one.save();
 
-    Account two = new Account();
-    String emailTwo = "two@test.com";
-    two.setEmailAddress(emailTwo);
-    two.addAdministeredProgram(toRemove);
-    two.addAdministeredProgram(extra);
-    two.save();
+        Account two = new Account();
+        String emailTwo = "two@test.com";
+        two.setEmailAddress(emailTwo);
+        two.addAdministeredProgram(toRemove);
+        two.addAdministeredProgram(extra);
+        two.save();
 
-    assertThat(one.getAdministeredProgramNames()).containsOnly(programName);
-    assertThat(two.getAdministeredProgramNames()).containsOnly(programName, extraName);
+        assertThat(one.getAdministeredProgramNames()).containsOnly(programName);
+        assertThat(two.getAdministeredProgramNames()).containsOnly(programName, extraName);
 
-    service.removeProgramAdmins(toRemove.id(), ImmutableSet.of(emailOne, emailTwo));
+        service.removeProgramAdmins(toRemove.id(), ImmutableSet.of(emailOne, emailTwo));
 
-    assertThat(userRepository.lookupAccountByEmail(emailOne).get().getAdministeredProgramNames())
-        .isEmpty();
-    assertThat(userRepository.lookupAccountByEmail(emailTwo).get().getAdministeredProgramNames())
-        .containsOnly(extraName);
-  }
+        assertThat(userRepository.lookupAccountByEmail(emailOne).get().getAdministeredProgramNames())
+                .isEmpty();
+        assertThat(userRepository.lookupAccountByEmail(emailTwo).get().getAdministeredProgramNames())
+                .containsOnly(extraName);
+    }
 
-  @Test
-  public void removeProgramAdmins_noProgram_throwsProgramNotFoundException() {
-    assertThatThrownBy(() -> service.removeProgramAdmins(1234L, ImmutableSet.of("test")))
-        .isInstanceOf(ProgramNotFoundException.class);
-  }
+    @Test
+    public void removeProgramAdmins_noProgram_throwsProgramNotFoundException() {
+        assertThatThrownBy(() -> service.removeProgramAdmins(1234L, ImmutableSet.of("test")))
+                .isInstanceOf(ProgramNotFoundException.class);
+    }
 
-  @Test
-  public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
-    String globalAdminEmail = "global@admin";
-    Account globalAdmin = new Account();
-    globalAdmin.setEmailAddress(globalAdminEmail);
-    globalAdmin.setGlobalAdmin(true);
-    globalAdmin.save();
+    @Test
+    public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
+        String globalAdminEmail = "global@admin";
+        Account globalAdmin = new Account();
+        globalAdmin.setEmailAddress(globalAdminEmail);
+        globalAdmin.setGlobalAdmin(true);
+        globalAdmin.save();
 
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    assertThat(service.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
-        .isEqualTo(
-            Optional.of(
-                CiviFormError.of(
-                    String.format(
-                        "The following are already CiviForm admins and could not be added as"
-                            + " program admins: %s",
-                        globalAdminEmail))));
-  }
+        Config config = ConfigFactory.parseMap(
+                ImmutableMap.of(
+                        "allow_global_admin_acccess_programs",
+                        "false"));
+
+        RoleService serviceWithGlobalAdminDisabled = new RoleService(
+                instanceOf(ProgramService.class),
+                instanceOf(UserRepository.class),
+                config);
+
+        assertThat(serviceWithGlobalAdminDisabled.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
+                .isEqualTo(
+                        Optional.of(
+                                CiviFormError.of(
+                                        String.format(
+                                                "The following are already CiviForm admins and could not be added as"
+                                                        + " program admins: %s",
+                                                globalAdminEmail))));
+    }
+
+    @Test
+    public void makeProgramAdmins_allowGlobalAdmin() throws ProgramNotFoundException {
+        String globalAdminEmail = "global@admin";
+        Account globalAdmin = new Account();
+        globalAdmin.setEmailAddress(globalAdminEmail);
+        globalAdmin.setGlobalAdmin(true);
+        globalAdmin.save();
+
+        String programName = "test program";
+        Program program = ProgramBuilder.newDraftProgram(programName).build();
+
+        Config config = ConfigFactory.parseMap(
+                ImmutableMap.of(
+                        "allow_global_admin_acccess_programs",
+                        "true"));
+
+        RoleService serviceWithGlobalAdminEnabled = new RoleService(
+                instanceOf(ProgramService.class),
+                instanceOf(UserRepository.class),
+                config);
+        assertThat(
+                serviceWithGlobalAdminEnabled.makeProgramAdmins(
+                        program.id, ImmutableSet.of(globalAdminEmail)))
+                .isEmpty();
+
+        globalAdmin = userRepository.lookupAccountByEmail(globalAdminEmail).get();
+
+        assertThat(globalAdmin.getAdministeredProgramNames()).containsOnly(programName);
+    }
 }


### PR DESCRIPTION
### Description

Adding new config flag: allow_global_admin_acccess_programs
When set to true Global Admins can also be Program Admins.
It will enable Global Admin assign themselves as Program Admins, and get access to  all Applications for that program.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes https://github.com/civiform/civiform/issues/1593
