### PR TITLE
Replace sbt-web with custom task

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -1,4 +1,5 @@
-import sbt.internal.io.{Source, WatchState}
+import TypescriptBuilder.autoImport.compileTypescript
+import sbt.internal.io.Source
 import play.sbt.PlayImport.PlayKeys.playRunHooks
 import com.typesafe.sbt.web.SbtWeb
 import com.typesafe.sbt.web.Import.pipelineStages
@@ -119,10 +120,10 @@ lazy val root = (project in file("."))
     // After 2 transitive steps, do more aggressive invalidation
     // https://github.com/sbt/zinc/issues/911
     incOptions := incOptions.value.withTransitiveStep(2),
-    pipelineStages := Seq(digest, gzip), // plugins to use for assets
+    pipelineStages := Seq(compileTypescript, digest, gzip), // plugins to use for assets
     // Enable digest for local dev so that files can be served çached improving
     // page speed and also browser tests speed.
-    Assets / pipelineStages := Seq(digest, gzip),
+    Assets / pipelineStages := Seq(compileTypescript, digest, gzip),
 
     // Make verbose tests
     Test / testOptions := Seq(
@@ -207,7 +208,6 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % "2.13.4",
   "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.4"
 )
-resolveFromWebjarsNodeModulesDir := true
 playRunHooks += TailwindBuilder(baseDirectory.value)
 // Reload when the build.sbt file changes.
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,9 +8,6 @@
       "name": "server",
       "version": "0.0.1",
       "license": "CC0-1.0",
-      "dependencies": {
-        "typescript": "^4.8.3"
-      },
       "devDependencies": {
         "@tailwindcss/line-clamp": "0.4.2",
         "@tsconfig/recommended": "1.0.1",
@@ -19,7 +16,8 @@
         "autoprefixer": "10.4.12",
         "eslint": "8.24.0",
         "postcss": "8.4.16",
-        "tailwindcss": "2.2.19"
+        "tailwindcss": "2.2.19",
+        "typescript": "4.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2486,6 +2484,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4439,7 +4438,8 @@
     "typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "universalify": {
       "version": "2.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,9 @@
       "name": "server",
       "version": "0.0.1",
       "license": "CC0-1.0",
+      "dependencies": {
+        "typescript": "^4.8.3"
+      },
       "devDependencies": {
         "@tailwindcss/line-clamp": "0.4.2",
         "@tsconfig/recommended": "1.0.1",
@@ -2480,11 +2483,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true,
-      "peer": true,
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4436,11 +4437,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true,
-      "peer": true
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -18,5 +18,8 @@
     "postcss": "8.4.16",
     "tailwindcss": "2.2.19",
     "eslint": "8.24.0"
+  },
+  "dependencies": {
+    "typescript": "^4.8.3"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -19,5 +19,5 @@
     "tailwindcss": "2.2.19",
     "eslint": "8.24.0",
     "typescript": "4.8.3"
-  },
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -17,9 +17,7 @@
     "autoprefixer": "10.4.12",
     "postcss": "8.4.16",
     "tailwindcss": "2.2.19",
-    "eslint": "8.24.0"
+    "eslint": "8.24.0",
+    "typescript": "4.8.3"
   },
-  "dependencies": {
-    "typescript": "^4.8.3"
-  }
 }

--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -27,7 +27,7 @@ import scala.sys.process.{Process, ProcessLogger}
   * pipeline stage. Read about Asset Pipeline tasks
   * https://github.com/sbt/sbt-web#asset-pipeline The task implements Asset
   * Pipeline task and not Source File task because the latter doesn't allow us
-  * to keep ∂irectory structure: we want that file `assets/javascripts/foo.ts`
+  * to keep directory structure: we want that file `assets/javascripts/foo.ts`
   * be compiled to `assets/javascripts/foo.js`. So we are using Pipeline.Stage
   * for that.
   *
@@ -38,6 +38,12 @@ object TypescriptBuilder extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
+    // compileTypescript is the entry point of this plugin. It is a task
+    // which is called by sbt-web when it prepares assets. This task
+    // receives a seq of all assets (images, css, TS files), compiles TS files
+    // and returns seq of all input assets plus newly compiled JS files.
+    //
+    // This is task declaration. Implementation is below.
     val compileTypescript = taskKey[Pipeline.Stage](
       "Compiles typescript from assets/javascript folder"
     )
@@ -47,22 +53,40 @@ object TypescriptBuilder extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     compileTypescript := { inputFiles =>
       val streamsVal = (Assets / streams).value: @sbtUnchecked
-      // dir for compiled JS files
+      // targetDir will contain compiled JS files.
       val targetDir = new File(webTarget.value, "typescript/javascripts")
       val cacheDir = new File(streamsVal.cacheDirectory, "run")
-      recompileTypescriptIfFilesChanged(
+      val compiledJsFiles = recompileTypescriptIfFilesChanged(
         inputFiles,
         targetDir,
         cacheDir,
         streamsVal.log
       )
-      // get list of compiled JS files and maps from targetDir folder and return them together with input files.
+      // transform compiles JS files to PathMapping and add "javascripts" as part of the file name.
+      // That way JS files fille be added in /assets/javascripts/*.js in final output.
       val jsFiles: Seq[PathMapping] =
-        targetDir.listFiles().map({ f => (f, "javascripts/" + f.getName) })
+        compiledJsFiles.map({ f => (f, "javascripts/" + f.getName) })
+
       inputFiles ++ jsFiles
     }
   )
 
+  /** Given list of all assets (css, image, TS files) figures out whether any TS
+    * files have been changed and recompiles them. If no files have been changed
+    * assumes JS files have been compiled at earlier iterations and returns
+    * them.
+    *
+    * @param inputFiles
+    *   All assets files passed by sbt-web.
+    * @param targetDir
+    *   Directory that contains compiled JS files.
+    * @param cacheDir
+    *   Directory that contains cache file, used by syncIncremental.
+    * @param log
+    *   Logger object to output compilation errors to sbt console.
+    * @return
+    *   Seq of compiled JS files and sourcemaps.
+    */
   def recompileTypescriptIfFilesChanged(
     inputFiles: Seq[(File, String)],
     targetDir: File,
@@ -81,20 +105,34 @@ object TypescriptBuilder extends AutoPlugin {
     // we are using sbt-web syncIncremental function. It's somewhat complicated. For our
     // use case we just want to see if any of TS files changed and if so - recompile
     // everything.
-    incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
-      if (modifiedFiles.nonEmpty) {
+    val res = incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
+      if (modifiedFiles.nonEmpty || !targetDir.exists()) {
         log.info("Typescript files changed. Recompiling...")
         compileTypescriptInternal(targetDir, log)
       }
+      val compiledJsFiles: Seq[File] = targetDir.listFiles()
       // ignore opResults. We are not using full functionality of syncIncremental
       // so we always return dummy opResults with OpSuccess for each TS file.
       val opResults: Map[File, OpResult] = modifiedFiles
         .map(f => f -> OpSuccess(Set.empty[File], Set.empty[File]))
         .toMap
-      (opResults, ())
+
+      (opResults, compiledJsFiles)
     })(fileHasher)
+
+    res._2
   }
 
+  /** Function that compiles TS files. It relies on tsconfig.json to contain all
+    * necessary settings including which source files to compile. Note that we
+    * don't pass input source files. Instead we simply compile everything in
+    * server/app/assets/javascripts folder (check server/tsconfig.json).
+    *
+    * @param targetDir
+    *   Directory in which compiled JS and sourcemap files will be added.
+    * @param log
+    *   Logger object to output compilation errors to sbt console.
+    */
   def compileTypescriptInternal(targetDir: File, log: ManagedLogger) = {
     val compilationCommand =
       "npx tsc --pretty --project tsconfig.json --outDir " + targetDir

--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -105,22 +105,23 @@ object TypescriptBuilder extends AutoPlugin {
     // we are using sbt-web syncIncremental function. It's somewhat complicated. For our
     // use case we just want to see if any of TS files changed and if so - recompile
     // everything.
-    val res = incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
-      if (modifiedFiles.nonEmpty || !targetDir.exists()) {
-        log.info("Typescript files changed. Recompiling...")
-        compileTypescriptInternal(targetDir, log)
-      }
-      val compiledJsFiles: Seq[File] = targetDir.listFiles()
-      // ignore opResults. We are not using full functionality of syncIncremental
-      // so we always return dummy opResults with OpSuccess for each TS file.
-      val opResults: Map[File, OpResult] = modifiedFiles
-        .map(f => f -> OpSuccess(Set.empty[File], Set.empty[File]))
-        .toMap
+    val (_, compiledJsFiles) =
+      incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
+        if (modifiedFiles.nonEmpty || !targetDir.exists()) {
+          log.info("Typescript files changed. Recompiling...")
+          compileTypescriptInternal(targetDir, log)
+        }
+        val compiledJsFiles: Seq[File] = targetDir.listFiles()
+        // ignore opResults. We are not using full functionality of syncIncremental
+        // so we always return dummy opResults with OpSuccess for each TS file.
+        val opResults: Map[File, OpResult] = modifiedFiles
+          .map(f => f -> OpSuccess(Set.empty[File], Set.empty[File]))
+          .toMap
 
-      (opResults, compiledJsFiles)
-    })(fileHasher)
+        (opResults, compiledJsFiles)
+      })(fileHasher)
 
-    res._2
+    compiledJsFiles
   }
 
   /** Function that compiles TS files. It relies on tsconfig.json to contain all

--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -51,12 +51,12 @@ object TypescriptBuilder extends AutoPlugin {
   import autoImport._
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    compileTypescript := { inputFiles =>
+    compileTypescript := { inputFiles: Seq[PathMapping] =>
       val streamsVal = (Assets / streams).value: @sbtUnchecked
       // targetDir will contain compiled JS files.
       val targetDir = new File(webTarget.value, "typescript/javascripts")
       val cacheDir = new File(streamsVal.cacheDirectory, "run")
-      val compiledJsFiles = recompileTypescriptIfFilesChanged(
+      val compiledJsFiles: Seq[File] = recompileTypescriptIfFilesChanged(
         inputFiles,
         targetDir,
         cacheDir,
@@ -88,11 +88,11 @@ object TypescriptBuilder extends AutoPlugin {
     *   Seq of compiled JS files and sourcemaps.
     */
   def recompileTypescriptIfFilesChanged(
-    inputFiles: Seq[(File, String)],
+    inputFiles: Seq[PathMapping],
     targetDir: File,
     cacheDir: File,
     log: ManagedLogger
-  ) = {
+  ): Seq[File] = {
     // function that provides hash for each file. Includes fileName + timestamp.
     val fileHasher: OpInputHasher[File] =
       OpInputHasher[File](f =>

--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -1,0 +1,114 @@
+import com.typesafe.sbt.web.Import.WebKeys.webTarget
+import com.typesafe.sbt.web.{PathMapping, incremental}
+import com.typesafe.sbt.web.pipeline.Pipeline
+import sbt.Keys.streams
+import com.typesafe.sbt.web.Import._
+import com.typesafe.sbt.web.incremental.{
+  OpInputHash,
+  OpInputHasher,
+  OpResult,
+  OpSuccess
+}
+import sbt.internal.util.ManagedLogger
+import sbt.{AutoPlugin, File, Setting, sbtUnchecked, taskKey}
+
+import scala.sys.process.{Process, ProcessLogger}
+
+/** Custom plugin to compile TypeScript code. We are not using sbt-typescript
+  * https://github.com/joost-de-vries/sbt-typescript plugin because it hasn't
+  * been updated since 2018 and uses Typescript 2 while current Typescript
+  * version is 4.
+  *
+  * Our custom plugin invokes `tsc` compiler directly. `tsconfig.json` is setup
+  * to compile code from `app/assets/javascripts` directory and outputs result
+  * to `target/web/typescript/javascripts` folder.
+  *
+  * This plugin introduces `compileTypescript` task which will be used as a
+  * pipeline stage. Read about Asset Pipeline tasks
+  * https://github.com/sbt/sbt-web#asset-pipeline The task implements Asset
+  * Pipeline task and not Source File task because the latter doesn't allow us
+  * to keep ∂irectory structure: we want that file `assets/javascripts/foo.ts`
+  * be compiled to `assets/javascripts/foo.js`. So we are using Pipeline.Stage
+  * for that.
+  *
+  * This plugin is enabled by adding `compileTypescript` as first task in
+  * pipelineStages in build.sbt.
+  */
+object TypescriptBuilder extends AutoPlugin {
+  override def trigger = allRequirements
+
+  object autoImport {
+    val compileTypescript = taskKey[Pipeline.Stage](
+      "Compiles typescript from assets/javascript folder"
+    )
+  }
+  import autoImport._
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    compileTypescript := { inputFiles =>
+      val streamsVal = (Assets / streams).value: @sbtUnchecked
+      // dir for compiled JS files
+      val targetDir = new File(webTarget.value, "typescript/javascripts")
+      val cacheDir = new File(streamsVal.cacheDirectory, "run")
+      recompileTypescriptIfFilesChanged(
+        inputFiles,
+        targetDir,
+        cacheDir,
+        streamsVal.log
+      )
+      // get list of compiled JS files and maps from targetDir folder and return them together with input files.
+      val jsFiles: Seq[PathMapping] =
+        targetDir.listFiles().map({ f => (f, "javascripts/" + f.getName) })
+      inputFiles ++ jsFiles
+    }
+  )
+
+  def recompileTypescriptIfFilesChanged(
+    inputFiles: Seq[(File, String)],
+    targetDir: File,
+    cacheDir: File,
+    log: ManagedLogger
+  ) = {
+    // function that provides hash for each file. Includes fileName + timestamp.
+    val fileHasher: OpInputHasher[File] =
+      OpInputHasher[File](f =>
+        OpInputHash.hashString(f.getCanonicalPath + f.lastModified)
+      )
+    // we are interested only in TS files.
+    val tsFiles = inputFiles map { p => p._1 } filter { f =>
+      f.getName.endsWith(".ts")
+    }
+    // we are using sbt-web syncIncremental function. It's somewhat complicated. For our
+    // use case we just want to see if any of TS files changed and if so - recompile
+    // everything.
+    incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
+      if (modifiedFiles.nonEmpty) {
+        log.info("Typescript files changed. Recompiling...")
+        compileTypescriptInternal(targetDir, log)
+      }
+      // ignore opResults. We are not using full functionality of syncIncremental
+      // so we always return dummy opResults with OpSuccess for each TS file.
+      val opResults: Map[File, OpResult] = modifiedFiles
+        .map(f => f -> OpSuccess(Set.empty[File], Set.empty[File]))
+        .toMap
+      (opResults, ())
+    })(fileHasher)
+  }
+
+  def compileTypescriptInternal(targetDir: File, log: ManagedLogger) = {
+    val compilationCommand =
+      "npx tsc --pretty --project tsconfig.json --outDir " + targetDir
+    val res = Process(compilationCommand) ! ProcessLogger(
+      line => log.error(line),
+      line => log.error(line)
+    )
+    if (res != 0) {
+      log.info(
+        "To debug TS code compilation can run the following command from 'server' folder:\n    " + compilationCommand
+      )
+      throw new sbt.MessageOnlyException(
+        "TypeScript compilation failed. Check console to see compilation errors."
+      )
+    }
+  }
+}

--- a/server/project/plugins.sbt
+++ b/server/project/plugins.sbt
@@ -1,7 +1,6 @@
 // Play plugins
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 addSbtPlugin("com.typesafe.play" % "sbt-play-ebean" % "6.2.0-RC4")
-addSbtPlugin("name.de-vries" % "sbt-typescript" % "2.6.2")
 
 // Dependency tree plugin. To use, open an sbt shell and run dependencyBrowseTree
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "lib": ["es6", "es2017", "dom"],
-    "paths": {
-      "*": ["*", "node_modules/@types/node/*"]
-    },
+    "lib": ["es2019", "dom"],
     "sourceMap": true,
-    "mapRoot": "/assets",
-    "sourceRoot": "/assets"
-  }
+    "mapRoot": "/assets/javascripts",
+    "sourceRoot": "/assets/javascripts",
+    "baseUrl": "./",
+    "strict": false
+  },
+  "include": ["app/assets/javascripts/*"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,10 +2,16 @@
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "lib": ["es2019", "dom"],
+    // While we support only latest browsers (chrome, firefox, safari, edge)
+    // we can't use ES2015+ or above because it breaks unit tests. We have
+    // security unit tests which use webdriver which in turn uses HtmlUnitDriver
+    // to evalute html and that thing doesn't support modern JS.
+    "target": "es5",
     "sourceMap": true,
     "mapRoot": "/assets/javascripts",
     "sourceRoot": "/assets/javascripts",
     "baseUrl": "./",
+    // TODO(#3361): fix and reenable strict checks.
     "strict": false
   },
   "include": ["app/assets/javascripts/*"]


### PR DESCRIPTION
### Description

[sbt-web](https://github.com/joost-de-vries/sbt-typescript) plugin we are using is no longer maintained and 5 years old. It uses Typescript 2 while current one is Typescript 4. Which means we can't use latest features and improvements. 

This PR removes sbt-web and instead adds custom TypescriptBuilder.scala file, similar to TailwindBuilder.scala. That file defines a task that calls `tsc` (typescript compiler) to compile our few TS files. Code is a bit complicated due to sbt APIs which aren't very straightforward. 

That task is hooked into sbt-web pipeline in `build.sbt` and runs before digest/gzip tasks. In dev mode, upon recompilation TS files will be recompiled only if some of them was changed. TS files are not recompiled on java file updates.

Additionally this PR updates TS version to 4.8. I couldn't find a way to split these two changes. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
