### PR TITLE
Update casing on aria-describedby to use all lowercase

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -40,9 +40,9 @@ function validateFileUploadQuestions(formEl: Element): boolean {
         // Only allow this to be done once so we don't repeatedly append the error id.
         wasSetInvalid = true
         fileInput.setAttribute('aria-invalid', 'true')
-        const ariaDescribedBy = fileInput.getAttribute('aria-describedBy')
+        const ariaDescribedBy = fileInput.getAttribute('aria-describedby')
         fileInput.setAttribute(
-          'aria-describedBy',
+          'aria-describedby',
           `${errorId} ${ariaDescribedBy}`,
         )
       }

--- a/server/app/views/AwsFileUploadViewStrategy.java
+++ b/server/app/views/AwsFileUploadViewStrategy.java
@@ -60,7 +60,7 @@ public final class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
             .condAttr(hasErrors, "aria-invalid", "true")
             .condAttr(
                 !ariaDescribedByIds.isEmpty(),
-                "aria-describedBy",
+                "aria-describedby",
                 StringUtils.join(ariaDescribedByIds, " "))
             .withType("file")
             .withName("file")

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -50,7 +50,7 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
             .condAttr(hasErrors, "aria-invalid", "true")
             .condAttr(
                 !ariaDescribedByIds.isEmpty(),
-                "aria-describedBy",
+                "aria-describedby",
                 StringUtils.join(ariaDescribedByIds, " "))
             .withType("file")
             .withName("file")

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -495,7 +495,7 @@ public class FieldWithLabel {
     }
     ImmutableList<String> ariaIds = ariaDescribedByBuilder.build();
 
-    fieldTag.condAttr(!ariaIds.isEmpty(), "aria-describedBy", StringUtils.join(ariaIds, " "));
+    fieldTag.condAttr(!ariaIds.isEmpty(), "aria-describedby", StringUtils.join(ariaIds, " "));
     fieldTag.condAttr(
         shouldForceAriaInvalid || fieldErrorsInfo.hasFieldErrors, "aria-invalid", "true");
 

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -130,7 +130,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         // Composite questions should be rendered with fieldset and legend for screen reader users.
         questionTag =
             fieldset()
-                .attr("aria-describedBy", StringUtils.join(ariaDescribedByIds, " "))
+                .attr("aria-describedby", StringUtils.join(ariaDescribedByIds, " "))
                 .with(
                     // Legend must be a direct child of fieldset for screen readers to work
                     // properly.

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -166,7 +166,7 @@ public class FieldWithLabelTest {
     String rendered = fieldWithLabel.getNumberTag().render();
 
     assertThat(rendered).contains("aria-invalid=\"true\"");
-    assertThat(rendered).contains("aria-describedBy=\"field-id-errors\"");
+    assertThat(rendered).contains("aria-describedby=\"field-id-errors\"");
     assertThat(rendered).contains("id=\"field-id-errors\"");
     assertThat(rendered).contains("an error message");
   }

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -95,7 +95,7 @@ public class CheckboxQuestionRendererTest extends ResetPostgres {
             result
                 .render()
                 .matches(
-                    ".*fieldset aria-describedBy=\"[A-Za-z]{8}-validation-error"
+                    ".*fieldset aria-describedby=\"[A-Za-z]{8}-validation-error"
                         + " [A-Za-z]{8}-description\".*"))
         .isTrue();
   }

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -78,7 +78,7 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
                 .render()
                 .matches(
                     ".*input type=\"text\" currency value=\"\""
-                        + " aria-describedBy=\"[A-Za-z]{8}-description\".*"))
+                        + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 }

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -87,7 +87,7 @@ public class DropdownQuestionRendererTest extends ResetPostgres {
   public void render_withAriaLabels() {
     DivTag result = renderer.render(params);
 
-    assertThat(result.render().matches(".*select aria-describedBy=\"[A-Za-z]{8}-description\".*"))
+    assertThat(result.render().matches(".*select aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 }

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -100,7 +100,7 @@ public class IdQuestionRendererTest extends ResetPostgres {
                 .render()
                 .matches(
                     ".*input type=\"text\" value=\"\""
-                        + " aria-describedBy=\"[A-Za-z]{8}-description\".*"))
+                        + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 }

--- a/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -91,7 +91,7 @@ public class RadioButtonQuestionRendererTest {
   public void render_withAriaLabels() {
     DivTag result = renderer.render(params);
 
-    assertThat(result.render().matches(".*fieldset aria-describedBy=\"[A-Za-z]{8}-description\".*"))
+    assertThat(result.render().matches(".*fieldset aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 }

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -91,7 +91,7 @@ public class TextQuestionRendererTest extends ResetPostgres {
                 .render()
                 .matches(
                     ".*input type=\"text\" value=\"\""
-                        + " aria-describedBy=\"[A-Za-z]{8}-description\".*"))
+                        + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 }


### PR DESCRIPTION
### Description

Use all lowercase for `aria-describedby`. In practice, any casing is fine, since it just all gets lowercased anyway. This is to avoid developer confusion.

## Release notes:

N/A

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

