### PR TITLE
Fix provider name for Auth0Provider

### DIFF
--- a/server/app/auth/oidc/applicant/Auth0Provider.java
+++ b/server/app/auth/oidc/applicant/Auth0Provider.java
@@ -31,7 +31,7 @@ public class Auth0Provider extends GenericOidcProvider {
 
   @Override
   protected Optional<String> getProviderName() {
-    return getConfigurationValue("Auth0");
+    return Optional.of("Auth0");
   }
 
   @Override

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -58,6 +58,11 @@ public class Auth0ProviderTest extends ResetPostgres {
   }
 
   @Test
+  public void testProviderName() {
+    assertThat(auth0Provider.getProviderName()).contains("Auth0");
+  }
+
+  @Test
   public void testLogout() throws Exception {
     String afterLogoutUri = "https://civiform.dev";
     var logoutAction =


### PR DESCRIPTION
### Description

I made a mistake in the original implementation. In the buggy implementation we were reading non-existing "Auth0" config setting and it fallback to "OidcClient". In the new we always return "Auth0". This change is safe as Auth0 is used only by our staging and I updated Auth0 application config to include new redirect URI.

