### PR TITLE
Remove default hardcoded google analytics id and allow it to be empty

### DIFF
--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import j2html.tags.specialized.ScriptTag;
 import java.net.URI;
+import java.util.Optional;
 import javax.inject.Inject;
 import play.twirl.api.Content;
 import views.components.ToastMessage;
@@ -34,7 +35,7 @@ public class BaseHtmlLayout {
       "Do not enter actual or personal data in this demo site";
 
   public final ViewUtils viewUtils;
-  private final String measurementId;
+  private final Optional<String> measurementId;
   private final String hostName;
   private final boolean isStaging;
 
@@ -42,7 +43,10 @@ public class BaseHtmlLayout {
   public BaseHtmlLayout(ViewUtils viewUtils, Config configuration) {
     checkNotNull(configuration);
     this.viewUtils = checkNotNull(viewUtils);
-    this.measurementId = configuration.getString("measurement_id");
+    this.measurementId =
+        configuration.hasPath("measurement_id")
+            ? Optional.of(configuration.getString("measurement_id"))
+            : Optional.empty();
 
     String baseUrl = configuration.getString("base_url");
     String stagingHostname = configuration.getString("staging_hostname");
@@ -93,7 +97,10 @@ public class BaseHtmlLayout {
     bundle.addStylesheets(viewUtils.makeLocalCssTag(TAILWIND_COMPILED_FILENAME));
 
     // Add Google analytics scripts.
-    bundle.addFooterScripts(getAnalyticsScripts(measurementId).toArray(new ScriptTag[0]));
+    measurementId.ifPresent(
+        (id) -> {
+          bundle.addFooterScripts(getAnalyticsScripts(id).toArray(new ScriptTag[0]));
+        });
 
     // Add default scripts.
     for (String source : FOOTER_SCRIPTS) {

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -97,10 +97,9 @@ public class BaseHtmlLayout {
     bundle.addStylesheets(viewUtils.makeLocalCssTag(TAILWIND_COMPILED_FILENAME));
 
     // Add Google analytics scripts.
-    measurementId.ifPresent(
-        (id) -> {
-          bundle.addFooterScripts(getAnalyticsScripts(id).toArray(new ScriptTag[0]));
-        });
+    measurementId
+        .map(id -> getAnalyticsScripts(id).toArray(new ScriptTag[0]))
+        .ifPresent(bundle::addFooterScripts);
 
     // Add default scripts.
     for (String source : FOOTER_SCRIPTS) {

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -184,6 +184,7 @@ staging_hostname = "staging.seattle.civiform.com"
 staging_hostname = ${?STAGING_HOSTNAME}
 
 measurement_id = ${?MEASUREMENT_ID}
+
 ## Support Email Address
 # This email address is listed in the footer for applicants to contact support
 support_email_address = "CiviForm@seattle.gov"

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -183,9 +183,7 @@ base_url = ${?BASE_URL}
 staging_hostname = "staging.seattle.civiform.com"
 staging_hostname = ${?STAGING_HOSTNAME}
 
-measurement_id = "G-HXM0Y35TGE"
 measurement_id = ${?MEASUREMENT_ID}
-
 ## Support Email Address
 # This email address is listed in the footer for applicants to contact support
 support_email_address = "CiviForm@seattle.gov"


### PR DESCRIPTION
### Description

By default we should not be including Google Analytics and only deployments that want it need to enable it. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.
