### PR TITLE
Ignore sporadic failures coming from browser error watcher

### DIFF
--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -39,16 +39,21 @@ export class BrowserErrorWatcher {
 
     // Catch requests failed due to 4xx or 5xx responses.
     page.on('requestfinished', (request) => {
-      void request.response().then((response) => {
-        if (response == null) return
-        const statusCode = response.status()
-        if (statusCode >= 400 && statusCode < 600) {
-          this.errors.push({
-            message: `Got response with status code ${statusCode}`,
-            url: request.url(),
-          })
-        }
-      })
+      try {
+        void request.response().then((response) => {
+          if (response == null) return
+          const statusCode = response.status()
+          if (statusCode >= 400 && statusCode < 600) {
+            this.errors.push({
+              message: `Got response with status code ${statusCode}`,
+              url: request.url(),
+            })
+          }
+        })
+      } catch (e) {
+        // do nothing. Sometimes we are getting error like:
+        // request.response: Target page, context or browser has been closed
+      }
     })
   }
 


### PR DESCRIPTION
### Description

Looks like we can't reliably get response from request objects on playwright's `requestfinished` event as those request can belong to sessions that has been closed. It's not a big deal and just means that we might not detect some corner-case failures that don't affect test success anyway. 

I noticed this error while running browser tests locally.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.
