### PR TITLE
Accessibility improvements for the program index page

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -97,7 +97,6 @@ public enum MessageKey {
   TITLE_CREATE_AN_ACCOUNT("title.createAnAccount"),
   TITLE_PROGRAMS("title.programs"),
   TITLE_PROGRAMS_ACTIVE_UPDATED("title.activeProgramsUpdated"),
-  TITLE_PROGRAM_CARD("title.programCard"),
   TITLE_PROGRAMS_IN_PROGRESS_UPDATED("title.inProgressProgramsUpdated"),
   TITLE_PROGRAM_PREVIEW("title.programPreview"),
   TITLE_PROGRAM_REVIEW("title.programReview"),

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -182,7 +182,10 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.inProgress(),
-              MessageKey.BUTTON_CONTINUE));
+              MessageKey.BUTTON_CONTINUE,
+              // TODO(#3577): Once button.continueSr translations are available, switch to using
+              // those.
+              MessageKey.BUTTON_APPLY_SR));
     }
     if (!relevantPrograms.submitted().isEmpty()) {
       content.with(
@@ -193,7 +196,10 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.submitted(),
-              MessageKey.BUTTON_EDIT));
+              MessageKey.BUTTON_EDIT,
+              // TODO(#3577): Once button.editSr translations are available, switch to using
+              // those.
+              MessageKey.BUTTON_APPLY_SR));
     }
     if (!relevantPrograms.unapplied().isEmpty()) {
       content.with(
@@ -204,7 +210,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               applicantId,
               preferredLocale,
               relevantPrograms.unapplied(),
-              MessageKey.BUTTON_APPLY));
+              MessageKey.BUTTON_APPLY,
+              MessageKey.BUTTON_APPLY_SR));
     }
 
     return div().withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.PLACE_ITEMS_CENTER).with(content);
@@ -231,7 +238,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       long applicantId,
       Locale preferredLocale,
       ImmutableList<ApplicantService.ApplicantProgramData> cards,
-      MessageKey buttonTitle) {
+      MessageKey buttonTitle,
+      MessageKey buttonSrText) {
     String sectionHeaderId = Modal.randomModalId();
     return div()
         .withClass(ReferenceClasses.APPLICATION_PROGRAM_SECTION)
@@ -247,7 +255,12 @@ public final class ProgramIndexView extends BaseHtmlView {
                         cards,
                         (card) ->
                             programCard(
-                                messages, card, applicantId, preferredLocale, buttonTitle))));
+                                messages,
+                                card,
+                                applicantId,
+                                preferredLocale,
+                                buttonTitle,
+                                buttonSrText))));
   }
 
   private LiTag programCard(
@@ -255,7 +268,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       ApplicantService.ApplicantProgramData cardData,
       Long applicantId,
       Locale preferredLocale,
-      MessageKey buttonTitle) {
+      MessageKey buttonTitle,
+      MessageKey buttonSrText) {
     ProgramDefinition program = cardData.program();
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
 

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -156,9 +156,6 @@ title.activeProgramsUpdated=Not started
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Submitted
 
-# Screen reader format string for program cards
-title.programCard=Program {0} of {1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: application ID {0}
 

--- a/server/conf/messages.am
+++ b/server/conf/messages.am
@@ -148,9 +148,6 @@ title.activeProgramsUpdated=ያልተጀመሩ
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=የገቡ
 
-# Screen reader format string for program cards
-title.programCard=ፕሮግራም {0} ከ{1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=በተሳካ ሁኔታ የተቀመጠ ማመልከቻ፦ የማመልከቻ መታወቂያ {0}
 

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -153,9 +153,6 @@ title.activeProgramsUpdated=Not started
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Submitted
 
-# Screen reader format string for program cards
-title.programCard=Program {0} of {1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: application ID {0}
 

--- a/server/conf/messages.es-US
+++ b/server/conf/messages.es-US
@@ -150,9 +150,6 @@ title.activeProgramsUpdated=Sin comenzar
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Enviados
 
-# Screen reader format string for program cards
-title.programCard=Programa {0} de {1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Solicitud guardada con éxito: ID de la solicitud {0}
 

--- a/server/conf/messages.ko
+++ b/server/conf/messages.ko
@@ -148,9 +148,6 @@ title.activeProgramsUpdated=시작 안 함
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=제출됨
 
-# Screen reader format string for program cards
-title.programCard=프로그램 {1}~{2} 중 {0}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=신청서 저장됨: 신청서 ID {0}
 

--- a/server/conf/messages.so
+++ b/server/conf/messages.so
@@ -130,9 +130,6 @@ link.externalLink=Goobta dibadda
 # The title of the page for the list of programs.
 title.programs=Barnaamijyada iyo adeegyada
 
-# Screen reader format string for program cards
-title.programCard=Barnaamijka {0} ee {1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Codsiga si guul leh loo keydiyay: ID codsiga {0}
 

--- a/server/conf/messages.tl
+++ b/server/conf/messages.tl
@@ -129,9 +129,6 @@ link.externalLink=Panlabas na site
 # The title of the page for the list of programs.
 title.programs=Mga programa at mga serbisyo
 
-# Screen reader format string for program cards
-title.programCard=Programa {0} ng {1} -- {2} 
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: Matagumpay na nai-save ang aplikasyon: ID ng aplikasyon {0}
 

--- a/server/conf/messages.vi
+++ b/server/conf/messages.vi
@@ -148,9 +148,6 @@ title.activeProgramsUpdated=Chưa bắt đầu
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Đã gửi
 
-# Screen reader format string for program cards
-title.programCard=Chương trình {0} của {1} -- {2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Đã lưu thành công đơn đăng ký: mã đơn đăng ký {0}
 

--- a/server/conf/messages.zh-TW
+++ b/server/conf/messages.zh-TW
@@ -148,9 +148,6 @@ title.activeProgramsUpdated=未開始
 # Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=已提交
 
-# Screen reader format string for program cards
-title.programCard=第 {0} 項計畫，共 {1} 項：{2}
-
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=申請資料儲存成功：申請編號 {0}
 

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -94,9 +94,12 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
-    // A program's name appears in the index view page content 4 times.
-    // If it appeared 8 times, that means there is a duplicate of the program.
-    assertThat(numberOfSubstringsInString(contentAsString(result), programName)).isEqualTo(4);
+    // A program's name appears in the index view page content 3 times:
+    //  1) Program card title
+    //  2) Program details aria-label
+    //  3) Apply button aria-label
+    // If it appears 6 times, that means there is a duplicate of the program.
+    assertThat(numberOfSubstringsInString(contentAsString(result), programName)).isEqualTo(3);
   }
 
   /** Returns the number of times a substring appears in the string. */


### PR DESCRIPTION
### Description

Notably this removes the screen-reader only `<h4>` tag used in each program card. Previously, this text included the relative index of the program within the list. By putting each section of programs inside of a `<ol>` and having each card be a `<li>`, we can instead just use the program title in the `<h4>` and screen readers will have sufficient context to give us the "2 of 5" announcement "for free".

### Testing

Manually tested by enabling the screenreader. Using the shortcuts from https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts, I:
  * Used "Next heading" until I reached the "Not started" section
  * Used "Next List", which selected all of the programs in that section
  * Used right arrow to navigate through the list
  * The `<h4>` was announced as "Heading level 4 <program name> 1 of 5"

## Release notes:

Improves navigation within the applicant-facing program index pages for users with screen readers.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3555; Fixes #3556