### PR TITLE
fix prober to not check for create on aws staging

### DIFF
--- a/browser-test/src/landing_page.test.ts
+++ b/browser-test/src/landing_page.test.ts
@@ -1,15 +1,19 @@
 import {
+  AuthStrategy,
   createTestContext,
   validateAccessibility,
   validateScreenshot,
 } from './support'
+import {TEST_USER_AUTH_STRATEGY} from './support/config'
 
 describe('the landing page', () => {
   const ctx = createTestContext()
 
   it('it has login options', async () => {
     expect(await ctx.page.textContent('html')).toContain('Continue as guest')
-    expect(await ctx.page.textContent('html')).toContain('Create account')
+    if (TEST_USER_AUTH_STRATEGY !== AuthStrategy.AWS_STAGING) {
+      expect(await ctx.page.textContent('html')).toContain('Create account')
+    }
     await validateScreenshot(ctx.page, 'landing-page')
   })
 


### PR DESCRIPTION
### Description

Don't check for "Create account" button on AWS staging since that value is not set.

## Release notes:

Describe the change as it should be communicated to partners in the release notes.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
