### PR TITLE
Setting lang for language radio select, dropdown, and the always-English brand

### DIFF
--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -68,7 +68,7 @@ public final class LanguageSelector {
             locale -> {
               String value = locale.toLanguageTag();
               String label = formatLabel(locale);
-              OptionTag optionTag = option(label).withValue(value);
+              OptionTag optionTag = option(label).withLang(value).withValue(value);
               if (value.equals(preferredLanguage)) {
                 optionTag.isSelected();
               }
@@ -85,14 +85,15 @@ public final class LanguageSelector {
                 options.with(
                     renderRadioOption(
                         formatLabel(locale),
-                        locale.toLanguageTag(),
+                        locale,
                         locale.toLanguageTag().equals(preferredLanguage))));
     return options;
   }
 
-  private DivTag renderRadioOption(String text, String value, boolean checked) {
+  private DivTag renderRadioOption(String text, Locale locale, boolean checked) {
     LabelTag labelTag =
         label()
+            .withLang(locale.toLanguageTag())
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.RADIO_LABEL,
@@ -101,7 +102,7 @@ public final class LanguageSelector {
                 input()
                     .withType("radio")
                     .withName("locale")
-                    .withValue(value)
+                    .withValue(locale.toLanguageTag())
                     .withCondChecked(checked)
                     .withClasses(
                         StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO)))

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -22,6 +22,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.NavTag;
 import j2html.tags.specialized.SelectTag;
+import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.slf4j.Logger;
@@ -174,6 +175,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
         .with(
             div()
                 .withId("brand-id")
+                .withLang(Locale.ENGLISH.toLanguageTag())
                 .withClasses(ApplicantStyles.CIVIFORM_LOGO)
                 .withText("CiviForm"));
   }


### PR DESCRIPTION
### Description

## Release notes:

Add language hints to the applicant-facing language selection screen, language dropdown, and brand ID.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3546
