### PR TITLE
Refactor evaluation of Visibility questions and add getting of Eligibility questions

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -74,7 +74,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
               request,
               programDefinition,
               blockDefinition,
-              programDefinition.getAvailablePredicateQuestionDefinitions(blockDefinitionId)));
+              programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockDefinitionId)));
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
     } catch (ProgramBlockDefinitionNotFoundException e) {

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -74,7 +74,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
               request,
               programDefinition,
               blockDefinition,
-              programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockDefinitionId)));
+              programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(
+                  blockDefinitionId)));
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
     } catch (ProgramBlockDefinitionNotFoundException e) {

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -488,7 +488,7 @@ public abstract class ProgramDefinition {
   }
 
   /**
-   * Returns a list of the question definitions that may be used to define show/hide predicates on
+   * Returns a list of the question definitions that may be used to define visibility predicates on
    * the block definition with the id {@code blockId}.
    *
    * <p>The available question definitions for predicates satisfy ALL of the following:
@@ -502,6 +502,8 @@ public abstract class ProgramDefinition {
    */
   public ImmutableList<QuestionDefinition> getAvailableVisibilityPredicateQuestionDefinitions(
       long blockId) throws ProgramBlockDefinitionNotFoundException {
+    // Questions through the block before this one are available for this block's visibility
+    // conditions.
     return getAvailablePredicateQuestionDefinitions(blockId - 1);
   }
 
@@ -514,9 +516,23 @@ public abstract class ProgramDefinition {
    */
   public ImmutableList<QuestionDefinition> getAvailableEligibilityPredicateQuestionDefinitions(
       long blockId) throws ProgramBlockDefinitionNotFoundException {
+    // Questions through the block are available for this block's eligibility conditions.
     return getAvailablePredicateQuestionDefinitions(blockId);
   }
 
+  /**
+   * Returns a list of the question definitions that may be used to define predicates on the block
+   * definition with the id {@code blockId}.
+   *
+   * <p>The available question definitions for predicates satisfy ALL of the following:
+   *
+   * <ul>
+   *   <li>In a block definition that comes sequentially before the given block definition.
+   *   <li>In a block definition that either has the same enumerator ID as the given block
+   *       definition, or has the same enumerator ID as some "parent" of the given block definition.
+   *   <li>Is not an enumerator.
+   * </ul>
+   */
   private ImmutableList<QuestionDefinition> getAvailablePredicateQuestionDefinitions(long blockId)
       throws ProgramBlockDefinitionNotFoundException {
     if (blockId <= 0) {
@@ -556,7 +572,6 @@ public abstract class ProgramDefinition {
 
     // Only include sequentially earlier block definitions.
     for (BlockDefinition siblingBlockDefinition : siblingBlockDefinitions) {
-
       builder.add(siblingBlockDefinition);
       // Stop adding block definitions once we reach this block.
       if (siblingBlockDefinition.id() == blockDefinition.id()) break;

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -565,12 +565,12 @@ public abstract class ProgramDefinition {
     // If this block is repeated, recurse "upward". In other words, add all the available predicate
     // block definitions for its enumerator. Do this before adding its sibling block definitions to
     // maintain sequential order of the block definitions in the result.
-    if (blockDefinition.isRepeated()) {
+    if (maybeEnumeratorId.isPresent()) {
       builder.addAll(
           getAvailablePredicateBlockDefinitions(this.getBlockDefinition(maybeEnumeratorId.get())));
     }
 
-    // Only include sequentially earlier block definitions.
+    // Only include block definitions up through the specified block.
     for (BlockDefinition siblingBlockDefinition : siblingBlockDefinitions) {
       builder.add(siblingBlockDefinition);
       // Stop adding block definitions once we reach this block.

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -488,8 +488,8 @@ public abstract class ProgramDefinition {
   }
 
   /**
-   * Returns a list of the question definitions that may be used to define predicates on the block
-   * definition with the given ID.
+   * Returns a list of the question definitions that may be used to define show/hide predicates on
+   * the block definition with the id {@code blockId}.
    *
    * <p>The available question definitions for predicates satisfy ALL of the following:
    *
@@ -500,10 +500,30 @@ public abstract class ProgramDefinition {
    *   <li>Is not an enumerator.
    * </ul>
    */
-  public ImmutableList<QuestionDefinition> getAvailablePredicateQuestionDefinitions(long blockId)
-      throws ProgramBlockDefinitionNotFoundException {
-    ImmutableList.Builder<QuestionDefinition> builder = ImmutableList.builder();
+  public ImmutableList<QuestionDefinition> getAvailableVisibilityPredicateQuestionDefinitions(
+      long blockId) throws ProgramBlockDefinitionNotFoundException {
+    return getAvailablePredicateQuestionDefinitions(blockId - 1);
+  }
 
+  /**
+   * Returns a list of the question definitions that may be used to define eligibility predicates on
+   * the block definition with the id {@code blockId}.
+   *
+   * <p>This is the same as {@link #getAvailableVisibilityPredicateQuestionDefinitions} but it
+   * includes questions in the provided {@code blockId}.
+   */
+  public ImmutableList<QuestionDefinition> getAvailableEligibilityPredicateQuestionDefinitions(
+      long blockId) throws ProgramBlockDefinitionNotFoundException {
+    return getAvailablePredicateQuestionDefinitions(blockId);
+  }
+
+  private ImmutableList<QuestionDefinition> getAvailablePredicateQuestionDefinitions(long blockId)
+      throws ProgramBlockDefinitionNotFoundException {
+    if (blockId <= 0) {
+      return ImmutableList.of();
+    }
+
+    ImmutableList.Builder<QuestionDefinition> builder = ImmutableList.builder();
     for (BlockDefinition blockDefinition :
         getAvailablePredicateBlockDefinitions(this.getBlockDefinition(blockId))) {
       builder.addAll(
@@ -536,10 +556,10 @@ public abstract class ProgramDefinition {
 
     // Only include sequentially earlier block definitions.
     for (BlockDefinition siblingBlockDefinition : siblingBlockDefinitions) {
-      // Stop adding block definitions once we reach this block.
-      if (siblingBlockDefinition.id() == blockDefinition.id()) break;
 
       builder.add(siblingBlockDefinition);
+      // Stop adding block definitions once we reach this block.
+      if (siblingBlockDefinition.id() == blockDefinition.id()) break;
     }
 
     return builder.build();

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -527,7 +527,7 @@ public abstract class ProgramDefinition {
    * <p>The available question definitions for predicates satisfy ALL of the following:
    *
    * <ul>
-   *   <li>In a block definition that comes sequentially before the given block definition.
+   *   <li>In the provided block definition or one that comes sequentially before it.
    *   <li>In a block definition that either has the same enumerator ID as the given block
    *       definition, or has the same enumerator ID as some "parent" of the given block definition.
    *   <li>Is not an enumerator.

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -318,15 +318,23 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .build();
 
     // block1
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(block1QAQB.id()))
+    assertThat(
+            programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(block1QAQB.id()))
         .isEmpty();
+    assertThat(
+            programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(block1QAQB.id()))
+        .containsExactly(questionA, questionB);
     // block2
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(block2QC.id()))
+    assertThat(programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(block2QC.id()))
+        .containsExactly(questionA, questionB);
+    assertThat(programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(block2QC.id()))
         .containsExactly(questionA, questionB);
     // block3
     // Doesn't include the file upload question, which don't support predicates.
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(block3QD.id()))
+    assertThat(programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(block3QD.id()))
         .containsExactly(questionA, questionB);
+    assertThat(programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(block3QD.id()))
+        .containsExactly(questionA, questionB, questionD);
   }
 
   @Test
@@ -408,19 +416,34 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .build();
 
     // blockA (applicantName)
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(blockA.id())).isEmpty();
+    assertThat(programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockA.id()))
+        .isEmpty();
+    assertThat(programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(blockA.id()))
+        .containsExactly(questionA);
     // blockB (applicantHouseholdMembers)
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(blockBEnum.id()))
+    assertThat(
+            programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockBEnum.id()))
+        .containsExactly(questionA);
+    assertThat(
+            programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(blockBEnum.id()))
         .containsExactly(questionA);
     // blockC (applicantHouseholdMembers.householdMemberName)
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(blockC.id()))
+    assertThat(programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockC.id()))
         .containsExactly(questionA);
+    assertThat(programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(blockC.id()))
+        .containsExactly(questionA, questionC);
     // blockD (applicantHouseholdMembers.householdMemberJobs)
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(blockDEnum.id()))
+    assertThat(
+            programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockDEnum.id()))
+        .containsExactly(questionA, questionC);
+    assertThat(
+            programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(blockDEnum.id()))
         .containsExactly(questionA, questionC);
     // blockE (applicantHouseholdMembers.householdMemberJobs.householdMemberJobIncome)
-    assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(blockE.id()))
+    assertThat(programDefinition.getAvailableVisibilityPredicateQuestionDefinitions(blockE.id()))
         .containsExactly(questionA, questionC);
+    assertThat(programDefinition.getAvailableEligibilityPredicateQuestionDefinitions(blockE.id()))
+        .containsExactly(questionA, questionC, questionE);
   }
 
   @Test


### PR DESCRIPTION
### Description

Adds lookup for which questions are available for eligibility conditions for a given block.

refactors the logic used to make the same determination for visibility so that the main method effectively finds all visible questions up to and including a given block.  Visibility then looks for the questions available through the block before it, and eligibility through its block.


## Release notes

No-op Refactor of logic to determine which questions are available to Visibility conditions to support the in-development eligibility feature.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
