### PR TITLE
Add currency to predicate options

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -210,6 +210,7 @@ describe('create and edit predicates', () => {
     await adminQuestions.addTextQuestion({questionName: 'list of strings'})
     await adminQuestions.addNumberQuestion({questionName: 'single-long'})
     await adminQuestions.addNumberQuestion({questionName: 'list of longs'})
+    await adminQuestions.addCurrencyQuestion({questionName: 'predicate-currency'})
     await adminQuestions.addDateQuestion({questionName: 'predicate-date'})
     await adminQuestions.addCheckboxQuestion({
       questionName: 'both sides are lists',
@@ -231,6 +232,7 @@ describe('create and edit predicates', () => {
     await adminPrograms.addProgramBlock(programName, 'list of longs', [
       'list of longs',
     ])
+    await adminPrograms.addProgramBlock(programName, 'currency', ['predicate-currency'])
     await adminPrograms.addProgramBlock(programName, 'date', ['predicate-date'])
     await adminPrograms.addProgramBlock(programName, 'two lists', [
       'both sides are lists',
@@ -279,8 +281,18 @@ describe('create and edit predicates', () => {
       '123, 456',
     )
 
-    // Date predicate
+    // Currency predicate
     await adminPrograms.goToEditBlockPredicatePage(programName, 'Screen 6')
+    await adminPredicates.addPredicate(
+      'predicate-currency',
+      'shown if',
+      'currency',
+      'is greater than',
+      '100.01',
+    )
+
+    // Date predicate
+    await adminPrograms.goToEditBlockPredicatePage(programName, 'Screen 7')
     await adminPredicates.addPredicate(
       'predicate-date',
       'shown if',
@@ -290,7 +302,7 @@ describe('create and edit predicates', () => {
     )
 
     // Lists of strings on both sides (multi-option question checkbox)
-    await adminPrograms.goToEditBlockPredicatePage(programName, 'Screen 7')
+    await adminPrograms.goToEditBlockPredicatePage(programName, 'Screen 8')
     await adminPredicates.addPredicate(
       'both sides are lists',
       'shown if',
@@ -315,6 +327,8 @@ describe('create and edit predicates', () => {
     await applicantQuestions.answerNumberQuestion('42')
     await applicantQuestions.clickNext()
     await applicantQuestions.answerNumberQuestion('123')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.answerNumberQuestion('100.02')
     await applicantQuestions.clickNext()
     await applicantQuestions.answerDateQuestion('1998-09-04')
     await applicantQuestions.clickNext()

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -332,7 +332,7 @@ describe('create and edit predicates', () => {
     await applicantQuestions.clickNext()
     await applicantQuestions.answerNumberQuestion('123')
     await applicantQuestions.clickNext()
-    await applicantQuestions.answerNumberQuestion('100.02')
+    await applicantQuestions.answerCurrencyQuestion('100.02')
     await applicantQuestions.clickNext()
     await applicantQuestions.answerDateQuestion('1998-09-04')
     await applicantQuestions.clickNext()

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -210,7 +210,9 @@ describe('create and edit predicates', () => {
     await adminQuestions.addTextQuestion({questionName: 'list of strings'})
     await adminQuestions.addNumberQuestion({questionName: 'single-long'})
     await adminQuestions.addNumberQuestion({questionName: 'list of longs'})
-    await adminQuestions.addCurrencyQuestion({questionName: 'predicate-currency'})
+    await adminQuestions.addCurrencyQuestion({
+      questionName: 'predicate-currency',
+    })
     await adminQuestions.addDateQuestion({questionName: 'predicate-date'})
     await adminQuestions.addCheckboxQuestion({
       questionName: 'both sides are lists',
@@ -232,7 +234,9 @@ describe('create and edit predicates', () => {
     await adminPrograms.addProgramBlock(programName, 'list of longs', [
       'list of longs',
     ])
-    await adminPrograms.addProgramBlock(programName, 'currency', ['predicate-currency'])
+    await adminPrograms.addProgramBlock(programName, 'currency', [
+      'predicate-currency',
+    ])
     await adminPrograms.addProgramBlock(programName, 'date', ['predicate-date'])
     await adminPrograms.addProgramBlock(programName, 'two lists', [
       'both sides are lists',

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -5,6 +5,7 @@ import static play.mvc.Results.notFound;
 import static play.mvc.Results.ok;
 
 import auth.Authorizers;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -173,7 +174,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
    *
    * <p>If value is the empty string, then parses the list of values instead.
    */
-  private PredicateValue parsePredicateValue(
+  @VisibleForTesting
+  static PredicateValue parsePredicateValue(
       Scalar scalar, Operator operator, String value, List<String> values) {
 
     // If the scalar is SELECTION or SELECTIONS then this is a multi-option question predicate, and
@@ -184,6 +186,11 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     }
 
     switch (scalar.toScalarType()) {
+      case CURRENCY_CENTS:
+        // Currency is inputted as dollars and cents but stored as cents.
+        Float cents = Float.parseFloat(value) * 100;
+        return PredicateValue.of(cents.longValue());
+
       case DATE:
         LocalDate localDate = LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         return PredicateValue.of(localDate);

--- a/server/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/server/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -67,12 +67,12 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     Optional<QuestionDefinition> question =
         questions.stream().filter(q -> q.getId() == questionId()).findFirst();
+    String displayValue =
+        question
+            .map(q -> comparedValue().toDisplayString(q))
+            .orElseGet(() -> comparedValue().value());
     String phrase =
-        Joiner.on(' ')
-            .join(
-                scalar().toDisplayString(),
-                operator().toDisplayString(),
-                comparedValue().toDisplayString(question));
+        Joiner.on(' ').join(scalar().toDisplayString(), operator().toDisplayString(), displayValue);
     return question.isEmpty()
         ? phrase
         : String.format(

--- a/server/app/services/program/predicate/Operator.java
+++ b/server/app/services/program/predicate/Operator.java
@@ -6,16 +6,28 @@ import services.question.types.ScalarType;
 /** Represents a JsonPath operator (https://github.com/json-path/JsonPath#filter-operators). */
 public enum Operator {
   ANY_OF("anyof", "contains any of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS)),
-  EQUAL_TO("==", "is equal to", ImmutableSet.of(ScalarType.LONG, ScalarType.STRING)),
-  GREATER_THAN(">", "is greater than", ImmutableSet.of(ScalarType.LONG)),
-  GREATER_THAN_OR_EQUAL_TO(">=", "is greater than or equal to", ImmutableSet.of(ScalarType.LONG)),
+  EQUAL_TO(
+      "==",
+      "is equal to",
+      ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG, ScalarType.STRING)),
+  GREATER_THAN(">", "is greater than", ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG)),
+  GREATER_THAN_OR_EQUAL_TO(
+      ">=",
+      "is greater than or equal to",
+      ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG)),
   IN("in", "is one of", ImmutableSet.of(ScalarType.STRING, ScalarType.LONG)),
   IS_AFTER(">=", "is later than", ImmutableSet.of(ScalarType.DATE)),
   IS_BEFORE("<=", "is earlier than", ImmutableSet.of(ScalarType.DATE)),
-  LESS_THAN("<", "is less than", ImmutableSet.of(ScalarType.LONG)),
-  LESS_THAN_OR_EQUAL_TO("<=", "is less than or equal to", ImmutableSet.of(ScalarType.LONG)),
+  LESS_THAN("<", "is less than", ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG)),
+  LESS_THAN_OR_EQUAL_TO(
+      "<=",
+      "is less than or equal to",
+      ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG)),
   NONE_OF("noneof", "is none of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS)),
-  NOT_EQUAL_TO("!=", "is not equal to", ImmutableSet.of(ScalarType.LONG, ScalarType.STRING)),
+  NOT_EQUAL_TO(
+      "!=",
+      "is not equal to",
+      ImmutableSet.of(ScalarType.CURRENCY_CENTS, ScalarType.LONG, ScalarType.STRING)),
   NOT_IN("nin", "is not one of", ImmutableSet.of(ScalarType.STRING, ScalarType.LONG)),
   SUBSET_OF("subsetof", "is a subset of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS));
 

--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -86,7 +86,7 @@ public abstract class PredicateValue {
 
     /* Special handling of "simple" question types, EG non-multivalued questions. */
 
-    // Cents are stored, display as dollars/cents with 2 cent digits.
+    // Currency is stored as cents and displayed as dollars/cents with 2 cent digits.
     if (question.getQuestionType().equals(QuestionType.CURRENCY)) {
       long storedCents = Long.parseLong(value());
       long dollars = storedCents / 100;

--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -12,9 +12,9 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
 
 /**
  * Represents the value on the right side of a JsonPath (https://github.com/json-path/JsonPath)
@@ -73,18 +73,26 @@ public abstract class PredicateValue {
    * Returns the value in a human-readable format.
    *
    * <ul>
+   *   <li>Currency: $1000.23, $3.00
    *   <li>Dates: yyyy-MM-dd
    *   <li>User entered strings: Always quoted, including in lists
    *   <li>Question defined strings: as defined in the default locale, unquoted
    *   <li>Lists: bracketed - [1, 2, 3] ["Charles", "Jane"] [Option1, Option2]
    * </ul>
    *
-   * <p>If this represents a multi option question's value, the question must be specified as {@code
-   * multiOptionValueQuestion} as it contains the human-readable strings.
+   * @param question the question the predicate is applied to.
    */
-  public String toDisplayString(Optional<QuestionDefinition> multiOptionValueQuestion) {
+  public String toDisplayString(QuestionDefinition question) {
 
     /* Special handling of "simple" question types, EG non-multivalued questions. */
+
+    // Cents are stored, display as dollars/cents with 2 cent digits.
+    if (question.getQuestionType().equals(QuestionType.CURRENCY)) {
+      long storedCents = Long.parseLong(value());
+      long dollars = storedCents / 100;
+      long cents = storedCents % 100;
+      return String.format("$%d.%02d", dollars, cents);
+    }
 
     // Convert to a human-readable date.
     if (type() == OperatorRightHandType.DATE) {
@@ -95,8 +103,7 @@ public abstract class PredicateValue {
     }
 
     // For all other "simple" questions use the stored value directly.
-    if (multiOptionValueQuestion.isEmpty()
-        || !multiOptionValueQuestion.get().getQuestionType().isMultiOptionType()) {
+    if (!question.getQuestionType().isMultiOptionType()) {
       return value();
     }
 
@@ -105,8 +112,7 @@ public abstract class PredicateValue {
     // We return the readable values in the default locale.
     // If an ID is not valid for the question, show "<obsolete>"; An obsolete ID does not affect
     // evaluation.
-    MultiOptionQuestionDefinition multiOptionQuestion =
-        (MultiOptionQuestionDefinition) multiOptionValueQuestion.get();
+    MultiOptionQuestionDefinition multiOptionQuestion = (MultiOptionQuestionDefinition) question;
     if (type() == OperatorRightHandType.LIST_OF_STRINGS) {
       return Splitter.on(", ")
           // Un quote-escape each value.

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -8,6 +8,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.fakeRequest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import models.Program;
 import org.junit.Before;
@@ -16,6 +17,9 @@ import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.ResetPostgres;
+import services.applicant.question.Scalar;
+import services.program.predicate.Operator;
+import services.program.predicate.PredicateValue;
 import support.ProgramBuilder;
 
 public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
@@ -323,5 +327,16 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     Result redirectResult =
         controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
+  }
+
+  @Test
+  public void testParsePredicateValue_currency() {
+    PredicateValue got =
+        AdminProgramBlockPredicatesController.parsePredicateValue(
+            Scalar.CURRENCY_CENTS, Operator.EQUAL_TO, "100.01", ImmutableList.of());
+
+    assertThat(
+            got.toDisplayString(testQuestionBank.applicantMonthlyIncome().getQuestionDefinition()))
+        .isEqualTo("$100.01");
   }
 }

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -41,7 +41,7 @@ public class PredicateValueTest {
         testQuestionBank.applicantMonthlyIncome().getQuestionDefinition();
     PredicateValue value = PredicateValue.of(10001);
 
-    assertThat(value.value()).isEqualTo(10010);
+    assertThat(value.value()).isEqualTo(10001);
     assertThat(value.toDisplayString(currencyDef)).isEqualTo("$100.01");
   }
 

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.Test;
 import services.question.types.QuestionDefinition;
 import support.TestQuestionBank;
@@ -37,26 +36,40 @@ public class PredicateValueTest {
   }
 
   @Test
+  public void toDisplayString_currency() {
+    QuestionDefinition currencyDef =
+        testQuestionBank.applicantMonthlyIncome().getQuestionDefinition();
+    PredicateValue value = PredicateValue.of(10001);
+
+    assertThat(value.value()).isEqualTo(10010);
+    assertThat(value.toDisplayString(currencyDef)).isEqualTo("$100.01");
+  }
+
+  @Test
   public void toDisplayString_date() {
+    QuestionDefinition dateDef = testQuestionBank.applicantDate().getQuestionDefinition();
     PredicateValue value = PredicateValue.of(LocalDate.ofYearDay(2021, 1));
 
     assertThat(value.value()).isEqualTo("1609459200000");
-    assertThat(value.toDisplayString(Optional.empty())).isEqualTo("2021-01-01");
+    assertThat(value.toDisplayString(dateDef)).isEqualTo("2021-01-01");
   }
 
   @Test
   public void toDisplayString_listOfLongs() {
+    QuestionDefinition longDef = testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
     PredicateValue value = PredicateValue.listOfLongs(ImmutableList.of(1L, 2L, 3L));
 
     assertThat(value.value()).isEqualTo("[1, 2, 3]");
-    assertThat(value.toDisplayString(Optional.empty())).isEqualTo("[1, 2, 3]");
+    assertThat(value.toDisplayString(longDef)).isEqualTo("[1, 2, 3]");
   }
 
   @Test
   public void toDisplayString_simpleList() {
+    QuestionDefinition stringDef =
+        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     PredicateValue value = PredicateValue.listOfStrings(ImmutableList.of("kangaroo", "turtle"));
 
-    assertThat(value.toDisplayString(Optional.empty())).isEqualTo("[\"kangaroo\", \"turtle\"]");
+    assertThat(value.toDisplayString(stringDef)).isEqualTo("[\"kangaroo\", \"turtle\"]");
   }
 
   @Test
@@ -65,8 +78,7 @@ public class PredicateValueTest {
 
     PredicateValue value = PredicateValue.listOfStrings(ImmutableList.of("1", "2"));
 
-    assertThat(value.toDisplayString(Optional.of(multiOption)))
-        .isEqualTo("[chocolate, strawberry]");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("[chocolate, strawberry]");
   }
 
   @Test
@@ -76,7 +88,7 @@ public class PredicateValueTest {
 
     PredicateValue value = PredicateValue.of("1");
 
-    assertThat(value.toDisplayString(Optional.of(multiOption))).isEqualTo("toaster");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("toaster");
   }
 
   @Test
@@ -86,7 +98,6 @@ public class PredicateValueTest {
     PredicateValue value =
         PredicateValue.listOfStrings(ImmutableList.of("1", "100")); // 100 is not a valid ID
 
-    assertThat(value.toDisplayString(Optional.of(multiOption)))
-        .isEqualTo("[chocolate, <obsolete>]");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("[chocolate, <obsolete>]");
   }
 }

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -41,7 +41,7 @@ public class PredicateValueTest {
         testQuestionBank.applicantMonthlyIncome().getQuestionDefinition();
     PredicateValue value = PredicateValue.of(10001);
 
-    assertThat(value.value()).isEqualTo(10001);
+    assertThat(value.value()).isEqualTo("10001");
     assertThat(value.toDisplayString(currencyDef)).isEqualTo("$100.01");
   }
 


### PR DESCRIPTION
### Description

Allows currency question types to be used in Predicates.  Currently they are selectable but have no operators.

Note: currency is stored as a cents value. This PR takes the user provided predicate dollars/cents value and converts it to cents for storage, and likewise converts cents to dollars/cents when displayed.

`PredicateValue.toDisplayString()` is updated to now require the question the predicate is on.  The method only has one caller and it now directly handles the case where the question is not available.  (This situation is likely indicative of a coding/data bug though)

## Release notes:

Currency questions are now available for visibility predicate logic conditions.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3854
