### PR TITLE
Ignore JS errors from login page in seattle staging tests

### DIFF
--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -17,7 +17,8 @@ export class BrowserErrorWatcher {
   private readonly urlsToIgnore: RegExp[] = [
     // Some react JS errors on seattle login page.
     /qalogin\.seattle\.gov/,
-    // ERR_ABORTED errors coming from qalogin.seattle.gov
+    // ERR_ABORTED errors coming from qalogin.seattle.gov which tries to load
+    // google translate but redirect happens before resources are loaded.
     /www\.gstatic\.com/,
   ]
 

--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -14,7 +14,12 @@ interface ErrorOnPage {
 export class BrowserErrorWatcher {
   private readonly errors: ErrorOnPage[] = []
   private readonly downloadUrls = new Set<string>()
-  private readonly urlsToIgnore: RegExp[] = []
+  private readonly urlsToIgnore: RegExp[] = [
+    // Some react JS errors on seattle login page.
+    /qalogin\.seattle\.gov/,
+    // ERR_ABORTED errors coming from qalogin.seattle.gov
+    /www\.gstatic\.com/,
+  ]
 
   constructor(page: Page) {
     // Catch JS errors on page.


### PR DESCRIPTION
### Description

Seattle staging login page throws JS errors sometimes. They don't seem to be blocking actual login process but they trigger error detector. This PR adds exception for those errors.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
