### PR TITLE
Requiring a program URL to be in slug format.

### DIFF
--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -12,7 +12,7 @@ describe('address applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single required address question', () => {
-    const programName = 'test program for single address'
+    const programName = 'test-program-for-single-address'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -131,7 +131,7 @@ describe('address applicant flow', () => {
   })
 
   describe('multiple address questions', () => {
-    const programName = 'test program for multiple addresses'
+    const programName = 'test-program-for-multiple-addresses'
 
     beforeAll(async () => {
       const {page, adminPrograms, adminQuestions} = ctx
@@ -267,7 +267,7 @@ describe('address applicant flow', () => {
 
   // One optional address followed by one required address.
   describe('optional address question', () => {
-    const programName = 'test program for optional address'
+    const programName = 'test-program-for-optional-address'
 
     beforeAll(async () => {
       const {page, adminPrograms, adminQuestions} = ctx

--- a/browser-test/src/admin_api_keys.test.ts
+++ b/browser-test/src/admin_api_keys.test.ts
@@ -7,7 +7,7 @@ describe('Managing API keys', () => {
     const {page, adminApiKeys, adminPrograms} = ctx
     await loginAsAdmin(page)
 
-    const programName = 'API using program'
+    const programName = 'api-using-program'
     const programDescription = 'This program uses the API.'
     await adminPrograms.addProgram(programName, programDescription, '', false)
     await adminPrograms.publishAllPrograms()

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -14,7 +14,7 @@ describe('view program statuses', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('without program statuses', () => {
-    const programWithoutStatusesName = 'test program without statuses'
+    const programWithoutStatusesName = 'test-program-without-statuses'
     beforeAll(async () => {
       const {page, adminPrograms, applicantQuestions} = ctx
       await loginAsAdmin(page)
@@ -62,7 +62,7 @@ describe('view program statuses', () => {
   })
 
   describe('with program statuses', () => {
-    const programWithStatusesName = 'test program with statuses'
+    const programWithStatusesName = 'test-program-with-statuses'
     const noEmailStatusName = 'No email status'
     const emailStatusName = 'Email status'
 
@@ -257,7 +257,7 @@ describe('view program statuses', () => {
   })
 
   describe('filtering list with program statuses', () => {
-    const programForFilteringName = 'test program for filtering statuses'
+    const programForFilteringName = 'test-program-for-filtering-statuses'
     const approvedStatusName = 'Approved'
     const rejectedStatusName = 'Rejected'
 

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -29,7 +29,7 @@ describe('create and edit predicates', () => {
       questionText: 'conditional question',
     })
 
-    const programName = 'create hide predicate'
+    const programName = 'create-hide-predicate'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'first screen', [
       'hide-predicate-q',
@@ -118,7 +118,7 @@ describe('create and edit predicates', () => {
       questionText: 'conditional question',
     })
 
-    const programName = 'create show predicate'
+    const programName = 'create-show-predicate'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'first screen', [
       'show-predicate-q',
@@ -216,7 +216,7 @@ describe('create and edit predicates', () => {
       questionName: 'depends on previous',
     })
 
-    const programName = 'test all predicate types'
+    const programName = 'test-all-predicate-types'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'string', [
       'single-string',

--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -8,7 +8,7 @@ describe('manage program admins', () => {
 
     await loginAsAdmin(page)
 
-    const programName = 'add program admins'
+    const programName = 'add-program-admins'
     await adminPrograms.addProgram(programName)
 
     // Add two program admins and save

--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -27,7 +27,7 @@ describe('program creation', () => {
       enumeratorName: 'apc-enumerator',
     })
 
-    const programName = 'apc program'
+    const programName = 'apc-program'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'apc program description')
 
@@ -83,7 +83,7 @@ describe('program creation', () => {
       await adminQuestions.addTextQuestion({questionName: question})
     }
 
-    const programName = 'apc program 2'
+    const programName = 'apc-program-2'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'apc program description')
 
@@ -122,7 +122,7 @@ describe('program creation', () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
-    const programName = 'apc program 3'
+    const programName = 'apc-program-3'
     await adminPrograms.addProgram(programName)
     await adminPrograms.goToManageQuestionsPage(programName)
     await page.click('#create-question-button')

--- a/browser-test/src/admin_program_hidden.test.ts
+++ b/browser-test/src/admin_program_hidden.test.ts
@@ -15,7 +15,7 @@ describe('Hide a program that should not be public yet', () => {
     await loginAsAdmin(page)
 
     // Create a hidden program
-    const programName = 'Hidden Program'
+    const programName = 'hidden-program'
     const programDescription = 'Description'
     await adminPrograms.addProgram(programName, programDescription, '', true)
     await adminPrograms.publishAllPrograms()
@@ -39,7 +39,7 @@ describe('Hide a program that should not be public yet', () => {
     await loginAsAdmin(page)
 
     // Create a hidden program
-    const programName = 'Public Program'
+    const programName = 'public-program'
     const programDescription = 'Description'
     await adminPrograms.addProgram(programName, programDescription, '', false)
     await adminPrograms.publishAllPrograms()

--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -7,8 +7,8 @@ describe('Most recently updated program is at top of list.', () => {
 
     await loginAsAdmin(page)
 
-    const programOne = 'list test program one'
-    const programTwo = 'list test program two'
+    const programOne = 'list-test-program-one'
+    const programTwo = 'list-test-program-two'
     await adminPrograms.addProgram(programOne)
     await adminPrograms.addProgram(programTwo)
 

--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -25,7 +25,7 @@ describe('Most recently updated program is at top of list.', () => {
     await expectProgramListElements(adminPrograms, [programOne, programTwo])
 
     // Now create a new program, which should be on top.
-    const programThree = 'list test program three'
+    const programThree = 'list-test-program-three'
     await adminPrograms.addProgram(programThree)
     await expectProgramListElements(adminPrograms, [
       programThree,

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -15,7 +15,7 @@ describe('Admin can manage translations', () => {
 
     await loginAsAdmin(page)
 
-    const programName = 'program to be translated (no statuses)'
+    const programName = 'program-to-be-translated-no-statuses'
     await adminPrograms.addProgram(programName)
 
     // Go to manage translations page.
@@ -61,7 +61,7 @@ describe('Admin can manage translations', () => {
 
     await loginAsAdmin(page)
 
-    const programName = 'program to be translated (with statuses)'
+    const programName = 'program-to-be-translated-with-statuses'
     await adminPrograms.addProgram(programName)
 
     // Add two statuses, one with a configured email and another without
@@ -173,7 +173,7 @@ describe('Admin can manage translations', () => {
     )
 
     // Add the question to a program and publish
-    const programName = 'spanish question'
+    const programName = 'spanish-question-program'
     await adminPrograms.addProgram(
       programName,
       'program description',
@@ -231,7 +231,7 @@ describe('Admin can manage translations', () => {
     ])
 
     // Add the question to a program and publish
-    const programName = 'spanish question multi-option'
+    const programName = 'spanish-question-multi-option-program'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'block', [questionName])
     await adminPrograms.publishProgram(programName)
@@ -270,7 +270,7 @@ describe('Admin can manage translations', () => {
     ])
 
     // Add the question to a program and publish
-    const programName = 'spanish question enumerator'
+    const programName = 'spanish-question-enumerator-program'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'block', [questionName])
     await adminPrograms.publishProgram(programName)
@@ -350,7 +350,7 @@ describe('Admin can manage translations', () => {
     // Add a new program with one non-translated question
     await loginAsAdmin(page)
 
-    const programName = 'toast'
+    const programName = 'toast-program'
     await adminPrograms.addProgram(programName)
 
     await adminQuestions.addNameQuestion({questionName: 'name-english'})

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -28,7 +28,7 @@ describe('normal application flow', () => {
 
     await loginAsAdmin(page)
 
-    const programName = 'test program for export'
+    const programName = 'test-program-for-export'
     await adminQuestions.addDropdownQuestion({
       questionName: 'dropdown-csv-download',
       options: ['op1', 'op2', 'op3'],

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -11,7 +11,7 @@ describe('Applicant navigation flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('navigation with four blocks', () => {
-    const programName = 'test program for navigation flows'
+    const programName = 'test-program-for-navigation-flows'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -19,7 +19,7 @@ describe('view an application in an older version', () => {
     // Create a program with one question
     const questionName = 'text-to-be-obsolete-q'
     await adminQuestions.addTextQuestion({questionName})
-    const programName = 'program with previous applications'
+    const programName = 'program-with-previous-applications'
     await adminPrograms.addAndPublishProgramWithQuestions(
       [questionName],
       programName,

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -52,7 +52,7 @@ describe('Program admin review of submitted applications', () => {
     await adminQuestions.addStaticQuestion({questionName: 'first-static-q'})
     await adminQuestions.addStaticQuestion({questionName: 'second-static-q'})
 
-    const programName = 'a shiny new program'
+    const programName = 'a-shiny-new-program'
     await adminPrograms.addProgram(programName)
 
     await adminPrograms.editProgramBlock(programName, 'block description', [
@@ -250,7 +250,7 @@ describe('Program admin review of submitted applications', () => {
     await loginAsAdmin(page)
 
     await adminQuestions.addTextQuestion({questionName: 'fruit-text-q'})
-    const programName = 'fruit program'
+    const programName = 'fruit-program'
     await adminPrograms.addAndPublishProgramWithQuestions(
       ['fruit-text-q'],
       programName,

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -12,7 +12,7 @@ describe('Checkbox question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single checkbox question', () => {
-    const programName = 'test program for single checkbox'
+    const programName = 'test-program-for-single-checkbox'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -151,7 +151,7 @@ describe('Checkbox question for applicant flow', () => {
   })
 
   describe('multiple checkbox questions', () => {
-    const programName = 'test program for multiple checkboxes'
+    const programName = 'test-program-for-multiple-checkboxes'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/civiform_admin_program_statuses.test.ts
+++ b/browser-test/src/civiform_admin_program_statuses.test.ts
@@ -18,7 +18,7 @@ describe('modify program statuses', () => {
     it('creates a new program and has no statuses', async () => {
       const {adminPrograms, adminProgramStatuses} = ctx
       // Add a draft program, no questions are needed.
-      const programName = 'test program without statuses'
+      const programName = 'test-program-without-statuses'
       await adminPrograms.addProgram(programName)
       await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
       await adminProgramStatuses.expectNoStatuses()
@@ -26,7 +26,7 @@ describe('modify program statuses', () => {
   })
 
   describe('new status creation', () => {
-    const programName = 'test program create statuses'
+    const programName = 'test-program-create-statuses'
 
     beforeAll(async () => {
       const {page, adminPrograms} = ctx
@@ -84,7 +84,7 @@ describe('modify program statuses', () => {
   })
 
   describe('edit existing statuses', () => {
-    const programName = 'test program edit statuses'
+    const programName = 'test-program-edit-statuses'
     const firstStatusName = 'First status'
     const secondStatusName = 'Second status'
 
@@ -210,7 +210,7 @@ describe('modify program statuses', () => {
   })
 
   describe('delete existing status', () => {
-    const programName = 'test program delete status'
+    const programName = 'test-program-delete-status'
     const firstStatusName = 'First status'
     const secondStatusName = 'Second status'
 

--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -25,7 +25,7 @@ describe('Most recently updated question is at top of list.', () => {
 
     // A question cannot be published in isolation. In order to allow making created questions
     // active, create a fake program.
-    const programName = 'question list test program'
+    const programName = 'question-list-test-program'
     await adminPrograms.addProgram(programName)
 
     // Most recently added question is on top.

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -15,7 +15,7 @@ describe('currency applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single currency question', () => {
-    const programName = 'test program for single currency'
+    const programName = 'test-program-for-single-currency'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -83,7 +83,7 @@ describe('currency applicant flow', () => {
   })
 
   describe('multiple currency questions', () => {
-    const programName = 'test program for multiple currencies'
+    const programName = 'test-program-for-multiple-currencies'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -12,7 +12,7 @@ describe('Date question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single date question', () => {
-    const programName = 'test program for single date'
+    const programName = 'test-program-for-single-date'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -79,7 +79,7 @@ describe('Date question for applicant flow', () => {
   })
 
   describe('multiple date questions', () => {
-    const programName = 'test program for multiple date questions'
+    const programName = 'test-program-for-multiple-date-questions'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -12,7 +12,7 @@ describe('Dropdown question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single dropdown question', () => {
-    const programName = 'test program for single dropdown'
+    const programName = 'test-program-for-single-dropdown'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -120,7 +120,7 @@ describe('Dropdown question for applicant flow', () => {
   })
 
   describe('multiple dropdown questions', () => {
-    const programName = 'test program for multiple dropdowns'
+    const programName = 'test-program-for-multiple-dropdowns'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -12,7 +12,7 @@ describe('Email question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single email question', () => {
-    const programName = 'test program for single email'
+    const programName = 'test-program-for-single-email'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -78,7 +78,7 @@ describe('Email question for applicant flow', () => {
   })
 
   describe('multiple email questions', () => {
-    const programName = 'test program for multiple emails'
+    const programName = 'test-program-for-multiple-emails'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -12,7 +12,7 @@ import {
 } from './support'
 
 describe('End to end enumerator test', () => {
-  const programName = 'ete enumerator program'
+  const programName = 'ete-enumerator-program'
   const ctx = createTestContext(/* clearDb= */ false)
 
   it('Updates enumerator elements in preview', async () => {

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -22,7 +22,7 @@ describe('file upload applicant flow', () => {
   })
 
   describe('single file upload question', () => {
-    const programName = 'test program for single file upload'
+    const programName = 'test-program-for-single-file-upload'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -121,7 +121,7 @@ describe('file upload applicant flow', () => {
 
   // Optional file upload.
   describe('optional file upload question', () => {
-    const programName = 'test program for optional file upload'
+    const programName = 'test-program-for-optional-file-upload'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -12,7 +12,7 @@ describe('Id question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single id question', () => {
-    const programName = 'test program for single id'
+    const programName = 'test-program-for-single-id'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -128,7 +128,7 @@ describe('Id question for applicant flow', () => {
   })
 
   describe('multiple id questions', () => {
-    const programName = 'test program for multiple ids'
+    const programName = 'test-program-for-multiple-ids'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -15,7 +15,7 @@ describe('name applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single required name question', () => {
-    const programName = 'test program for single name'
+    const programName = 'test-program-for-single-name'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -94,7 +94,7 @@ describe('name applicant flow', () => {
   })
 
   describe('multiple name questions', () => {
-    const programName = 'test program for multiple names'
+    const programName = 'test-program-for-multiple-names'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -186,7 +186,7 @@ describe('name applicant flow', () => {
 
   // One optional name followed by one required name.
   describe('optional name question', () => {
-    const programName = 'test program for optional name'
+    const programName = 'test-program-for-optional-name'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -13,7 +13,7 @@ describe('Number question for applicant flow', () => {
   const numberInputError = 'div.cf-question-number-error'
 
   describe('single number question', () => {
-    const programName = 'test program for single number'
+    const programName = 'test-program-for-single-number'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -97,7 +97,7 @@ describe('Number question for applicant flow', () => {
   })
 
   describe('multiple number questions', () => {
-    const programName = 'test program for multiple numbers'
+    const programName = 'test-program-for-multiple-numbers'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -24,7 +24,7 @@ describe('navigating to a deep link', () => {
       questionText,
     })
 
-    const programName = 'Test Deep Link'
+    const programName = 'test-deep-link'
     await adminPrograms.addProgram(programName)
     await adminPrograms.editProgramBlock(programName, 'first description', [
       'Test address question',

--- a/browser-test/src/question_delete.test.ts
+++ b/browser-test/src/question_delete.test.ts
@@ -8,7 +8,7 @@ describe('deleting question lifecycle', () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
-    const programName = 'deleting program'
+    const programName = 'deleting-program'
     const onlyUsedQuestion = 'delete-address'
     await adminQuestions.addQuestionForType(
       QuestionType.ADDRESS,

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -59,7 +59,7 @@ describe('normal question lifecycle', () => {
 
       await adminQuestions.updateQuestion(questionName)
 
-      const programName = `program for ${type} question lifecycle`
+      const programName = `program-for-${type}-question-lifecycle`
       await adminPrograms.addProgram(programName)
       await adminPrograms.editProgramBlock(
         programName,
@@ -254,7 +254,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.gotoAdminQuestionsPage()
     await adminQuestions.addNameQuestion({questionName: 'name-q'})
 
-    const programName = 'test program'
+    const programName = 'test-program'
     await adminPrograms.addProgram(programName)
     await adminPrograms.publishProgram(programName)
 

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -12,7 +12,7 @@ describe('Radio button question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single radio button question', () => {
-    const programName = 'test program for single radio button'
+    const programName = 'test-program-for-single-radio-button'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -121,7 +121,7 @@ describe('Radio button question for applicant flow', () => {
   })
 
   describe('multiple radio button questions', () => {
-    const programName = 'test program for multiple radio button qs'
+    const programName = 'test-program-for-multiple-radio-button-qs'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('Static text question for applicant flow', () => {
   const staticText = 'Hello, I am some static text!'
-  const programName = 'test program for static text'
+  const programName = 'test-program-for-static-text'
   const ctx = createTestContext(/* clearDb= */ false)
 
   beforeAll(async () => {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -31,7 +31,7 @@ export enum QuestionType {
   RADIO = 'radio',
   TEXT = 'text',
   ENUMERATOR = 'enumerator',
-  FILE_UPLOAD = 'file_upload',
+  FILE_UPLOAD = 'file-upload',
 }
 /* eslint-enable */
 

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -12,7 +12,7 @@ describe('Text question for applicant flow', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
   describe('single text question', () => {
-    const programName = 'test program for single text q'
+    const programName = 'test-program-for-single-text-q'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx
@@ -115,7 +115,7 @@ describe('Text question for applicant flow', () => {
   })
 
   describe('multiple text questions', () => {
-    const programName = 'test program for multiple text qs'
+    const programName = 'test-program-for-multiple-text-qs'
 
     beforeAll(async () => {
       const {page, adminQuestions, adminPrograms} = ctx

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -3,6 +3,7 @@ package services.program;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -337,6 +338,15 @@ public abstract class ProgramDefinition {
     return (0 <= index && index < getBlockCount())
         ? Optional.of(blockDefinitions().get(index))
         : Optional.empty();
+  }
+
+  /**
+   * Visible since the /dev/seed view uses Jackson's ObjectMapper to only have keys for explicit
+   * getters.
+   */
+  @VisibleForTesting
+  public String getAdminNameForTests() {
+    return adminName();
   }
 
   /**

--- a/server/test/controllers/dev/DatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/DatabaseSeedControllerTest.java
@@ -35,17 +35,23 @@ public class DatabaseSeedControllerTest {
     // Navigate to index before seeding - should not have the fake program.
     Result result = controller.index(addCSRFToken(fakeRequest()).build());
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).doesNotContain("Mock program");
+    assertThat(contentAsString(result)).doesNotContain("mock-program");
 
     // Seed the fake data.
     result = controller.seed();
     assertThat(result.redirectLocation()).hasValue(routes.DatabaseSeedController.index().url());
     assertThat(result.flash().get("success")).hasValue("The database has been seeded");
+    result = controller.index(addCSRFToken(fakeRequest()).build());
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).contains("mock-program");
 
     // Clear the data.
     result = controller.clear();
     assertThat(result.redirectLocation()).hasValue(routes.DatabaseSeedController.index().url());
     assertThat(result.flash().get("success")).hasValue("The database has been cleared");
+    result = controller.index(addCSRFToken(fakeRequest()).build());
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain("mock-program");
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -18,12 +18,15 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import models.Account;
 import models.DisplayMode;
 import models.Program;
 import models.Question;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import repository.ResetPostgres;
 import services.CiviFormError;
 import services.ErrorAnd;
@@ -42,6 +45,7 @@ import services.question.types.QuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.ProgramBuilder;
 
+@RunWith(JUnitParamsRunner.class)
 public class ProgramServiceImplTest extends ResetPostgres {
 
   private QuestionDefinition addressQuestion;
@@ -103,7 +107,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
-            "ProgramService",
+            "test-program",
             "description",
             "name",
             "description",
@@ -118,7 +122,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   public void createProgram_hasEmptyBlock() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
-            "ProgramService",
+            "test-program",
             "description",
             "name",
             "description",
@@ -151,7 +155,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   @Test
   public void createProgramWithoutDisplayMode_returnsError() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.createProgramDefinition("ProgramService", "description", "name", "description", "", "");
+        ps.createProgramDefinition("test-program", "description", "name", "description", "", "");
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
@@ -181,26 +185,15 @@ public class ProgramServiceImplTest extends ResetPostgres {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsExactly(CiviFormError.of("a program named name already exists"));
+        .containsExactly(CiviFormError.of("A program URL of name already exists"));
   }
 
   @Test
-  public void createProgram_protectsAgainstProgramSlugCollisions() {
-    // Two programs with names that are different but slugify to same value.
-    ps.createProgramDefinition(
-        "name one",
-        "description",
-        "display name",
-        "display description",
-        "",
-        DisplayMode.PUBLIC.getValue());
-
+  @Parameters({"name with spaces", "DiFfErEnT-cAsEs", "special-characters-$#@"})
+  public void createProgram_requiresSlug(String adminName) {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
-            // Program name here is missing the extra space
-            // so that the names are different but the resulting
-            // slug is the same.
-            "name  one",
+            adminName,
             "description",
             "display name",
             "display description",
@@ -210,7 +203,45 @@ public class ProgramServiceImplTest extends ResetPostgres {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsExactly(CiviFormError.of("a program named name  one already exists"));
+        .containsExactly(
+            CiviFormError.of(
+                "A program URL may only contain lowercase letters, numbers, and dashes"));
+  }
+
+  @Test
+  public void createProgram_protectsAgainstProgramSlugCollisions() {
+    // Two programs with names that are different but slugify to same value.
+    // To simulate this state, we first create a program with a slugified name, then manually
+    // update the Program entity in order to add a name value that slugifies to the same value.
+    ProgramDefinition originalProgramDefinition =
+        ps.createProgramDefinition(
+                "name-one",
+                "description",
+                "display name",
+                "display description",
+                "",
+                DisplayMode.PUBLIC.getValue())
+            .getResult();
+    // Program name here is missing the extra space
+    // so that the names are different but the resulting
+    // slug is the same.
+    Program updatedProgram =
+        originalProgramDefinition.toBuilder().setAdminName("name    one").build().toProgram();
+    updatedProgram.update();
+    assertThat(updatedProgram.getProgramDefinition().adminName()).isEqualTo("name    one");
+
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition(
+            "name-one",
+            "description",
+            "display name",
+            "display description",
+            "",
+            DisplayMode.PUBLIC.getValue());
+    assertThat(result.hasResult()).isFalse();
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .containsExactly(CiviFormError.of("A program URL of name-one already exists"));
   }
 
   @Test


### PR DESCRIPTION
### Description

Program creation emphasizes the external-facing program name and dispalys the internal-facing identifier in its slugified version as of #3441. To reduce ambiguity, new programs now require the value to be a slug itself.

This is stage 3 of the changes outlined in https://github.com/civiform/civiform/issues/3085#issuecomment-1246008757.

The majority of this change is updating tests.

## Release notes:

When CiviForm admins create a new program, require the provided program URL to only consist of lowercase letters, numbers, and hypens.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3085