### PR TITLE
Add two sbt commands to run civiform and dev and browser test modes

### DIFF
--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -13,7 +13,7 @@ services:
     tty: true # docker run -t
     ports:
       - 9457:9457
-    command: -jvm-debug "*:9457" ~run -Dconfig.file=conf/application.dev-browser-tests.conf
+    command: -jvm-debug "*:9457" ~runBrowserTestsServer
 
 volumes:
   node_modules-data:

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -28,7 +28,4 @@ services:
       - BASE_URL=http://civiform:9000
       - LOCALSTACK_URL=http://localstack:4566
       - CIVIFORM_TIME_ZONE_ID
-      # The default value is true, we set it to false here because we do not know
-      # the IP address that will be used to call the API in the browser tests.
-      - CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET=false
-    command: ~run -Dconfig.file=conf/application.dev-browser-tests.conf
+    command: ~runBrowserTestsServer

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       - 9000:9000
       - 8457:8457
     # -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
-    command: -jvm-debug "*:8457" ~run -Dsbt.offline -Dconfig.file=conf/application.dev.conf
+    command: -jvm-debug "*:8457" ~runDevServer -Dsbt.offline
 
   civiform-shell:
     image: civiform-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,4 +99,4 @@ services:
       - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
-    command: ~run -Dconfig.file=conf/application.dev.conf
+    command: ~runDevServer

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -218,3 +218,13 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 // uncomment to show debug logging.
 //logLevel := Level.Debug
 //Compile / compile / logLevel := Level.Debug
+
+// Register commands that run server in different modes from sbt shell.
+addCommandAlias(
+  "runDevServer",
+  ";eval System.setProperty(\"config.file\", \"conf/application.dev.conf\");run"
+)
+addCommandAlias(
+  "runBrowserTestsServer",
+  ";eval System.setProperty(\"config.file\", \"conf/application.dev-browser-tests.conf\");run"
+)

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -12,3 +12,7 @@ db {
 # they should enable them via the Feature Flags HTTP
 # handler as needed.
 application_status_tracking_enabled = false
+
+# The default value is true, we set it to false here because we do not know
+# the IP address that will be used to call the API in the browser tests.
+api_keys_ban_global_subnet = false


### PR DESCRIPTION
### Description

This makes it possible to switch between servers from sbt shell. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3727