### PR TITLE
Set value for user.name

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -61,6 +61,9 @@ def main():
         shell_cmd(
             f'git config user.email ' +
             f'"{os.environ["GITHUB_ACTOR"]}@users.noreply.github.com"')
+        shell_cmd(
+            f'git config user.name ' +
+            f'"{os.environ["GITHUB_ACTOR"]}"')
     releaser_email = shell_cmd('git config --get user.email')
 
     ################################################################################

--- a/bin/create-release
+++ b/bin/create-release
@@ -61,9 +61,7 @@ def main():
         shell_cmd(
             f'git config user.email ' +
             f'"{os.environ["GITHUB_ACTOR"]}@users.noreply.github.com"')
-        shell_cmd(
-            f'git config user.name ' +
-            f'"{os.environ["GITHUB_ACTOR"]}"')
+        shell_cmd(f'git config user.name ' + f'"{os.environ["GITHUB_ACTOR"]}"')
     releaser_email = shell_cmd('git config --get user.email')
 
     ################################################################################


### PR DESCRIPTION
### Description

Script failed since git config user.name wasn't set. This will now set it.


## Release notes:

Sets the git config user.name to the github_actor value in the release script


