### PR TITLE
Don't use github secrets for dockerhub username

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -49,7 +49,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: ${{ matrix.script }}
 
   build_dependancies:
@@ -122,5 +122,5 @@ jobs:
           DOCKER_BUILDKIT: 1
           PLATFORM: ${{ matrix.platform }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: ${{ matrix.script }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          username: civiform
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Run bin/create-release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,19 +53,19 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-browser-tests
       - name: Build dev-oidc
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-dev-oidc
       - name: Build localstack
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-localstack-env
       - name: Bring up test env with Localstack
         run: bin/run-browser-test-env --aws --ci
@@ -110,19 +110,19 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-browser-tests
       - name: Build dev-oidc
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-dev-oidc
       - name: Build localstack
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_USERNAME: civiform
         run: bin/build-localstack-env
       - name: Bring up test env with Azurite
         run: bin/run-browser-test-env --azure --ci


### PR DESCRIPTION
### Description

Dockerhub username is well known - "civiform". There is no security benefit if having it as secret. The only benefit it provides is sharing it across multple github action files, simplifying its update if we even need to use a different account.

However the downside is that github clears all mentions of string "civiform" from logs replacing them with *** which makes logs confusing and hard to read. Example:

![image](https://user-images.githubusercontent.com/252053/196834095-27e5718d-84b4-4751-8a14-bb1770975455.png)


### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
