### PR TITLE
Normalize image diff Timezones to PDT

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -504,13 +504,10 @@ export const validateScreenshot = async (
 const normalizeElements = async (page: Frame | Page) => {
   await page.evaluate(() => {
     for (const date of Array.from(document.querySelectorAll('.cf-bt-date'))) {
-      // Use regexp replacement instead of full replacement to make sure that format of the text
-      // matches what we expect. In case underlying format changes to "September 20, 2022" then
-      // regexp will break and it will show up in screenshots.
       date.textContent = date
         .textContent!.replace(/\d{4}\/\d{2}\/\d{2}/, '2030/01/01')
         .replace(/^(\d{1,2}\/\d{1,2}\/\d{2})$/, '1/1/30')
-        .replace(/\d{1,2}:\d{2} (PM|AM)/, '11:22 PM')
+        .replace(/\d{1,2}:\d{2} (AM|PM) [A-Z]{2,3}/, '11:22 PM PDT')
     }
     // Process application id values.
     for (const applicationId of Array.from(


### PR DESCRIPTION
### Description

Fix the timezone in screenshot diffs to be static. The recent daylight savings change surfaced this issue.

## Release notes:

NA - testing

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
