### PR TITLE
Update release.yml to better handle labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
   categories:
     - title: Features
       labels:
-        - '*'
+        - feature
 
     - title: Bug fixes
       labels:
@@ -17,3 +17,7 @@ changelog:
     - title: Dependencies
       labels:
         - dependencies
+
+    - title: Other changes
+      labels:
+        - '*'


### PR DESCRIPTION
### Description

At the moment all pull requests considered to be a Feature as they all match * label. This PR changes it so that only PRs with `feature` label considered Features. PR with no label now go to "Other changes".

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
