### PR TITLE
Show flag settings on the dev feature flag page

### DIFF
--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -1,6 +1,7 @@
 package controllers.dev;
 
 import auth.Authorizers.Labels;
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import featureflags.FeatureFlags;
 import javax.inject.Inject;
@@ -29,12 +30,20 @@ public final class FeatureFlagOverrideController extends DevController {
 
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result index(Request request) {
+    ImmutableMap<String, Boolean> flags = featureFlags.getAllFlags(request);
+
+    var flagSettingsString = new StringBuilder();
+    for (String key : flags.keySet()) {
+      flagSettingsString.append(String.format("    %s: %s\n", key, flags.get(key)));
+    }
+
     return ok(
         String.format(
             "Overrides are allowed if all are true:\n"
                 + "Server environment: %s\n"
-                + "Configuration: %s",
-            isDevOrStagingEnvironment(), featureFlags.areOverridesEnabled()));
+                + "Configuration: %s\n\n"
+                + "Current flags:\n%s",
+            isDevOrStagingEnvironment(), featureFlags.areOverridesEnabled(), flagSettingsString));
   }
 
   @Secure(authorizers = Labels.ANY_ADMIN)

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -2,6 +2,7 @@ package featureflags;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -50,6 +51,12 @@ public final class FeatureFlags {
 
   public boolean allowCiviformAdminAccessPrograms(Request request) {
     return getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS);
+  }
+
+  public ImmutableMap<String, Boolean> getAllFlags(Request request) {
+    return ImmutableMap.of(
+        ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS, allowCiviformAdminAccessPrograms(request),
+        APPLICATION_STATUS_TRACKING_ENABLED, isStatusTrackingEnabled(request));
   }
 
   /**

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -1,11 +1,11 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.NOT_FOUND;
+import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeRequest;
 
 import java.util.Optional;
 import org.junit.After;
@@ -80,7 +80,7 @@ public class FeatureFlagOverrideControllerTest {
   }
 
   @Test
-  public void index(){
+  public void index() {
     // Setup
     setupControllerInMode(Mode.DEV);
 

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -1,9 +1,11 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.contentAsString;
 
 import java.util.Optional;
 import org.junit.After;
@@ -75,6 +77,19 @@ public class FeatureFlagOverrideControllerTest {
     // Verify
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.session().get(FLAG_NAME)).hasValue("true");
+  }
+
+  @Test
+  public void index(){
+    // Setup
+    setupControllerInMode(Mode.DEV);
+
+    // Execute
+    var result = controller.index(fakeRequest().build());
+
+    // Verify
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).startsWith("Overrides are allowed");
   }
 
   private void setupControllerInMode(Mode mode) {


### PR DESCRIPTION
### Description

Show feature flag settings on the /dev/feature  page

## Release notes:

Show feature flag settings on the /dev/feature  page

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

