### PR TITLE
Add screen reader text for errors for translation

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -47,6 +47,7 @@ public enum MessageKey {
   CONTENT_OR("content.or"),
   CONTENT_PLEASE_CREATE_ACCOUNT("content.pleaseCreateAccount"),
   CONTENT_SELECT_LANGUAGE("label.selectLanguage"),
+  ERROR_ANNOUNCEMENT_SR("validation.errorAnnouncementSr"),
   ERROR_NOT_FOUND_TITLE("error.notFoundTitle"),
   ERROR_NOT_FOUND_DESCRIPTION("error.notFoundDescription"),
   ERROR_NOT_FOUND_DESCRIPTION_LINK("error.notFoundDescriptionLink"),

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -42,6 +42,9 @@ validation.isRequired=This question is required.
 # Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Please enter valid input.
 
+# Error message announced to screen reader when there are errors on the current page.
+validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
+
 # Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
 


### PR DESCRIPTION
### Description

This will be used to announce that errors are present for screen reader users. I checked with UX that this text sounds good.

## Release notes:

N/A

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3563 