### PR TITLE
Remove admin restriction to allow applicant flows to set feature flags

### DIFF
--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -1,11 +1,9 @@
 package controllers.dev;
 
-import auth.Authorizers.Labels;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import featureflags.FeatureFlags;
 import javax.inject.Inject;
-import org.pac4j.play.java.Secure;
 import play.Environment;
 import play.mvc.Http.HeaderNames;
 import play.mvc.Http.Request;
@@ -28,7 +26,6 @@ public final class FeatureFlagOverrideController extends DevController {
     this.featureFlags = featureFlags;
   }
 
-  @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result index(Request request) {
     ImmutableMap<String, Boolean> flags = featureFlags.getAllFlags(request);
 
@@ -46,7 +43,6 @@ public final class FeatureFlagOverrideController extends DevController {
             isDevOrStagingEnvironment(), featureFlags.areOverridesEnabled(), flagSettingsString));
   }
 
-  @Secure(authorizers = Labels.ANY_ADMIN)
   public Result enable(Request request, String flagName) {
     if (!isDevOrStagingEnvironment()) {
       return notFound();
@@ -56,7 +52,6 @@ public final class FeatureFlagOverrideController extends DevController {
     return redirect(redirectTo).addingToSession(request, flagName, "true");
   }
 
-  @Secure(authorizers = Labels.ANY_ADMIN)
   public Result disable(Request request, String flagName) {
     if (!isDevOrStagingEnvironment()) {
       return notFound();


### PR DESCRIPTION
### Description

For browser and manual tests of applicant flows they need to set feature flags via HTTP.

The system still requires a env configuration to be set as well doesn't allow overrides for prod environments.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
