### PR TITLE
PredicateController and View code and comment clarity

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -58,7 +58,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   }
 
   /**
-   * Return a HTML page containing current show-hide configurations and forms to edit the
+   * Return an HTML page containing current show-hide configurations and forms to edit the
    * configurations.
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
@@ -99,54 +99,53 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       return redirect(
               routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
           .flashing("error", errorMessageBuilder.toString());
-    } else {
-      // TODO(https://github.com/seattle-uat/civiform/issues/322): Implement complex predicates.
-      //  Right now we only support "leaf node" predicates (a single logical statement based on one
-      //  question). In the future we should support logical statements that combine multiple "leaf
-      //  node" predicates with ANDs and ORs.
-      BlockVisibilityPredicateForm predicateForm = predicateFormWrapper.get();
+    }
 
-      Scalar scalar = Scalar.valueOf(predicateForm.getScalar());
-      Operator operator = Operator.valueOf(predicateForm.getOperator());
-      PredicateValue predicateValue =
-          parsePredicateValue(
-              scalar,
-              operator,
-              predicateForm.getPredicateValue(),
-              predicateForm.getPredicateValues());
+    // TODO(https://github.com/seattle-uat/civiform/issues/322): Implement complex predicates.
+    //  Right now we only support "leaf node" predicates (a single logical statement based on one
+    //  question). In the future we should support logical statements that combine multiple "leaf
+    //  node" predicates with ANDs and ORs.
+    BlockVisibilityPredicateForm predicateForm = predicateFormWrapper.get();
 
-      LeafOperationExpressionNode leafExpression =
-          LeafOperationExpressionNode.create(
-              predicateForm.getQuestionId(), scalar, operator, predicateValue);
-      PredicateAction action = PredicateAction.valueOf(predicateForm.getPredicateAction());
-      PredicateDefinition predicateDefinition =
-          PredicateDefinition.create(PredicateExpressionNode.create(leafExpression), action);
+    Scalar scalar = Scalar.valueOf(predicateForm.getScalar());
+    Operator operator = Operator.valueOf(predicateForm.getOperator());
+    PredicateValue predicateValue =
+        parsePredicateValue(
+            scalar,
+            operator,
+            predicateForm.getPredicateValue(),
+            predicateForm.getPredicateValues());
 
-      try {
-        programService.setBlockPredicate(programId, blockDefinitionId, predicateDefinition);
-      } catch (ProgramNotFoundException e) {
-        return notFound(String.format("Program ID %d not found.", programId));
-      } catch (ProgramBlockDefinitionNotFoundException e) {
-        return notFound(
-            String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
-      } catch (IllegalPredicateOrderingException e) {
-        return redirect(
-                routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
-            .flashing("error", e.getLocalizedMessage());
-      }
+    LeafOperationExpressionNode leafExpression =
+        LeafOperationExpressionNode.create(
+            predicateForm.getQuestionId(), scalar, operator, predicateValue);
+    PredicateAction action = PredicateAction.valueOf(predicateForm.getPredicateAction());
+    PredicateDefinition predicateDefinition =
+        PredicateDefinition.create(PredicateExpressionNode.create(leafExpression), action);
 
-      ReadOnlyQuestionService roQuestionService =
-          questionService.getReadOnlyQuestionService().toCompletableFuture().join();
-
+    try {
+      programService.setBlockPredicate(programId, blockDefinitionId, predicateDefinition);
+    } catch (ProgramNotFoundException e) {
+      return notFound(String.format("Program ID %d not found.", programId));
+    } catch (ProgramBlockDefinitionNotFoundException e) {
+      return notFound(
+          String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
+    } catch (IllegalPredicateOrderingException e) {
       return redirect(
               routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
-          .flashing(
-              "success",
-              String.format(
-                  "Saved visibility condition: %s %s",
-                  action.toDisplayString(),
-                  leafExpression.toDisplayString(roQuestionService.getUpToDateQuestions())));
+          .flashing("error", e.getLocalizedMessage());
     }
+
+    ReadOnlyQuestionService roQuestionService =
+        questionService.getReadOnlyQuestionService().toCompletableFuture().join();
+
+    return redirect(routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+        .flashing(
+            "success",
+            String.format(
+                "Saved visibility condition: %s %s",
+                action.toDisplayString(),
+                leafExpression.toDisplayString(roQuestionService.getUpToDateQuestions())));
   }
 
   /** POST endpoint for deleting show-hide configurations. */

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -139,16 +139,14 @@ public final class ProgramBlockPredicatesEditView extends ProgramBlockView {
                 div()
                     .with(
                         h2(H2_CURRENT_VISIBILITY_CONDITION).withClasses("font-semibold", "text-lg"))
-                    .condWith(
-                        blockDefinition.visibilityPredicate().isPresent(),
+                    .with(
                         div(blockDefinition
                                 .visibilityPredicate()
-                                .get()
-                                .toDisplayString(blockDefinition.name(), predicateQuestions))
-                            .withClasses(ReferenceClasses.PREDICATE_DISPLAY))
-                    .condWith(
-                        blockDefinition.visibilityPredicate().isEmpty(),
-                        div(TEXT_NO_VISIBILITY_CONDITIONS)
+                                .map(
+                                    pred ->
+                                        pred.toDisplayString(
+                                            blockDefinition.name(), predicateQuestions))
+                                .orElse(TEXT_NO_VISIBILITY_CONDITIONS))
                             .withClasses(ReferenceClasses.PREDICATE_DISPLAY)))
             // Show the control to remove the current predicate.
             .with(removePredicateForm)


### PR DESCRIPTION
### Description

Updated docs, coding and naming for clarity.

## Release notes:

NA

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
