### PR TITLE
Update AWS java deps and change S3 setup for localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,14 @@ services:
       - '4566'
     environment:
       - SERVICES=s3,ses
+    networks:
+      default:
+        aliases:
+          # We use hosted-style for s3 bucket urls. Which matches production.
+          # https://docs.localstack.cloud/user-guide/aws/s3/
+          # So we need to add host mapping for test bucket civiform-local-s3
+          - civiform-local-s3.localhost.localstack.cloud
+          - localhost.localstack.cloud
 
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -32,8 +32,8 @@ lazy val root = (project in file("."))
       "com.j2html" % "j2html" % "1.6.0",
 
       // Amazon AWS SDK
-      "software.amazon.awssdk" % "s3" % "2.17.295",
-      "software.amazon.awssdk" % "ses" % "2.17.295",
+      "software.amazon.awssdk" % "s3" % "2.18.40",
+      "software.amazon.awssdk" % "ses" % "2.18.40",
 
       // Microsoft Azure SDK
       "com.azure" % "azure-identity" % "1.7.2",

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -596,7 +596,7 @@ aws.ses.sender="noreply@fake.identity"
 aws.ses.sender=${?AWS_SES_SENDER}
 aws.s3.bucket=civiform-local-s3
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
-aws.local.endpoint="http://localstack:4566"
+aws.local.endpoint="http://localhost.localstack.cloud:4566"
 # Max size of file in Mb allowed to be uploaded to S3.
 aws.s3.filelimitmb=100
 aws.s3.filelimitmb=${?AWS_S3_FILE_LIMIT_MB}


### PR DESCRIPTION
### Description

AWS S3 supports two styles of addressing buckets ([docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)). For production we use hosted-styled (recommended). For tests we've been using path-styled (not recommended). With the awssdk deps 2.18.0 update they updated underlying endpoint providers that changed our localstack setup to use hosted-styled URLs:

Instead of `http://localstack:4566/civiform-local-s3` 
It now uses `http://civiform-local-s3.localstack:4566/`

It broke tests as that new domain was not setup in Docker. This PR updates docket network and uses `civiform-local-s3.localhost.localstack.cloud` domain for localstack as it explicitly wants `localhost.localstack.cloud` ([docs](https://docs.localstack.cloud/user-guide/aws/s3/)) in order to read Host header. 

This PR should have no effect on production. Though will test on staging once its submitted. 
### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

