### PR TITLE
Add option to ignore npm version mismatch

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Run ESLint on browser tests
         working-directory: browser-test
+        # Remove --force once fixed https://github.com/civiform/civiform/issues/3678
         run: npm install --force && npx eslint . --ext .ts
 
       - name: Run ESLint on server

--- a/browser-test/.npmrc
+++ b/browser-test/.npmrc
@@ -1,0 +1,2 @@
+# Remove once is fixed https://github.com/civiform/civiform/issues/3678
+legacy-peer-deps=true

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -32,6 +32,7 @@ fi
 
 # Install any new packages not built into the image
 # Also saves any package-lock.json changes back to your local filesystem.
+# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
 npm install --force --quiet
 
 echo "Polling to check server start. Server url: ${BASE_URL}"

--- a/browser-test/package-lock.json
+++ b/browser-test/package-lock.json
@@ -6583,8 +6583,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -8041,8 +8040,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.0.0",

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -15,12 +15,14 @@ WORKDIR $PROJECT_DIR
 # get re-downloaded every time code changes.
 COPY package.json ${PROJECT_DIR}
 COPY package-lock.json ${PROJECT_DIR}
+# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
 RUN npm install --force
 RUN npx playwright install
 
 COPY . ${PROJECT_DIR}
 
 # Re-run, to install from cache after overriting it.
+# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
 RUN npm install --force
 RUN npx playwright install
 

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -54,6 +54,7 @@ cd server
 npm install --silent
 npx eslint --fix "app/assets/javascripts/**/*.ts"
 cd ../browser-test
+# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
 npm install --force --silent
 npx eslint --fix "src/**/*.ts"
 cd ..

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p $BROWSER_TEST_DIR
 COPY browser-test/package.json $BROWSER_TEST_DIR
 COPY browser-test/package-lock.json $BROWSER_TEST_DIR
 WORKDIR $BROWSER_TEST_DIR
+# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
 RUN npm install --force
 
 # Fetch node js dependencies for `server` directory.


### PR DESCRIPTION
### Description

See https://github.com/civiform/civiform/issues/3678 for more details. This PR adds `.npmrc` with option that ignores version mismatch. This is required for rennovate bot to be happy. Currently it fails to update some npm dependencies because it trips over that warning. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
