### PR TITLE
Add required field annotation msg for translation

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -91,7 +91,7 @@ public enum MessageKey {
   NUMBER_VALIDATION_TOO_BIG("validation.numberTooBig"),
   NUMBER_VALIDATION_TOO_SMALL("validation.numberTooSmall"),
   NUMBER_VALIDATION_NON_INTEGER("validation.numberNonInteger"),
-  REQUIRED_FIELDS_ANNOTATION("validation.requiredFieldsAnnotation"),
+  REQUIRED_FIELDS_ANNOTATION("content.requiredFieldsAnnotation"),
   SUBMITTED_DATE("content.submittedDate"),
   TEXT_VALIDATION_TOO_LONG("validation.textTooLong"),
   TEXT_VALIDATION_TOO_SHORT("validation.textTooShort"),

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -91,6 +91,7 @@ public enum MessageKey {
   NUMBER_VALIDATION_TOO_BIG("validation.numberTooBig"),
   NUMBER_VALIDATION_TOO_SMALL("validation.numberTooSmall"),
   NUMBER_VALIDATION_NON_INTEGER("validation.numberNonInteger"),
+  REQUIRED_FIELDS_ANNOTATION("validation.requiredFieldsAnnotation"),
   SUBMITTED_DATE("content.submittedDate"),
   TEXT_VALIDATION_TOO_LONG("validation.textTooLong"),
   TEXT_VALIDATION_TOO_SHORT("validation.textTooShort"),

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -43,7 +43,7 @@ validation.isRequired=This question is required.
 validation.invalidInput=Please enter valid input.
 
 # Message displayed at the top of a question page denoting fields with a * are required.
-validation.requiredFieldsAnnotation=Note: Fields marked with a * are required.
+content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
 
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -42,6 +42,9 @@ validation.isRequired=This question is required.
 # Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Please enter valid input.
 
+# Message displayed at the top of a question page denoting fields with a * are required.
+validation.requiredFieldsAnnotation=Note: Fields marked with a * are required.
+
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#


### PR DESCRIPTION
### Description

Add copy to be translated. Message is used to denote required fields will be marked with a *.

## Release notes:


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Part of #3381
