### PR TITLE
Remove unused param in ApplicantService.createApplicant()

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -41,7 +41,6 @@ import repository.TimeFilter;
 import repository.UserRepository;
 import repository.VersionRepository;
 import services.Path;
-import services.applicant.ApplicantService.ApplicantProgramData;
 import services.applicant.exception.ApplicantNotFoundException;
 import services.applicant.exception.ApplicationSubmissionException;
 import services.applicant.exception.ProgramBlockNotFoundException;
@@ -111,8 +110,9 @@ public final class ApplicantService {
         checkNotNull(configuration).getString("staging_applicant_notification_mailing_list");
   }
 
-  /** Create a new {@link Applicant} for a given user. */
-  public CompletionStage<Applicant> createApplicant(long userId) {
+  /** Create a new {@link Applicant}. */
+  public CompletionStage<Applicant> createApplicant() {
+
     Applicant applicant = new Applicant();
     return userRepository.insertApplicant(applicant).thenApply((unused) -> applicant);
   }

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -84,7 +84,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to stage empty updates
     // for a required question.
     createProgramWithOptionalQuestion(questionDefinition);
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     subject
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", ImmutableMap.of())
         .toCompletableFuture()
@@ -106,7 +106,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to update a required
     // question with an empty string (done below).
     createProgramWithOptionalQuestion(questionDefinition);
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Path questionPath = Path.create("applicant.name");
 
     // Put something in there
@@ -148,7 +148,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
         testQuestionBank.applicantKitchenTools().getQuestionDefinition());
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Path questionPath = Path.create("applicant.kitchen_tools");
 
     // Put checkbox answer in
@@ -198,7 +198,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         currencyQuestion.getQuestionDefinition(),
         numberQuestion.getQuestionDefinition());
 
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     // Stage invalid updates for each question.
     ImmutableMap<String, String> updates =
@@ -241,7 +241,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
         testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
@@ -310,7 +310,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
             .buildDefinition();
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
@@ -366,7 +366,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_withUpdates_isOk() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     ImmutableMap<String, String> updates =
         ImmutableMap.<String, String>builder()
@@ -387,7 +387,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_updatesMetadataForQuestionOnce() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     ImmutableMap<String, String> updates =
         ImmutableMap.<String, String>builder()
@@ -429,7 +429,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(multiSelectQuestion);
 
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     Path checkboxPath = Path.create("applicant.checkbox").join(Scalar.SELECTIONS).asArrayElement();
     ImmutableMap<String, String> updates =
@@ -489,7 +489,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
     createProgram(enumeratorQuestionDefinition);
 
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(enumeratorQuestionDefinition.getQuestionPathSegment());
@@ -521,7 +521,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(enumeratorQuestionDefinition);
 
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(enumeratorQuestionDefinition.getQuestionPathSegment());
@@ -557,7 +557,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_hasProgramNotFoundException() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     ImmutableMap<String, String> updates = ImmutableMap.of();
     long badProgramId = programDefinition.id() + 1000L;
 
@@ -575,7 +575,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_hasProgramBlockNotFoundException() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     ImmutableMap<String, String> updates = ImmutableMap.of();
     String badBlockId = "100";
 
@@ -594,7 +594,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_hasPathNotInBlockException() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     ImmutableMap<String, String> updates =
         ImmutableMap.of(
             Path.create("applicant.name.first").toString(), "Alice",
@@ -614,7 +614,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_hasIllegalArgumentExceptionForReservedMetadataScalarKeys() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     String reservedScalar = Path.create("applicant.name").join(Scalar.UPDATED_AT).toString();
     ImmutableMap<String, String> updates = ImmutableMap.of(reservedScalar, "12345");
 
@@ -632,7 +632,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void
       stageAndUpdateIfValid_withIllegalArrayElement_hasIllegalArgumentExceptionForReservedMetadataScalarKeys() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     String reservedScalar =
         Path.create("applicant.name")
             .join(Scalar.UPDATED_AT)
@@ -654,14 +654,14 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void createApplicant_createsANewApplicant() {
-    Applicant applicant = subject.createApplicant(1l).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     assertThat(applicant.id).isNotNull();
   }
 
   @Test
   public void createApplicant_ApplicantTime() {
-    Applicant applicant = subject.createApplicant(1l).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     Instant t = Instant.now();
 
@@ -671,7 +671,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getReadOnlyApplicantService_getsReadOnlyApplicantServiceForTheApplicantAndProgram() {
-    Applicant applicant = subject.createApplicant(1l).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     ReadOnlyApplicantProgramService roApplicantProgramService =
         subject
@@ -684,7 +684,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void submitApplication_returnsSavedApplication() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
     ImmutableMap<String, String> updates =
@@ -712,7 +712,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void submitApplication_addsProgramToStoredFileAcls() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
@@ -779,7 +779,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void submitApplication_obsoletesOldApplication() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
     ImmutableMap<String, String> updates =
@@ -947,7 +947,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Program programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
@@ -993,8 +993,8 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant_otherApplicant() {
-    Applicant primaryApplicant = subject.createApplicant(1L).toCompletableFuture().join();
-    Applicant otherApplicant = subject.createApplicant(2L).toCompletableFuture().join();
+    Applicant primaryApplicant = subject.createApplicant().toCompletableFuture().join();
+    Applicant otherApplicant = subject.createApplicant().toCompletableFuture().join();
     Program programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
@@ -1032,7 +1032,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant_withNewerProgramVersion() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     // Create a draft based on the original version of a program.
     Program originalProgramForDraft =
@@ -1090,7 +1090,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // This ensures that the applicant can always see that draft
     // applications for a given program, even if a newer version of the
     // program is hidden from the index.
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     // Create a submitted application based on the original version of a program.
     Program originalProgramForDraftApp =
@@ -1155,7 +1155,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Creates an app + draft app for a program as well as
     // an application for another program and ensures that
     // the submitted timestamp is present.
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
 
     // Create a submitted application based on the original version of a program.
     Program programForDraftApp =
@@ -1203,7 +1203,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant_multipleActiveAndDraftApplications() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Program programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
@@ -1293,7 +1293,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant_withApplicationStatus() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Program program =
         ProgramBuilder.newActiveProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
@@ -1323,7 +1323,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void relevantProgramsForApplicant_withApplicationStatusAndOlderProgramVersion() {
-    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     Program originalProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))


### PR DESCRIPTION
### Description

Presumably this method tried to set the applicant ID at some point, but that is determined by the Database.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
