### PR TITLE
Refactor question bank to support multiple blocks

### DIFF
--- a/server/app/assets/javascripts/questionBank.ts
+++ b/server/app/assets/javascripts/questionBank.ts
@@ -1,5 +1,16 @@
-/** The question bank controller is responsible for manipulating the question bank. */
-
+/**
+ * The question bank controller is responsible for manipulating the question bank.
+ * The question bank contains questions for all blocks. Question bank is
+ * normally hidden. It is shown upon admin clickin "Add question" button.
+ *
+ * When shown the question bank filters question to match the selected block
+ * based on block id from the `data-block-id` attribute of the button that
+ * triggered it.
+ *
+ * Additionally the question bank can read current block from url `sqb` url
+ * param which is used when user refreshes the page or comes back to the page
+ * using back button or redirect expecting that question bank is open.
+ */
 class QuestionBankController {
   static readonly FILTER_ID = 'question-bank-filter'
   static readonly QUESTION_CLASS = 'cf-question-bank-element'
@@ -7,6 +18,10 @@ class QuestionBankController {
   static readonly CLOSE_QUESTION_BANK_BUTTON = 'cf-close-question-bank-button'
   static readonly QUESTION_BANK_CONTAINER = 'cf-question-bank-container'
   static readonly QUESTION_BANK_HIDDEN = 'cf-question-bank-hidden'
+  static readonly CURRENT_BLOCK_ATTRIBUTE = 'data-block-id'
+
+  // Url param containing id of currently selected block. If url contains this
+  // param it means that question bank is open.
   static readonly BANK_SHOWN_URL_PARAM = 'sqb'
 
   constructor() {
@@ -48,8 +63,8 @@ class QuestionBankController {
       ),
     )
     for (const element of openQuestionBankElements) {
-      element.addEventListener('click', () => {
-        QuestionBankController.showQuestionBank(questionBankContainer)
+      element.addEventListener('click', (event: Event) => {
+        QuestionBankController.showQuestionBank(questionBankContainer, event)
       })
     }
     const closeQuestionBankElements = Array.from(
@@ -64,17 +79,24 @@ class QuestionBankController {
     }
   }
 
-  static showQuestionBank(container: HTMLElement) {
+  private static showQuestionBank(container: HTMLElement, event: Event) {
+    // Update url to indciate that question bank is in open state and also
+    // specify which
+    const blockId = (event.currentTarget as HTMLElement).getAttribute(
+      QuestionBankController.CURRENT_BLOCK_ATTRIBUTE,
+    )
+    const url = new URL(location.href)
+    url.searchParams.set(QuestionBankController.BANK_SHOWN_URL_PARAM, blockId)
+    window.history.replaceState({}, '', url.toString())
+    QuestionBankController.filterQuestions()
+
     container.classList.remove('hidden')
     window.requestAnimationFrame(() => {
       container.classList.remove(QuestionBankController.QUESTION_BANK_HIDDEN)
     })
-    const url = new URL(location.href)
-    url.searchParams.set(QuestionBankController.BANK_SHOWN_URL_PARAM, 'true')
-    window.history.replaceState({}, '', url.toString())
   }
 
-  static hideQuestionBank(container: HTMLElement) {
+  private static hideQuestionBank(container: HTMLElement) {
     container.querySelector('.cf-question-bank-panel').addEventListener(
       'transitionend',
       () => {
@@ -91,23 +113,26 @@ class QuestionBankController {
   /**
    * Filter questions in the question bank with the filter input string, on the question name and description.
    */
-  static filterQuestions() {
+  private static filterQuestions() {
     const filterString = (
       document.getElementById(
         QuestionBankController.FILTER_ID,
       ) as HTMLInputElement
     ).value.toUpperCase()
+    const blockId =
+      new URL(location.href).searchParams.get(
+        QuestionBankController.BANK_SHOWN_URL_PARAM,
+      ) ?? 'data-screen-none'
     const questions = Array.from(
       document.getElementsByClassName(QuestionBankController.QUESTION_CLASS),
-    )
+    ) as HTMLElement[]
     questions.forEach((question) => {
-      const questionElement = question as HTMLElement
-      const questionContents = questionElement.innerText
-      questionElement.classList.toggle(
-        'hidden',
-        filterString.length &&
-          !questionContents.toUpperCase().includes(filterString),
-      )
+      const questionContents = question.innerText
+      const hidden =
+        !question.hasAttribute(blockId) ||
+        (filterString.length &&
+          !questionContents.toUpperCase().includes(filterString))
+      question.classList.toggle('hidden', hidden)
     })
   }
 }

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -87,7 +87,8 @@ public class AdminProgramBlockQuestionsController extends Controller {
 
     return redirect(
         QuestionBank.addShowQuestionBankParam(
-            controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId).url()));
+            controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId).url(),
+            blockId));
   }
 
   /** POST endpoint for removing a question from a screen. */

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -373,6 +373,7 @@ public final class ProgramBlockEditView extends ProgramBlockView {
                 AdminStyles.PRIMARY_BUTTON_STYLES,
                 ReferenceClasses.OPEN_QUESTION_BANK_BUTTON,
                 "my-4");
+    QuestionBank.setCurrentBlockAttribute(addQuestion, blockDefinition.id());
 
     return div()
         .withClasses("w-7/12", "py-6", "px-4")
@@ -628,7 +629,8 @@ public final class ProgramBlockEditView extends ProgramBlockView {
         QuestionBank.addShowQuestionBankParam(
             controllers.admin.routes.AdminProgramBlocksController.edit(
                     program.id(), blockDefinition.id())
-                .url());
+                .url(),
+            blockDefinition.id());
     QuestionBank qb =
         new QuestionBank(
             QuestionBank.QuestionBankParams.builder()
@@ -636,10 +638,10 @@ public final class ProgramBlockEditView extends ProgramBlockView {
                 .setCsrfTag(csrfTag)
                 .setQuestions(questionDefinitions)
                 .setProgram(program)
-                .setBlockDefinition(blockDefinition)
+                .setVisibility(questionBankVisibility)
                 .setQuestionCreateRedirectUrl(redirectUrl)
                 .build());
-    return qb.getContainer(questionBankVisibility);
+    return qb.getContainer();
   }
 
   private Modal blockDescriptionModal(


### PR DESCRIPTION
### Description

As preparation for #3419 this PR refactors question bank component to support displaying questions for multiple blocks on the same page. We are planning to refactor program edit page to contain all blocks and questions on the same page and admin can add question to any block from that page. 

Previously question bank was used to display questions only for a specific block. We filtered questions relevant to that block server side during rendering. Now question bank contains all questions that can be added to at least 1 block in a given program. All questions rendered hidden initially but their DOM elements contain additional attributes: `data-block-1`, `data-block-4`, ... indicating to which blocks given question can be added. 

Upon admin clicking "Add question" we show the question bank and using JS filter out questions which are not eligible for the given block. The block id is retrieved from the "Add question" button DOM attribute. So now page contain multiple "Add question" button and as long as they have correct DOM attributes with block id the question bank will show correct questions.

Additionally we now use `sqb` URL param to indicate two things:
1. Question bank is in open state.
2. Block id that the question bank should show eligible questions for.

The URL param allows us to keep question bank open state between page refreshes and redirects improving user experience.

This PR has no effect on admin experience. 

## Release notes:

Refactor question bank in program edit page to prepare for the upcoming program edit redesign. This change has no impact on UI.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3419
