### PR TITLE
Remove `--force` from npm install

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -53,8 +53,7 @@ jobs:
 
       - name: Run ESLint on browser tests
         working-directory: browser-test
-        # Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-        run: npm install --force && npx eslint . --ext .ts
+        run: npm install && npx eslint . --ext .ts
 
       - name: Run ESLint on server
         working-directory: server

--- a/browser-test/.npmrc
+++ b/browser-test/.npmrc
@@ -1,2 +1,0 @@
-# Remove once is fixed https://github.com/civiform/civiform/issues/3678
-legacy-peer-deps=true

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -32,8 +32,7 @@ fi
 
 # Install any new packages not built into the image
 # Also saves any package-lock.json changes back to your local filesystem.
-# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-npm install --force --quiet
+npm install --quiet
 
 echo "Polling to check server start. Server url: ${BASE_URL}"
 

--- a/browser-test/package-lock.json
+++ b/browser-test/package-lock.json
@@ -6500,7 +6500,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -7900,7 +7901,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.2.0",

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -15,15 +15,13 @@ WORKDIR $PROJECT_DIR
 # get re-downloaded every time code changes.
 COPY package.json ${PROJECT_DIR}
 COPY package-lock.json ${PROJECT_DIR}
-# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-RUN npm install --force
+RUN npm install
 RUN npx playwright install
 
 COPY . ${PROJECT_DIR}
 
 # Re-run, to install from cache after overriting it.
-# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-RUN npm install --force
+RUN npm install
 RUN npx playwright install
 
 ENTRYPOINT ["/bin/bash"]

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -64,8 +64,7 @@ else
   npm install --silent
   npx eslint --fix "app/assets/javascripts/**/*.ts"
   cd ../browser-test
-  # Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-  npm install --force --silent
+  npm install --silent
   npx eslint --fix
   cd ..
   echo 'Done formatting with eslint'

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -39,8 +39,7 @@ RUN mkdir -p $BROWSER_TEST_DIR
 COPY browser-test/package.json $BROWSER_TEST_DIR
 COPY browser-test/package-lock.json $BROWSER_TEST_DIR
 WORKDIR $BROWSER_TEST_DIR
-# Remove --force once fixed https://github.com/civiform/civiform/issues/3678
-RUN npm install --force
+RUN npm install
 
 # Fetch node js dependencies for `server` directory.
 ENV SERVER_DIR /code/server


### PR DESCRIPTION
### Description

We added `--force` due to incompatibility of jest-image-snapshot library with jest 29. It has been fixed and we no longer need it. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3678
