### PR TITLE
Fix "Create account" link for idcs use case

### DIFF
--- a/server/app/auth/AuthIdentityProviderName.java
+++ b/server/app/auth/AuthIdentityProviderName.java
@@ -29,13 +29,13 @@ public enum AuthIdentityProviderName {
     }
     String providerName = config.getString(AUTH_APPLICANT_CONFIG_PATH);
     for (var provider : AuthIdentityProviderName.values()) {
-      if (provider.getString().equals(providerName)) {
+      if (provider.getValue().equals(providerName)) {
         return provider;
       }
     }
     String supportedOptions =
         Arrays.stream(AuthIdentityProviderName.values())
-            .map(AuthIdentityProviderName::getString)
+            .map(AuthIdentityProviderName::getValue)
             .collect(Collectors.joining(", "));
     throw new IllegalArgumentException(
         "Unsupported auth.applicant_idp value: "
@@ -45,7 +45,7 @@ public enum AuthIdentityProviderName {
   }
 
   /** Returns the string value associated with the enum. */
-  public String getString() {
+  public String getValue() {
     return authIdentityProviderNameString;
   }
 }

--- a/server/app/controllers/LoginController.java
+++ b/server/app/controllers/LoginController.java
@@ -80,13 +80,13 @@ public class LoginController extends Controller {
       idp = AuthIdentityProviderName.IDCS_APPLICANT.toString();
     }
 
-    boolean isIDCS = idp.equals(AuthIdentityProviderName.IDCS_APPLICANT.toString());
+    boolean isIDCS = idp.equals(AuthIdentityProviderName.IDCS_APPLICANT.getValue());
 
     // Because this is only being called when we know IDCS is available, this route should
     // technically
     // never happen.
     if (!isIDCS) {
-      logger.warn("Attempted to do IDCS registration with other provider");
+      logger.warn("Attempted to do IDCS registration with provider " + idp);
       return login(request, applicantClient);
     }
 

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -197,7 +197,7 @@ public class LoginForm extends BaseHtmlView {
   private ButtonTag loginButton(Messages messages) {
     String msg = messages.at(MessageKey.BUTTON_LOGIN.getKeyName());
     return redirectButton(
-            applicantIdp.getString(),
+        applicantIdp.getValue(),
             msg,
             routes.LoginController.applicantLogin(Optional.empty()).url())
         .withClasses(BaseStyles.LOGIN_REDIRECT_BUTTON);

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -197,7 +197,7 @@ public class LoginForm extends BaseHtmlView {
   private ButtonTag loginButton(Messages messages) {
     String msg = messages.at(MessageKey.BUTTON_LOGIN.getKeyName());
     return redirectButton(
-        applicantIdp.getValue(),
+            applicantIdp.getValue(),
             msg,
             routes.LoginController.applicantLogin(Optional.empty()).url())
         .withClasses(BaseStyles.LOGIN_REDIRECT_BUTTON);

--- a/server/test/auth/AuthIdentityProviderNameTest.java
+++ b/server/test/auth/AuthIdentityProviderNameTest.java
@@ -22,7 +22,7 @@ public class AuthIdentityProviderNameTest {
         ConfigFactory.parseMap(
             ImmutableMap.of(
                 AuthIdentityProviderName.AUTH_APPLICANT_CONFIG_PATH,
-                AuthIdentityProviderName.GENERIC_OIDC_APPLICANT.getString()));
+                AuthIdentityProviderName.GENERIC_OIDC_APPLICANT.getValue()));
     assertThat(AuthIdentityProviderName.fromConfig(config))
         .isEqualTo(AuthIdentityProviderName.GENERIC_OIDC_APPLICANT);
   }


### PR DESCRIPTION
### Description

The bug was in LoginController.java calling toString() instead of getString() on the enum. That resulted in the comparison to always be False and registration url never used.

Renamed the method to be getValue() to avoid confusion in the future.

## Release notes:

"Create account" link now correctly leads to registration page.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
