### PR TITLE
Expand predicate test to evaluate negative assertions.

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -324,20 +324,69 @@ describe('create and edit predicates', () => {
     await selectApplicantLanguage(page, 'English')
     await applicantQuestions.applyProgram(programName)
 
+    // For each condition:
+    // - submit an invalid option
+    // - verify the other screens aren't show and the review page is shown
+    // - go back
+    // - enter an allowed value
+
+    // "hidden" first name is not allowed.
+    await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerNameQuestion('show', 'next', 'screen')
     await applicantQuestions.clickNext()
+
+    // "blue" or "green" are allowed.
+    await applicantQuestions.answerTextQuestion('red')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerTextQuestion('blue')
     await applicantQuestions.clickNext()
+
+    // 42 is allowed.
+    await applicantQuestions.answerNumberQuestion('1')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerNumberQuestion('42')
     await applicantQuestions.clickNext()
+
+    // 123 or 456 are allowed.
+    await applicantQuestions.answerNumberQuestion('11111')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerNumberQuestion('123')
     await applicantQuestions.clickNext()
+
+    // Greater than 100.01 is allowed
+    await applicantQuestions.answerCurrencyQuestion('100.01')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerCurrencyQuestion('100.02')
     await applicantQuestions.clickNext()
+
+    // Earlier than 2021-01-01 is allowed
+    // TODO(#3859): 2021-01-01 evaluates as earlier, but it shouldn't.
+    await applicantQuestions.answerDateQuestion('2021-01-02')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerDateQuestion('1998-09-04')
     await applicantQuestions.clickNext()
+
+    // "dog" or "cat" are allowed.
+    await applicantQuestions.answerCheckboxQuestion(['rabbit'])
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectReviewPage()
+    await page.goBack()
     await applicantQuestions.answerCheckboxQuestion(['cat'])
     await applicantQuestions.clickNext()
+
     await applicantQuestions.answerTextQuestion('last one!')
     await applicantQuestions.clickNext()
 

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -376,7 +376,7 @@ describe('create and edit predicates', () => {
     await applicantQuestions.clickNext()
     await applicantQuestions.expectReviewPage()
     await page.goBack()
-    await applicantQuestions.answerDateQuestion('1998-09-04')
+    await applicantQuestions.answerDateQuestion('2020-12-31')
     await applicantQuestions.clickNext()
 
     // "dog" or "cat" are allowed.

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -321,11 +321,15 @@ export class ApplicantQuestions {
     expect(this.page.url().split('/').pop()).toEqual('programs')
   }
 
-  async submitFromReviewPage() {
-    // Assert that we're on the review page.
+  async expectReviewPage() {
     expect(await this.page.innerText('h2')).toContain(
       'Program application review',
     )
+  }
+
+  async submitFromReviewPage() {
+    // Assert that we're on the review page.
+    await this.expectReviewPage()
 
     // Click on submit button.
     await this.page.click('text="Submit"')


### PR DESCRIPTION
### Description

Predicate browser tests only test positive assertions which could be achieved by the server just evaluating true on everything, this adds a negative assertion at each step.

This discovered #3859 in Date evaluations.

## Release notes:

NA testing.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
