### PR TITLE
set releaser email in the script. Remove check for civiform login name

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -59,8 +59,8 @@ def main():
     release_number = sys.argv[2]
     if 'GITHUB_ACTOR' in os.environ:
         shell_cmd(
-            f'git config --global user.email ' +
-            f'{os.environ["GITHUB_ACTOR"]}@users.noreply.github.com')
+            f'git config user.email ' +
+            f'"{os.environ["GITHUB_ACTOR"]}@users.noreply.github.com"')
     releaser_email = shell_cmd('git config --get user.email')
 
     ################################################################################

--- a/bin/create-release
+++ b/bin/create-release
@@ -57,9 +57,11 @@ def main():
 
     commit_sha = sys.argv[1]
     release_number = sys.argv[2]
-    releaser_email = os.environ[
-        'GITHUB_ACTOR'] if 'GITHUB_ACTOR' in os.environ else shell_cmd(
-            'git config --get user.email')
+    if 'GITHUB_ACTOR' in os.environ:
+        shell_cmd(
+            f'git config --global user.email ' +
+            f'{os.environ["GITHUB_ACTOR"]}@users.noreply.github.com')
+    releaser_email = shell_cmd('git config --get user.email')
 
     ################################################################################
     # Resolve and validate GitHub token, check auth
@@ -86,12 +88,6 @@ def main():
 
     if not 'Login Succeeded' in shell_cmd('docker login'):
         print('Unable to login to docker hub', file=sys.stderr)
-        exit(1)
-
-    if not 'civiform' in shell_cmd('docker info'):
-        print(
-            'Login information does not contain civiform user name',
-            file=sys.stderr)
         exit(1)
 
     ################################################################################


### PR DESCRIPTION
### Description

Latest fail was complaining about releaser email - setting it explicitly in the script.
Remove check for civiform login name that doesn't work locally depending on docker version.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Should help with [#3436](https://github.com/civiform/civiform/issues/3436)
