### PR TITLE
Adding feature flag for address validation

### DIFF
--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -23,6 +23,8 @@ public final class FeatureFlags {
       "application_status_tracking_enabled";
   public static final String ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS =
       "allow_civiform_admin_access_programs";
+  public static final String FEATURE_FLAG_ADDRESS_VALIDATION_ENABLED =
+      "feature_flag.address_validation_enabled";
   private final Config config;
 
   @Inject
@@ -53,10 +55,15 @@ public final class FeatureFlags {
     return getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS);
   }
 
+  public boolean isAddressValidationEnabled(Request request) {
+    return getFlagEnabled(request, FEATURE_FLAG_ADDRESS_VALIDATION_ENABLED);
+  }
+
   public ImmutableMap<String, Boolean> getAllFlags(Request request) {
     return ImmutableMap.of(
         ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS, allowCiviformAdminAccessPrograms(request),
-        APPLICATION_STATUS_TRACKING_ENABLED, isStatusTrackingEnabled(request));
+        APPLICATION_STATUS_TRACKING_ENABLED, isStatusTrackingEnabled(request),
+        FEATURE_FLAG_ADDRESS_VALIDATION_ENABLED, isAddressValidationEnabled(request));
   }
 
   /**

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -648,3 +648,8 @@ application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_EN
 # work as expected in production if there are multiple servers.
 feature_flag_overrides_enabled = false
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
+
+feature_flag {
+  address_validation_enabled = false
+  address_validation_enabled = ${?FEATURE_FLAG_ADDRESS_VALIDATION_ENABLED}
+}

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -30,3 +30,8 @@ play.filters {
 application_status_tracking_enabled = true
 feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
+
+feature_flag {
+  address_validation_enabled = true
+  address_validation_enabled = ${?FEATURE_FLAG_ADDRESS_VALIDATION_ENABLED}
+}


### PR DESCRIPTION
### Description

Adding feature flag for address validation 

## Release notes:

Adding feature flag for address validation

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [x] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.
