### PR TITLE
Fix JS error during file upload on azure

### DIFF
--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -21,13 +21,6 @@ describe('file upload applicant flow', () => {
     await page.goto(BASE_URL)
   })
 
-  beforeEach(() => {
-    // TODO(#3896): fix and remove this exclusion
-    ctx.browserErrorWatcher.ignoreErrorsFromUrl(
-      /applicants\/\d+\/programs\/\d+\/blocks\/\d+\/edit/,
-    )
-  })
-
   describe('single file upload question', () => {
     const programName = 'Test program for single file upload'
 

--- a/server/app/assets/javascripts/azure_upload.ts
+++ b/server/app/assets/javascripts/azure_upload.ts
@@ -36,6 +36,11 @@ class AzureUploadController {
       throw new Error('Attempted to upload to null container')
     }
     const azureUploadProps = this.getAzureUploadProps(uploadContainer)
+    if (azureUploadProps.file == null) {
+      // No file selected by the user. Validation is done in file_upload.ts so
+      // here we simply halt uploading.
+      return
+    }
 
     const redirectUrl = new URL(azureUploadProps.successActionRedirect)
 


### PR DESCRIPTION
### Description

During file upload on azure JS code doesn't check whether user actually chose a file which leads to the following error:

```
azure_upload.ts:44 Uncaught TypeError: Cannot read properties of undefined (reading 'type')
    at AzureUploadController.attemptUpload (azure_upload.ts:44:48)
    at HTMLFormElement.<anonymous> (azure_upload.ts:20:12)
```

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3896