### PR TITLE
Status Tracking: Verify user request is based on latest data

### DIFF
--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -12,6 +12,7 @@ class AdminApplicationView {
   // ProgramApplicationView.java.
   private static PROGRAM_ID_INPUT_NAME = 'programId'
   private static APPLICATION_ID_INPUT_NAME = 'applicationId'
+  private static CURRENT_STATUS_INPUT_NAME = 'currentStatus'
   private static NEW_STATUS_INPUT_NAME = 'newStatus'
   private static SEND_EMAIL_INPUT_NAME = 'sendEmail'
   private static NOTE_INPUT_NAME = 'note'
@@ -56,6 +57,10 @@ class AdminApplicationView {
               10,
             ),
             data: {
+              currentStatus: this.extractInputValueFromForm(
+                formEl,
+                AdminApplicationView.CURRENT_STATUS_INPUT_NAME,
+              ),
               newStatus: this.extractInputValueFromForm(
                 formEl,
                 AdminApplicationView.NEW_STATUS_INPUT_NAME,

--- a/server/app/assets/javascripts/admin_applications.ts
+++ b/server/app/assets/javascripts/admin_applications.ts
@@ -7,9 +7,10 @@ class AdminApplications {
   // This value should be kept in sync with that in AdminApplicationController.java.
   private static SELECTED_APPLICATION_URI_PARAM_NAME = 'selectedApplicationUri'
 
-  // These values should be kept in sync with those in admin_application_view.ts and
+  // These values should be kept in sync with those in admin_application_view.ts
   // and ProgramApplicationView.java.
   private static SUCCESS_REDIRECT_URI_INPUT_NAME = 'successRedirectUri'
+  private static CURRENT_STATUS_INPUT_NAME = 'currentStatus'
   private static NEW_STATUS_INPUT_NAME = 'newStatus'
   private static SEND_EMAIL_INPUT_NAME = 'sendEmail'
   private static NOTE_INPUT_NAME = 'note'
@@ -146,6 +147,10 @@ class AdminApplications {
           inputValue: this.currentRelativeUrl(),
         },
         {
+          inputName: AdminApplications.CURRENT_STATUS_INPUT_NAME,
+          inputValue: data.currentStatus,
+        },
+        {
           inputName: AdminApplications.NEW_STATUS_INPUT_NAME,
           inputValue: data.newStatus,
         },
@@ -223,6 +228,7 @@ interface ApplicationViewMessage {
 }
 
 interface UpdateStatusData {
+  currentStatus: string
   newStatus: string
   sendEmail: string
 }

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -393,6 +393,9 @@ public final class AdminApplicationController extends CiviFormController {
                 "The application state has changed since the page was loaded. Please reload and"
                     + " try again.");
       }
+    } else if (!maybeCurrentStatus.get().isBlank()) {
+      return badRequest(
+          String.format("The %s field should be empty as there is no status set", CURRENT_STATUS));
     }
     // Save the new data.
     String newStatus = maybeNewStatus.get();

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -370,8 +370,6 @@ public final class AdminApplicationController extends CiviFormController {
     Optional<String> maybeSendEmail = Optional.ofNullable(formData.get(SEND_EMAIL));
     Optional<String> maybeSuccessRedirectUri =
         Optional.ofNullable(formData.get(SUCCESS_REDIRECT_URI));
-    // TODO(#3263): check that the previous status is the current previous status for
-    // consistency.
     if (maybeCurrentStatus.isEmpty()) {
       return badRequest(String.format("The %s field is not present", CURRENT_STATUS));
     }
@@ -387,14 +385,6 @@ public final class AdminApplicationController extends CiviFormController {
     // Verify the UI is changing from the actual current status to detect an out of date UI.
     if (application.getLatestStatus().isPresent()) {
       if (!application.getLatestStatus().get().equals(maybeCurrentStatus.get())) {
-        // return redirect(
-        //  routes.AdminApplicationController.index(programId,
-        //  Optional.empty(),
-        //    Optional.empty(),
-        //    Optional.empty(),
-        //    Optional.empty(),
-        //    Optional.empty(),
-        //    Optional.of(routes.AdminApplicationController.show(programId, applicationId).path())))
         // Only allow relative URLs to ensure that we redirect to the same domain.
         String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeSuccessRedirectUri.orElse(""));
         return redirect(redirectUrl)

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -144,6 +144,10 @@ public final class ProgramApplicationListView extends BaseHtmlView {
     if (maybeSuccessMessage.isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));
     }
+    Optional<String> maybeErrorMessage = request.flash().get("error");
+    if (maybeErrorMessage.isPresent()) {
+      htmlBundle.addToastMessages(ToastMessage.error(maybeErrorMessage.get()));
+    }
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -310,7 +310,10 @@ public final class ProgramApplicationView extends BaseHtmlView {
       Application application,
       String applicantNameWithApplicationId,
       StatusDefinitions.Status status) {
-    String previousStatus = application.getLatestStatus().orElse("Unset");
+    // The previous status as it should be displayed and passed as data in the
+    // update.
+    String previousStatusDisplay = application.getLatestStatus().orElse("Unset");
+    String previousStatusData = application.getLatestStatus().orElse("");
     // No form action or content is rendered since admin_application_view.ts extracts the values
     // and calls postMessage rather than attempting a submission. The main frame is responsible for
     // constructing a form to update the status.
@@ -325,7 +328,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     .isHidden(),
                 p().with(
                         span("Status Change: "),
-                        span(previousStatus).withClass(Styles.FONT_SEMIBOLD),
+                        span(previousStatusDisplay).withClass(Styles.FONT_SEMIBOLD),
                         span(" -> ").withClass(Styles.FONT_SEMIBOLD),
                         span(status.statusText()).withClass(Styles.FONT_SEMIBOLD),
                         span(" (visible to applicant)")),
@@ -342,7 +345,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                             .withType("text")
                             .withName(NEW_STATUS)
                             .withValue(status.statusText()))
-                    // Add the original status to the form hidden so we can
+                    // Add the original status to the form hidden so that we can
                     // detect if the data has changed since this UI was
                     // generated.
                     .with(
@@ -350,7 +353,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                             .isHidden()
                             .withType("text")
                             .withName(CURRENT_STATUS)
-                            .withValue(previousStatus))
+                            .withValue(previousStatusData))
                     .with(
                         renderStatusUpdateConfirmationModalEmailSection(
                             applicantNameWithApplicationId, application, status)),

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -61,6 +61,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
   private static final String PROGRAM_ID = "programId";
   private static final String APPLICATION_ID = "applicationId";
   public static final String SEND_EMAIL = "sendEmail";
+  public static final String CURRENT_STATUS = "currentStatus";
   public static final String NEW_STATUS = "newStatus";
   public static final String NOTE = "note";
   private final BaseHtmlLayout layout;
@@ -341,6 +342,15 @@ public final class ProgramApplicationView extends BaseHtmlView {
                             .withType("text")
                             .withName(NEW_STATUS)
                             .withValue(status.statusText()))
+                    // Add the original status to the form hidden so we can
+                    // detect if the data has changed since this UI was
+                    // generated.
+                    .with(
+                        input()
+                            .isHidden()
+                            .withType("text")
+                            .withName(CURRENT_STATUS)
+                            .withValue(previousStatus))
                     .with(
                         renderStatusUpdateConfirmationModalEmailSection(
                             applicantNameWithApplicationId, application, status)),

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -63,6 +63,7 @@ import views.admin.programs.ProgramApplicationListView;
 import views.admin.programs.ProgramApplicationView;
 
 public class AdminApplicationControllerTest extends ResetPostgres {
+  private static final String UNSET_STATUS_TEXT = "Unset";
   private static final StatusDefinitions.Status APPROVED_STATUS =
       StatusDefinitions.Status.builder()
           .setStatusText("Approved")
@@ -203,9 +204,14 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri", "/",
-                            "sendEmail", "",
-                            "newStatus", "NOT A REAL STATUS")))
+                            "successRedirectUri",
+                            "/",
+                            "sendEmail",
+                            "",
+                            "currentStatus",
+                            UNSET_STATUS_TEXT,
+                            "newStatus",
+                            "NOT A REAL STATUS")))
             .build();
 
     // Execute
@@ -253,10 +259,15 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri", "/",
-                            "newStatus", APPROVED_STATUS.statusText(),
+                            "successRedirectUri",
+                            "/",
+                            "currentStatus",
+                            UNSET_STATUS_TEXT,
+                            "newStatus",
+                            APPROVED_STATUS.statusText(),
                             // Only "on" is a valid checkbox state.
-                            "sendEmail", "false")))
+                            "sendEmail",
+                            "false")))
             .build();
 
     // Execute
@@ -289,6 +300,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                         Map.of(
                             "successRedirectUri",
                             "/",
+                            "currentStatus",
+                            UNSET_STATUS_TEXT,
                             "newStatus",
                             APPROVED_STATUS.statusText(),
                             "sendEmail",
@@ -335,6 +348,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                             // Only "on" is a valid checkbox state.
                             "sendEmail",
                             "",
+                            "currentStatus",
+                            UNSET_STATUS_TEXT,
                             "newStatus",
                             APPROVED_STATUS.statusText())))
             .build();


### PR DESCRIPTION
### Description

Protect against outdated Application views UIs.

When the Frontend sends a request to update an Application's status, we now send the UIs believed current status and check that it is in fact the current one.  If it isn't we reload the page with an error toast.

## Release notes:

Application status updates have extra consistency verification.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3263