### PR TITLE
Making cloned enumerator field entries have unique IDs

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -176,7 +176,7 @@ describe('End to end enumerator test', () => {
     await validateAccessibility(page)
 
     // Adding enumerator answers causes a clone of a hidden DOM element. This element
-    // should have no unique IDs. If not, it should cause accessibility violations.
+    // should have unique IDs. If not, it will cause accessibility violations.
     // See https://github.com/civiform/civiform/issues/3565.
     await applicantQuestions.addEnumeratorAnswer('Bugs')
     await applicantQuestions.addEnumeratorAnswer('Daffy')

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -174,6 +174,19 @@ describe('End to end enumerator test', () => {
 
     // Validate that enumerators are accessible
     await validateAccessibility(page)
+
+    // Adding enumerator answers causes a clone of a hidden DOM element. This element
+    // should have no unique IDs. If not, it should cause accessibility violations.
+    // See https://github.com/civiform/civiform/issues/3565.
+    await applicantQuestions.addEnumeratorAnswer('Bugs')
+    await applicantQuestions.addEnumeratorAnswer('Daffy')
+    await validateAccessibility(page)
+
+    // Correspondingly, removing an element happens without a page refresh. Remove an
+    // element and add another to ensure that element IDs remain unique.
+    await applicantQuestions.deleteEnumeratorEntityByIndex(1)
+    await applicantQuestions.addEnumeratorAnswer('Porky')
+    await validateAccessibility(page)
   })
 
   it('validate screenshot', async () => {

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -119,6 +119,12 @@ function hideInput(event: Event) {
   inputDiv.classList.add('hidden')
 }
 
+// Used to allow us to generate a unique ID for each newly added enumerator entity.
+// We can't generate this based on the number of elements rendered since entities
+// can be dynamically removed by using the "Remove" button without refreshing the
+// page.
+let enumeratorCounter = 0
+
 /** In the enumerator form - add a new input field for a repeated entity. */
 function addNewEnumeratorField() {
   // Copy the enumerator field template
@@ -132,6 +138,21 @@ function addNewEnumeratorField() {
   newField
     .querySelector('[type=button]')
     .addEventListener('click', removeEnumeratorField)
+
+  // Update IDs from the template element so that they are unique.
+  const inputElement = newField.querySelector(
+    '#enumerator-field-template-input',
+  )
+  enumeratorCounter++
+  inputElement.id = `${inputElement.id}-${enumeratorCounter}`
+  const labelElement = newField.querySelector(
+    'label[for="enumerator-field-template-input"]',
+  )
+  labelElement.setAttribute('for', inputElement.id)
+  const errorsElement = newField.querySelector(
+    '#enumerator-field-template-input-errors',
+  )
+  errorsElement.id = `enumerator-field-template-input-${enumeratorCounter}-errors`
 
   // Add to the end of enumerator-fields div.
   const enumeratorFields = document.getElementById('enumerator-fields')

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -32,6 +32,8 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
   private static final String ENUMERATOR_FIELDS_ID = "enumerator-fields";
   private static final String ADD_ELEMENT_BUTTON_ID = "enumerator-field-add-button";
   private static final String ENUMERATOR_FIELD_TEMPLATE_ID = "enumerator-field-template";
+  private static final String ENUMERATOR_FIELD_TEMPLATE_INPUT_ID =
+      "enumerator-field-template-input";
   private static final String DELETE_ENTITY_TEMPLATE_ID = "enumerator-delete-template";
 
   private static final String ENUMERATOR_FIELD_CLASSES =
@@ -72,7 +74,8 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
               /* existingIndex= */ Optional.of(index),
               /* extraStyle= */ Optional.empty(),
               /* isDisabled= */ false,
-              hasErrors));
+              hasErrors,
+              /* elementId= */ Optional.empty()));
     }
 
     DivTag enumeratorQuestionFormContent =
@@ -102,7 +105,8 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
                         /* extraStyle= */ Optional.of(Styles.HIDDEN),
                         // Do not submit this with the form.
                         /* isDisabled= */ true,
-                        hasErrors)
+                        hasErrors,
+                        /* elementId= */ Optional.of(ENUMERATOR_FIELD_TEMPLATE_INPUT_ID))
                     .withId(ENUMERATOR_FIELD_TEMPLATE_ID));
 
     return enumeratorQuestionFormContent;
@@ -120,7 +124,8 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
       Optional<Integer> existingIndex,
       Optional<String> extraStyle,
       boolean isDisabled,
-      boolean hasErrors) {
+      boolean hasErrors,
+      Optional<String> elementId) {
     FieldWithLabel entityNameInputField =
         FieldWithLabel.input()
             .setFieldName(contextualizedPath.toString())
@@ -131,6 +136,9 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
                     localizedEntityType))
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT);
+    if (elementId.isPresent()) {
+      entityNameInputField.setId(elementId.get());
+    }
     if (hasErrors) {
       entityNameInputField.forceAriaInvalid();
     }


### PR DESCRIPTION
### Description

We generate a "template" for the enumerated entity server-side. Previously this was generated a random ID. However, when the JavaScript in main.ts cloned the node, it also carried the ID along, generating a non-unique ID.

This keeps a global counter and replaces the ID each time a new entity is added.

Also updated integration tests to test these scenarios as well. I manually validated that it failed when I:
  * Didn't update the input element's ID
  * Didn't update the `label` element's `for` attribute
  * Didn't update the error div's ID

## Release notes:

Fix accessibility violations when applicants were adding answers to an enumerated question.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3565