### PR TITLE
Fix deprecation warning; Specify action version

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -31,10 +31,10 @@ jobs:
         uses: trilom/file-changes-action@v1.2.4
         with:
           output: 'json'
-      - uses: axel-op/googlejavaformat-action@master
+      - uses: axel-op/googlejavaformat-action@v3
         with:
           version: 1.9
-          skipCommit: true
+          skip-commit: true
 
       - name: show diff
         run: git add .; git diff --exit-code HEAD


### PR DESCRIPTION
Changes skipCommit to skip-commit to fix a deprecation warning. 

Set the googlejavaformat-action to v3 instead of master. Technically they are the same (right now), but seems safer to use the official tagged release version over master.
