### PR TITLE
Remove shaded Preconditions import

### DIFF
--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -1,6 +1,6 @@
 package controllers.applicant;
 
-import static autovalue.shaded.com.google$.common.base.$Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static views.components.ToastMessage.ToastType.ALERT;
 


### PR DESCRIPTION
### Description

Unsure why this was originally favored but it is seemingly unnecessary and doesn't work with the new version of AutoValue 1.10 in #3635 

`
/usr/src/server/app/controllers/applicant/RedirectController.java:3:1: package autovalue.shaded.com.google$.common.base does not exist
`

Was added in https://github.com/civiform/civiform/commit/68db4b29dc31de11c764ef469c47f9ebb3472eca#diff-f4a4a51a33b341f6a641a7e55f3ca6b53da6af19bc2083ff114d04113cfc16c4

## Release notes:

Fix import by removing shaded checkNotNull usage in AutoValue

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
