### PR TITLE
Clean up updatePredicateNode

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -344,7 +344,7 @@ public final class VersionRepository {
     // ErrorProne will require the switch handle all types since there isn't a default, we should
     // never get here.
     throw new AssertionError(
-        String.format("Predicate type is unhandled and must be %s", node.getType()));
+        String.format("Predicate type is unhandled and must be: %s", node.getType()));
   }
 
   /**

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -341,6 +341,9 @@ public final class VersionRepository {
         return PredicateExpressionNode.create(
             leaf.toBuilder().setQuestionId(updated.orElseThrow().id).build());
     }
+    // ErrorProne will require the switch handle all types since there isn't a default, we should
+    // never get here.
+    throw new AssertionError("Predicate type is unhandled and must be %s", node.getType());
   }
 
   /**

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -302,40 +302,44 @@ public final class VersionRepository {
       PredicateDefinition oldPredicate = block.visibilityPredicate().get();
       updatedBlock.setVisibilityPredicate(
           PredicateDefinition.create(
-              updatePredicateNode(oldPredicate.rootNode()), oldPredicate.action()));
+              updatePredicateNodeVersions(oldPredicate.rootNode()), oldPredicate.action()));
     }
     if (block.optionalPredicate().isPresent()) {
       PredicateDefinition oldPredicate = block.optionalPredicate().get();
       updatedBlock.setOptionalPredicate(
           Optional.of(
               PredicateDefinition.create(
-                  updatePredicateNode(oldPredicate.rootNode()), oldPredicate.action())));
+                  updatePredicateNodeVersions(oldPredicate.rootNode()), oldPredicate.action())));
     }
     return updatedBlock.build();
   }
 
-  // Update the referenced question IDs in all leaf nodes. Since nodes are immutable, we
-  // recursively recreate the tree with updated leaf nodes.
+  /**
+   * Updates the referenced question IDs in all leaf nodes of {@code node} to the latest versions.
+   *
+   * <p>Since nodes are immutable, we recursively recreate the tree with updated leaf nodes and
+   * return it.
+   */
   @VisibleForTesting
-  PredicateExpressionNode updatePredicateNode(PredicateExpressionNode current) {
-    switch (current.getType()) {
+  PredicateExpressionNode updatePredicateNodeVersions(PredicateExpressionNode node) {
+    switch (node.getType()) {
       case AND:
-        AndNode and = current.getAndNode();
+        AndNode and = node.getAndNode();
         ImmutableSet<PredicateExpressionNode> updatedAndChildren =
-            and.children().stream().map(this::updatePredicateNode).collect(toImmutableSet());
+            and.children().stream()
+                .map(this::updatePredicateNodeVersions)
+                .collect(toImmutableSet());
         return PredicateExpressionNode.create(AndNode.create(updatedAndChildren));
       case OR:
-        OrNode or = current.getOrNode();
+        OrNode or = node.getOrNode();
         ImmutableSet<PredicateExpressionNode> updatedOrChildren =
-            or.children().stream().map(this::updatePredicateNode).collect(toImmutableSet());
+            or.children().stream().map(this::updatePredicateNodeVersions).collect(toImmutableSet());
         return PredicateExpressionNode.create(OrNode.create(updatedOrChildren));
       case LEAF_OPERATION:
-        LeafOperationExpressionNode leaf = current.getLeafNode();
+        LeafOperationExpressionNode leaf = node.getLeafNode();
         Optional<Question> updated = getLatestVersionOfQuestion(leaf.questionId());
         return PredicateExpressionNode.create(
             leaf.toBuilder().setQuestionId(updated.orElseThrow().id).build());
-      default:
-        return current;
     }
   }
 

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -343,7 +343,8 @@ public final class VersionRepository {
     }
     // ErrorProne will require the switch handle all types since there isn't a default, we should
     // never get here.
-    throw new AssertionError("Predicate type is unhandled and must be %s", node.getType());
+    throw new AssertionError(
+        String.format("Predicate type is unhandled and must be %s", node.getType()));
   }
 
   /**

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -319,7 +319,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     PredicateExpressionNode and =
         PredicateExpressionNode.create(AndNode.create(ImmutableSet.of(leafOne, or)));
 
-    PredicateExpressionNode updated = versionRepository.updatePredicateNode(and);
+    PredicateExpressionNode updated = versionRepository.updatePredicateNodeVersions(and);
 
     // The tree should have the same structure, just with question IDs for the draft version.
     PredicateExpressionNode expectedLeafOne =


### PR DESCRIPTION
### Description

Updates updatePredicateNode to updatePredicateNodeVersions for clarity and consistency with other sibling methods.

Remove default in switch handling for node types.  We should explicitly handle each type; currently all 3 are so removal has no effect and ErrorProne will detect new ones that aren't explicitly handled in MissingCasesInEnumSwitch

## Release notes:

NA

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
