### PR TITLE
Disable "submit form on Enter" behavior

### DIFF
--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -112,6 +112,33 @@ describe('Text question for applicant flow', () => {
         'Must contain at most 20 characters.',
       )
     })
+
+    it('hitting enter on text does not trigger submission', async () => {
+      const {page, applicantQuestions} = ctx
+      await loginAsGuest(page)
+      await selectApplicantLanguage(page, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+
+      // Ensure that clicking enter while on text input doesn't trigger form
+      // submission.
+      await page.focus('input[type=text]')
+      await page.keyboard.press('Enter')
+      expect(await page.locator('input[type=text]').isVisible()).toEqual(true)
+
+      // Check that pressing Enter on button works.
+      await page.focus('button:has-text("Save and next")')
+      await page.keyboard.press('Enter')
+      await applicantQuestions.expectReviewPage()
+
+      // Go back to question and ensure that "Review" button is also clickable
+      // via Enter.
+      await page.click('a:has-text("Edit")')
+      await page.focus('a:has-text("Review")')
+      await page.keyboard.press('Enter')
+      await applicantQuestions.expectReviewPage()
+    })
   })
 
   describe('no max text question', () => {

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -375,6 +375,21 @@ function attachStopPropogationListenerOnFormButtons() {
   })
 }
 
+/**
+ * Disables default browser behavior where pressing Enter on any input in a form
+ * triggers form submission. See https://github.com/civiform/civiform/issues/3872
+ */
+function disableEnterToSubmitBehaviorOnForms() {
+  addEventListenerToElements('form', 'keydown', (e: KeyboardEvent) => {
+    const target = (e.target as HTMLElement).tagName.toLowerCase()
+    // if event originated from a button or link - it should proceed with
+    // default action.
+    if (target !== 'button' && target !== 'a' && e.key === 'Enter') {
+      e.preventDefault()
+    }
+  })
+}
+
 window.addEventListener('load', () => {
   attachDropdown('create-question-button')
   Array.from(document.querySelectorAll('.cf-with-dropdown')).forEach((el) => {
@@ -445,6 +460,7 @@ window.addEventListener('load', () => {
 
   attachRedirectToPageListeners()
   attachStopPropogationListenerOnFormButtons()
+  disableEnterToSubmitBehaviorOnForms()
 
   // Advertise (e.g., for browser tests) that main.ts initialization is done
   document.body.dataset.loadMain = 'true'


### PR DESCRIPTION
### Description

The form can be submitted only by clicking on the submit button or hitting "Enter" while focused on the button. 

## Release notes

Hitting "Enter" button while filling text fields or checkbox no longer triggers submission when editing a question or filling a form.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3872
