### PR TITLE
Don't clear cml output and lazy load browser test server

### DIFF
--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -155,4 +155,6 @@ for i in {1..60}; do
   fi
 done &
 
-docker attach "${COMPOSE_PROJECT_NAME}-civiform-1"
+if truth::is_disabled continuous_integration; then
+  docker attach "${COMPOSE_PROJECT_NAME}-civiform-1"
+fi

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -144,7 +144,6 @@ if truth::is_enabled continuous_integration; then
 else
   compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate --wait -d
 fi
-echo "Running now, starting load loop"
 
 # Start a warmup request loop so that when the subsequent server startup is ready, we trigger lazy
 # loading its edit-refresh resources so save developer time.

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -146,7 +146,7 @@ else
 fi
 
 # Start a warmup request loop so that when the subsequent server startup is ready, we trigger lazy
-# loading its edit-refresh resources so save developer time.
+# loading its edit-refresh resources to save developer time.
 for i in {1..60}; do
   sleep 5
   if curl --output /dev/null --silent --fail http://localhost:9999/loginForm; then

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -142,5 +142,17 @@ echo "Running docker compose to start the CiviForm environment:"
 if truth::is_enabled continuous_integration; then
   compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate >.dockerlogs 2>&1 &
 else
-  compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate
+  compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate --wait -d
 fi
+echo "Running now, starting load loop"
+
+# Start a warmup request loop so that when the subsequent server startup is ready, we trigger lazy
+# loading its edit-refresh resources so save developer time.
+for i in {1..60}; do
+  sleep 5
+  if curl --output /dev/null --silent --fail http://localhost:9999/loginForm; then
+    break
+  fi
+done &
+
+docker attach "${COMPOSE_PROJECT_NAME}-civiform-1"


### PR DESCRIPTION
### Description

For browser test setup

1. Stop clearing the output to the console as it hides compile errors.
2. Add a lazy load loop to fully initialize the server sooner.

## Release notes:

NA testing only

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
