### PR TITLE
Deduplicate browser test scripts

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -11,14 +11,9 @@ bin/pull-image
 # Additionally we map node_modules to a separate volume so that it doesn't
 # conflict with node_modules created locally.
 # --init enables https://github.com/krallin/tini
-# The display name returned by test_oidc_provider.js is <username>@example.com.
 docker run --rm -it \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
-  -e TEST_USER_AUTH_STRATEGY="fake-oidc" \
-  -e TEST_USER_LOGIN="testuser" \
-  -e TEST_USER_PASSWORD="anotsecretpassword" \
-  -e TEST_USER_DISPLAY_NAME="testuser@example.com" \
   --network "${DOCKER_NETWORK_NAME}" \
   --init \
   civiform/civiform-browser-test:latest \

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -10,16 +10,10 @@ export RECORD_VIDEO=1
 source bin/lib.sh
 docker::set_project_name_browser_tests
 
-docker volume create browser-tests-node-modules
 # The display name returned by test_oidc_provider.js is <username>@example.com.
 docker run \
   -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
-  -v "browser-tests-node-modules:/usr/src/civiform-browser-tests/node_modules" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
-  -e TEST_USER_AUTH_STRATEGY="fake-oidc" \
-  -e TEST_USER_LOGIN="testuser" \
-  -e TEST_USER_PASSWORD="anotsecretpassword" \
-  -e TEST_USER_DISPLAY_NAME="testuser@example.com" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -3,34 +3,11 @@
 # DOC: Run the browser tests locally. Requires browser test env already running.
 
 source bin/lib.sh
-export BASE_URL=http://localhost:9999
+# Disable screenshots for local tests because it will be use browser on current
+# machine which can be different from the browser used by browser-test docker
+# image and produce different screenshots.
 export DISABLE_SCREENSHOTS=true
-export TEST_USER_AUTH_STRATEGY=fake-oidc
-export TEST_USER_LOGIN=testuser
-export TEST_USER_PASSWORD=anotsecretpassword
-# The display name returned by test_oidc_provider.js is <username>@example.com.
-export TEST_USER_DISPLAY_NAME=testuser@example.com
+export BASE_URL=http://localhost:9999
 
-START_TIME=$(date +%s)
-DEADLINE=$(($START_TIME + 500))
-
-if ! output="$(node -v)"; then
-  echo output
-  echo "You must have node installed locally to run this command. Go to https://nodejs.org/en/download/package-manager/ for installation instructions."
-  exit 1
-fi
-
-npm install --force --prefix browser-test --quiet
-
-echo "Polling to check server start"
-
-until $(curl --output /dev/null --silent --head --fail --max-time 2 "${BASE_URL}"); do
-  if (($(date +%s) > "${DEADLINE}")); then
-    echo "Deadline exceeded waiting for server start"
-    exit 1
-  fi
-done
-
-echo "Detected server start"
-
-npm test --prefix browser-test "$@"
+cd browser-test
+bin/wait_for_server_start_and_run_tests.sh "$@"

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -4,15 +4,37 @@ set -euo pipefail
 
 START_TIME=$(date +%s)
 DEADLINE=$(($START_TIME + 500))
-SERVER_URL="http://civiform:9000"
+
+# Allow callers to override BASE_URL if they want (e.g. for run-browser-tests-local).
+# Defaults civiform:9000 when running from within docker.
+export BASE_URL="${BASE_URL:-http://civiform:9000}"
+
+export TEST_USER_AUTH_STRATEGY=fake-oidc
+export TEST_USER_LOGIN=testuser
+export TEST_USER_PASSWORD=anotsecretpassword
+# The display name returned by test_oidc_provider.js is <username>@example.com.
+export TEST_USER_DISPLAY_NAME=testuser@example.com
+
+if ! output="$(node -v)"; then
+  echo output
+  echo "You must have node installed locally to run this command. Go to https://nodejs.org/en/download/package-manager/ for installation instructions."
+  exit 1
+fi
+
+# Sanity check that this script was called from within browser-test directory.
+if [ ! -d "image_snapshots" ]; then
+  echo output
+  echo "$(basename "$0") must be run from within browser-test directory."
+  exit 1
+fi
 
 # Install any new packages not built into the image
 # Also saves any package-lock.json changes back to your local filesystem.
 npm install --force --quiet
 
-echo "Polling to check server start"
+echo "Polling to check server start. Server url: ${BASE_URL}"
 
-until $(curl --output /dev/null --silent --head --fail --max-time 2 "${SERVER_URL}"); do
+until $(curl --output /dev/null --silent --head --fail --max-time 2 "${BASE_URL}"); do
   if (($(date +%s) > "${DEADLINE}")); then
     echo "Deadline exceeded waiting for server start"
     exit 1
@@ -30,7 +52,7 @@ for arg; do
 done
 
 if (($debug == 1)); then
-  DEBUG="pw:api" BASE_URL="${SERVER_URL}" npm test "$@"
+  DEBUG="pw:api" npm test "$@"
 else
-  BASE_URL="${SERVER_URL}" npm test "$@"
+  npm test "$@"
 fi

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -43,16 +43,4 @@ done
 
 echo "Detected server start"
 
-debug=0
-for arg; do
-  shift
-  # if debug flag, set the var and leave it out of the forwarded args list
-  [ "$arg" = "--debug" ] && debug=1 && continue
-  set -- "$@" "$arg"
-done
-
-if (($debug == 1)); then
-  DEBUG="pw:api" npm test "$@"
-else
-  npm test "$@"
-fi
+npm test "$@"

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -22,6 +22,8 @@ if ! output="$(node -v)"; then
 fi
 
 # Sanity check that this script was called from within browser-test directory.
+# This is done by checking whether the current directory looks like browser-test:
+# it should contains image_snapshots subdirectory.
 if [ ! -d "image_snapshots" ]; then
   echo output
   echo "$(basename "$0") must be run from within browser-test directory."


### PR DESCRIPTION
### Description

Today we have 2 scripts that run browser tests: `bin/run-browser-tests-local` and `wait_for_server_start_and_run_tests.sh`. They do basically the same thing with the only difference in server urls they use to call CiviForm. This PR updates `bin/run-browser-tests-local` to call `wait_for_server_start_and_run_tests.sh` and have the latter the meaty logic of running tests. 

Additionally removes --debug option from `wait_for_server_start_and_run_tests.sh`. That option outputs extra API logs which I don't believe we use. We have different debugging approach described in https://docs.civiform.us/contributor-guide/developer-guide/testing#debugging-browser-tests that allows to run playwright inspector and step-through the code.

If some engineer will need to go deep into playwright debugging they can read guides like this: https://www.browserstack.com/guide/playwright-debugging and figure out which knobs need to be set.

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

