### PR TITLE
Improve ts-jest config

### DIFF
--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
-  testMatch: ['**/__tests__/**/*.+(ts|js)', '**/?(*.)+(spec|test).+(ts|js)'],
+  testMatch: ['**/?(*.)+(spec|test).+(ts|js)'],
   transform: {
     '^.+\\.(ts)$': [
       'ts-jest',

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -75,13 +75,17 @@ function makeBrowserContext(browser: Browser): Promise<BrowserContext> {
     const dirs = ['tmp/videos']
     if ('expect' in global && expect.getState() != null) {
       const testPath = expect.getState().testPath
+      if (testPath == null) {
+        throw new Error('testPath cannot be null');
+      }
       const testFile = testPath.substring(testPath.lastIndexOf('/') + 1)
       dirs.push(testFile)
       // Some test initialize context in beforeAll at which point test name is
       // not set.
-      if (expect.getState().currentTestName) {
+      const testName = expect.getState().currentTestName
+      if (testName) {
         // remove special characters
-        dirs.push(expect.getState().currentTestName.replace(/[:"<>|*?]/g, ''))
+        dirs.push(testName.replaceAll(/[:"<>|*?]/g, ''))
       }
     }
     return browser.newContext({

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "strict": true,
     "module": "commonjs",
     "noEmit": true,
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": ["."]
 }


### PR DESCRIPTION
### Description

Until now we used preset ts-jest config. It used some default values and ignored our `tsconfig.json` file. This PR makes ts-jest use our tsconfig.json. Benefits:

1. We can use latest JS features (e.g. String.replaceAll) by specifying esnext in tsconfig.json. Given that this is browser test code - it's safe to do.
2. Uses stricter compilation checks.
3. We can use target esnext which prevents transpilation of async/await code and improves stack traces:
before
```
Expected: "Create, edit and publish programs in TestCity"
Received: "Create, edit and publish programs in Civiteam"
  47 |   async expectAdminProgramsPage() {
  48 |     expect(await this.page.innerText('h1')).toEqual('Program dashboard')
> 49 |     expect(await this.page.innerText('h2')).toEqual(
     |                                             ^
  50 |       'Create, edit and publish programs in ' + TEST_CIVIC_ENTITY_SHORT_NAME,
  51 |     )
  52 |   }

  at AdminPrograms.<anonymous> (src/support/admin_programs.ts:49:45)
  at fulfilled (src/support/admin_programs.ts:5:58)
```

After:

```
Expected: "Create, edit and publish programs in TestCity"
Received: "Create, edit and publish programs in Civiteam"

  47 |   async expectAdminProgramsPage() {
  48 |     expect(await this.page.innerText('h1')).toEqual('Program dashboard')
> 49 |     expect(await this.page.innerText('h2')).toEqual(
     |                                             ^
  50 |       'Create, edit and publish programs in ' + TEST_CIVIC_ENTITY_SHORT_NAME,
  51 |     )
  52 |   }

  at AdminPrograms.expectAdminProgramsPage (src/support/admin_programs.ts:49:45)
  at AdminPrograms.gotoAdminProgramsPage (src/support/admin_programs.ts:43:5)
  at AdminPrograms.addProgram (src/support/admin_programs.ts:72:5)
  at AdminPrograms.addAndPublishProgramWithQuestions (src/support/admin_programs.ts:812:5)
  at Object.<anonymous> (src/address.test.ts:24:7)
```


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
