### PR TITLE
Null check value

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -60,7 +60,7 @@ function makeBrowserContext(browser: Browser): Promise<BrowserContext> {
     // until it causes a problem. In practice, this
     // will only be used when debugging failures.
     const dirs = ['tmp/videos']
-    if ('expect' in global) {
+    if ('expect' in global && expect.getState() != null) {
       const testPath = expect.getState().testPath
       const testFile = testPath.substring(testPath.lastIndexOf('/') + 1)
       dirs.push(testFile)


### PR DESCRIPTION
### Description

Null check value as caught in new version of ts-jest v29.0.3 #3574 

```
Error: Jest: Got error running globalSetup - /usr/src/***-browser-tests/src/delete_database.ts, reason: [TSError: src/support/index.ts:64:24 - error TS2532: Object is possibly 'undefined'.

64       const testFile = testPath.substring(testPath.lastIndexOf('/') + 1)
                          ~~~~~~~~
src/support/index.ts:64:43 - error TS2532: Object is possibly 'undefined'.

64       const testFile = testPath.substring(testPath.lastIndexOf('/') + 1)
                                             ~~~~~~~~
src/support/index.ts:70:[19](https://github.com/civiform/civiform/actions/runs/3149234497/jobs/5120631108#step:9:20) - error TS2532: Object is possibly 'undefined'.

70         dirs.push(expect.getState().currentTestName.replace(/[:"<>|*?]/g, ''))
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]
```

## Release notes:

NA - testing cleanup

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
