### PR TITLE
Set pac4j logout URL pattern

### DIFF
--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -81,6 +81,13 @@ public class SecurityModule extends AbstractModule {
     logoutController.setDefaultUrl(baseUrl + routes.HomeController.index().url());
     logoutController.setLocalLogout(true);
     logoutController.setDestroySession(true);
+    /**
+     * This mitigates a vulnerability in the logout process described here:
+     * https://groups.google.com/g/pac4j-security/c/poWGfZKo-ww/m/S-h4ggaSAgAJ
+     *
+     * <p>Can be removed after upgrading to pac4j v5.6.1
+     */
+    logoutController.setLogoutUrlPattern("^(\\/|\\/[^\\/].*)$");
 
     Boolean shouldPerformAuthProviderLogout = configuration.getBoolean("auth.oidc_provider_logout");
     logoutController.setCentralLogout(shouldPerformAuthProviderLogout);


### PR DESCRIPTION
This mitigates a vulnerability in the logout process described here: https://groups.google.com/g/pac4j-security/c/poWGfZKo-ww/m/S-h4ggaSAgAJ

At the time of the vulnerability announcement, upgrading to the next version of pac4j is causing a build failure: https://github.com/civiform/civiform/pull/3575

This can be removed after upgrading to pac4j v5.6.1

## Release notes

Mitigate vulnerability in pac4j logout logic [reported here](https://groups.google.com/g/pac4j-security/c/poWGfZKo-ww/m/S-h4ggaSAgAJ)