### PR TITLE
Always close BrowserContext after test finishes 

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -194,9 +194,10 @@ export const createTestContext = (clearDb = true): TestContext => {
           ctx.browserErrorWatcher.failIfContainsErrors()
         }
       } finally {
-        // browserErrorWatcher might throw error that should be bubble up all
-        // the way to user. But even if error is thrown we need to close the
-        // browser context, for example to save videos.
+        // browserErrorWatcher might throw an error that should bubble up all
+        // the way to the developer. Regardless whether the error is thrown or
+        // not we need to close the browser context. Without that some processes
+        // won't be finished, like saving videos.
         await browserContext.close()
       }
     }

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -189,10 +189,16 @@ export const createTestContext = (clearDb = true): TestContext => {
   // we'll get one huge video for all tests.
   async function resetContext() {
     if (browserContext != null) {
-      if (!DISABLE_BROWSER_ERROR_WATCHER) {
-        ctx.browserErrorWatcher.failIfContainsErrors()
+      try {
+        if (!DISABLE_BROWSER_ERROR_WATCHER) {
+          ctx.browserErrorWatcher.failIfContainsErrors()
+        }
+      } finally {
+        // browserErrorWatcher might throw error that should be bubble up all
+        // the way to user. But even if error is thrown we need to close the
+        // browser context, for example to save videos.
+        await browserContext.close()
       }
-      await browserContext.close()
     }
     browserContext = await makeBrowserContext(browser)
     ctx.page = await browserContext.newPage()


### PR DESCRIPTION
At the moment if test finished but there is an error detected then BrowserContext isn't closed properly. It leads to video not being saved or potentially other inconveniences. 