### PR TITLE
Update export test to account for Status being enabled or not.

### DIFF
--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -190,7 +190,7 @@ describe('normal application flow', () => {
         'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,Status,name (first_name),name (middle_name),name (last_name),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection)',
       )
       expect(demographicsCsvContent).toContain(
-        'sarah,,smith,1000.00,05/10/2021,op2',
+        ',,sarah,,smith,1000.00,05/10/2021,op2',
       )
     } else {
       expect(demographicsCsvContent).toContain(

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -182,12 +182,24 @@ describe('normal application flow', () => {
     await adminPrograms.gotoAdminProgramsPage()
     const demographicsCsvContent = await adminPrograms.getDemographicsCsv()
 
-    expect(demographicsCsvContent).toContain(
-      'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,name (first_name),name (middle_name),name (last_name),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection)',
-    )
-    expect(demographicsCsvContent).toContain(
-      'sarah,,smith,1000.00,05/10/2021,op2',
-    )
+    // Export doesn't let us control if Status Tracking is on or off through
+    // browser tests, and different environments have it configured differently
+    // so test for both situations.
+    if (demographicsCsvContent.includes('Status')) {
+      expect(demographicsCsvContent).toContain(
+        'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,Status,name (first_name),name (middle_name),name (last_name),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection)',
+      )
+      expect(demographicsCsvContent).toContain(
+        'sarah,,smith,1000.00,05/10/2021,op2',
+      )
+    } else {
+      expect(demographicsCsvContent).toContain(
+        'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,name (first_name),name (middle_name),name (last_name),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection)',
+      )
+      expect(demographicsCsvContent).toContain(
+        'sarah,,smith,1000.00,05/10/2021,op2',
+      )
+    }
 
     await adminQuestions.createNewVersion('Name')
     await adminQuestions.exportQuestionOpaque('Name')
@@ -196,9 +208,15 @@ describe('normal application flow', () => {
     await adminPrograms.gotoAdminProgramsPage()
     const newDemographicsCsvContent = await adminPrograms.getDemographicsCsv()
 
-    expect(newDemographicsCsvContent).toContain(
-      'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),name (first_name),name (middle_name),name (last_name)',
-    )
+    if (demographicsCsvContent.includes('Status')) {
+      expect(newDemographicsCsvContent).toContain(
+        'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,Status,csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),name (first_name),name (middle_name),name (last_name)',
+      )
+    } else {
+      expect(newDemographicsCsvContent).toContain(
+        'Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),name (first_name),name (middle_name),name (last_name)',
+      )
+    }
     expect(newDemographicsCsvContent).not.toContain(',sarah,,smith')
     expect(newDemographicsCsvContent).toContain(',op2,')
     expect(newDemographicsCsvContent).toContain(',1600,')

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -108,8 +108,8 @@ lazy val root = (project in file("."))
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
       "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF",
-      "-implicit:class"
-      //"-Werror"
+      "-implicit:class",
+      "-Werror"
     ),
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
     // Recompile everything if >30% files have changed, to help avoid infinate

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -108,8 +108,8 @@ lazy val root = (project in file("."))
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
       "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF",
-      "-implicit:class",
-      "-Werror"
+      "-implicit:class"
+      //"-Werror"
     ),
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
     // Recompile everything if >30% files have changed, to help avoid infinate


### PR DESCRIPTION
### Description

Addressed browser test not handling when Status tracking is enabled.

Browser tests environments vary including what features are enabled or not.

Normally browser tests could force the feature flag state, however for export that isn't available as it doesn't fit the other usage patters for feature flags.  We could update that with a bit of extra complexity, but this is blocking releases to taking a more dynamic approach here.

## Release notes:

NA - testing only

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
