### PR TITLE
updates edit program link to redirect to last block

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -181,6 +181,11 @@ describe('program creation', () => {
     ])
   })
 
+  /**
+   * There was a bug where if you deleted the first block
+   * and then go to edit the program, it would error
+   * because it would go to the block with ID == 1
+   */
   it('delete first block and edit', async () => {
     const {page, adminPrograms} = ctx
 
@@ -190,6 +195,18 @@ describe('program creation', () => {
     await adminPrograms.addProgram(programName)
     await adminPrograms.addProgramBlock(programName)
     await adminPrograms.removeProgramBlock(programName, 'Screen 1')
+    await adminPrograms.goToManageQuestionsPage(programName)
+  })
+
+  it('delete last block and edit', async () => {
+    const {page, adminPrograms} = ctx
+
+    await loginAsAdmin(page)
+
+    const programName = 'Test program 6'
+    await adminPrograms.addProgram(programName)
+    await adminPrograms.addProgramBlock(programName)
+    await adminPrograms.removeProgramBlock(programName, 'Screen 2')
     await adminPrograms.goToManageQuestionsPage(programName)
   })
 

--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -181,6 +181,18 @@ describe('program creation', () => {
     ])
   })
 
+  it('delete first block and edit', async () => {
+    const {page, adminPrograms} = ctx
+
+    await loginAsAdmin(page)
+
+    const programName = 'Test program 5'
+    await adminPrograms.addProgram(programName)
+    await adminPrograms.addProgramBlock(programName)
+    await adminPrograms.removeProgramBlock(programName, 'Screen 1')
+    await adminPrograms.goToManageQuestionsPage(programName)
+  })
+
   async function expectQuestionsOrderWithinBlock(
     page: Page,
     expectedQuestions: string[],

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -317,6 +317,13 @@ export class AdminPrograms {
     }
   }
 
+  async removeProgramBlock(programName: string, blockName: string) {
+    await this.goToBlockInProgram(programName, blockName)
+    await this.page.click('#delete-block-button')
+    await waitForPageJsLoad(this.page)
+    await this.gotoAdminProgramsPage()
+  }
+
   private async waitForQuestionBankAnimationToFinish() {
     // Animation is 150ms. Give whole second to avoid flakiness on slow CPU
     // https://tailwindcss.com/docs/transition-property

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -366,7 +366,7 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   ButtonTag renderEditLink(boolean isActive, ProgramDefinition program, Http.Request request) {
     String editLink =
-        controllers.admin.routes.AdminProgramBlocksController.edit(program.id(), 1).url();
+        controllers.admin.routes.AdminProgramBlocksController.index(program.id()).url();
     String editLinkId = "program-edit-link-" + program.id();
     if (isActive) {
       editLink = controllers.admin.routes.AdminProgramController.newVersionFrom(program.id()).url();


### PR DESCRIPTION
### Description

This updates the edit program link to go to `/blocks` which gets the last block in a program and redirects to `/edit` with the last block ID.

## Release notes

Updates the edit program link to go to `/blocks` which gets the last block in a program and redirects to `/edit` with the last block ID.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3887 
