### PR TITLE
Fix scrolling issue with question bank question

### DIFF
--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -41,6 +41,10 @@ public final class CreateQuestionButton {
                 "absolute",
                 "ml-3",
                 "mt-1",
+                // add extra padding at the bottom to account for the fact
+                // that question bank is pushed down by the header and its
+                // lower part is always hidden
+                "pb-12",
                 "hidden");
 
     for (QuestionType type : QuestionType.values()) {


### PR DESCRIPTION
### Description

When creating a new question from the question bank, the bottom-most question is not visible. This is due implementation details of question bank where bottom 48px are always below the screen. To fix it we add 48px padding to the question type list to make all questions visible.

I didn't add/update any tests. I tried using playwright's `isVisible()` to check whether the bottom-most question is visible but it returns true even if it's below the screen. 

Before:
![image](https://user-images.githubusercontent.com/252053/199606971-a2087b96-00a9-4abf-a747-838fd65a4743.png)

After: 
![image](https://user-images.githubusercontent.com/252053/199606640-3c7bcd74-0d24-4da3-b941-7614d603ae41.png)

## Release notes:

Fixes inaccessible question type when creating a new question from question bank.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3748.
