### PR TITLE
Rename successRedirectUri to redirectUri

### DIFF
--- a/server/app/assets/javascripts/admin_applications.ts
+++ b/server/app/assets/javascripts/admin_applications.ts
@@ -7,9 +7,10 @@ class AdminApplications {
   // This value should be kept in sync with that in AdminApplicationController.java.
   private static SELECTED_APPLICATION_URI_PARAM_NAME = 'selectedApplicationUri'
 
+  // These values should be kept in sync with those in AdminApplicationController.java.
+  private static REDIRECT_URI_INPUT_NAME = 'redirectUri'
   // These values should be kept in sync with those in admin_application_view.ts
   // and ProgramApplicationView.java.
-  private static SUCCESS_REDIRECT_URI_INPUT_NAME = 'successRedirectUri'
   private static CURRENT_STATUS_INPUT_NAME = 'currentStatus'
   private static NEW_STATUS_INPUT_NAME = 'newStatus'
   private static SEND_EMAIL_INPUT_NAME = 'sendEmail'
@@ -143,7 +144,7 @@ class AdminApplications {
       action: `/admin/programs/${programId}/applications/${applicationId}/updateStatus`,
       inputs: [
         {
-          inputName: AdminApplications.SUCCESS_REDIRECT_URI_INPUT_NAME,
+          inputName: AdminApplications.REDIRECT_URI_INPUT_NAME,
           inputValue: this.currentRelativeUrl(),
         },
         {
@@ -175,7 +176,7 @@ class AdminApplications {
       action: `/admin/programs/${programId}/applications/${applicationId}/updateNote`,
       inputs: [
         {
-          inputName: AdminApplications.SUCCESS_REDIRECT_URI_INPUT_NAME,
+          inputName: AdminApplications.REDIRECT_URI_INPUT_NAME,
           inputValue: this.currentRelativeUrl(),
         },
         {inputName: AdminApplications.NOTE_INPUT_NAME, inputValue: data.note},

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -64,7 +64,7 @@ import views.admin.programs.ProgramApplicationView;
 public final class AdminApplicationController extends CiviFormController {
   private static final int PAGE_SIZE = 10;
 
-  private static final String REDIRECT_URI_KEY = "RedirectUri";
+  private static final String REDIRECT_URI_KEY = "redirectUri";
 
   private final ApplicantService applicantService;
   private final ProgramAdminApplicationService programAdminApplicationService;

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -64,7 +64,7 @@ import views.admin.programs.ProgramApplicationView;
 public final class AdminApplicationController extends CiviFormController {
   private static final int PAGE_SIZE = 10;
 
-  private static final String SUCCESS_REDIRECT_URI = "successRedirectUri";
+  private static final String REDIRECT_URI_KEY = "RedirectUri";
 
   private final ApplicantService applicantService;
   private final ProgramAdminApplicationService programAdminApplicationService;
@@ -368,8 +368,7 @@ public final class AdminApplicationController extends CiviFormController {
     Optional<String> maybeCurrentStatus = Optional.ofNullable(formData.get(CURRENT_STATUS));
     Optional<String> maybeNewStatus = Optional.ofNullable(formData.get(NEW_STATUS));
     Optional<String> maybeSendEmail = Optional.ofNullable(formData.get(SEND_EMAIL));
-    Optional<String> maybeSuccessRedirectUri =
-        Optional.ofNullable(formData.get(SUCCESS_REDIRECT_URI));
+    Optional<String> maybeRedirectUri = Optional.ofNullable(formData.get(REDIRECT_URI_KEY));
     if (maybeCurrentStatus.isEmpty()) {
       return badRequest(String.format("The %s field is not present", CURRENT_STATUS));
     }
@@ -379,14 +378,14 @@ public final class AdminApplicationController extends CiviFormController {
     if (maybeSendEmail.isEmpty()) {
       return badRequest(String.format("The %s field is not present", SEND_EMAIL));
     }
-    if (maybeSuccessRedirectUri.isEmpty()) {
-      return badRequest(String.format("The %s field is not present", SUCCESS_REDIRECT_URI));
+    if (maybeRedirectUri.isEmpty()) {
+      return badRequest(String.format("The %s field is not present", REDIRECT_URI_KEY));
     }
     // Verify the UI is changing from the actual current status to detect an out of date UI.
     if (application.getLatestStatus().isPresent()) {
       if (!application.getLatestStatus().get().equals(maybeCurrentStatus.get())) {
         // Only allow relative URLs to ensure that we redirect to the same domain.
-        String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeSuccessRedirectUri.orElse(""));
+        String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeRedirectUri.orElse(""));
         return redirect(redirectUrl)
             .flashing(
                 "error",
@@ -416,7 +415,7 @@ public final class AdminApplicationController extends CiviFormController {
             .build(),
         profileUtils.currentUserProfile(request).get().getAccount().join());
     // Only allow relative URLs to ensure that we redirect to the same domain.
-    String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeSuccessRedirectUri.orElse(""));
+    String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeRedirectUri.orElse(""));
     return redirect(redirectUrl).flashing("success", "Application status updated");
   }
 
@@ -448,13 +447,12 @@ public final class AdminApplicationController extends CiviFormController {
 
     Map<String, String> formData = formFactory.form().bindFromRequest(request).rawData();
     Optional<String> maybeNote = Optional.ofNullable(formData.get(NOTE));
-    Optional<String> maybeSuccessRedirectUri =
-        Optional.ofNullable(formData.get("successRedirectUri"));
+    Optional<String> maybeRedirectUri = Optional.ofNullable(formData.get(REDIRECT_URI_KEY));
     if (maybeNote.isEmpty()) {
       return badRequest("A note is not present.");
     }
     String note = maybeNote.get();
-    if (maybeSuccessRedirectUri.isEmpty()) {
+    if (maybeRedirectUri.isEmpty()) {
       return badRequest("A redirect URI is not present");
     }
 
@@ -464,7 +462,7 @@ public final class AdminApplicationController extends CiviFormController {
         profileUtils.currentUserProfile(request).get().getAccount().join());
 
     // Only allow relative URLs to ensure that we redirect to the same domain.
-    String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeSuccessRedirectUri.orElse(""));
+    String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeRedirectUri.orElse(""));
     return redirect(redirectUrl).flashing("success", "Application note updated");
   }
 

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -207,7 +207,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "sendEmail",
                             "",
@@ -241,7 +241,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "sendEmail",
                             "",
@@ -276,7 +276,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "sendEmail",
                             "",
@@ -309,7 +309,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "sendEmail",
                             "",
@@ -342,7 +342,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "currentStatus",
                             UNSET_STATUS_TEXT,
@@ -386,7 +386,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "sendEmail",
                             "",
@@ -425,7 +425,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             "currentStatus",
                             UNSET_STATUS_TEXT,
@@ -470,7 +470,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
                 Helpers.fakeRequest()
                     .bodyForm(
                         Map.of(
-                            "successRedirectUri",
+                            "redirectUri",
                             "/",
                             // Only "on" is a valid checkbox state.
                             "sendEmail",
@@ -565,8 +565,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                Helpers.fakeRequest().bodyForm(Map.of("successRedirectUri", "/", "note", noteText)))
+        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
             .build();
 
     // Execute.
@@ -596,8 +595,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                Helpers.fakeRequest().bodyForm(Map.of("successRedirectUri", "/", "note", noteText)))
+        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
             .build();
 
     // Execute.


### PR DESCRIPTION
### Description

The redirect is used more generally now (for errors and showing toasts also), so renaming the url param and cleaning up the code a tad.

## Release notes:

Renames a url parameter used in the application view page.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
