### PR TITLE
remove idcs_register_uri in favor of applicant_register_uri

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -81,7 +81,6 @@ auth {
 
   # Direct URI to create new account.
   register_uri = ${?APPLICANT_REGISTER_URI}
-  register_uri = ${?IDCS_REGISTER_URI}
 }
 
 ## IDCS integration


### PR DESCRIPTION
### Description

Remove deprecated idcs_register_uri flag once Seattle prod has switched.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
