### PR TITLE
Use `replace` since `replaceAll` can cause TypeScript compiler issues

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -68,7 +68,7 @@ function makeBrowserContext(browser: Browser): Promise<BrowserContext> {
       if (expect.getState().currentTestName) {
         // remove special characters
         dirs.push(
-          expect.getState().currentTestName.replaceAll(/[:"<>|*?]/g, ''),
+          expect.getState().currentTestName.replace(/[:"<>|*?]/g, ''),
         )
       }
     }

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -67,9 +67,7 @@ function makeBrowserContext(browser: Browser): Promise<BrowserContext> {
       // not set.
       if (expect.getState().currentTestName) {
         // remove special characters
-        dirs.push(
-          expect.getState().currentTestName.replace(/[:"<>|*?]/g, ''),
-        )
+        dirs.push(expect.getState().currentTestName.replace(/[:"<>|*?]/g, ''))
       }
     }
     return browser.newContext({


### PR DESCRIPTION
### Description

See https://github.com/civiform/civiform/issues/3302#issuecomment-1258429591. Since we're already using a regex in the callsite and specifying `/g`, `replace` is equivalent to `replaceAll` and is already available in the current TypeScript bindings.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3302