### PR TITLE
Add new database for unit and browser tests to dev postgres

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,6 +54,7 @@ services:
       # isolate and persist dev database.
       - project-data:/project
       - db-data:/var/lib/postgresql/data
+      - ./init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
 
   pgadmin:
     profiles: ['pgadmin']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,10 +47,6 @@ services:
     expose:
       - '9000'
       - '8457'
-    volumes:
-      # Needed for unit tests running in github actions to upload coverage
-      # when tests finish.
-      - ./server/code-coverage:/usr/src/server/code-coverage
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - '5432'
     environment:
       POSTGRES_PASSWORD: example
+    volumes:
+      - ./init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
 
   civiform:
     image: civiform-dev
@@ -45,6 +47,10 @@ services:
     expose:
       - '9000'
       - '8457'
+    volumes:
+      # Needed for unit tests running in github actions to upload coverage
+      # when tests finish.
+      - ./server/code-coverage:/usr/src/server/code-coverage
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}

--- a/init_postgres.sql
+++ b/init_postgres.sql
@@ -1,0 +1,6 @@
+-- Initialize databases used for unit tests and browser tests.
+-- Those databases are separated from the default database as they are wiped out
+-- by tests while the default database used by the developer.
+CREATE DATABASE unittests;
+GRANT ALL PRIVILEGES ON DATABASE unittests TO postgres;
+

--- a/init_postgres.sql
+++ b/init_postgres.sql
@@ -2,5 +2,7 @@
 -- Those databases are separated from the default database as they are wiped out
 -- by tests while the default database used by the developer.
 CREATE DATABASE unittests;
+CREATE DATABASE browsertests;
 GRANT ALL PRIVILEGES ON DATABASE unittests TO postgres;
+GRANT ALL PRIVILEGES ON DATABASE browsertests TO postgres;
 

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -1,6 +1,11 @@
 # Configuration for the dev browser test CiviForm server.
 include "application.dev.conf"
 
+db {
+  default.driver = org.postgresql.Driver
+  default.url = "jdbc:postgresql://db:5432/browsertests"
+}
+
 # The dev server turns somethings on by default so
 # they're easier to see and use.
 # Browser tests shouldn't turn features on by default,

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -8,7 +8,7 @@ play.modules {
 
 db {
   default.driver = org.postgresql.Driver
-  default.url = "jdbc:postgresql://db:5432/postgres"
+  default.url = "jdbc:postgresql://db:5432/unittests"
 }
 
 play.evolutions.db.default.enabled = "true"

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRES_PASSWORD: example
     volumes:
-    - ../init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
+      - ../init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
 
   oidc:
     image: civiform/oidc-provider

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - '5432'
     environment:
       POSTGRES_PASSWORD: example
+    volumes:
+    - ../init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
 
   oidc:
     image: civiform/oidc-provider


### PR DESCRIPTION
### Description

This PR adds an `init_postgres.sql` script that is mapped to postgres container upon startup. The script creates additional database to be used by unit tests. That way same database can be used by multiple users without overriding each other data. For example for local development and for unit testing which wipes out data between runs. 

In follow up PRs I'm going to change unit tests to use the same environment as dev.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3727
