### PR TITLE
Add dedicated Auth0 provider

### DIFF
--- a/server/app/auth/AuthIdentityProviderName.java
+++ b/server/app/auth/AuthIdentityProviderName.java
@@ -11,6 +11,7 @@ public enum AuthIdentityProviderName {
   ADFS_ADMIN("adfs"),
   GENERIC_OIDC_APPLICANT("generic-oidc"),
   LOGIN_GOV_APPLICANT("login-gov"),
+  AUTH0_APPLICANT("auth0"),
   DISABLED_APPLICANT("disabled");
 
   public static String AUTH_APPLICANT_CONFIG_PATH = "auth.applicant_idp";

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -1,6 +1,5 @@
 package auth.oidc;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
@@ -48,13 +47,7 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
       final State state) {
 
     super(uri, /* idTokenHint */ null, postLogoutRedirectURI, state);
-
-    if (Strings.isNullOrEmpty(postLogoutRedirectParam)) {
-      // default to OIDC spec
-      this.postLogoutRedirectParam = "post_logout_redirect_uri";
-    } else {
-      this.postLogoutRedirectParam = postLogoutRedirectParam;
-    }
+    this.postLogoutRedirectParam = postLogoutRedirectParam;
     this.postLogoutRedirectURI = postLogoutRedirectURI;
     if (extraParams == null) {
       this.extraParams = ImmutableMap.of();

--- a/server/app/auth/oidc/applicant/Auth0Provider.java
+++ b/server/app/auth/oidc/applicant/Auth0Provider.java
@@ -1,0 +1,62 @@
+package auth.oidc.applicant;
+
+import auth.ProfileFactory;
+import auth.oidc.CiviformOidcLogoutActionBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.typesafe.config.Config;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import javax.inject.Provider;
+import org.pac4j.oidc.client.OidcClient;
+import repository.UserRepository;
+
+/**
+ * Provider for auth0.com. Auth0 mostly implements OIDC protocol so it relies on base implementation
+ * of GenericOidcProvider. But Auth0 doesn't implement logout well which is encapsulated in this
+ * class.
+ *
+ * <p>https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
+ */
+public class Auth0Provider extends GenericOidcProvider {
+
+  @Inject
+  public Auth0Provider(
+      Config configuration,
+      ProfileFactory profileFactory,
+      Provider<UserRepository> applicantRepositoryProvider) {
+    super(configuration, profileFactory, applicantRepositoryProvider);
+  }
+
+  @Override
+  protected Optional<String> getProviderName() {
+    return getConfigurationValue("Auth0");
+  }
+
+  @Override
+  protected Optional<String> getLogoutURL() {
+    // Auth0 doesn't set end_session_endpoint like spec suggests.
+    // https://openid.net/specs/openid-connect-session-1_0-17.html#OPMetadata
+    // Instead, we need to set it to /v2/logout ourselves:
+    // https://auth0.com/docs/api/authentication#logout
+    try {
+      URL discoveryUri = new URL(getDiscoveryURI());
+      return Optional.of(new URL(discoveryUri, "/v2/logout").toString());
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Unparseable discovery URI used for applicant OIDC", e);
+    }
+  }
+
+  @Override
+  public OidcClient get() {
+    OidcClient client = super.get();
+
+    // See https://auth0.com/docs/api/authentication#logout
+    ((CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder())
+        .setPostLogoutRedirectParam("returnTo")
+        .setExtraParams(ImmutableMap.of("client_id", getClientID()));
+
+    return client;
+  }
+}

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -16,6 +16,7 @@ import auth.GuestClient;
 import auth.ProfileFactory;
 import auth.Roles;
 import auth.oidc.admin.AdfsProvider;
+import auth.oidc.applicant.Auth0Provider;
 import auth.oidc.applicant.GenericOidcProvider;
 import auth.oidc.applicant.IdcsProvider;
 import auth.oidc.applicant.LoginGovProvider;
@@ -163,6 +164,12 @@ public class SecurityModule extends AbstractModule {
               .annotatedWith(ApplicantAuthClient.class)
               .toProvider(LoginGovProvider.class);
           logger.info("Using login.gov PKCE OIDC for applicant auth provider");
+          break;
+        case AUTH0_APPLICANT:
+          bind(IndirectClient.class)
+              .annotatedWith(ApplicantAuthClient.class)
+              .toProvider(Auth0Provider.class);
+          logger.info("Using Auth0 for applicant auth provider");
           break;
         default:
           logger.info("No provider specified for for applicants");

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -1,0 +1,77 @@
+package auth.oidc.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.test.Helpers.fakeRequest;
+
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.net.URI;
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.play.PlayWebContext;
+import play.api.test.Helpers;
+import play.mvc.Http.Request;
+import repository.ResetPostgres;
+import repository.UserRepository;
+import support.CfTestHelpers;
+
+@RunWith(JUnitParamsRunner.class)
+public class Auth0ProviderTest extends ResetPostgres {
+  private Auth0Provider auth0Provider;
+  private static final String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static final String BASE_URL =
+      String.format("http://localhost:%d", Helpers.testServerPort());
+  private static final String CLIENT_ID = "someFakeClientId";
+
+  private static final SessionStore mockSessionStore = Mockito.mock(SessionStore.class);
+  private static final Request requestMock = fakeRequest().remoteAddress("1.1.1.1").build();
+  private static final PlayWebContext webContext = new PlayWebContext(requestMock);
+
+  @Before
+  public void setup() {
+    UserRepository userRepository = instanceOf(UserRepository.class);
+    ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    Config config =
+        ConfigFactory.parseMap(
+            ImmutableMap.<String, String>builder()
+                .put("applicant_generic_oidc.client_id", CLIENT_ID)
+                .put("applicant_generic_oidc.client_secret", "secret_here")
+                .put("applicant_generic_oidc.response_mode", "form_post")
+                .put("applicant_generic_oidc.response_type", "id_token")
+                .put("applicant_generic_oidc.email_attribute", "email")
+                .put("applicant_generic_oidc.discovery_uri", DISCOVERY_URI)
+                .put("base_url", BASE_URL)
+                .build());
+
+    // Just need some complete adaptor to access methods.
+    auth0Provider =
+        new Auth0Provider(
+            config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
+  }
+
+  @Test
+  public void testLogout() throws Exception {
+    String afterLogoutUri = "https://civiform.dev";
+    var logoutAction =
+        auth0Provider
+            .get()
+            .getLogoutAction(
+                webContext, mockSessionStore, new CiviFormProfileData(), afterLogoutUri);
+    assertThat(logoutAction).containsInstanceOf(FoundAction.class);
+    var logoutUri = new URI(((FoundAction) logoutAction.get()).getLocation());
+    assertThat(logoutUri)
+        // host and path come from DISCOVERY_URI
+        .hasHost("oidc")
+        .hasPath("/v2/logout")
+        .hasParameter("client_id", CLIENT_ID)
+        .hasParameter("returnTo", afterLogoutUri);
+  }
+}


### PR DESCRIPTION
### Description

We use Auth0 on staging and for browser tests. Auth0 implements OIDC protocol mostly well, except for logout. To support logout out-of-box this PR adds Auth0Provider class that contains logout-specific logic. The class inherits from GenericOidcProvider so it reuses existing logic for login.

## Release notes:

Support Auth0 as dedicated option for applicant auth. Including both login and logout flows.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Issue #3621
