### PR TITLE
Fix SQL-related error that shows up when starting CiviForm with empty DB

### DIFF
--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -29,7 +29,11 @@ public final class DatabaseSeedModule extends AbstractModule {
       actorSystem
           .scheduler()
           .scheduleOnce(
-              Duration.ofMillis(10), () -> databaseSeedTaskProvider.get().run(), executionContext);
+              // schedule seed task for 5 sec from now. There is a race condition
+              // with Play evolutions. Evolutions must run before we seed database.
+              // It doesn't seem to be a way to run code after evolutions so just
+              // give them few sec to run.
+              Duration.ofSeconds(5), () -> databaseSeedTaskProvider.get().run(), executionContext);
     }
   }
 }


### PR DESCRIPTION
### Description

The exception is caused when seed database task runs before evolutions applied. This is not a great fix, but should be ok given that within the first five seconds unlikely anyone will be meaningfully using the app.

Error:

```
[error] a.d.TaskInvocation - Query threw SQLException:ERROR: relation "questions" does not exist
  Position: 335 Bind values:[] Query was:select t0.id, t0.name, t0.enumerator_id, t0.description, t0.legacy_question_text, t0.question_text, t0.legacy_question_help_text, t0.question_help_text, t0.question_type, t0.validation_predicates, t0.legacy_question_options, t0.question_options, t0.enumerator_entity_type, t0.question_tags, t0.create_time, t0.last_modified_time from questions t0 where t0.name = any(?) order by t0.id
javax.persistence.PersistenceException: Query threw SQLException:ERROR: relation "questions" does not exist
  Position: 335 Bind values:[] Query was:select t0.id, t0.name, t0.enumerator_id, t0.description, t0.legacy_question_text, t0.question_text, t0.legacy_question_help_text, t0.question_help_text, t0.question_type, t0.validation_predicates, t0.legacy_question_options, t0.question_options, t0.enumerator_entity_type, t0.question_tags, t0.create_time, t0.last_modified_time from questions t0 where t0.name = any(?) order by t0.id
	at io.ebean.config.dbplatform.SqlCodeTranslator.translate(SqlCodeTranslator.java:55)
	at io.ebean.config.dbplatform.DatabasePlatform.translate(DatabasePlatform.java:231)
	at io.ebeaninternal.server.query.CQueryEngine.translate(CQueryEngine.java:145)
	at io.ebeaninternal.server.query.DefaultOrmQueryEngine.translate(DefaultOrmQueryEngine.java:43)
	at io.ebeaninternal.server.core.OrmQueryRequest.translate(OrmQueryRequest.java:106)
	at io.ebeaninternal.server.query.CQuery.createPersistenceException(CQuery.java:692)
	at io.ebeaninternal.server.query.CQueryEngine.findMany(CQueryEngine.java:396)
	at io.ebeaninternal.server.query.DefaultOrmQueryEngine.findMany(DefaultOrmQueryEngine.java:131)
	at io.ebeaninternal.server.core.OrmQueryRequest.findList(OrmQueryRequest.java:470)
	at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1536)
	at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1515)
	at io.ebeaninternal.server.querydefn.DefaultOrmQuery.findList(DefaultOrmQuery.java:1604)
	at repository.QuestionRepository.getExistingQuestions(QuestionRepository.java:188)
	at services.question.QuestionService.getExistingQuestions(QuestionService.java:79)
	at tasks.DatabaseSeedTask.seedCanonicalQuestions(DatabaseSeedTask.java:110)
	at tasks.DatabaseSeedTask.run(DatabaseSeedTask.java:97)
	at modules.DatabaseSeedModule$DatabaseSeedScheduler.lambda$new$0(DatabaseSeedModule.java:32)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
```


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
