### PR TITLE
Update tsconfig to fix warnings in upcoming jest monorepo update

### DIFF
--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
   },
   globalSetup: './src/delete_database.ts',
   globals: {
-    // TODO(clouser): Fix this.
     'ts-jest': {
       tsconfig: 'src/tsconfig.json',
     },

--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   globalSetup: './src/delete_database.ts',
   globals: {
+    // TODO(clouser): Fix this.
     'ts-jest': {
       tsconfig: 'src/tsconfig.json',
     },

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -7,6 +7,7 @@
     "probe": "jest --testTimeout=180000 --forceExit --maxConcurrency=1 --runInBand"
   },
   "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
     "@types/jest": "27.5.2",
     "@types/jest-image-snapshot": "5.1.0",
     "@types/node": "16.11.56",
@@ -14,6 +15,7 @@
     "@typescript-eslint/parser": "5.36.1",
     "axe-core": "4.4.3",
     "axios": "0.27.2",
+    "eslint": "8.23.1",
     "jest": "27.5.1",
     "jest-image-snapshot": "5.1.1",
     "jest-playwright-preset": "1.7.2",
@@ -21,7 +23,6 @@
     "ts-jest": "27.1.5",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.8.2",
-    "eslint": "8.23.1"
+    "typescript": "4.8.2"
   }
 }

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext", "ES2021"],

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "ES2021"],
     "strict": true,
     "module": "commonjs",
     "noEmit": true,

--- a/browser-test/yarn.lock
+++ b/browser-test/yarn.lock
@@ -652,6 +652,11 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@tsconfig/recommended@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
+  integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz"


### PR DESCRIPTION
### Description

See https://github.com/civiform/civiform/issues/3302#issuecomment-1258429591 for details on the specific warnings.

Notably, we:
  * Use the `@tsconfig/recommended` package, similar to what we do for our server-side TSConfig. This fixes a warning about `esModuleInterop`.
  * Add a reference to the `ES2021` lib, which is necessary to make use of `String.replaceAll`.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3302