### PR TITLE
Update Oncall Template to use #CI Slack Channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/oncall-rotation.md
+++ b/.github/ISSUE_TEMPLATE/oncall-rotation.md
@@ -31,5 +31,5 @@ Resources:
 
 - [ ] Create an Oncall issue for the next rotation
 - [ ] Check Security lists daily
-- [ ] Check #deployment-bot Slack channel daily to monitor failed pushes
+- [ ] Check #ci Slack channel daily to monitor failed pushes
 - [ ] Check Dependency updates once


### PR DESCRIPTION
Because we renamed #Deployment-Bot to #CI in Slack