### PR TITLE
Refactor question renderer classes to have a composite and single parent class

### DIFF
--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -28,7 +28,7 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -2,7 +2,6 @@ package views.questiontypes;
 
 import static j2html.TagCreator.div;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
@@ -17,10 +16,10 @@ import views.style.ReferenceClasses;
 import views.style.Styles;
 
 /** Renders an address question. */
-public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer {
 
   public AddressQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.COMPOSITE);
+    super(question);
   }
 
   @Override
@@ -29,10 +28,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 

--- a/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
@@ -39,9 +39,7 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
       ImmutableList<String> ariaDescribedByIds,
       ImmutableList<DomContent> questionTextDoms,
       DivTag questionSecondaryTextDiv) {
-    ContainerTag questionTag;
-
-    questionTag =
+    ContainerTag questionTag =
         fieldset()
             .attr("aria-describedby", StringUtils.join(ariaDescribedByIds, " "))
             .with(

--- a/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
@@ -28,7 +28,7 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
     super(question);
   }
 
-  protected abstract DivTag renderInputTag(
+  protected abstract DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
 

--- a/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
@@ -1,0 +1,59 @@
+package views.questiontypes;
+
+import static j2html.TagCreator.fieldset;
+import static j2html.TagCreator.legend;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import j2html.tags.ContainerTag;
+import j2html.tags.DomContent;
+import j2html.tags.specialized.DivTag;
+import org.apache.commons.lang3.StringUtils;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
+import services.applicant.question.ApplicantQuestion;
+import views.style.ApplicantStyles;
+import views.style.ReferenceClasses;
+
+/*
+ * Superclass for questions that have multiple input fields.
+ *
+ * Questions with multiple input fields should use a fieldset and legend for a11y. Question level
+ * errors and descriptions are attached at the fieldset level, instead of to individual inputs.
+ */
+abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRendererImpl {
+
+  ApplicantCompositeQuestionRenderer(ApplicantQuestion question) {
+    super(question);
+  }
+
+  protected abstract DivTag renderInputTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
+
+  @Override
+  protected final ContainerTag renderQuestionTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ImmutableList<String> ariaDescribedByIds,
+      ImmutableList<DomContent> questionTextDoms,
+      DivTag questionSecondaryTextDiv) {
+    ContainerTag questionTag;
+
+    questionTag =
+        fieldset()
+            .attr("aria-describedby", StringUtils.join(ariaDescribedByIds, " "))
+            .with(
+                // Legend must be a direct child of fieldset for screen readers to work
+                // properly.
+                legend()
+                    .with(questionTextDoms)
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT))
+            .with(questionSecondaryTextDiv)
+            .with(renderInputTag(params, validationErrors));
+
+    return questionTag;
+  }
+}

--- a/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
@@ -50,7 +50,7 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
                     .withClasses(
                         ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT))
             .with(questionSecondaryTextDiv)
-            .with(renderInputTag(params, validationErrors));
+            .with(renderInputTags(params, validationErrors));
 
     return questionTag;
   }

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -23,9 +23,9 @@ import views.style.Styles;
 /**
  * Superclass for all applicant question renderers with input field(s) for the applicant to answer
  * the question. Question renderers should not subclass from ApplicantQuestionRendererImpl directly;
- * instead they should subclass from one of the child classes, either: -
- * ApplicantCompositeQuestionRenderer (for multiple input fields) or -
- * ApplicantSingleQuestionRenderer (for single input field)
+ * instead they should subclass from one of the child classes, either
+ * ApplicantCompositeQuestionRenderer (for multiple input fields) or ApplicantSingleQuestionRenderer
+ * (for single input field).
  */
 abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
 

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -2,8 +2,6 @@ package views.questiontypes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.fieldset;
-import static j2html.TagCreator.legend;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -12,7 +10,6 @@ import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.DivTag;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
 import play.i18n.Messages;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
@@ -25,26 +22,21 @@ import views.style.Styles;
 
 /**
  * Superclass for all applicant question renderers with input field(s) for the applicant to answer
- * the question.
+ * the question. Question renderers should not subclass from ApplicantQuestionRendererImpl directly;
+ * instead they should subclass from one of the child classes, either: -
+ * ApplicantCompositeQuestionRenderer (for multiple input fields) or -
+ * ApplicantSingleQuestionRenderer (for single input field)
  */
 abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
 
-  /** Whether the question is comprised of a single input field or multiple. */
-  protected enum InputFieldType {
-    SINGLE,
-    COMPOSITE
-  }
-
   protected final ApplicantQuestion question;
-  private final InputFieldType inputFieldType;
   // HTML id tags for various elements within this question.
   private final String questionId;
   private final String descriptionId;
   private final String errorId;
 
-  ApplicantQuestionRendererImpl(ApplicantQuestion question, InputFieldType inputFieldType) {
+  ApplicantQuestionRendererImpl(ApplicantQuestion question) {
     this.question = checkNotNull(question);
-    this.inputFieldType = checkNotNull(inputFieldType);
     this.questionId = RandomStringUtils.randomAlphabetic(8);
     this.descriptionId = String.format("%s-description", questionId);
     this.errorId = String.format("%s-error", questionId);
@@ -54,10 +46,13 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
 
-  protected abstract DivTag renderTag(
+  /** Renders the question tag. */
+  protected abstract ContainerTag renderQuestionTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds);
+      ImmutableList<String> ariaDescribedByIds,
+      ImmutableList<DomContent> questionTextDoms,
+      DivTag questionSecondaryTextDiv);
 
   @Override
   public final DivTag render(ApplicantQuestionRendererParams params) {
@@ -102,49 +97,19 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
       ariaDescribedByBuilder.add(errorId);
     }
 
-    ContainerTag questionTag;
     ImmutableList<DomContent> questionTextDoms =
         TextFormatter.createLinksAndEscapeText(
             question.getQuestionText(), TextFormatter.UrlOpenAction.NewTab);
     // Reverse the list to have errors appear first.
     ImmutableList<String> ariaDescribedByIds = ariaDescribedByBuilder.build().reverse();
-    switch (inputFieldType) {
-      case COMPOSITE:
-        // Composite questions should be rendered with fieldset and legend for screen reader users.
-        questionTag =
-            fieldset()
-                .attr("aria-describedby", StringUtils.join(ariaDescribedByIds, " "))
-                .with(
-                    // Legend must be a direct child of fieldset for screen readers to work
-                    // properly.
-                    legend()
-                        .with(questionTextDoms)
-                        .withClasses(
-                            ReferenceClasses.APPLICANT_QUESTION_TEXT,
-                            ApplicantStyles.QUESTION_TEXT))
-                .with(questionSecondaryTextDiv)
-                // Question level ariaDescribedByIds are attached to fieldset for composite
-                // questions.
-                .with(
-                    renderTag(
-                        params, validationErrors, /* ariaDescribedByIds= */ ImmutableList.of()));
-        break;
-      case SINGLE:
-        questionTag =
-            div()
-                .with(
-                    div()
-                        .with(questionTextDoms)
-                        .withClasses(
-                            ReferenceClasses.APPLICANT_QUESTION_TEXT,
-                            ApplicantStyles.QUESTION_TEXT))
-                .with(questionSecondaryTextDiv)
-                .with(renderTag(params, validationErrors, ariaDescribedByIds));
-        break;
-      default:
-        throw new IllegalArgumentException(
-            String.format("Unhandled input field type: %s", inputFieldType));
-    }
+
+    ContainerTag questionTag =
+        renderQuestionTag(
+            params,
+            validationErrors,
+            ariaDescribedByIds,
+            questionTextDoms,
+            questionSecondaryTextDiv);
 
     return div()
         .withId(questionId)

--- a/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
@@ -35,9 +35,7 @@ abstract class ApplicantSingleQuestionRenderer extends ApplicantQuestionRenderer
       ImmutableList<String> ariaDescribedByIds,
       ImmutableList<DomContent> questionTextDoms,
       DivTag questionSecondaryTextDiv) {
-    ContainerTag questionTag;
-
-    questionTag =
+    ContainerTag questionTag =
         div()
             .with(
                 div()

--- a/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
@@ -1,0 +1,52 @@
+package views.questiontypes;
+
+import static j2html.TagCreator.div;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import j2html.tags.ContainerTag;
+import j2html.tags.DomContent;
+import j2html.tags.specialized.DivTag;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
+import services.applicant.question.ApplicantQuestion;
+import views.style.ApplicantStyles;
+import views.style.ReferenceClasses;
+
+/*
+ * Superclass for questions that have a single input field.
+ */
+abstract class ApplicantSingleQuestionRenderer extends ApplicantQuestionRendererImpl {
+
+  ApplicantSingleQuestionRenderer(ApplicantQuestion question) {
+    super(question);
+  }
+
+  protected abstract DivTag renderInputTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ImmutableList<String> ariaDescribedByIds);
+
+  @Override
+  protected final ContainerTag renderQuestionTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      ImmutableList<String> ariaDescribedByIds,
+      ImmutableList<DomContent> questionTextDoms,
+      DivTag questionSecondaryTextDiv) {
+    ContainerTag questionTag;
+
+    questionTag =
+        div()
+            .with(
+                div()
+                    .with(questionTextDoms)
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT))
+            .with(questionSecondaryTextDiv)
+            .with(renderInputTag(params, validationErrors, ariaDescribedByIds));
+
+    return questionTag;
+  }
+}

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.span;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
@@ -22,7 +21,7 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders a checkbox question. */
-public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer {
 
   @Override
   public String getReferenceClass() {
@@ -30,14 +29,13 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   public CheckboxQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.COMPOSITE);
+    super(question);
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
 
     boolean hasErrors = !validationErrors.isEmpty();
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -33,7 +33,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
 

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -14,10 +14,10 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 import views.style.Styles;
 
-public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public CurrencyQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -26,7 +26,7 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -14,10 +14,10 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders a date question. */
-public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class DateQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public DateQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -26,7 +26,7 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -17,10 +17,10 @@ import services.question.LocalizedQuestionOption;
 import views.components.SelectWithLabel;
 
 /** Renders a dropdown question. */
-public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public DropdownQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -29,7 +29,7 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -12,10 +12,10 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders an email question. */
-public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public EmailQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -24,7 +24,7 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -52,7 +52,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -26,7 +26,7 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders an enumerator question. */
-public final class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
+public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestionRenderer {
 
   // Hardcoded ids used by client side javascript.
   private static final String ENUMERATOR_FIELDS_ID = "enumerator-fields";
@@ -43,7 +43,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantQuestionRendererI
           Styles.MB_4);
 
   public EnumeratorQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.COMPOSITE);
+    super(question);
   }
 
   @Override
@@ -52,10 +52,9 @@ public final class EnumeratorQuestionRenderer extends ApplicantQuestionRendererI
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -23,7 +23,7 @@ import views.style.Styles;
  * <p>A file upload question requires a different form. See {@code
  * views.applicant.ApplicantProgramBlockEditView#renderFileUploadBlock}.
  */
-public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer {
   private final FileUploadViewStrategy fileUploadViewStrategy;
   private final FileUploadQuestion fileUploadQuestion;
   // The ID used to associate the file input field with its screen reader label.
@@ -44,14 +44,14 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public FileUploadQuestionRenderer(
       ApplicantQuestion question, FileUploadViewStrategy fileUploadViewStrategy) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
     this.fileUploadQuestion = question.createFileUploadQuestion();
     this.fileUploadViewStrategy = fileUploadViewStrategy;
     this.fileInputId = RandomStringUtils.randomAlphabetic(8);
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -11,10 +11,10 @@ import services.applicant.question.IdQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders an id question. */
-public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class IdQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public IdQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -23,7 +23,7 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -27,7 +27,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -2,7 +2,6 @@ package views.questiontypes;
 
 import static j2html.TagCreator.div;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
@@ -16,10 +15,10 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders a name question. */
-public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
 
   public NameQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.COMPOSITE);
+    super(question);
   }
 
   @Override
@@ -28,10 +27,9 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -14,10 +14,10 @@ import services.applicant.question.NumberQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders a number question. */
-public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class NumberQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public NumberQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -26,7 +26,7 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.span;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
@@ -24,10 +23,10 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders a radio button question. */
-public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRenderer {
 
   public RadioButtonQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.COMPOSITE);
+    super(question);
   }
 
   @Override
@@ -36,10 +35,9 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
     boolean hasErrors = !validationErrors.isEmpty();
 

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -35,7 +35,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -11,10 +11,10 @@ import services.applicant.question.TextQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders a text question. */
-public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
+public class TextQuestionRenderer extends ApplicantSingleQuestionRenderer {
 
   public TextQuestionRenderer(ApplicantQuestion question) {
-    super(question, InputFieldType.SINGLE);
+    super(question);
   }
 
   @Override
@@ -23,7 +23,7 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected DivTag renderTag(
+  protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds) {


### PR DESCRIPTION
### Description

Adds another layer of superclasses to the question renderer. Composite questions (contains multiple input fields) use fieldset and legends for rendering, while single input questions (contains only one input field) do not.

## Release notes:

N/A - internal refactor

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3392
