### PR TITLE
Fix login / select language page titles to be more accessible

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -106,8 +106,7 @@ public enum MessageKey {
   TOAST_LOCALE_NOT_SUPPORTED("toast.localeNotSupported"),
   TOAST_PROGRAM_COMPLETED("toast.programCompleted"),
   USER_NAME("header.userName"),
-  VALIDATION_REQUIRED("validation.isRequired"),
-  CONTENT_APPLICANT_INFORMATION("content.applicantInformation");
+  VALIDATION_REQUIRED("validation.isRequired");
 
   private final String keyName;
 

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.meta;
 import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.script;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import j2html.tags.specialized.ScriptTag;
@@ -24,6 +25,7 @@ public class BaseHtmlLayout {
   private final String civiformImageTag;
   private final String civiformFaviconUrl;
 
+  private static final String CIVIFORM_TITLE = "CiviForm";
   private static final String TAILWIND_COMPILED_FILENAME = "tailwind";
   private static final String[] FOOTER_SCRIPTS = {"main", "accordion", "modal", "radio", "toast"};
   private static final String BANNER_TEXT =
@@ -106,7 +108,17 @@ public class BaseHtmlLayout {
    * page.
    */
   public Content render(HtmlBundle bundle) {
+    String currentTitle = bundle.getTitle();
+    if (Strings.isNullOrEmpty(currentTitle)) {
+      bundle.setTitle(getTitleSuffix());
+    } else {
+      bundle.setTitle(String.format("%s — %s", currentTitle, getTitleSuffix()));
+    }
     return bundle.render();
+  }
+
+  protected String getTitleSuffix() {
+    return CIVIFORM_TITLE;
   }
 
   /** Creates Google Analytics scripts for the site. */

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -66,17 +66,17 @@ public final class AdminLayout extends BaseHtmlLayout {
     bundle.addMainStyles(
         AdminStyles.MAIN, isCentered ? AdminStyles.MAIN_CENTERED : AdminStyles.MAIN_FULL);
     bundle.addBodyStyles(AdminStyles.BODY);
-    String currentTitle = bundle.getTitle();
-
-    if (currentTitle != null && !currentTitle.isEmpty()) {
-      bundle.setTitle(currentTitle + " - CiviForm Admin Console");
-    }
 
     for (String source : FOOTER_SCRIPTS) {
       bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
     }
 
     return super.render(bundle);
+  }
+
+  @Override
+  protected String getTitleSuffix() {
+    return "CiviForm Admin Console";
   }
 
   @Override

--- a/server/app/views/applicant/ApplicantInformationView.java
+++ b/server/app/views/applicant/ApplicantInformationView.java
@@ -73,15 +73,13 @@ public class ApplicantInformationView extends BaseHtmlView {
         submitButton(submitText).withClasses(ApplicantStyles.BUTTON_SELECT_LANGUAGE);
     formContent.with(formSubmit);
 
+    String title = "Select lanaguage";
     HtmlBundle bundle =
         layout
             .getBundle()
-            .setTitle(messages.at(MessageKey.CONTENT_APPLICANT_INFORMATION.getKeyName()))
+            .setTitle(title)
             .addMainStyles(ApplicantStyles.MAIN_APPLICANT_INFO)
-            .addMainContent(formContent);
-    bundle.addMainContent(
-        h1(messages.at(MessageKey.CONTENT_APPLICANT_INFORMATION.getKeyName()))
-            .withClasses(Styles.SR_ONLY));
+            .addMainContent(h1(title).withClasses(Styles.SR_ONLY), formContent);
 
     // We probably don't want the nav bar here (or we need it somewhat different - no dropdown.)
     return layout.renderWithNav(request, userName, messages, bundle);

--- a/server/app/views/applicant/ApplicantInformationView.java
+++ b/server/app/views/applicant/ApplicantInformationView.java
@@ -75,7 +75,7 @@ public class ApplicantInformationView extends BaseHtmlView {
 
     // No translation needed since this appears before applicants select their preferred language,
     // so we always use the default.
-    String title = "Select lanaguage";
+    String title = "Select language";
     HtmlBundle bundle =
         layout
             .getBundle()

--- a/server/app/views/applicant/ApplicantInformationView.java
+++ b/server/app/views/applicant/ApplicantInformationView.java
@@ -73,6 +73,8 @@ public class ApplicantInformationView extends BaseHtmlView {
         submitButton(submitText).withClasses(ApplicantStyles.BUTTON_SELECT_LANGUAGE);
     formContent.with(formSubmit);
 
+    // No translation needed since this appears before applicants select their preferred language,
+    // so we always use the default.
     String title = "Select lanaguage";
     HtmlBundle bundle =
         layout

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -44,7 +44,6 @@ import views.style.Styles;
 /** Contains methods rendering common compoments used across applicant pages. */
 public class ApplicantLayout extends BaseHtmlLayout {
 
-  private static final String CIVIFORM_TITLE = "CiviForm";
   private static final Logger logger = LoggerFactory.getLogger(ApplicantLayout.class);
 
   private final ProfileUtils profileUtils;
@@ -83,13 +82,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
   @Override
   public Content render(HtmlBundle bundle) {
     bundle.addBodyStyles(ApplicantStyles.BODY);
-    String currentTitle = bundle.getTitle();
-
-    if (currentTitle != null && !currentTitle.isEmpty()) {
-      bundle.setTitle(String.format("%s — %s", currentTitle, CIVIFORM_TITLE));
-    } else {
-      bundle.setTitle(CIVIFORM_TITLE);
-    }
 
     bundle.addFooterStyles(Styles.MT_24);
 

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -20,9 +20,6 @@ button.logout=Logout
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # Message displayed before the support email address in the page footer for applicants.

--- a/server/conf/messages.am
+++ b/server/conf/messages.am
@@ -10,9 +10,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -18,9 +18,6 @@ button.logout=Logout
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # Message displayed before the support email address in the page footer for applicants.

--- a/server/conf/messages.es-US
+++ b/server/conf/messages.es-US
@@ -14,9 +14,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/conf/messages.ko
+++ b/server/conf/messages.ko
@@ -10,9 +10,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/conf/messages.so
+++ b/server/conf/messages.so
@@ -12,9 +12,6 @@ button.logout=ka bixida
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # Message displayed before the support email address in the page footer for applicants.

--- a/server/conf/messages.tl
+++ b/server/conf/messages.tl
@@ -10,9 +10,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/conf/messages.vi
+++ b/server/conf/messages.vi
@@ -10,9 +10,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/conf/messages.zh-TW
+++ b/server/conf/messages.zh-TW
@@ -10,9 +10,6 @@
 label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.applicantInformation=Applicant Information
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
 # The text on the button an applicant clicks to log out of their session.

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -57,4 +57,18 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
             "<link href=\"moose.css\" rel=\"stylesheet\"><link"
                 + " href=\"/assets/stylesheets/[a-z0-9]+-tailwind.css\" rel=\"stylesheet\">");
   }
+
+  @Test
+  public void withNoExplicitTitle() {
+    Content content = layout.render(layout.getBundle());
+
+    assertThat(content.body()).contains("<title>CiviForm</title>");
+  }
+
+  @Test
+  public void withProvidedTitle() {
+    Content content = layout.render(layout.getBundle().setTitle("A title"));
+
+    assertThat(content.body()).contains("<title>A title - CiviForm</title>");
+  }
 }

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -69,6 +69,6 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
   public void withProvidedTitle() {
     Content content = layout.render(layout.getBundle().setTitle("A title"));
 
-    assertThat(content.body()).contains("<title>A title - CiviForm</title>");
+    assertThat(content.body()).contains("<title>A title — CiviForm</title>");
   }
 }


### PR DESCRIPTION
### Description

#### Login page
We had logic to suffix the page title with text depending on the layout (e.g. `- CiviForm` for applicants and `- CiviForm Admin Console` for program/CiviForm admins).

Our login page wasn't make use of either of those specific layouts. This pushes the "suffix the page title" logic down to the `BaseHtmlLayout` class with a default value of "CiviForm".

Note: While here, I also filed #3548 to track the fact that the "Login" text is not localized.

#### Select language
This had an incorrect set of text. Since it wasn't localized, I also removed it from the translations files and inlined it directly with a comment. Finally, I moved the `<h1>` SR-only tag above the content that it was describing for clarity.

## Release notes:

Updating the titles for the login page and language selection page to be more accessible.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3545
