### PR TITLE
Don't explicitly set width/height on svg elements

### DIFF
--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -127,7 +127,7 @@ public final class ViewUtils {
             Joiner.on(" ").join(extraClasses))
         .withStyle("width: 100px")
         .with(
-            Icons.svg(Icons.NOISE_CONTROL_OFF).withClasses("inline-block", "ml-3.5"),
+            Icons.svg(Icons.NOISE_CONTROL_OFF).withClasses("inline-block", "ml-3.5", "w-5", "h-5"),
             span(badgeText).withClass("mr-4"));
   }
 

--- a/server/app/views/components/Icons.java
+++ b/server/app/views/components/Icons.java
@@ -390,17 +390,9 @@ public enum Icons {
    * classes like any other element.
    */
   public static SvgTag svg(Icons icon) {
-    // Setting the viewBox to a specific height/width is insufficient to
-    // actually cause the SVG's bounds to match. Here, the width / height
-    // of the SVG element are explicitly set, which is more consistent
-    // with what one would expect given the method signature.
     return svg()
         .with(path(icon.path))
-        .attr("viewBox", String.format("0 0 %1$d %2$d", icon.size, icon.size))
-        // TODO(#3148): don't set width/height on the element. Callers should
-        // style element themselves using tailwind's classes.
-        .withWidth(String.valueOf(icon.size))
-        .withHeight(String.valueOf(icon.size));
+        .attr("viewBox", String.format("0 0 %1$d %2$d", icon.size, icon.size));
   }
 
   private static SvgTag svg() {


### PR DESCRIPTION
### Description

This is tech debt cleanup. In #3148 I refactored icons so that callers always explicitly set size of icon element instead of relying on whatever `Icons.svg()` sets. Setting width/height is no longer necessary and removing it makes it clear that callers must set desired size themselves. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

