### PR TITLE
Don't fail on codecov

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,9 @@ jobs:
         with:
           file: server/code-coverage/report/jacoco.xml
           verbose: true
-          fail_ci_if_error: true
+          # We're getting intermittent issues with codecov trying to upload lately
+          # disabling it from failing the entire pipeline for now.
+          fail_ci_if_error: false
 
   run_browser_tests_aws:
     strategy:


### PR DESCRIPTION
We're getting intermittent issues with codecov trying to upload lately. Disabling it from failing the entire pipeline for now.