### PR TITLE
Improve custom logout url support

### DIFF
--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -4,10 +4,12 @@ import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.pac4j.core.exception.TechnicalException;
 
 /**
  * Custom Logout Request that allows for divergence from the [oidc
@@ -85,8 +87,8 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
     if (getEndpointURI().getRawFragment() != null) {
       try {
         return new URI(uri + "#" + getEndpointURI().getRawFragment());
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (URISyntaxException e) {
+        throw new TechnicalException(e);
       }
     }
     return uri;

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -29,14 +29,14 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
   /** The optional post-logout redirection URI. */
   private final URI postLogoutRedirectURI;
 
-  /** Pptional extra query params to add to the URL. */
+  /** Otional extra query params to add to the URL. */
   private final ImmutableMap<String, String> extraParams;
 
   /**
    * Create new OIDC logout request with a optional redirect url, optional client id, and other
    * params. If the OIDC provider requires the optional state param for logout (see
    * https://openid.net/specs/openid-connect-rpinitiated-1_0.html), include it here. Note that the
-   * state here is not saved and validated by the client, so it does not achive the goal of
+   * state here is not saved and validated by the client, so it does not achieve the goal of
    * "maintain state between the logout request and the callback" as specified by the spec.
    */
   public CustomOidcLogoutRequest(
@@ -56,49 +56,13 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
     }
   }
 
-  /** Creates a new OIDC logout request without a state. */
-  public CustomOidcLogoutRequest(
-      final URI uri,
-      final String postLogoutRedirectParam,
-      final URI postLogoutRedirectURI,
-      final ImmutableMap<String, String> extraParams) {
-    this(uri, postLogoutRedirectParam, postLogoutRedirectURI, extraParams, /*state*/ null);
-  }
-
-  /** Creates a new OIDC logout request without extra params or a custom postLogoutRedirectParam. */
-  public CustomOidcLogoutRequest(final URI uri, final URI postLogoutRedirectURI) {
-
-    this(uri, /* postLogoutRedirectParam */ null, postLogoutRedirectURI, /* extraParams */ null);
-  }
-
-  /** Creates a new OIDC logout request without a post-logout redirection. */
-  public CustomOidcLogoutRequest(final URI uri, final ImmutableMap<String, String> extraParams) {
-
-    this(uri, /* postLogoutRedirectParam */ null, /* postLogoutRedirectURI */ null, extraParams);
-  }
-
-  /** Creates a new OIDC logout request without extra params. */
-  public CustomOidcLogoutRequest(
-      final URI uri, final String postLogoutRedirectParam, final URI postLogoutRedirectURI) {
-
-    this(uri, postLogoutRedirectParam, postLogoutRedirectURI, /* extraParams */ null);
-  }
-
-  /** Creates a new OIDC logout request without a post-logout redirection or extra params. */
-  public CustomOidcLogoutRequest(final URI uri) {
-
-    this(
-        uri, /* postLogoutRedirectParam */ null, /* postLogoutRedirectURI */ null, /* extraParams */
-        null);
-  }
-
   /** Returns the URI query parameters for this logout request. */
   @Override
   public Map<String, List<String>> toParameters() {
 
     Map<String, List<String>> params = new LinkedHashMap<>();
 
-    if (postLogoutRedirectURI != null) {
+    if (postLogoutRedirectURI != null && !postLogoutRedirectParam.isEmpty()) {
       params.put(
           postLogoutRedirectParam, Collections.singletonList(postLogoutRedirectURI.toString()));
     }
@@ -109,5 +73,22 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
     extraParams.forEach((key, value) -> params.put(key, Collections.singletonList(value)));
 
     return params;
+  }
+
+  @Override
+  public URI toURI() {
+    URI uri = super.toURI();
+    // default behavior of LogoutRequest.toURI() removes fragment from the URI.
+    // For some usecases (e.g. IDCS on Seattle) they use logout URI that contains
+    // fragment and read it client-side. Here we add fragment back if it was
+    // present in the original logout URI.
+    if (getEndpointURI().getRawFragment() != null) {
+      try {
+        return new URI(uri + "#" + getEndpointURI().getRawFragment());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return uri;
   }
 }

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -29,7 +29,7 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
   /** The optional post-logout redirection URI. */
   private final URI postLogoutRedirectURI;
 
-  /** Otional extra query params to add to the URL. */
+  /** Optional extra query params to add to the URL. */
   private final ImmutableMap<String, String> extraParams;
 
   /**

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -70,6 +70,7 @@ play.http.secret.key = ${?SECRET_KEY}
 auth {
   # Configure which IDP to use for applicant and admin authentication.
   applicant_idp = "idcs"
+  applicant_idp = ${?CIVIFORM_APPLICANT_IDP}
 
   # Logout options when using OIDC (idcs, or applicant_generic_oidc)
   oidc_provider_logout = false
@@ -99,6 +100,7 @@ auth {
 idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?IDCS_SECRET}
 idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
+idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration
 # LoginRadius secrets must be provided by environment variables - we cannot check them in.

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -70,13 +70,24 @@ play.http.secret.key = ${?SECRET_KEY}
 auth {
   # Configure which IDP to use for applicant and admin authentication.
   applicant_idp = "idcs"
-  applicant_idp = ${?CIVIFORM_APPLICANT_IDP}
 
   # Logout options when using OIDC (idcs, or applicant_generic_oidc)
   oidc_provider_logout = false
   oidc_provider_logout = ${?APPLICANT_OIDC_PROVIDER_LOGOUT}
+  # By default for logout endpoint 'end_session_endpoint' from auth provider
+  # discovery metadata file is used. But for some integration that standard flow
+  # might not be working and we need to override logout URL.
   oidc_override_logout_url = ${?APPLICANT_OIDC_OVERRIDE_LOGOUT_URL}
+
+  # URL param used to pass post logout redirect url in the logout request to the
+  # auth provider. It defaults to 'post_logout_redirect_uri' if this value is
+  # unset. If this value set to empty string - post logout redirect url is not
+  # passed at all and instead it needs to be hardcoded on the auth provider
+  # (otherwise user won't be redirected back to civiform after logout).
   oidc_post_logout_param = ${?APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM}
+
+  # URL param used to pass client id in the logout request to the auth provider.
+  # If unset - client id is not added to the request.
   oidc_logout_client_id_param = ${?APPLICANT_OIDC_LOGOUT_CLIENT_PARAM}
 
   # Direct URI to create new account.
@@ -88,7 +99,6 @@ auth {
 idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?IDCS_SECRET}
 idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
-idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration
 # LoginRadius secrets must be provided by environment variables - we cannot check them in.

--- a/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
+++ b/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
@@ -1,0 +1,69 @@
+package auth.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.LogoutRequest;
+import java.net.URI;
+import org.junit.Test;
+
+public class CustomOidcLogoutRequestTest {
+
+  @Test
+  public void toUri_simple() throws Exception {
+    LogoutRequest request =
+        new CustomOidcLogoutRequest(
+            new URI("https://auth.com/logout"),
+            "post_logout_redirect_uri",
+            /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
+            /* extraParams= */ ImmutableMap.of(),
+            /* state= */ null);
+    assertThat(request.toURI().toString())
+        .isEqualTo(
+            "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F");
+  }
+
+  @Test
+  public void toUri_extraParams() throws Exception {
+    LogoutRequest request =
+        new CustomOidcLogoutRequest(
+            new URI("https://auth.com/logout"),
+            "post_logout_redirect_uri",
+            /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
+            /* extraParams= */ ImmutableMap.of("clientId", "12345"),
+            /* state= */ null);
+    assertThat(request.toURI().toString())
+        .isEqualTo(
+            "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&clientId=12345");
+  }
+
+  @Test
+  public void toUri_withState() throws Exception {
+    LogoutRequest request =
+        new CustomOidcLogoutRequest(
+            new URI("https://auth.com/logout"),
+            "post_logout_redirect_uri",
+            /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
+            /* extraParams= */ ImmutableMap.of(),
+            new State("stateValue"));
+    assertThat(request.toURI().toString())
+        .isEqualTo(
+            "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&state=stateValue");
+  }
+
+  @Test
+  public void toUri_withFragmentAndNoParams() throws Exception {
+    // This specific test is to imitate one of auth setups where we need to
+    // use non-standard logout url containing fragment and ensure that final
+    // url doesn't contain any extra url params.
+    LogoutRequest request =
+        new CustomOidcLogoutRequest(
+            new URI("https://auth.com/logout#fragmentHere"),
+            "",
+            /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
+            /* extraParams= */ ImmutableMap.of(),
+            /* state= */ null);
+    assertThat(request.toURI().toString()).isEqualTo("https://auth.com/logout#fragmentHere");
+  }
+}


### PR DESCRIPTION
### Description

For some environments the standard OIDC logout flow is not working well. For them we need to use custom logout url. For example for Seattle we need to use the following URL (with no extra URL params): `https://login.seattle.gov/#/logout?appName=CIVIFORM`. This PR improves CiviForm logic to support this use case. In particular it does:

1. Allow custom logout URL to have fragment `#`. Default pac4j logic removes everything after the fragment. Unclear whether it's intentional or it just was implemented that way, before client-side rendering/routing became popular. For context here is pac4j logic: [link](https://sourcegraph.com/maven/com.nimbusds/oauth2-oidc-sdk/-/blob/com/nimbusds/openid/connect/sdk/LogoutRequest.java?L266). 

2. Handle empty `auth.oidc_post_logout_param` config setting as signal to omit logout redirect param from logout request. 

3. Remove unused constructors.

In parallel Seatlle is talking to Oracle about IDCS and whether we maybe using standard logout flow incorrectly. If it gets resolved - then we might not need these changes. But meanwhile I wanted to add support given that it's not many changes.

## Release notes:

Improve support for using custom logout URL.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3621