### PR TITLE
Invert colors on language selector on hover/focus

### DIFF
--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -54,12 +54,20 @@ public final class LanguageSelector {
                 Styles.PX_3,
                 Styles.MX_3,
                 Styles.PY_1,
-                Styles.BORDER,
-                Styles.BORDER_GRAY_500,
-                Styles.ROUNDED_FULL,
-                Styles.BG_WHITE,
                 Styles.TEXT_XS,
-                StyleUtils.focus(BaseStyles.BORDER_SEATTLE_BLUE));
+                Styles.ROUNDED_FULL,
+                Styles.BORDER,
+                // On hover/focus, invert the colors to make the focus state visually distinctive.
+                // See https://github.com/civiform/civiform/issues/3558.
+                Styles.BORDER_GRAY_500,
+                StyleUtils.focus(Styles.BORDER_BLACK),
+                StyleUtils.hover(Styles.BORDER_BLACK),
+                Styles.BG_WHITE,
+                StyleUtils.focus(Styles.BG_BLACK),
+                StyleUtils.hover(Styles.BG_BLACK),
+                Styles.TEXT_BLACK,
+                StyleUtils.focus(Styles.TEXT_WHITE),
+                StyleUtils.hover(Styles.TEXT_WHITE));
 
     // An option consists of the language (localized to that language - for example,
     // this would display 'Español' for es-US), and the value is the ISO code.


### PR DESCRIPTION
### Description

Default state:
![Screen Shot 2022-09-29 at 11 23 43 AM](https://user-images.githubusercontent.com/1870301/193112727-0b45267a-d3ea-44ba-9a6b-e7d083a0c2bb.png)

Focus / hover:
![Screen Shot 2022-09-29 at 11 23 51 AM](https://user-images.githubusercontent.com/1870301/193112762-64096b43-bf29-4b1b-9ec7-1455f2b818b5.png)


## Release notes:

Update the language selector to visually distinguish itself upon hover / focus states in order to improve accessibility.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3558