### PR TITLE
Removing test assertions that dealt with DBs not being previously cleared between test cases

### DIFF
--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -1,4 +1,4 @@
-import {createTestContext, loginAsAdmin} from './support'
+import {AdminPrograms, createTestContext, loginAsAdmin} from './support'
 
 describe('Most recently updated program is at top of list.', () => {
   const ctx = createTestContext()
@@ -12,37 +12,36 @@ describe('Most recently updated program is at top of list.', () => {
     await adminPrograms.addProgram(programOne)
     await adminPrograms.addProgram(programTwo)
 
-    // Note: CI tests already have test programs
-    // available. As such, we only assert the order
-    // of the programs added in this test.
-
     // Most recently added program is on top.
-    let programNames = await adminPrograms.programNames()
-    expect(programNames.length).toBeGreaterThanOrEqual(2)
-    expect(programNames.slice(0, 2)).toEqual([programTwo, programOne])
+    await expectProgramListElements(adminPrograms, [programTwo, programOne])
 
     // Publish all programs, order should be maintained.
     await adminPrograms.publishAllPrograms()
-    programNames = await adminPrograms.programNames()
-    expect(programNames.length).toBeGreaterThanOrEqual(2)
-    expect(programNames.slice(0, 2)).toEqual([programTwo, programOne])
+    await expectProgramListElements(adminPrograms, [programTwo, programOne])
 
     // Now create a draft version of the previously last program. After,
     // it should be on top.
     await adminPrograms.createNewVersion(programOne)
-    programNames = await adminPrograms.programNames()
-    expect(programNames.length).toBeGreaterThanOrEqual(2)
-    expect(programNames.slice(0, 2)).toEqual([programOne, programTwo])
+    await expectProgramListElements(adminPrograms, [programOne, programTwo])
 
     // Now create a new program, which should be on top.
     const programThree = 'list test program three'
     await adminPrograms.addProgram(programThree)
-    programNames = await adminPrograms.programNames()
-    expect(programNames.length).toBeGreaterThanOrEqual(3)
-    expect(programNames.slice(0, 3)).toEqual([
+    await expectProgramListElements(adminPrograms, [
       programThree,
       programOne,
       programTwo,
     ])
   })
+
+  async function expectProgramListElements(
+    adminPrograms: AdminPrograms,
+    expectedPrograms: string[],
+  ) {
+    if (!expectedPrograms) {
+      throw new Error('expected at least one program')
+    }
+    const programListNames = await adminPrograms.programNames()
+    expect(programListNames).toEqual(expectedPrograms)
+  }
 })

--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -23,23 +23,17 @@ describe('Most recently updated question is at top of list.', () => {
       questionText: questionTwoPublishedText,
     })
 
-    // Note: CI tests already have test questions
-    // available. As such, we only assert the order
-    // of the questions added in this test.
-    // TODO(#3029): Consider asserting on the whole list if it can be considered stable even in
-    // prober environments and with canonical question creation.
-
     // A question cannot be published in isolation. In order to allow making created questions
     // active, create a fake program.
     const programName = 'question list test program'
     await adminPrograms.addProgram(programName)
 
     // Most recently added question is on top.
-    await expectQuestionListTopElements(adminQuestions, [
+    await expectQuestionListElements(adminQuestions, [
       questionTwoPublishedText,
       questionOnePublishedText,
     ])
-    await expectQuestionBankTopElements(programName, adminPrograms, [
+    await expectQuestionBankElements(programName, adminPrograms, [
       questionTwoPublishedText,
       questionOnePublishedText,
     ])
@@ -48,11 +42,11 @@ describe('Most recently updated question is at top of list.', () => {
     await adminPrograms.publishProgram(programName)
     // Create a draft version of the program so that the question bank can be accessed.
     await adminPrograms.createNewVersion(programName)
-    await expectQuestionListTopElements(adminQuestions, [
+    await expectQuestionListElements(adminQuestions, [
       questionTwoPublishedText,
       questionOnePublishedText,
     ])
-    await expectQuestionBankTopElements(programName, adminPrograms, [
+    await expectQuestionBankElements(programName, adminPrograms, [
       questionTwoPublishedText,
       questionOnePublishedText,
     ])
@@ -62,11 +56,11 @@ describe('Most recently updated question is at top of list.', () => {
     await adminQuestions.createNewVersion(questionOnePublishedText)
     // CreateNewVersion implicitly updates the question text to be suffixed with " new version".
     const questionOneDraftText = `${questionOnePublishedText} new version`
-    await expectQuestionListTopElements(adminQuestions, [
+    await expectQuestionListElements(adminQuestions, [
       questionOneDraftText,
       questionTwoPublishedText,
     ])
-    await expectQuestionBankTopElements(programName, adminPrograms, [
+    await expectQuestionBankElements(programName, adminPrograms, [
       questionOnePublishedText,
       questionTwoPublishedText,
     ])
@@ -77,19 +71,19 @@ describe('Most recently updated question is at top of list.', () => {
       questionName: questionThreePublishedText,
       questionText: questionThreePublishedText,
     })
-    await expectQuestionListTopElements(adminQuestions, [
+    await expectQuestionListElements(adminQuestions, [
       questionThreePublishedText,
       questionOneDraftText,
       questionTwoPublishedText,
     ])
-    await expectQuestionBankTopElements(programName, adminPrograms, [
+    await expectQuestionBankElements(programName, adminPrograms, [
       questionThreePublishedText,
       questionOnePublishedText,
       questionTwoPublishedText,
     ])
   })
 
-  async function expectQuestionListTopElements(
+  async function expectQuestionListElements(
     adminQuestions: AdminQuestions,
     expectedQuestions: string[],
   ) {
@@ -97,15 +91,10 @@ describe('Most recently updated question is at top of list.', () => {
       throw new Error('expected at least one question')
     }
     const questionListNames = await adminQuestions.questionNames()
-    expect(questionListNames.length).toBeGreaterThanOrEqual(
-      expectedQuestions.length,
-    )
-    expect(questionListNames.slice(0, expectedQuestions.length)).toEqual(
-      expectedQuestions,
-    )
+    expect(questionListNames).toEqual(expectedQuestions)
   }
 
-  async function expectQuestionBankTopElements(
+  async function expectQuestionBankElements(
     programName: string,
     adminPrograms: AdminPrograms,
     expectedQuestions: string[],
@@ -114,11 +103,6 @@ describe('Most recently updated question is at top of list.', () => {
       throw new Error('expected at least one question')
     }
     const questionBankNames = await adminPrograms.questionBankNames(programName)
-    expect(questionBankNames.length).toBeGreaterThanOrEqual(
-      expectedQuestions.length,
-    )
-    expect(questionBankNames.slice(0, expectedQuestions.length)).toEqual(
-      expectedQuestions,
-    )
+    expect(questionBankNames).toEqual(expectedQuestions)
   }
 })


### PR DESCRIPTION
## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3029
