### PR TITLE
Use same dev-oidc host/port in unit tests as in dev

### DIFF
--- a/server/test/app/SecurityBrowserTest.java
+++ b/server/test/app/SecurityBrowserTest.java
@@ -24,7 +24,7 @@ public class SecurityBrowserTest extends BaseBrowserTest {
   protected Application provideApplication() {
     ImmutableMap<String, Object> config =
         new ImmutableMap.Builder<String, Object>()
-            .putAll(CfTestHelpers.oidcConfig("oidc", 3380))
+            .putAll(CfTestHelpers.oidcConfig("dev-oidc", 3390))
             .build();
     return fakeApplication(config);
   }

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -41,8 +41,8 @@ public class ProfileMergeTest extends ResetPostgres {
   public void setupFactory() {
     profileFactory = instanceOf(ProfileFactory.class);
     userRepository = instanceOf(UserRepository.class);
-    OidcClient client = CfTestHelpers.getOidcClient("oidc", 3380);
-    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("oidc", 3380);
+    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
+    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
     idcsProfileAdapter =
         new IdcsProfileAdapter(

--- a/server/test/auth/oidc/OidcProfileAdapterTest.java
+++ b/server/test/auth/oidc/OidcProfileAdapterTest.java
@@ -35,8 +35,8 @@ public class OidcProfileAdapterTest extends ResetPostgres {
   public void setup() {
     userRepository = instanceOf(UserRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
-    OidcClient client = CfTestHelpers.getOidcClient("oidc", 3380);
-    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("oidc", 3380);
+    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
+    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
     oidcProfileAdapter =
         new IdcsProfileAdapter(

--- a/server/test/auth/oidc/OidcProviderTest.java
+++ b/server/test/auth/oidc/OidcProviderTest.java
@@ -29,7 +29,7 @@ public class OidcProviderTest extends ResetPostgres {
   private OidcProvider oidcProvider;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
-  private static String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static String DISCOVERY_URI = "http://dev-oidc:3390/.well-known/openid-configuration";
   private static String BASE_URL = String.format("http://localhost:%d", Helpers.testServerPort());
 
   @Before

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -26,7 +26,8 @@ import support.CfTestHelpers;
 @RunWith(JUnitParamsRunner.class)
 public class Auth0ProviderTest extends ResetPostgres {
   private Auth0Provider auth0Provider;
-  private static final String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static final String DISCOVERY_URI =
+      "http://dev-oidc:3390/.well-known/openid-configuration";
   private static final String BASE_URL =
       String.format("http://localhost:%d", Helpers.testServerPort());
   private static final String CLIENT_ID = "someFakeClientId";
@@ -74,7 +75,7 @@ public class Auth0ProviderTest extends ResetPostgres {
     var logoutUri = new URI(((FoundAction) logoutAction.get()).getLocation());
     assertThat(logoutUri)
         // host and path come from DISCOVERY_URI
-        .hasHost("oidc")
+        .hasHost("dev-oidc")
         .hasPath("/v2/logout")
         .hasParameter("client_id", CLIENT_ID)
         .hasParameter("returnTo", afterLogoutUri);

--- a/server/test/auth/oidc/applicant/GenericOidcProfileAdapterTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcProfileAdapterTest.java
@@ -36,8 +36,8 @@ public class GenericOidcProfileAdapterTest extends ResetPostgres {
   public void setup() {
     userRepository = instanceOf(UserRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
-    OidcClient client = CfTestHelpers.getOidcClient("oidc", 3380);
-    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("oidc", 3380);
+    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
+    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
     oidcProfileAdapter =
         new GenericOidcProfileAdapter(

--- a/server/test/auth/oidc/applicant/GenericOidcProviderTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcProviderTest.java
@@ -25,7 +25,7 @@ public class GenericOidcProviderTest extends ResetPostgres {
   private GenericOidcProvider genericOidcProvider;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
-  private static String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static String DISCOVERY_URI = "http://dev-oidc:3390/.well-known/openid-configuration";
   private static String BASE_URL = String.format("http://localhost:%d", Helpers.testServerPort());
 
   @Before

--- a/server/test/auth/oidc/applicant/IdcsProviderTest.java
+++ b/server/test/auth/oidc/applicant/IdcsProviderTest.java
@@ -23,7 +23,7 @@ public class IdcsProviderTest extends ResetPostgres {
   private IdcsProvider idcsProvider;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
-  private static String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static String DISCOVERY_URI = "http://dev-oidc:3390/.well-known/openid-configuration";
   private static String BASE_URL = String.format("http://localhost:%d", Helpers.testServerPort());
 
   @Before

--- a/server/test/auth/oidc/applicant/LoginGovProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovProviderTest.java
@@ -29,7 +29,8 @@ import support.CfTestHelpers;
 @RunWith(JUnitParamsRunner.class)
 public class LoginGovProviderTest extends ResetPostgres {
   private LoginGovProvider loginGovProvider;
-  private static final String DISCOVERY_URI = "http://oidc:3380/.well-known/openid-configuration";
+  private static final String DISCOVERY_URI =
+      "http://dev-oidc:3390/.well-known/openid-configuration";
   private static final String BASE_URL =
       String.format("http://localhost:%d", Helpers.testServerPort());
   private static final String CLIENT_ID = "login:gov:client";
@@ -120,7 +121,7 @@ public class LoginGovProviderTest extends ResetPostgres {
     var logoutUri = new URI(((FoundAction) logoutAction.get()).getLocation());
     assertThat(logoutUri)
         // host and path come from DISCOVERY_URI
-        .hasHost("oidc")
+        .hasHost("dev-oidc")
         .hasPath("/session/end")
         .hasParameter("state")
         .hasParameter("client_id", CLIENT_ID)

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -15,6 +15,8 @@ services:
     restart: always
     expose:
       - 3390
+    environment:
+      - OIDC_PORT=3390
 
   civiform:
     image: civiform-dev
@@ -33,7 +35,7 @@ services:
     environment:
       - IDCS_CLIENT_ID=idcs-fake-oidc-client
       - IDCS_SECRET=idcs-fake-oidc-secret
-      - IDCS_DISCOVERY_URI=http://oidc:3380/.well-known/openid-configuration
+      - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
       - BASE_URL=http://localhost:9000
       - CIVIFORM_TIME_ZONE_ID

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -8,18 +8,18 @@ services:
     environment:
       POSTGRES_PASSWORD: example
 
-  oidc:
+  dev-oidc:
     image: civiform/oidc-provider
     restart: always
-    ports: # For debugging
-      - 3380:3380
+    expose:
+      - 3390
 
   civiform:
     image: civiform-dev
     restart: always
     links:
       - 'db:database'
-      - 'oidc'
+      - 'dev-oidc'
     volumes:
       - ../server/code-coverage:/usr/src/server/code-coverage
     entrypoint: /bin/bash


### PR DESCRIPTION
### Description

This allows to run unit tests during development from the same sbt instance from which developer run server. Removed exposing port to host as I don't see the use case. The comment said for debugging, but I struggle to think of a usecase where one might need to debug specifically unit test environment and not from the container, but from the developer host machine.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3727
