### PR TITLE
Add flag to disable browser error watcher

### DIFF
--- a/browser-test/src/support/config.ts
+++ b/browser-test/src/support/config.ts
@@ -7,4 +7,5 @@ export const {
   TEST_USER_DISPLAY_NAME = '',
   TEST_CIVIC_ENTITY_SHORT_NAME = 'TestCity',
   DISABLE_SCREENSHOTS = false,
+  DISABLE_BROWSER_ERROR_WATCHER = false,
 } = process.env

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -20,6 +20,7 @@ import {
   TEST_USER_LOGIN,
   TEST_USER_PASSWORD,
   TEST_USER_DISPLAY_NAME,
+  DISABLE_BROWSER_ERROR_WATCHER,
 } from './config'
 import {AdminQuestions} from './admin_questions'
 import {AdminPrograms} from './admin_programs'
@@ -188,7 +189,9 @@ export const createTestContext = (clearDb = true): TestContext => {
   // we'll get one huge video for all tests.
   async function resetContext() {
     if (browserContext != null) {
-      ctx.browserErrorWatcher.failIfContainsErrors()
+      if (!DISABLE_BROWSER_ERROR_WATCHER) {
+        ctx.browserErrorWatcher.failIfContainsErrors()
+      }
       await browserContext.close()
     }
     browserContext = await makeBrowserContext(browser)


### PR DESCRIPTION
### Description

It is useful for staging prober tests where we don't control some sites such as auth providers and they might cause JS or network errors that don't fail test but trigger the error watcher. The main goal of brower error watcher to catch errors in civiform and that is covered well enough by browser tests.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
