### PR TITLE
Update pac4j to 5.6.1 and logback to 1.3.4

### DIFF
--- a/server/app/auth/oidc/admin/AdfsProfileAdapter.java
+++ b/server/app/auth/oidc/admin/AdfsProfileAdapter.java
@@ -5,8 +5,8 @@ import auth.ProfileFactory;
 import auth.Roles;
 import auth.oidc.OidcProfileAdapter;
 import com.google.common.collect.ImmutableSet;
-import com.nimbusds.jose.shaded.json.JSONArray;
 import com.typesafe.config.Config;
+import java.util.List;
 import javax.inject.Provider;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
@@ -65,11 +65,12 @@ public class AdfsProfileAdapter extends OidcProfileAdapter {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private boolean isGlobalAdmin(OidcProfile profile) {
-    JSONArray groups = (JSONArray) null;
-    if (profile.containsAttribute(this.ad_groups_attribute_name)) {
-      groups = profile.getAttribute(this.ad_groups_attribute_name, JSONArray.class);
-    }
+    List<Object> groups =
+        profile.containsAttribute(this.ad_groups_attribute_name)
+            ? profile.getAttribute(this.ad_groups_attribute_name, List.class)
+            : null;
 
     if (groups == null) {
       logger.error("Missing group claim in ADFS OIDC profile.");

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -65,13 +65,13 @@ lazy val root = (project in file("."))
       // Security libraries
       // pac4j core (https://github.com/pac4j/play-pac4j)
       "org.pac4j" %% "play-pac4j" % "11.1.0-PLAY2.8",
-      "org.pac4j" % "pac4j-core" % "5.4.5",
+      "org.pac4j" % "pac4j-core" % "5.6.1",
       // basic http authentication (for the anonymous client)
-      "org.pac4j" % "pac4j-http" % "5.4.5",
+      "org.pac4j" % "pac4j-http" % "5.6.1",
       // OIDC authentication
-      "org.pac4j" % "pac4j-oidc" % "5.4.5",
+      "org.pac4j" % "pac4j-oidc" % "5.6.1",
       // SAML authentication
-      "org.pac4j" % "pac4j-saml" % "5.4.5",
+      "org.pac4j" % "pac4j-saml" % "5.6.1",
 
       // Encrypted cookies require encryption.
       "org.apache.shiro" % "shiro-crypto-cipher" % "1.10.0",
@@ -97,7 +97,11 @@ lazy val root = (project in file("."))
       "commons-net" % "commons-net" % "3.8.0",
 
       // Url detector for program descriptions.
-      "com.linkedin.urls" % "url-detector" % "0.1.17"
+      "com.linkedin.urls" % "url-detector" % "0.1.17",
+
+      // Override defaul Play logback version. We need to use logback
+      // compatible with sl4j 2.0 because the latter pulled in by pac4j.
+      "ch.qos.logback" % "logback-classic" % "1.3.4"
     ),
     javacOptions ++= Seq(
       "-encoding",


### PR DESCRIPTION
### Description

Pac4j update pulls in slf4j API 2.0. Which breaks logging as logback 1.2 used by Play framework by default is not compatible with slf4j 2.0. Updating logback to 1.3 seems to just work. I tried it few months ago and there were still some issues. But not it looks ok. Things I tested:

1. Deployed civiform with updated logback and pac4j dependencies.
2. Logged in as admin to make sure that upated AdfsProfileAdapter works.
3. Ensured that logs are emitted and available in AWS console.  

## Release notes:

Update pac4j to 5.6.1 and logback to 1.3.4

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Fixes #3260