### PR TITLE
Add `use_js_bundles` feature flag

### DIFF
--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -23,6 +23,7 @@ public final class FeatureFlags {
       "application_status_tracking_enabled";
   public static final String ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS =
       "allow_civiform_admin_access_programs";
+  private static final String USE_JS_BUNDLES = "use_js_bundles";
   private final Config config;
 
   @Inject
@@ -51,6 +52,10 @@ public final class FeatureFlags {
 
   public boolean allowCiviformAdminAccessPrograms(Request request) {
     return getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS);
+  }
+
+  public boolean isJsBundlingEnabled() {
+    return config.getBoolean(USE_JS_BUNDLES);
   }
 
   public ImmutableMap<String, Boolean> getAllFlags(Request request) {

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.input;
 
 import com.google.common.collect.ImmutableList;
+import featureflags.FeatureFlags;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.ScriptTag;
 import java.util.Optional;
@@ -15,10 +16,12 @@ import services.cloud.azure.BlobStorageUploadRequest;
 public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
 
   private final ViewUtils viewUtils;
+  private final FeatureFlags featureFlags;
 
   @Inject
-  AzureFileUploadViewStrategy(ViewUtils viewUtils) {
+  AzureFileUploadViewStrategy(ViewUtils viewUtils, FeatureFlags featureFlags) {
     this.viewUtils = checkNotNull(viewUtils);
+    this.featureFlags = checkNotNull(featureFlags);
   }
 
   @Override
@@ -68,10 +71,13 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
 
   @Override
   protected ImmutableList<ScriptTag> extraScriptTags() {
-    return ImmutableList.of(
-        viewUtils.makeAzureBlobStoreScriptTag(),
-        viewUtils.makeLocalJsTag("azure_upload"),
-        viewUtils.makeLocalJsTag("azure_delete"));
+    ImmutableList.Builder<ScriptTag> builder = ImmutableList.builder();
+    builder.add(viewUtils.makeAzureBlobStoreScriptTag());
+    if (!featureFlags.isJsBundlingEnabled()) {
+      builder.add(viewUtils.makeLocalJsTag("azure_upload"));
+      builder.add(viewUtils.makeLocalJsTag("azure_delete"));
+    }
+    return builder.build();
   }
 
   @Override

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -8,6 +8,7 @@ import static j2html.TagCreator.script;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
+import featureflags.FeatureFlags;
 import j2html.tags.specialized.ScriptTag;
 import java.net.URI;
 import java.util.Optional;
@@ -35,14 +36,16 @@ public class BaseHtmlLayout {
       "Do not enter actual or personal data in this demo site";
 
   public final ViewUtils viewUtils;
+  protected final FeatureFlags featureFlags;
   private final Optional<String> measurementId;
   private final String hostName;
   private final boolean isStaging;
 
   @Inject
-  public BaseHtmlLayout(ViewUtils viewUtils, Config configuration) {
+  public BaseHtmlLayout(ViewUtils viewUtils, Config configuration, FeatureFlags featureFlags) {
     checkNotNull(configuration);
     this.viewUtils = checkNotNull(viewUtils);
+    this.featureFlags = checkNotNull(featureFlags);
     this.measurementId =
         configuration.hasPath("measurement_id")
             ? Optional.of(configuration.getString("measurement_id"))
@@ -59,7 +62,7 @@ public class BaseHtmlLayout {
 
   /** Creates a new {@link HtmlBundle} with default css, scripts, and toast messages. */
   public HtmlBundle getBundle() {
-    return getBundle(new HtmlBundle());
+    return getBundle(new HtmlBundle(viewUtils, featureFlags.isJsBundlingEnabled()));
   }
 
   /**
@@ -102,11 +105,14 @@ public class BaseHtmlLayout {
         .ifPresent(bundle::addFooterScripts);
 
     // Add default scripts.
-    for (String source : FOOTER_SCRIPTS) {
-      bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
+    if (!featureFlags.isJsBundlingEnabled()) {
+      for (String source : FOOTER_SCRIPTS) {
+        bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
+      }
     }
     // Add the favicon link
     bundle.setFavicon(civiformFaviconUrl);
+    bundle.setJsBundle(getJsBundle());
 
     return bundle;
   }
@@ -127,6 +133,10 @@ public class BaseHtmlLayout {
 
   protected String getTitleSuffix() {
     return CIVIFORM_TITLE;
+  }
+
+  protected JsBundle getJsBundle() {
+    return JsBundle.APPLICANT;
   }
 
   /** Creates Google Analytics scripts for the site. */

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -1,5 +1,6 @@
 package views;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.document;
 import static j2html.TagCreator.each;
@@ -41,6 +42,7 @@ public final class HtmlBundle {
   private String pageTitle;
   private String language = "en";
   private Optional<String> faviconURL = Optional.empty();
+  private JsBundle jsBundle = null;
 
   private final ArrayList<String> bodyStyles = new ArrayList<>();
   private final ArrayList<Tag> footerContent = new ArrayList<>();
@@ -55,6 +57,13 @@ public final class HtmlBundle {
   private final ArrayList<Modal> modals = new ArrayList<>();
   private final ArrayList<LinkTag> stylesheets = new ArrayList<>();
   private final ArrayList<ToastMessage> toastMessages = new ArrayList<>();
+  private final ViewUtils viewUtils;
+  private final boolean enableJsBundles;
+
+  public HtmlBundle(ViewUtils viewUtils, boolean enableJsBundles) {
+    this.viewUtils = checkNotNull(viewUtils);
+    this.enableJsBundles = enableJsBundles;
+  }
 
   public HtmlBundle addBodyStyles(String... styles) {
     bodyStyles.addAll(Arrays.asList(styles));
@@ -125,6 +134,11 @@ public final class HtmlBundle {
     return this;
   }
 
+  public HtmlBundle setJsBundle(JsBundle jsBundle) {
+    this.jsBundle = jsBundle;
+    return this;
+  }
+
   private HtmlTag getContent() {
     return html(renderHead(), renderBody()).withLang(language);
   }
@@ -167,6 +181,12 @@ public final class HtmlBundle {
 
   private FooterTag renderFooter() {
     FooterTag footerTag = footer().with(footerContent).with(footerScripts);
+    if (jsBundle == null) {
+      throw new IllegalStateException("JS bundle must be set for every page.");
+    }
+    if (enableJsBundles) {
+      footerTag.with(viewUtils.makeLocalJsTag(jsBundle.getJsPath()));
+    }
 
     if (footerStyles.size() > 0) {
       footerTag.withClasses(footerStyles.toArray(new String[0]));

--- a/server/app/views/JsBundle.java
+++ b/server/app/views/JsBundle.java
@@ -1,0 +1,16 @@
+package views;
+
+public enum JsBundle {
+  ADMIN("admin.bundle"),
+  APPLICANT("applicant.bundle");
+
+  private final String jsPath;
+
+  JsBundle(String jsPath) {
+    this.jsPath = jsPath;
+  }
+
+  public String getJsPath() {
+    return jsPath;
+  }
+}

--- a/server/app/views/JsBundle.java
+++ b/server/app/views/JsBundle.java
@@ -1,7 +1,23 @@
 package views;
 
+/**
+ * JS bundle is a bundled minified JS file containing client-side CiviForm code. Each page must
+ * include only one JS bundle. Each bundle compiled from an entry point that imports all necessary
+ * dependencies.
+ */
 public enum JsBundle {
+  /**
+   * Bundle used on admin pages: CiviForm admin and program admin pages.
+   *
+   * <p>Entry point is admin_entry_point.ts
+   */
   ADMIN("admin.bundle"),
+
+  /**
+   * Bundle used on applicant pages: pages that applicants and trusted intermediaries see.
+   *
+   * <p>Entry point is applicant_entry_point.ts
+   */
   APPLICANT("applicant.bundle");
 
   private final String jsPath;

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -7,12 +7,14 @@ import static j2html.TagCreator.span;
 
 import com.typesafe.config.Config;
 import controllers.admin.routes;
+import featureflags.FeatureFlags;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.NavTag;
 import play.twirl.api.Content;
 import views.BaseHtmlLayout;
 import views.HtmlBundle;
+import views.JsBundle;
 import views.ViewUtils;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
@@ -39,8 +41,9 @@ public final class AdminLayout extends BaseHtmlLayout {
 
   private AdminType primaryAdminType = AdminType.CIVI_FORM_ADMIN;
 
-  AdminLayout(ViewUtils viewUtils, Config configuration, NavPage activeNavPage) {
-    super(viewUtils, configuration);
+  AdminLayout(
+      ViewUtils viewUtils, Config configuration, NavPage activeNavPage, FeatureFlags featureFlags) {
+    super(viewUtils, configuration, featureFlags);
     this.activeNavPage = activeNavPage;
   }
 
@@ -66,8 +69,10 @@ public final class AdminLayout extends BaseHtmlLayout {
         AdminStyles.MAIN, isCentered ? AdminStyles.MAIN_CENTERED : AdminStyles.MAIN_FULL);
     bundle.addBodyStyles(AdminStyles.BODY);
 
-    for (String source : FOOTER_SCRIPTS) {
-      bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
+    if (!featureFlags.isJsBundlingEnabled()) {
+      for (String source : FOOTER_SCRIPTS) {
+        bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
+      }
     }
 
     return super.render(bundle);
@@ -80,7 +85,7 @@ public final class AdminLayout extends BaseHtmlLayout {
 
   @Override
   public HtmlBundle getBundle(HtmlBundle bundle) {
-    return super.getBundle(bundle).addHeaderContent(renderNavBar());
+    return super.getBundle(bundle).addHeaderContent(renderNavBar()).setJsBundle(JsBundle.ADMIN);
   }
 
   private NavTag renderNavBar() {

--- a/server/app/views/admin/AdminLayoutFactory.java
+++ b/server/app/views/admin/AdminLayoutFactory.java
@@ -2,20 +2,23 @@ package views.admin;
 
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
+import featureflags.FeatureFlags;
 import views.ViewUtils;
 
 public final class AdminLayoutFactory {
 
   private final ViewUtils viewUtils;
   private final Config configuration;
+  private final FeatureFlags featureFlags;
 
   @Inject
-  public AdminLayoutFactory(ViewUtils viewUtils, Config configuration) {
+  public AdminLayoutFactory(ViewUtils viewUtils, Config configuration, FeatureFlags featureFlags) {
     this.viewUtils = viewUtils;
     this.configuration = configuration;
+    this.featureFlags = featureFlags;
   }
 
   public AdminLayout getLayout(AdminLayout.NavPage navPage) {
-    return new AdminLayout(viewUtils, configuration, navPage);
+    return new AdminLayout(viewUtils, configuration, navPage, featureFlags);
   }
 }

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -17,6 +17,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import controllers.admin.routes;
+import featureflags.FeatureFlags;
 import j2html.TagCreator;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
@@ -62,16 +63,19 @@ public final class ProgramApplicationListView extends BaseHtmlView {
   private final AdminLayout layout;
   private final ApplicantUtils applicantUtils;
   private final DateConverter dateConverter;
+  private final FeatureFlags featureFlags;
   private final Logger log = LoggerFactory.getLogger(ProgramApplicationListView.class);
 
   @Inject
   public ProgramApplicationListView(
       AdminLayoutFactory layoutFactory,
       ApplicantUtils applicantUtils,
-      DateConverter dateConverter) {
+      DateConverter dateConverter,
+      FeatureFlags featureFlags) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS).setOnlyProgramAdminType();
     this.applicantUtils = checkNotNull(applicantUtils);
     this.dateConverter = checkNotNull(dateConverter);
+    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -129,10 +133,13 @@ public final class ProgramApplicationListView extends BaseHtmlView {
         layout
             .getBundle()
             .setTitle(program.adminName() + " - Applications")
-            .addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_applications"))
             .addModals(downloadModal)
             .addMainStyles("flex")
             .addMainContent(makeCsrfTokenInputTag(request), applicationListDiv, applicationShowDiv);
+
+    if (!featureFlags.isJsBundlingEnabled()) {
+      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_applications"));
+    }
     Optional<String> maybeSuccessMessage = request.flash().get("success");
     if (maybeSuccessMessage.isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.inject.Inject;
+import featureflags.FeatureFlags;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
@@ -65,11 +66,14 @@ public final class ProgramApplicationView extends BaseHtmlView {
   public static final String NOTE = "note";
   private final BaseHtmlLayout layout;
   private final Messages enUsMessages;
+  private final FeatureFlags featureFlags;
 
   @Inject
-  public ProgramApplicationView(BaseHtmlLayout layout, @EnUsLang Messages enUsMessages) {
+  public ProgramApplicationView(
+      BaseHtmlLayout layout, @EnUsLang Messages enUsMessages, FeatureFlags featureFlags) {
     this.layout = checkNotNull(layout);
     this.enUsMessages = checkNotNull(enUsMessages);
+    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -150,8 +154,10 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .addBodyStyles("flex")
             .addMainStyles("w-screen")
             .addModals(updateNoteModal)
-            .addModals(statusUpdateConfirmationModals)
-            .addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_application_view"));
+            .addModals(statusUpdateConfirmationModals);
+    if (!featureFlags.isJsBundlingEnabled()) {
+      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_application_view"));
+    }
     Optional<String> maybeSuccessMessage = request.flash().get("success");
     if (maybeSuccessMessage.isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -131,8 +131,10 @@ public final class ProgramIndexView extends BaseHtmlView {
             .getBundle()
             .setTitle(pageTitle)
             .addMainContent(contentDiv)
-            .addModals(demographicsCsvModal)
-            .addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
+            .addModals(demographicsCsvModal);
+    if (!featureFlags.isJsBundlingEnabled()) {
+      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
+    }
     maybePublishModal.ifPresent(htmlBundle::addModals);
 
     Http.Flash flash = request.flash();

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -15,6 +15,7 @@ import auth.ProfileUtils;
 import auth.Roles;
 import com.typesafe.config.Config;
 import controllers.routes;
+import featureflags.FeatureFlags;
 import io.jsonwebtoken.lang.Strings;
 import j2html.TagCreator;
 import j2html.tags.ContainerTag;
@@ -58,8 +59,9 @@ public class ApplicantLayout extends BaseHtmlLayout {
       ViewUtils viewUtils,
       Config configuration,
       ProfileUtils profileUtils,
-      LanguageSelector languageSelector) {
-    super(viewUtils, configuration);
+      LanguageSelector languageSelector,
+      FeatureFlags featureFlags) {
+    super(viewUtils, configuration, featureFlags);
     this.profileUtils = checkNotNull(profileUtils);
     this.languageSelector = checkNotNull(languageSelector);
     this.supportEmail = checkNotNull(configuration).getString("support_email_address");

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -7,6 +7,7 @@ import static j2html.TagCreator.form;
 
 import com.google.inject.assistedinject.Assisted;
 import controllers.applicant.routes;
+import featureflags.FeatureFlags;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -32,15 +33,18 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
   private final ApplicantLayout layout;
   private final FileUploadViewStrategy fileUploadStrategy;
   private final ApplicantQuestionRendererFactory applicantQuestionRendererFactory;
+  private final FeatureFlags featureFlags;
 
   @Inject
   ApplicantProgramBlockEditView(
       ApplicantLayout layout,
       FileUploadViewStrategy fileUploadStrategy,
-      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory) {
+      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory,
+      FeatureFlags featureFlags) {
     this.layout = checkNotNull(layout);
     this.fileUploadStrategy = checkNotNull(fileUploadStrategy);
     this.applicantQuestionRendererFactory = applicantQuestionRendererFactory;
+    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(Params params) {
@@ -67,10 +71,10 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
               params.applicantId(), params.programId(), params.messages()));
     }
 
-    if (params.block().isFileUpload()) {
+    if (params.block().isFileUpload() && !featureFlags.isJsBundlingEnabled()) {
       bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("file_upload"));
     }
-    if (params.block().isEnumerator()) {
+    if (params.block().isEnumerator() && !featureFlags.isJsBundlingEnabled()) {
       bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("enumerator"));
     }
 

--- a/server/app/views/dev/IconsView.java
+++ b/server/app/views/dev/IconsView.java
@@ -10,12 +10,14 @@ import static j2html.TagCreator.tr;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import featureflags.FeatureFlags;
 import j2html.tags.specialized.TableTag;
 import j2html.tags.specialized.TrTag;
 import play.twirl.api.Content;
 import views.BaseHtmlLayout;
 import views.BaseHtmlView;
 import views.HtmlBundle;
+import views.JsBundle;
 import views.components.Icons;
 import views.style.ReferenceClasses;
 
@@ -25,10 +27,12 @@ import views.style.ReferenceClasses;
  */
 public final class IconsView extends BaseHtmlView {
   private final BaseHtmlLayout layout;
+  private final FeatureFlags featureFlags;
 
   @Inject
-  public IconsView(BaseHtmlLayout layout) {
+  public IconsView(BaseHtmlLayout layout, FeatureFlags featureFlags) {
     this.layout = checkNotNull(layout);
+    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render() {
@@ -39,11 +43,10 @@ public final class IconsView extends BaseHtmlView {
                 tr().with(th("Icon name"), th("Icon"), th("Width"), th("Height")),
                 each(ImmutableList.copyOf(Icons.values()), this::renderIconRow));
     HtmlBundle bundle =
-        layout
-            .getBundle()
-            .setTitle("Icons")
-            .addMainContent(content)
-            .addFooterScripts(layout.viewUtils.makeLocalJsTag("dev_icons"));
+        layout.getBundle().setTitle("Icons").addMainContent(content).setJsBundle(JsBundle.ADMIN);
+    if (!featureFlags.isJsBundlingEnabled()) {
+      bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("dev_icons"));
+    }
     return layout.render(bundle);
   }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -660,7 +660,8 @@ application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_EN
 feature_flag_overrides_enabled = false
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
 
-
+# When set to true JS is served using JS bundles.
+# https://github.com/civiform/civiform/issues/3864
 use_js_bundles = false
 use_js_bundles = ${?USE_JS_BUNDLES}
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -659,3 +659,8 @@ application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_EN
 # work as expected in production if there are multiple servers.
 feature_flag_overrides_enabled = false
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
+
+
+use_js_bundles = false
+use_js_bundles = ${?USE_JS_BUNDLES}
+

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.ConfigFactory;
+import featureflags.FeatureFlags;
 import j2html.tags.specialized.LinkTag;
 import java.util.HashMap;
 import org.junit.Before;
@@ -26,7 +27,10 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
   @Before
   public void setUp() {
     layout =
-        new BaseHtmlLayout(instanceOf(ViewUtils.class), ConfigFactory.parseMap(DEFAULT_CONFIG));
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            ConfigFactory.parseMap(DEFAULT_CONFIG),
+            instanceOf(FeatureFlags.class));
   }
 
   @Test
@@ -56,7 +60,11 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
   public void addsGoogleAnalyticsWhenContainsId() {
     HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
     config.put("measurement_id", "abcdef");
-    layout = new BaseHtmlLayout(instanceOf(ViewUtils.class), ConfigFactory.parseMap(config));
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            ConfigFactory.parseMap(config),
+            instanceOf(FeatureFlags.class));
     HtmlBundle bundle = layout.getBundle();
     Content content = layout.render(bundle);
 
@@ -68,7 +76,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
   @Test
   public void canAddContentBefore() {
-    HtmlBundle bundle = new HtmlBundle();
+    HtmlBundle bundle = new HtmlBundle(instanceOf(ViewUtils.class), /* enableJsBundles= */ true);
 
     // Add stylesheet before default.
     LinkTag linkTag = link().withHref("moose.css").withRel("stylesheet");

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -3,15 +3,24 @@ package views;
 import static j2html.TagCreator.div;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import play.twirl.api.Content;
+import repository.ResetPostgres;
 
-public class HtmlBundleTest {
+public class HtmlBundleTest extends ResetPostgres {
+
+  private ViewUtils viewUtils;
+
+  @Before
+  public void setUp() {
+    viewUtils = instanceOf(ViewUtils.class);
+  }
 
   @Test
   public void testSetTitle() {
-    HtmlBundle bundle = new HtmlBundle();
-    bundle.setTitle("My title");
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    bundle.setTitle("My title").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
     assertThat(content.body()).contains("<title>My title</title>");
@@ -19,8 +28,8 @@ public class HtmlBundleTest {
 
   @Test
   public void testFavicon() {
-    HtmlBundle bundle = new HtmlBundle();
-    bundle.setFavicon("www.civiform.com/favicon");
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    bundle.setFavicon("www.civiform.com/favicon").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
     assertThat(content.body()).contains("<link rel=\"icon\" href=\"www.civiform.com/favicon\">");
@@ -28,16 +37,18 @@ public class HtmlBundleTest {
 
   @Test
   public void testNoFavicon() {
-    HtmlBundle bundle = new HtmlBundle();
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
 
+    bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
     assertThat(content.body()).doesNotContain("<link rel=\"icon\"");
   }
 
   @Test
   public void emptyBundleRendersOutline() {
-    HtmlBundle bundle = new HtmlBundle();
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
 
+    bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
     assertThat(content.body())
         .contains(
@@ -48,11 +59,24 @@ public class HtmlBundleTest {
 
   @Test
   public void rendersContentInOrder() {
-    HtmlBundle bundle = new HtmlBundle();
-    bundle.addMainContent(div("One"));
-    bundle.addMainContent(div("Two"));
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    bundle.addMainContent(div("One")).addMainContent(div("Two")).setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
     assertThat(content.body()).contains("<main><div>One</div><div>Two</div></main>");
+  }
+
+  @Test
+  public void renderWithJsBundlesDisabled() {
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    Content content = bundle.setJsBundle(JsBundle.APPLICANT).render();
+    assertThat(content.body()).doesNotContain("applicant.bundle.js");
+  }
+
+  @Test
+  public void renderWithJsBundlesEnabled() {
+    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ true);
+    Content content = bundle.setJsBundle(JsBundle.APPLICANT).render();
+    assertThat(content.body()).contains("applicant.bundle.js");
   }
 }


### PR DESCRIPTION
### Description

When the flag is enabled JS bundles will be served instead of individual JS files. The plan is to add the flag, flip the default value to true, ensuring that all tests pass, and wait for a release or two. After that I'll clean up the flag and the old approach.

## Release notes

Introduce `USE_JS_BUNDLES ` flag for controlling JS serving mode. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3864
