### PR TITLE
Renovate not grouping Jackson

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     },
     {
       "groupName": "jackson",
-      "matchPackagePrefixes": ["com.fasterxml.jackson:"]
+      "matchPackagePrefixes": ["com.fasterxml.jackson"]
     },
     {
       "groupName": "jupiter",


### PR DESCRIPTION
Removing the ending `:` which is preventing the com.fasterxml.jackson libraries from being correctly grouped by renovatebot.
