### PR TITLE
Add `client_id` to logout url when using login.gov

### DIFF
--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -76,7 +76,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
    * that the state is not saved and validated by the client, so it does not achive the goal of
    * "maintain state between the logout request and the callback" as specified by the spec.
    */
-  public void setStateGenerator(final ValueGenerator stateGenerator) {
+  public CiviformOidcLogoutActionBuilder setStateGenerator(final ValueGenerator stateGenerator) {
     if (stateGenerator == null) {
       this.stateGenerator = Optional.empty();
     }
@@ -87,7 +87,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
    * Additional url params to add to logout request. Some identity providers require including
    * client_id for example.
    */
-  public void setExtraParams(ImmutableMap<String, String> extraParams) {
+  public CiviformOidcLogoutActionBuilder setExtraParams(ImmutableMap<String, String> extraParams) {
     this.extraParams = extraParams;
   }
 

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -81,6 +81,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
       this.stateGenerator = Optional.empty();
     }
     this.stateGenerator = Optional.of(stateGenerator);
+    return this;
   }
 
   /**
@@ -89,6 +90,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
    */
   public CiviformOidcLogoutActionBuilder setExtraParams(ImmutableMap<String, String> extraParams) {
     this.extraParams = extraParams;
+    return this;
   }
 
   /**

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -39,7 +39,7 @@ import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
 public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuilder {
 
   private final Optional<String> postLogoutRedirectParam;
-  private final ImmutableMap<String, String> extraParams;
+  private ImmutableMap<String, String> extraParams;
   private Optional<ValueGenerator> stateGenerator = Optional.empty();
 
   public CiviformOidcLogoutActionBuilder(
@@ -81,6 +81,14 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
       this.stateGenerator = Optional.empty();
     }
     this.stateGenerator = Optional.of(stateGenerator);
+  }
+
+  /**
+   * Additional url params to add to logout request. Some identity providers require including
+   * client_id for example.
+   */
+  public void setExtraParams(ImmutableMap<String, String> extraParams) {
+    this.extraParams = extraParams;
   }
 
   /**

--- a/server/app/auth/oidc/applicant/LoginGovProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovProvider.java
@@ -96,10 +96,12 @@ public final class LoginGovProvider extends GenericOidcProvider {
     OidcClient client = super.get();
     var providerMetadata = client.getConfiguration().getProviderMetadata();
     providerMetadata.setCodeChallengeMethods(List.of(CodeChallengeMethod.S256));
-    CiviformOidcLogoutActionBuilder logoutBuilder =
-        (CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder();
-    logoutBuilder.setStateGenerator(stateGenerator);
-    logoutBuilder.setExtraParams(ImmutableMap.of("client_id", getClientID()));
+
+    // Apply logout settings specific to login.gov
+    ((CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder())
+        .setStateGenerator(stateGenerator)
+        // See https://developers.login.gov/oidc/#logout-request
+        .setExtraParams(ImmutableMap.of("client_id", getClientID()));
 
     return client;
   }

--- a/server/app/auth/oidc/applicant/LoginGovProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovProvider.java
@@ -4,6 +4,7 @@ import auth.ProfileFactory;
 import auth.oidc.CiviformOidcLogoutActionBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.typesafe.config.Config;
@@ -98,6 +99,7 @@ public final class LoginGovProvider extends GenericOidcProvider {
     CiviformOidcLogoutActionBuilder logoutBuilder =
         (CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder();
     logoutBuilder.setStateGenerator(stateGenerator);
+    logoutBuilder.setExtraParams(ImmutableMap.of("client_id", getClientID()));
 
     return client;
   }


### PR DESCRIPTION
### Description

Login.gov requires passing `client_id` in logout request: https://developers.login.gov/oidc/#logout-request This PR changes civiform to add such param automatically instead of each deployment using login.gov having to add extra environment variable. 

## Release notes:

Support login.gov logout out-of-box. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Issue #3621