### PR TITLE
Explicitly wait for browser to end up on login page after logout

### DIFF
--- a/browser-test/src/auth.test.ts
+++ b/browser-test/src/auth.test.ts
@@ -70,6 +70,7 @@ describe('applicant auth', () => {
       await page.click('button:has-text("Yes")')
     }
 
+    await ctx.page.waitForURL(/.*\/loginForm/)
     expect(await ctx.page.textContent('html')).toContain('Continue as guest')
   })
 


### PR DESCRIPTION
### Description

Until now we've been relying on implicit navigation event wait. That wait is added by `page.click()` and assumes that the next page that will be fully loaded is the loginForm page. That assumption comes from the fact that logout usually involves a series of redirects that end up on loginForm and that all redirects are server-side using 3xx responses. In Seattle staging one of those redirects is implemented client-side and that page fires navigation event violating our expectation.

In this PR I explicitly wait for browser to end up on the /loginForm page.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3621