### PR TITLE
Adding a role and aria-label for the icon shown next to the external site link

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -59,6 +59,7 @@ public enum MessageKey {
   ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),
   EXTERNAL_LINK("link.externalLink"),
+  EXTERNAL_LINK_OPENS_IN_NEW_TAB("link.externalLinkOpensInNewTab"),
   FILEUPLOAD_VALIDATION_FILE_REQUIRED("validation.fileRequired"),
   FOOTER_SUPPORT_LINK_DESCRIPTION("footer.supportLinkDescription"),
   GUEST("guest"),

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -323,6 +323,10 @@ public final class ProgramIndexView extends BaseHtmlView {
               .asAnchorText()
               .with(
                   Icons.svg(Icons.OPEN_IN_NEW)
+                      .attr("role", "img")
+                      .attr(
+                          "aria-label",
+                          messages.at(MessageKey.EXTERNAL_LINK_OPENS_IN_NEW_TAB.getKeyName()))
                       .withClasses(
                           Styles.FLEX_SHRINK_0,
                           Styles.H_5,

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -144,6 +144,9 @@ link.programDetailsSr=Program details for {0}
 # Link text to an external site to read more about a program.
 link.externalLink=External site
 
+# Screen reader text next to a link indicating that it opens in a new tab.
+link.externalLinkOpensInNewTab=Opens in a new tab
+
 # The title of the page for the list of programs.
 title.programs=Programs & services
 


### PR DESCRIPTION
### Description

## Release notes:

Adding accessibility attributes to the icon shown next to the "External site" link in the applicant program listing page.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3553