### PR TITLE
Redirect controller no longer grabs the latest draft application explicitly since the underlying method does it

### DIFF
--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -128,7 +128,6 @@ public final class RedirectController extends CiviFormController {
       long applicantId, String programSlug) {
     // Find all applicant's DRAFT applications for programs of the same slug
     // redirect to the newest program version with a DRAFT application.
-    // TODO(#2573): clean this up, don't compare on program ID
     return applicantService
         .relevantProgramsForApplicant(applicantId)
         .thenApplyAsync(

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import controllers.LanguageUtils;
 import controllers.routes;
-import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -135,7 +134,6 @@ public final class RedirectController extends CiviFormController {
                 relevantPrograms.inProgress().stream()
                     .map(ApplicantService.ApplicantProgramData::program)
                     .filter(program -> program.slug().equals(programSlug))
-                    .sorted(Comparator.comparingLong(ProgramDefinition::id).reversed())
                     .findFirst(),
             httpContext.current());
   }


### PR DESCRIPTION
### Description

The previous implementation of `relevantPrograms` had to account for multiple draft applications for different versions of the program being returned. We now filter these out in the [service method](https://github.com/civiform/civiform/blob/75a6d6c1c558cf8e7bebbeb4ba8665e52f828e77/server/app/services/applicant/ApplicantService.java#L527-L537).

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#2573