### PR TITLE
Remove style conflicts

### DIFF
--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -3,7 +3,8 @@ class RadioController {
   static radioDefaultClass = '.cf-radio-default'
   static radioInputClass = '.cf-radio-input'
   static radioOptionClass = '.cf-radio-option'
-  static selectedRadioClasses = ['!border-seattle-blue', 'bg-blue-200']
+  static selectedRadioClasses = ['border-seattle-blue', 'bg-blue-200']
+  static unselectedRadioClasses = ['border-gray-500', 'bg-white']
 
   constructor() {
     this.addRadioListeners()
@@ -57,6 +58,11 @@ class RadioController {
           if (radioContainer) {
             RadioController.selectedRadioClasses.forEach((selectedClass) =>
               radioContainer.classList.toggle(selectedClass, isChecked),
+            )
+            
+            // Prevents conflicting border classes from being applied.
+            RadioController.unselectedRadioClasses.forEach((unselectedClass) =>
+              radioContainer.classList.toggle(unselectedClass, !isChecked),
             )
           }
         }

--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -59,7 +59,7 @@ class RadioController {
             RadioController.selectedRadioClasses.forEach((selectedClass) =>
               radioContainer.classList.toggle(selectedClass, isChecked),
             )
-            
+
             // Prevents conflicting border classes from being applied.
             RadioController.unselectedRadioClasses.forEach((unselectedClass) =>
               radioContainer.classList.toggle(unselectedClass, !isChecked),

--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -3,7 +3,7 @@ class RadioController {
   static radioDefaultClass = '.cf-radio-default'
   static radioInputClass = '.cf-radio-input'
   static radioOptionClass = '.cf-radio-option'
-  static selectedRadioClasses = ['border-seattle-blue', 'bg-blue-200']
+  static selectedRadioClasses = ['!border-seattle-blue', 'bg-blue-200']
 
   constructor() {
     this.addRadioListeners()

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -103,7 +103,7 @@ public final class LanguageSelector {
         label()
             .withLang(locale.toLanguageTag())
             .withClasses(
-                ReferenceClasses.RADIO_OPTION, 
+                ReferenceClasses.RADIO_OPTION,
                 checked ? BaseStyles.RADIO_LABEL_SELECTED : BaseStyles.RADIO_LABEL)
             .with(
                 input()

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -102,9 +102,7 @@ public final class LanguageSelector {
     LabelTag labelTag =
         label()
             .withLang(locale.toLanguageTag())
-            .withClasses(
-                ReferenceClasses.RADIO_OPTION,
-                BaseStyles.RADIO_LABEL)
+            .withClasses(ReferenceClasses.RADIO_OPTION, BaseStyles.RADIO_LABEL)
             .with(
                 input()
                     .withType("radio")

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -102,7 +102,9 @@ public final class LanguageSelector {
     LabelTag labelTag =
         label()
             .withLang(locale.toLanguageTag())
-            .withClasses(ReferenceClasses.RADIO_OPTION, BaseStyles.RADIO_LABEL)
+            .withClasses(
+                ReferenceClasses.RADIO_OPTION, 
+                checked ? BaseStyles.RADIO_LABEL_SELECTED : BaseStyles.RADIO_LABEL)
             .with(
                 input()
                     .withType("radio")

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -104,8 +104,7 @@ public final class LanguageSelector {
             .withLang(locale.toLanguageTag())
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
-                BaseStyles.RADIO_LABEL,
-                checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+                BaseStyles.RADIO_LABEL)
             .with(
                 input()
                     .withType("radio")

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -483,8 +483,7 @@ public class FieldWithLabel {
     // before the calls to this method, thus simplifying the code.
     fieldTag
         .withClasses(
-            StyleUtils.joinStyles(
-                hasFieldErrors ? BaseStyles.INPUT_WITH_ERROR : BaseStyles.INPUT))
+            StyleUtils.joinStyles(hasFieldErrors ? BaseStyles.INPUT_WITH_ERROR : BaseStyles.INPUT))
         .withId(this.id)
         .withName(this.fieldName)
         .withCondDisabled(this.disabled)

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -484,7 +484,7 @@ public class FieldWithLabel {
     fieldTag
         .withClasses(
             StyleUtils.joinStyles(
-                BaseStyles.INPUT, hasFieldErrors ? BaseStyles.FORM_FIELD_ERROR_BORDER_COLOR : ""))
+                hasFieldErrors ? BaseStyles.INPUT_WITH_ERROR : BaseStyles.INPUT))
         .withId(this.id)
         .withName(this.fieldName)
         .withCondDisabled(this.disabled)

--- a/server/app/views/style/ApplicantStyles.java
+++ b/server/app/views/style/ApplicantStyles.java
@@ -102,9 +102,7 @@ public final class ApplicantStyles {
   private static final String BUTTON_BASE_OUTLINE =
       StyleUtils.joinStyles(
           // Remove "border-transparent" so it doesn't conflict with "border-seattle-blue".
-          StyleUtils.removeStyles(
-            BUTTON_BASE, Styles.BORDER_TRANSPARENT
-          ),
+          StyleUtils.removeStyles(BUTTON_BASE, Styles.BORDER_TRANSPARENT),
           Styles.BG_TRANSPARENT,
           BaseStyles.TEXT_SEATTLE_BLUE,
           BaseStyles.BORDER_SEATTLE_BLUE,
@@ -125,8 +123,7 @@ public final class ApplicantStyles {
   public static final String BUTTON_REVIEW =
       StyleUtils.joinStyles(BUTTON_BASE_OUTLINE_UPPERCASE, Styles.TEXT_BASE);
   public static final String BUTTON_SUBMIT_APPLICATION =
-      StyleUtils.joinStyles(
-          BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO);
+      StyleUtils.joinStyles(BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO);
   public static final String BUTTON_ENUMERATOR_ADD_ENTITY =
       StyleUtils.joinStyles(
           BUTTON_BASE_SOLID, Styles.TEXT_BASE, Styles.NORMAL_CASE, Styles.FONT_NORMAL, Styles.PX_4);

--- a/server/app/views/style/ApplicantStyles.java
+++ b/server/app/views/style/ApplicantStyles.java
@@ -101,10 +101,12 @@ public final class ApplicantStyles {
   /** Base styles for buttons with a transparent background and an outline. */
   private static final String BUTTON_BASE_OUTLINE =
       StyleUtils.joinStyles(
-          BUTTON_BASE,
+          // Remove "border-transparent" so it doesn't conflict with "border-seattle-blue".
+          StyleUtils.removeStyles(
+            BUTTON_BASE, Styles.BORDER_TRANSPARENT
+          ),
           Styles.BG_TRANSPARENT,
           BaseStyles.TEXT_SEATTLE_BLUE,
-          Styles.BORDER,
           BaseStyles.BORDER_SEATTLE_BLUE,
           StyleUtils.hover(Styles.BG_BLUE_100));
 
@@ -124,7 +126,7 @@ public final class ApplicantStyles {
       StyleUtils.joinStyles(BUTTON_BASE_OUTLINE_UPPERCASE, Styles.TEXT_BASE);
   public static final String BUTTON_SUBMIT_APPLICATION =
       StyleUtils.joinStyles(
-          BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO, Styles.BG_GREEN_700);
+          BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO);
   public static final String BUTTON_ENUMERATOR_ADD_ENTITY =
       StyleUtils.joinStyles(
           BUTTON_BASE_SOLID, Styles.TEXT_BASE, Styles.NORMAL_CASE, Styles.FONT_NORMAL, Styles.PX_4);

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -89,6 +89,7 @@ public final class BaseStyles {
       StyleUtils.joinStyles(INPUT_BASE, Styles.ALIGN_MIDDLE);
   /** Same as the above but for radio buttons. */
   public static final String RADIO_LABEL = CHECKBOX_LABEL;
+  public static final String RADIO_LABEL_SELECTED = StyleUtils.removeStyles(RADIO_LABEL, FORM_FIELD_BORDER_COLOR);
 
   /** For labelling a *group* of checkboxes that are related to the same thing. */
   public static final String CHECKBOX_GROUP_LABEL =

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -65,6 +65,8 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500);
+  public static final String INPUT_WITH_ERROR =
+      StyleUtils.joinStyles(StyleUtils.removeStyles(INPUT, BaseStyles.FORM_FIELD_BORDER_COLOR), FORM_FIELD_ERROR_BORDER_COLOR);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -65,8 +65,11 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500);
+
   public static final String INPUT_WITH_ERROR =
-      StyleUtils.joinStyles(StyleUtils.removeStyles(INPUT, BaseStyles.FORM_FIELD_BORDER_COLOR), FORM_FIELD_ERROR_BORDER_COLOR);
+      StyleUtils.joinStyles(
+          StyleUtils.removeStyles(INPUT, BaseStyles.FORM_FIELD_BORDER_COLOR),
+          FORM_FIELD_ERROR_BORDER_COLOR);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -89,7 +89,9 @@ public final class BaseStyles {
       StyleUtils.joinStyles(INPUT_BASE, Styles.ALIGN_MIDDLE);
   /** Same as the above but for radio buttons. */
   public static final String RADIO_LABEL = CHECKBOX_LABEL;
-  public static final String RADIO_LABEL_SELECTED = StyleUtils.removeStyles(RADIO_LABEL, FORM_FIELD_BORDER_COLOR);
+
+  public static final String RADIO_LABEL_SELECTED =
+      StyleUtils.removeStyles(RADIO_LABEL, FORM_FIELD_BORDER_COLOR);
 
   /** For labelling a *group* of checkboxes that are related to the same thing. */
   public static final String CHECKBOX_GROUP_LABEL =

--- a/server/app/views/style/StyleUtils.java
+++ b/server/app/views/style/StyleUtils.java
@@ -113,4 +113,13 @@ public final class StyleUtils {
   public static String joinStyles(String... styles) {
     return String.join(" ", styles);
   }
+
+  public static String removeStyles(String style, String... stylesToRemove) {
+    return Stream.of(stylesToRemove)
+        .reduce(
+            style,
+            (acc, styleToRemove) -> acc.replace(styleToRemove, ""),
+            (acc1, acc2) -> acc1 + acc2)
+        .trim();
+  }
 }

--- a/server/app/views/style/StyleUtils.java
+++ b/server/app/views/style/StyleUtils.java
@@ -116,10 +116,7 @@ public final class StyleUtils {
 
   public static String removeStyles(String style, String... stylesToRemove) {
     return Stream.of(stylesToRemove)
-        .reduce(
-            style,
-            (acc, styleToRemove) -> acc.replace(styleToRemove, ""),
-            (acc1, acc2) -> acc1 + acc2)
+        .reduce(style, (acc, styleToRemove) -> acc.replace(styleToRemove, ""))
         .trim();
   }
 }


### PR DESCRIPTION
*NOTE: This is a dependency of [upgrade tailwind css](https://github.com/civiform/civiform/pull/3438) and  [replace Styles.java calls with style literals](https://github.com/civiform/civiform/pull/2630), i.e. this PR needs to be merged before either of those are merged*

### Description

Needed to fix broken styles in [replace Styles.java calls with style literals](https://github.com/civiform/civiform/pull/2630)

Some of our elements have conflicting tailwind styles

Which one ends up being shown depends on their order in the tailwind.css file

The order of styles in tailwind.css depends on the order they were found during extraction

Before it just so happened that when the Styles.java was parsed, conflicting style classes didn't have an effect

But when style classes are scattered throughout the UI code, it can cause conflicts

Please explain the changes you made here.

## Release notes:

Make UI element style selection 

### Checklist

Note: Rebase the style literals PR on top of this one and make sure no styles are broken to test this one out 
  - keep in mind the style literals PR needs to be rebased on top of the [tailwind upgrade PR](https://github.com/civiform/civiform/pull/3438), so rebase the tailwind upgrade PR off of this first
 
- [x] Fix conflicting border transparency / non-transparency in REVIEW button
- [x] Fix conflicting styles in LanguageSelector radio field borders (presumably thats the cause of that broken style)