### PR TITLE
Less than sign in program details page is no longer announced for screenreaders

### DIFF
--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -63,10 +63,11 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
     String programsLinkText = messages.at(MessageKey.TITLE_PROGRAMS.getKeyName());
     String homeLink = routes.HomeController.index().url();
     ATag allProgramsDiv =
-        a("<")
-            .withHref(homeLink)
+        a().withHref(homeLink)
             .withClasses(Styles.TEXT_GRAY_500, Styles.TEXT_LEFT)
-            .with(span().withText(programsLinkText).withClasses(Styles.PX_4));
+            .with(
+                span("<").attr("aria-hidden", "true"),
+                span().withText(programsLinkText).withClasses(Styles.PX_4));
 
     H1Tag titleDiv =
         h1().withText(programTitle)


### PR DESCRIPTION
## Tested

Manually used screen reader and confirmed that the less-than sign is no longer announced when focusing the link back to Programs & Services.

## Release notes:

Less than sign in link back to Programs & Services is no longer announced for screenreaders.

### Checklist

- [X] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3589