### PR TITLE
Adding new strings to translate for screen readers for the Edit and Continue buttons

### DIFF
--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -179,7 +179,9 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.inProgress(),
-              MessageKey.BUTTON_CONTINUE));
+              MessageKey.BUTTON_CONTINUE,
+              // TODO(#3552): Once button.editSr translations are available, switch to using those.
+              MessageKey.BUTTON_APPLY_SR));
     }
     if (!relevantPrograms.submitted().isEmpty()) {
       content.with(
@@ -190,7 +192,10 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.submitted(),
-              MessageKey.BUTTON_EDIT));
+              MessageKey.BUTTON_EDIT,
+              // TODO(#3552): Once button.continueSr translations are available, switch to using
+              // those.
+              MessageKey.BUTTON_APPLY_SR));
     }
     if (!relevantPrograms.unapplied().isEmpty()) {
       content.with(
@@ -201,7 +206,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.unapplied(),
-              MessageKey.BUTTON_APPLY));
+              MessageKey.BUTTON_APPLY,
+              MessageKey.BUTTON_APPLY_SR));
     }
 
     return div().withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.PLACE_ITEMS_CENTER).with(content);
@@ -228,7 +234,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       long applicantId,
       Locale preferredLocale,
       ImmutableList<ApplicantService.ApplicantProgramData> cards,
-      MessageKey applyTitle) {
+      MessageKey applyTitle,
+      MessageKey applySr) {
     return div()
         .withClass(ReferenceClasses.APPLICATION_PROGRAM_SECTION)
         .with(
@@ -248,7 +255,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                                 cards.size(),
                                 applicantId,
                                 preferredLocale,
-                                applyTitle))));
+                                applyTitle,
+                                applySr))));
   }
 
   private DivTag programCard(
@@ -258,7 +266,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       int totalProgramCount,
       Long applicantId,
       Locale preferredLocale,
-      MessageKey applyTitle) {
+      MessageKey applyTitle,
+      MessageKey applySr) {
     ProgramDefinition program = cardData.program();
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
 
@@ -348,8 +357,7 @@ public final class ProgramIndexView extends BaseHtmlView {
             .attr(
                 "aria-label",
                 messages.at(
-                    MessageKey.BUTTON_APPLY_SR.getKeyName(),
-                    program.localizedName().getOrDefault(preferredLocale)))
+                    applySr.getKeyName(), program.localizedName().getOrDefault(preferredLocale)))
             .withText(messages.at(applyTitle.getKeyName()))
             .withId(baseId + "-apply")
             .withClasses(ReferenceClasses.APPLY_BUTTON, ApplicantStyles.BUTTON_PROGRAM_APPLY);

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -180,7 +180,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               preferredLocale,
               relevantPrograms.inProgress(),
               MessageKey.BUTTON_CONTINUE,
-              // TODO(#3552): Once button.editSr translations are available, switch to using those.
+              // TODO(#3552): Once button.continueSr translations are available, switch to using
+              // those.
               MessageKey.BUTTON_APPLY_SR));
     }
     if (!relevantPrograms.submitted().isEmpty()) {
@@ -193,7 +194,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               preferredLocale,
               relevantPrograms.submitted(),
               MessageKey.BUTTON_EDIT,
-              // TODO(#3552): Once button.continueSr translations are available, switch to using
+              // TODO(#3552): Once button.editSr translations are available, switch to using
               // those.
               MessageKey.BUTTON_APPLY_SR));
     }
@@ -234,8 +235,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       long applicantId,
       Locale preferredLocale,
       ImmutableList<ApplicantService.ApplicantProgramData> cards,
-      MessageKey applyTitle,
-      MessageKey applySr) {
+      MessageKey buttonTitle,
+      MessageKey buttonSrText) {
     return div()
         .withClass(ReferenceClasses.APPLICATION_PROGRAM_SECTION)
         .with(
@@ -255,8 +256,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                                 cards.size(),
                                 applicantId,
                                 preferredLocale,
-                                applyTitle,
-                                applySr))));
+                                buttonTitle,
+                                buttonSrText))));
   }
 
   private DivTag programCard(
@@ -266,8 +267,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       int totalProgramCount,
       Long applicantId,
       Locale preferredLocale,
-      MessageKey applyTitle,
-      MessageKey applySr) {
+      MessageKey buttonTitle,
+      MessageKey buttonSrText) {
     ProgramDefinition program = cardData.program();
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
 
@@ -357,8 +358,9 @@ public final class ProgramIndexView extends BaseHtmlView {
             .attr(
                 "aria-label",
                 messages.at(
-                    applySr.getKeyName(), program.localizedName().getOrDefault(preferredLocale)))
-            .withText(messages.at(applyTitle.getKeyName()))
+                    buttonSrText.getKeyName(),
+                    program.localizedName().getOrDefault(preferredLocale)))
+            .withText(messages.at(buttonTitle.getKeyName()))
             .withId(baseId + "-apply")
             .withClasses(ReferenceClasses.APPLY_BUTTON, ApplicantStyles.BUTTON_PROGRAM_APPLY);
 

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -180,7 +180,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               preferredLocale,
               relevantPrograms.inProgress(),
               MessageKey.BUTTON_CONTINUE,
-              // TODO(#3552): Once button.continueSr translations are available, switch to using
+              // TODO(#3577): Once button.continueSr translations are available, switch to using
               // those.
               MessageKey.BUTTON_APPLY_SR));
     }
@@ -194,7 +194,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               preferredLocale,
               relevantPrograms.submitted(),
               MessageKey.BUTTON_EDIT,
-              // TODO(#3552): Once button.editSr translations are available, switch to using
+              // TODO(#3577): Once button.editSr translations are available, switch to using
               // those.
               MessageKey.BUTTON_APPLY_SR));
     }

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -123,6 +123,10 @@ button.apply=Apply
 button.applySr=Apply to {0}
 # The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Edit
+# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
+button.editSr=Edit submitted application to {0}
+# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
+button.continueSr=Continue application to {0}
 
 # Text describing the date the application was last submitted.
 content.submittedDate=Submitted {0}


### PR DESCRIPTION
### Description

Once these are available, we can use them as the screen reader text to address #3552.

## Release notes:

N/A

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3552; #3577 