### PR TITLE
Update openjdk image to 11.0.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:11.0.16_8-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.16-8 as arm64
+FROM bellsoft/liberica-openjdk-alpine:11.0.17-7 as arm64
 
 FROM ${TARGETARCH}
 

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -4,7 +4,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:11.0.16_8-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.16-8 as arm64
+FROM bellsoft/liberica-openjdk-alpine:11.0.17-7 as arm64
 
 FROM ${TARGETARCH}
 


### PR DESCRIPTION
### Description

Version 11.0.7 should contain fixes for https://openjdk.org/groups/vulnerability/advisories/2022-10-18. This images are used only for development images. For production image we are still using 11.0.16 because amd64/eclipse-temurin haven't pushed updated version yet. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Issue #3674