### PR TITLE
Fix jest warning

### DIFF
--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -2,13 +2,10 @@ module.exports = {
   preset: 'ts-jest',
   testMatch: ['**/__tests__/**/*.+(ts|js)', '**/?(*.)+(spec|test).+(ts|js)'],
   transform: {
-    '^.+\\.(ts)$': 'ts-jest',
+    '^.+\\.(ts)$': ['ts-jest', {
+      tsconfig: 'src/tsconfig.json',
+    }],
   },
   globalSetup: './src/delete_database.ts',
-  globals: {
-    'ts-jest': {
-      tsconfig: 'src/tsconfig.json',
-    },
-  },
   setupFilesAfterEnv: ['./src/support/setup-jest.ts'],
 }

--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -2,9 +2,12 @@ module.exports = {
   preset: 'ts-jest',
   testMatch: ['**/__tests__/**/*.+(ts|js)', '**/?(*.)+(spec|test).+(ts|js)'],
   transform: {
-    '^.+\\.(ts)$': ['ts-jest', {
-      tsconfig: 'src/tsconfig.json',
-    }],
+    '^.+\\.(ts)$': [
+      'ts-jest',
+      {
+        tsconfig: 'src/tsconfig.json',
+      },
+    ],
   },
   globalSetup: './src/delete_database.ts',
   setupFilesAfterEnv: ['./src/support/setup-jest.ts'],


### PR DESCRIPTION
Warning: 

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```