### PR TITLE
Rename only use of ViewOnly to common ReadOnly

### DIFF
--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -181,7 +181,7 @@ public final class QuestionEditView extends BaseHtmlView {
         enumeratorOptionsFromMaybeEnumerationQuestionDefinition(maybeEnumerationQuestionDefinition);
     DivTag formContent =
         buildQuestionContainer(title, QuestionFormBuilder.create(questionDefinition))
-            .with(buildViewOnlyQuestionForm(questionForm, enumeratorOption));
+            .with(buildReadOnlyQuestionForm(questionForm, enumeratorOption));
 
     return renderWithPreview(formContent, questionType, title);
   }
@@ -197,12 +197,13 @@ public final class QuestionEditView extends BaseHtmlView {
 
   private FormTag buildSubmittableQuestionForm(
       QuestionForm questionForm, SelectWithLabel enumeratorOptions, boolean forCreate) {
-    return buildQuestionForm(questionForm, enumeratorOptions, true, forCreate);
+    return buildQuestionForm(questionForm, enumeratorOptions, /* submittable= */ true, forCreate);
   }
 
-  private FormTag buildViewOnlyQuestionForm(
+  private FormTag buildReadOnlyQuestionForm(
       QuestionForm questionForm, SelectWithLabel enumeratorOptions) {
-    return buildQuestionForm(questionForm, enumeratorOptions, false, false);
+    return buildQuestionForm(
+        questionForm, enumeratorOptions, /* submittable= */ false, /* forCreate= */ false);
   }
 
   private DivTag buildQuestionContainer(String title, QuestionForm questionForm) {


### PR DESCRIPTION
### Description

The code base commonly uses ReadOnly to indicate uneditable things.  This renames the only use of ViewOnly to that.

All of our UI rendering classes are called View regardless of if the content is editable or not so using ViewOnly for a different use of "View" in them is confusing.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
