### PR TITLE
Add screen reader text describing program preview page links

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -17,6 +17,8 @@ public enum MessageKey {
   ADDRESS_VALIDATION_NO_PO_BOX("validation.noPoBox"),
   ADDRESS_VALIDATION_STATE_REQUIRED("validation.stateRequired"),
   ADDRESS_VALIDATION_STREET_REQUIRED("validation.streetRequired"),
+  ARIA_LABEL_BEGIN("ariaLabel.begin"),
+  ARIA_LABEL_CONTINUE("ariaLabel.continue"),
   ARIA_LABEL_EDIT("ariaLabel.edit"),
   BUTTON_APPLY("button.apply"),
   BUTTON_APPLY_SR("button.applySr"),

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -191,6 +191,14 @@ link.begin=Start here
 # The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Edit
 
+# An aria-label for screen readers that helps provide context for the associated continue link. The link is for a specific
+# question, so this might say "Continue. What is your name?". The {0} variable is the question text.
+ariaLabel.continue=Continue. {0}
+
+# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
+# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
+ariaLabel.begin=Start here. {0}
+
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}


### PR DESCRIPTION
### Description

Add new sr text to be translated. Not used yet.

This will be used for the program preview page links. Currently it always reads "Edit" to screen readers, even when the visual labels are "Start here" and "Continue".

## Release notes:

N/A

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

#3559
