### PR TITLE
Remove noisy " Application {} does not include an applicant name" warning

### DIFF
--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -70,18 +69,15 @@ public class ApplicantData extends CfJsonDocumentContext {
   }
 
   public Optional<String> getApplicantName() {
-    try {
-      String firstName = readString(WellKnownPaths.APPLICANT_FIRST_NAME).get();
-      if (hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
-        String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
-        return Optional.of(String.format("%s, %s", lastName, firstName));
-      }
-      return Optional.of(firstName);
-    } catch (NoSuchElementException e) {
-      logger.warn(
-          "Application {} does not include an applicant name. This is expected for guest users.");
+    if (!hasPath(WellKnownPaths.APPLICANT_FIRST_NAME)) {
       return Optional.empty();
     }
+    String firstName = readString(WellKnownPaths.APPLICANT_FIRST_NAME).get();
+    if (hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
+      String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
+      return Optional.of(String.format("%s, %s", lastName, firstName));
+    }
+    return Optional.of(firstName);
   }
 
   public void setUserName(String displayName) {

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import services.CfJsonDocumentContext;
 import services.LocalizedStrings;
 import services.Path;
@@ -34,7 +32,6 @@ public class ApplicantData extends CfJsonDocumentContext {
   public static final Path APPLICANT_PATH = Path.create(APPLICANT);
   private static final String EMPTY_APPLICANT_DATA_JSON =
       String.format("{ \"%s\": {} }", APPLICANT);
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private Optional<Locale> preferredLocale;
 
   private Optional<ImmutableMap<Path, String>> failedUpdates;


### PR DESCRIPTION
### Description

During browser test run there is a lot of warnings in console like

```
[warn] s.a.ApplicantData - Application {} does not include an applicant name. This is expected for guest users.
```

They are misleading as they don't indicate that something is wrong or should be fixed. Additionally it uses incorrect template with missing application id. Reading the code there is no application id attached to ApplicantData as it is expected to contain answers to all questions. That's why I decided to remove this warning message altogether as it doesn't give any useful information.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

