### PR TITLE
Improve logout handling in browser tests

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -231,14 +231,13 @@ export const gotoEndpoint = async (page: Page, endpoint: string) => {
 
 export const logout = async (page: Page) => {
   await page.click('text=Logout')
-  try {
-    const pageContent = await page.textContent('html', {timeout: 100})
+  console.log(page.url())
+  if (page.url().match('fake-idcs.*/session/end')) {
+    const pageContent = await page.textContent('html')
     if (pageContent!.includes('Do you want to sign-out from')) {
       // OIDC central provider confirmation page
       await page.click('button:has-text("Yes")')
     }
-  } catch (e) {
-    console.log(`failed to load logout page`)
   }
 
   // Logout is handled by the play framework so it doesn't land on a

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -231,6 +231,9 @@ export const gotoEndpoint = async (page: Page, endpoint: string) => {
 
 export const logout = async (page: Page) => {
   await page.click('text=Logout')
+  // If user logged through OIDC previous - during logout page they are
+  // redirected to fake-idcs:PORT/session/end page. There they need to confirm
+  // logout.
   if (page.url().match('fake-idcs.*/session/end')) {
     const pageContent = await page.textContent('html')
     if (pageContent!.includes('Do you want to sign-out from')) {

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -231,7 +231,6 @@ export const gotoEndpoint = async (page: Page, endpoint: string) => {
 
 export const logout = async (page: Page) => {
   await page.click('text=Logout')
-  console.log(page.url())
   if (page.url().match('fake-idcs.*/session/end')) {
     const pageContent = await page.textContent('html')
     if (pageContent!.includes('Do you want to sign-out from')) {


### PR DESCRIPTION
### Description

During logout we need to have extra logic only when user was properly logged through OIDC. In those cases we need to click on "Yes" button on OIDC logout page. In other cases we should just continue.

Also removes timeout from `textContent` call. That timeout caused errors sometimes that could explain flakiness. 

Ran github actions 3 times and no failures in browser tests
 
### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3669
