### PR TITLE
Fail on new images being added

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
         run: bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
         run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
-      - name: Check no new image snapshots
+      - name: Verify no new image snapshots added
         run: git add browser-test/image_snapshots ; git diff --compact-summary --exit-code HEAD
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Run browser tests with Localstack
         run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Check no new image snapshots
-        run: git add .; git diff --exit-code HEAD
+        run: git add browser-test/image_snapshots ; git diff --compact-summary --exit-code HEAD
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,8 @@ jobs:
         run: bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
         run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+      - name: Check no new image snapshots
+        run: git add .; git diff --exit-code HEAD
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,6 +72,8 @@ jobs:
       - name: Run browser tests with Localstack
         run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Verify no new image snapshots added
+        # jest-image-snapshots automatically adds snapshot if it's missing.
+        # Use git diff to fail if we detect new images.
         run: git add browser-test/image_snapshots ; git diff --compact-summary --exit-code HEAD
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3

--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -37,8 +37,6 @@ describe('address applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'address')
-      await validateScreenshot(page, 'address-bla-bla')
-      await validateScreenshot(page, 'address-bla-bla-bla')
     })
 
     it('validate screenshot with errors', async () => {

--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -37,6 +37,8 @@ describe('address applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'address')
+      await validateScreenshot(page, 'address-bla-bla')
+      await validateScreenshot(page, 'address-bla-bla-bla')
     })
 
     it('validate screenshot with errors', async () => {


### PR DESCRIPTION
### Description

jest-image-snapshot automatically adds image snapshot if it's missing during test run. That's good for local development but for CI it's undesired: we want test to fail in cases of missing snapshots. This PR adds extra step to github action workflow which ensures that no screenshots being added after test run.

Here is how failure looks:

![image](https://user-images.githubusercontent.com/252053/192904594-6fe29227-ffdd-4558-ad88-c20d27a126f3.png)

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

