### PR TITLE
Ensure application data consistency at submit time

### DIFF
--- a/server/app/models/Application.java
+++ b/server/app/models/Application.java
@@ -53,8 +53,8 @@ public class Application extends BaseModel {
 
   public Application(Applicant applicant, Program program, LifecycleStage lifecycleStage) {
     this.applicant = applicant;
-    setApplicantData(applicant.getApplicantData());
     this.program = program;
+    this.object = "{}";
     this.lifecycleStage = lifecycleStage;
   }
 

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -105,6 +105,7 @@ public final class ApplicationRepository {
           drafts.isEmpty()
               ? new Application(applicant, program, LifecycleStage.ACTIVE)
               : drafts.get(0);
+      application.setApplicantData(applicant.getApplicantData());
       application.setLifecycleStage(LifecycleStage.ACTIVE);
       application.setSubmitTimeToNow();
       if (tiSubmitterEmail.isPresent()) {
@@ -198,8 +199,7 @@ public final class ApplicationRepository {
               .eq("lifecycle_stage", LifecycleStage.DRAFT)
               .findOneOrEmpty();
       Application application =
-          existingDraft.orElse(new Application(applicant, program, LifecycleStage.DRAFT));
-      application.setApplicantData(applicant.getApplicantData());
+          existingDraft.orElseGet(() -> new Application(applicant, program, LifecycleStage.DRAFT));
       application.save();
       database.commitTransaction();
       return application;

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -173,6 +173,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       @Nullable String status)
       throws Exception {
     Application application = new Application(applicant, program, lifecycleStage);
+    application.setApplicantData(applicant.getApplicantData());
     application.save();
 
     // CreateTime of an application is set through @onCreate to Instant.now(). To change
@@ -251,6 +252,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     applicantFive.save();
     CfTestHelpers.withMockedInstantNow(
         "2022-01-01T00:00:00Z", () -> applicationFive.setSubmitTimeToNow());
+    applicationFive.setApplicantData(applicantFive.getApplicantData());
     applicationFive.save();
     // Applicant six hasn't uploaded a file for the optional file upload question
     applicantSix = resourceCreator.insertApplicantWithAccount();
@@ -266,6 +268,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     applicantSix.save();
     CfTestHelpers.withMockedInstantNow(
         "2022-01-01T00:00:00Z", () -> applicationSix.setSubmitTimeToNow());
+    applicationSix.setApplicantData(applicantSix.getApplicantData());
     applicationSix.save();
   }
   /**
@@ -342,6 +345,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     applicantOne.save();
     applicationOne =
         new Application(applicantOne, fakeProgramWithEnumerator, LifecycleStage.ACTIVE);
+    applicationOne.setApplicantData(applicantOne.getApplicantData());
 
     CfTestHelpers.withMockedInstantNow(
         "2022-01-01T00:00:00Z", () -> applicationOne.setSubmitTimeToNow());
@@ -400,12 +404,14 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     applicantTwo.save();
     applicationTwo =
         new Application(applicantTwo, fakeProgramWithEnumerator, LifecycleStage.ACTIVE);
+    applicationTwo.setApplicantData(applicantTwo.getApplicantData());
     CfTestHelpers.withMockedInstantNow(
         "2022-02-01T00:00:00Z", () -> applicationTwo.setSubmitTimeToNow());
     applicationTwo.save();
 
     applicationThree =
         new Application(applicantTwo, fakeProgramWithEnumerator, LifecycleStage.OBSOLETE);
+    applicationThree.setApplicantData(applicantTwo.getApplicantData());
     CfTestHelpers.withMockedInstantNow(
         "2022-03-01T00:00:00Z", () -> applicationThree.setSubmitTimeToNow());
     applicationThree.save();


### PR DESCRIPTION
### Description

When an applicant answers their first question on a program application, CiviForm creates an application record for them associating them with the specific version of the program they're applying to. This application record would also get updated with the contents of the applicant's `ApplicantData` each time they answered a question. When the applicant submitted the application, CiviForm would change its status from `DRAFT` to `ACTIVE`.

This caused a bug where if Program A and Program B shared Question C and an applicant answered Question C in Program A but did not submit the application, then went to program B and changed their answer to Question C, then finally went back to Program A and submitted their application, their application to Program A would contain their original answer to Question C from being answered in Program A despite having shown the updated answer on the block and review pages.

This PR fixes the bug by changing the time that the application's `ApplicantData` gets set from when the applicant answers a question, to when they submit the application.

## Release notes

Fixes a subtle bug where stale question data could be submitted for applications containing shared questions that had been answered in a specific sequence between programs.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/3889