### PR TITLE
Refactor run-dev and sbt commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,7 @@ RUN sbt update compile pushRemoteCache -Dconfig.file=conf/application.dev.conf
 ### Get the volumes and startup commands set up       ###
 ########################################################
 
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash"]
 
 # Save build results to anonymous volumes for reuse
 # We do this first, so they don't get shadowed by the

--- a/bin/lib/docker.sh
+++ b/bin/lib/docker.sh
@@ -157,3 +157,17 @@ function docker::do_dockerhub_login() {
       --username $DOCKER_HUB_USERNAME \
       --password-stdin docker.io
 }
+
+#######################################
+# Runs sbt command inside dev civiform container. The container should be
+# already running.
+# Arguments:
+#   The function takes optional param - the command to run. If no argument is
+#   passed then sbt starts in interactive shell mode.
+# Globals:
+#   COMPOSE_PROJECT_NAME
+#######################################
+function docker::dev_server_sbt_command() {
+  # -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
+  docker exec -it "${COMPOSE_PROJECT_NAME}-civiform-1" ./entrypoint.sh -jvm-debug "*:8457" -Dsbt.offline $1
+}

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -65,13 +65,7 @@ done &
 
 echo "Civiform starting locally at http://localhost:9000/loginForm"
 
-# Attach to the civiform container.
-docker::compose_dev up civiform \
-  --force-recreate \
-  --no-deps \
-  --wait \
-  -d
-
-docker attach "${COMPOSE_PROJECT_NAME}-civiform-1"
+# -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
+docker exec -it "${COMPOSE_PROJECT_NAME}-civiform-1" ./entrypoint.sh -jvm-debug "*:8457" -Dsbt.offline runDevServer
 
 docker::compose_dev stop civiform

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -65,7 +65,6 @@ done &
 
 echo "Civiform starting locally at http://localhost:9000/loginForm"
 
-# -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
-docker exec -it "${COMPOSE_PROJECT_NAME}-civiform-1" ./entrypoint.sh -jvm-debug "*:8457" -Dsbt.offline runDevServer
+docker::dev_server_sbt_command runDevServer
 
 docker::compose_dev stop civiform

--- a/bin/sbt
+++ b/bin/sbt
@@ -8,5 +8,5 @@ docker::set_project_name_dev
 bin/pull-image
 
 docker::compose_dev up --wait -d
-docker exec -it "${COMPOSE_PROJECT_NAME}-civiform-1" ./entrypoint.sh -jvm-debug "*:8457" -Dsbt.offline
+docker::dev_server_sbt_command
 docker::compose_dev stop civiform

--- a/bin/sbt
+++ b/bin/sbt
@@ -7,6 +7,6 @@ docker::set_project_name_dev
 
 bin/pull-image
 
-docker::run_shell_container
-docker::run_shell_command sbt "$@"
-docker::stop_shell_container
+docker::compose_dev up --wait -d
+docker exec -it "${COMPOSE_PROJECT_NAME}-civiform-1" ./entrypoint.sh -jvm-debug "*:8457" -Dsbt.offline
+docker::compose_dev stop civiform

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -30,3 +30,4 @@ services:
       - LOCALSTACK_URL=http://localstack:4566
       - CIVIFORM_TIME_ZONE_ID
     command: ~runBrowserTestsServer
+    entrypoint: ./entrypoint.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,6 @@ services:
     ports:
       - 9000:9000
       - 8457:8457
-    # -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
-    command: -jvm-debug "*:8457" ~runDevServer -Dsbt.offline
 
   civiform-shell:
     image: civiform-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,4 +101,4 @@ services:
       - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
-    command: ~runDevServer
+    entrypoint: /bin/bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-npm install
-sbt "$@"

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# This is file is used with `docker exec` in bin scripts by civiform engineers.
+# It's not used in by prod civiform.
+
+npm install
+sbt "$@"

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # This is file is used with `docker exec` in bin scripts by civiform engineers.
-# It's not used in by prod civiform.
+# It's not used by prod civiform.
 
 npm install
 sbt "$@"


### PR DESCRIPTION
### Description

Changes docker files so that civiform container doesn't launch server upon start. Instead civiform server is launched by running `docker exec` on the running container. This allows to run different commands on the same environment. For example we can launch sbt shell and then launch server or run unit tests from the shell. 

This change should have no affect on current developer workflows. Running `bin/run-dev` will still launch civiform server as it does today. 

This PR moves `entrypoint.sh` from root directory to `server` as that file makes sense within the context of server. Additionally it's no longer used as default entry point for the image. Instead we call it directly in `docker exec`. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3727
