### PR TITLE
Fix no-unused-vars eslint check

### DIFF
--- a/formatter/eslintrc_base.json
+++ b/formatter/eslintrc_base.json
@@ -17,7 +17,10 @@
   "rules": {
     "require-jsdoc": "off",
     "valid-jsdoc": "warn",
-    "@typescript-eslint/no-unused-vars": "off", // overlaps with standard eslint no-unused-vars.
+    // default JS no-unused-vars causes false-positives on TS code. For example
+    // enums.
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
 
     // TODO(#3361): fix and reenable
     "@typescript-eslint/no-unsafe-member-access": "off",

--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -159,7 +159,7 @@ class AdminApplicationView {
     // Remember the original value here since neither the 'change/input' events provide the
     // previous selected value. We need to reset the value when the confirmation is rejected.
     const originalSelectedValue = statusSelector.value
-    statusSelector.addEventListener('change', (event) => {
+    statusSelector.addEventListener('change', () => {
       // Upon confirmation the model is responsible for reloading the page with the new status, so
       // don't await it and pro-actively reset the selection to the previous value for when the
       // user cancels the confirmation.

--- a/server/app/assets/javascripts/admin_validation.ts
+++ b/server/app/assets/javascripts/admin_validation.ts
@@ -102,5 +102,5 @@ class AdminValidationController {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const adminValidationController = new AdminValidationController()

--- a/server/app/assets/javascripts/modal.ts
+++ b/server/app/assets/javascripts/modal.ts
@@ -56,5 +56,5 @@ class ModalController {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const modalController = new ModalController()

--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -7,7 +7,6 @@ class PreviewController {
     'question-enumerator-select'
   private static readonly QUESTION_ENTITY_TYPE_INPUT_ID =
     'enumerator-question-entity-type-input'
-  private static readonly QUESTION_ADD_OPTION_ID = 'add-new-option'
   private static readonly QUESTION_SETTINGS_ID = 'question-settings'
   private static readonly QUESTION_ENTITY_TYPE_BUTTON_ID =
     'enumerator-field-add-button'
@@ -64,7 +63,7 @@ class PreviewController {
     if (textInput) {
       textInput.addEventListener(
         'input',
-        (ev) => {
+        () => {
           PreviewController.updateFromNewQuestionText(textInput.value)
         },
         false,
@@ -77,7 +76,7 @@ class PreviewController {
     if (helpTextInput) {
       helpTextInput.addEventListener(
         'input',
-        (ev) => {
+        () => {
           PreviewController.updateFromNewQuestionHelpText(helpTextInput.value)
         },
         false,
@@ -90,7 +89,7 @@ class PreviewController {
     if (enumeratorSelector) {
       enumeratorSelector.addEventListener(
         'input',
-        (ev) => {
+        () => {
           PreviewController.updateFromNewEnumeratorSelector(
             enumeratorSelector.value,
           )
@@ -107,7 +106,7 @@ class PreviewController {
     if (entityTypeInput) {
       entityTypeInput.addEventListener(
         'input',
-        (ev) => {
+        () => {
           PreviewController.updateFromNewEntityType(entityTypeInput.value)
         },
         false,
@@ -439,5 +438,5 @@ class PreviewController {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const previewController = new PreviewController()

--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -237,5 +237,5 @@ type ToastMessage = {
   type: string
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const toastController = new ToastController()


### PR DESCRIPTION
### Description

We've been using standard check that's intended for JS code. But our codebase is 95% TS and the standard check triggers false positives on some TS code. This PR updates config to use TS check. Additionally removes few unused parameters that were detected when the check was enabled. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
