### PR TITLE
Removing ordering from ActiveAndDraftQuestions since the sorting occurs elsewhere

### DIFF
--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -68,8 +68,6 @@ public final class ActiveAndDraftQuestions {
 
     versionedByName =
         Sets.union(activeNameToQuestion.keySet(), draftNameToQuestion.keySet()).stream()
-            // TODO(#3029): remove sorting once client-side sorting is implemented
-            .sorted()
             .collect(
                 ImmutableMap.toImmutableMap(
                     Function.identity(),

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -48,7 +48,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         .save();
 
     assertThat(newActiveAndDraftQuestions().getQuestionNames())
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             "active-and-draft-question",
             "active-only-question",
             "draft-only-question",


### PR DESCRIPTION
### Description

In #3431, we now perform sorting of questions in the list view itself (https://github.com/civiform/civiform/blob/4e6f220eb78cc84ef0e239aa0bcc39392d715937/server/app/views/admin/questions/QuestionsListView.java#L135-L142).

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3029
