### PR TITLE
Clean up USE_JS_BUNDLES flags

### DIFF
--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -31,7 +31,6 @@ public final class FeatureFlags {
   public static final String PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED =
       "program_eligibility_conditions_enabled";
   public static final String PROGRAM_READ_ONLY_VIEW_ENABLED = "program_read_only_view_enabled";
-  private static final String USE_JS_BUNDLES = "use_js_bundles";
 
   private final Config config;
 
@@ -85,10 +84,6 @@ public final class FeatureFlags {
 
   public boolean isReadOnlyProgramViewEnabled(Request request) {
     return getFlagEnabled(request, PROGRAM_READ_ONLY_VIEW_ENABLED);
-  }
-
-  public boolean isJsBundlingEnabled() {
-    return config.getBoolean(USE_JS_BUNDLES);
   }
 
   public ImmutableMap<String, Boolean> getAllFlags(Request request) {

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.input;
 
 import com.google.common.collect.ImmutableList;
-import featureflags.FeatureFlags;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.ScriptTag;
 import java.util.Optional;
@@ -16,12 +15,10 @@ import services.cloud.azure.BlobStorageUploadRequest;
 public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
 
   private final ViewUtils viewUtils;
-  private final FeatureFlags featureFlags;
 
   @Inject
-  AzureFileUploadViewStrategy(ViewUtils viewUtils, FeatureFlags featureFlags) {
+  AzureFileUploadViewStrategy(ViewUtils viewUtils) {
     this.viewUtils = checkNotNull(viewUtils);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   @Override
@@ -71,13 +68,7 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
 
   @Override
   protected ImmutableList<ScriptTag> extraScriptTags() {
-    ImmutableList.Builder<ScriptTag> builder = ImmutableList.builder();
-    builder.add(viewUtils.makeAzureBlobStoreScriptTag());
-    if (!featureFlags.isJsBundlingEnabled()) {
-      builder.add(viewUtils.makeLocalJsTag("azure_upload"));
-      builder.add(viewUtils.makeLocalJsTag("azure_delete"));
-    }
-    return builder.build();
+    return ImmutableList.of(viewUtils.makeAzureBlobStoreScriptTag());
   }
 
   @Override

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -31,7 +31,6 @@ public class BaseHtmlLayout {
 
   private static final String CIVIFORM_TITLE = "CiviForm";
   private static final String TAILWIND_COMPILED_FILENAME = "tailwind";
-  private static final String[] FOOTER_SCRIPTS = {"main", "accordion", "modal", "radio", "toast"};
   private static final String BANNER_TEXT =
       "Do not enter actual or personal data in this demo site";
 
@@ -62,7 +61,7 @@ public class BaseHtmlLayout {
 
   /** Creates a new {@link HtmlBundle} with default css, scripts, and toast messages. */
   public HtmlBundle getBundle() {
-    return getBundle(new HtmlBundle(viewUtils, featureFlags.isJsBundlingEnabled()));
+    return getBundle(new HtmlBundle(viewUtils));
   }
 
   /**
@@ -104,12 +103,6 @@ public class BaseHtmlLayout {
         .map(id -> getAnalyticsScripts(id).toArray(new ScriptTag[0]))
         .ifPresent(bundle::addFooterScripts);
 
-    // Add default scripts.
-    if (!featureFlags.isJsBundlingEnabled()) {
-      for (String source : FOOTER_SCRIPTS) {
-        bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
-      }
-    }
     // Add the favicon link
     bundle.setFavicon(civiformFaviconUrl);
     bundle.setJsBundle(getJsBundle());

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -58,11 +58,9 @@ public final class HtmlBundle {
   private final ArrayList<LinkTag> stylesheets = new ArrayList<>();
   private final ArrayList<ToastMessage> toastMessages = new ArrayList<>();
   private final ViewUtils viewUtils;
-  private final boolean enableJsBundles;
 
-  public HtmlBundle(ViewUtils viewUtils, boolean enableJsBundles) {
+  public HtmlBundle(ViewUtils viewUtils) {
     this.viewUtils = checkNotNull(viewUtils);
-    this.enableJsBundles = enableJsBundles;
   }
 
   public HtmlBundle addBodyStyles(String... styles) {
@@ -184,9 +182,7 @@ public final class HtmlBundle {
     if (jsBundle == null) {
       throw new IllegalStateException("JS bundle must be set for every page.");
     }
-    if (enableJsBundles) {
-      footerTag.with(viewUtils.makeLocalJsTag(jsBundle.getJsPath()));
-    }
+    footerTag.with(viewUtils.makeLocalJsTag(jsBundle.getJsPath()));
 
     if (footerStyles.size() > 0) {
       footerTag.withClasses(footerStyles.toArray(new String[0]));

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -37,8 +37,6 @@ public final class AdminLayout extends BaseHtmlLayout {
 
   private final NavPage activeNavPage;
 
-  private static final String[] FOOTER_SCRIPTS = {"preview", "questionBank", "admin_validation"};
-
   private AdminType primaryAdminType = AdminType.CIVI_FORM_ADMIN;
 
   AdminLayout(
@@ -68,12 +66,6 @@ public final class AdminLayout extends BaseHtmlLayout {
     bundle.addMainStyles(
         AdminStyles.MAIN, isCentered ? AdminStyles.MAIN_CENTERED : AdminStyles.MAIN_FULL);
     bundle.addBodyStyles(AdminStyles.BODY);
-
-    if (!featureFlags.isJsBundlingEnabled()) {
-      for (String source : FOOTER_SCRIPTS) {
-        bundle.addFooterScripts(viewUtils.makeLocalJsTag(source));
-      }
-    }
 
     return super.render(bundle);
   }

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -9,7 +9,6 @@ import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import controllers.admin.routes;
-import featureflags.FeatureFlags;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import java.util.List;
@@ -34,18 +33,15 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
   private final AdminLayout layout;
   private final String baseUrl;
   private final ProgramCardFactory programCardFactory;
-  private final FeatureFlags featureFlags;
 
   @Inject
   public ProgramAdministratorProgramListView(
       AdminLayoutFactory layoutFactory,
       Config config,
-      ProgramCardFactory programCardFactory,
-      FeatureFlags featureFlags) {
+      ProgramCardFactory programCardFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
     this.programCardFactory = checkNotNull(programCardFactory);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -72,10 +68,6 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                         .map(programCardFactory::renderCard)));
 
     HtmlBundle htmlBundle = layout.getBundle().setTitle(title).addMainContent(contentDiv);
-    if (!featureFlags.isJsBundlingEnabled()) {
-      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
-    }
-
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -36,9 +36,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
 
   @Inject
   public ProgramAdministratorProgramListView(
-      AdminLayoutFactory layoutFactory,
-      Config config,
-      ProgramCardFactory programCardFactory) {
+      AdminLayoutFactory layoutFactory, Config config, ProgramCardFactory programCardFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
     this.programCardFactory = checkNotNull(programCardFactory);

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -17,7 +17,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import controllers.admin.routes;
-import featureflags.FeatureFlags;
 import j2html.TagCreator;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
@@ -63,19 +62,16 @@ public final class ProgramApplicationListView extends BaseHtmlView {
   private final AdminLayout layout;
   private final ApplicantUtils applicantUtils;
   private final DateConverter dateConverter;
-  private final FeatureFlags featureFlags;
   private final Logger log = LoggerFactory.getLogger(ProgramApplicationListView.class);
 
   @Inject
   public ProgramApplicationListView(
       AdminLayoutFactory layoutFactory,
       ApplicantUtils applicantUtils,
-      DateConverter dateConverter,
-      FeatureFlags featureFlags) {
+      DateConverter dateConverter) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS).setOnlyProgramAdminType();
     this.applicantUtils = checkNotNull(applicantUtils);
     this.dateConverter = checkNotNull(dateConverter);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -137,9 +133,6 @@ public final class ProgramApplicationListView extends BaseHtmlView {
             .addMainStyles("flex")
             .addMainContent(makeCsrfTokenInputTag(request), applicationListDiv, applicationShowDiv);
 
-    if (!featureFlags.isJsBundlingEnabled()) {
-      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_applications"));
-    }
     Optional<String> maybeSuccessMessage = request.flash().get("success");
     if (maybeSuccessMessage.isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -67,8 +67,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
   private final Messages enUsMessages;
 
   @Inject
-  public ProgramApplicationView(
-      BaseHtmlLayout layout, @EnUsLang Messages enUsMessages) {
+  public ProgramApplicationView(BaseHtmlLayout layout, @EnUsLang Messages enUsMessages) {
     this.layout = checkNotNull(layout);
     this.enUsMessages = checkNotNull(enUsMessages);
   }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.inject.Inject;
-import featureflags.FeatureFlags;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -66,14 +65,12 @@ public final class ProgramApplicationView extends BaseHtmlView {
   public static final String NOTE = "note";
   private final BaseHtmlLayout layout;
   private final Messages enUsMessages;
-  private final FeatureFlags featureFlags;
 
   @Inject
   public ProgramApplicationView(
-      BaseHtmlLayout layout, @EnUsLang Messages enUsMessages, FeatureFlags featureFlags) {
+      BaseHtmlLayout layout, @EnUsLang Messages enUsMessages) {
     this.layout = checkNotNull(layout);
     this.enUsMessages = checkNotNull(enUsMessages);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -156,9 +153,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .addModals(updateNoteModal)
             .addModals(statusUpdateConfirmationModals)
             .setJsBundle(JsBundle.ADMIN);
-    if (!featureFlags.isJsBundlingEnabled()) {
-      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_application_view"));
-    }
     Optional<String> maybeSuccessMessage = request.flash().get("success");
     if (maybeSuccessMessage.isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -132,9 +132,6 @@ public final class ProgramIndexView extends BaseHtmlView {
             .setTitle(pageTitle)
             .addMainContent(contentDiv)
             .addModals(demographicsCsvModal);
-    if (!featureFlags.isJsBundlingEnabled()) {
-      htmlBundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
-    }
     maybePublishModal.ifPresent(htmlBundle::addModals);
 
     Http.Flash flash = request.flash();

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -7,7 +7,6 @@ import static j2html.TagCreator.form;
 
 import com.google.inject.assistedinject.Assisted;
 import controllers.applicant.routes;
-import featureflags.FeatureFlags;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -33,18 +32,15 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
   private final ApplicantLayout layout;
   private final FileUploadViewStrategy fileUploadStrategy;
   private final ApplicantQuestionRendererFactory applicantQuestionRendererFactory;
-  private final FeatureFlags featureFlags;
 
   @Inject
   ApplicantProgramBlockEditView(
       ApplicantLayout layout,
       FileUploadViewStrategy fileUploadStrategy,
-      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory,
-      FeatureFlags featureFlags) {
+      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory) {
     this.layout = checkNotNull(layout);
     this.fileUploadStrategy = checkNotNull(fileUploadStrategy);
     this.applicantQuestionRendererFactory = applicantQuestionRendererFactory;
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(Params params) {
@@ -78,14 +74,6 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
           renderLocaleNotSupportedToast(
               params.applicantId(), params.programId(), params.messages()));
     }
-
-    if (params.block().isFileUpload() && !featureFlags.isJsBundlingEnabled()) {
-      bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("file_upload"));
-    }
-    if (params.block().isEnumerator() && !featureFlags.isJsBundlingEnabled()) {
-      bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("enumerator"));
-    }
-
     return layout.renderWithNav(
         params.request(), params.applicantName(), params.messages(), bundle);
   }

--- a/server/app/views/dev/IconsView.java
+++ b/server/app/views/dev/IconsView.java
@@ -10,7 +10,6 @@ import static j2html.TagCreator.tr;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import featureflags.FeatureFlags;
 import j2html.tags.specialized.TableTag;
 import j2html.tags.specialized.TrTag;
 import play.twirl.api.Content;
@@ -27,12 +26,10 @@ import views.style.ReferenceClasses;
  */
 public final class IconsView extends BaseHtmlView {
   private final BaseHtmlLayout layout;
-  private final FeatureFlags featureFlags;
 
   @Inject
-  public IconsView(BaseHtmlLayout layout, FeatureFlags featureFlags) {
+  public IconsView(BaseHtmlLayout layout) {
     this.layout = checkNotNull(layout);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render() {
@@ -44,9 +41,6 @@ public final class IconsView extends BaseHtmlView {
                 each(ImmutableList.copyOf(Icons.values()), this::renderIconRow));
     HtmlBundle bundle =
         layout.getBundle().setTitle("Icons").addMainContent(content).setJsBundle(JsBundle.ADMIN);
-    if (!featureFlags.isJsBundlingEnabled()) {
-      bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("dev_icons"));
-    }
     return layout.render(bundle);
   }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -666,8 +666,4 @@ program_eligibility_conditions_enabled = ${?PROGRAM_ELIGIBILITY_CONDITIONS_ENABL
 feature_flag_overrides_enabled = false
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
 
-# When set to true JS is served using JS bundles.
-# https://github.com/civiform/civiform/issues/3864
-use_js_bundles = true
-use_js_bundles = ${?USE_JS_BUNDLES}
 

--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -109,7 +109,6 @@ object TypescriptBuilder extends AutoPlugin {
       incremental.syncIncremental(cacheDir, tsFiles)({ modifiedFiles =>
         if (modifiedFiles.nonEmpty || !targetDir.exists()) {
           log.info("Typescript files changed. Recompiling...")
-          compileTypescriptInternal(targetDir, log)
           runWebpack(targetDir, log)
         }
         val compiledJsFiles: Seq[File] = targetDir.listFiles()
@@ -123,33 +122,6 @@ object TypescriptBuilder extends AutoPlugin {
       })(fileHasher)
 
     compiledJsFiles
-  }
-
-  /** Function that compiles TS files. It relies on tsconfig.json to contain all
-    * necessary settings including which source files to compile. Note that we
-    * don't pass input source files. Instead we simply compile everything in
-    * server/app/assets/javascripts folder (check server/tsconfig.json).
-    *
-    * @param targetDir
-    *   Directory in which compiled JS and sourcemap files will be added.
-    * @param log
-    *   Logger object to output compilation errors to sbt console.
-    */
-  def compileTypescriptInternal(targetDir: File, log: ManagedLogger) = {
-    val compilationCommand =
-      "npx tsc --pretty --project tsconfig.json --outDir " + targetDir
-    val res = Process(compilationCommand) ! ProcessLogger(
-      line => log.error(line),
-      line => log.error(line)
-    )
-    if (res != 0) {
-      log.info(
-        "To debug TS code compilation run the following command from 'server' folder:\n    " + compilationCommand
-      )
-      throw new sbt.MessageOnlyException(
-        "TypeScript compilation failed. Check console to see compilation errors."
-      )
-    }
   }
 
   def runWebpack(targetDir: File, log: ManagedLogger) = {

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -72,7 +72,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
   @Test
   public void canAddContentBefore() {
-    HtmlBundle bundle = new HtmlBundle(instanceOf(ViewUtils.class), /* enableJsBundles= */ true);
+    HtmlBundle bundle = new HtmlBundle(instanceOf(ViewUtils.class));
 
     // Add stylesheet before default.
     LinkTag linkTag = link().withHref("moose.css").withRel("stylesheet");

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -19,7 +19,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testSetTitle() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
     bundle.setTitle("My title").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
@@ -28,7 +28,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testFavicon() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
     bundle.setFavicon("www.civiform.com/favicon").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
@@ -37,7 +37,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testNoFavicon() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
 
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
@@ -46,7 +46,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void emptyBundleRendersOutline() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
 
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
@@ -59,7 +59,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void rendersContentInOrder() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
     bundle.addMainContent(div("One")).addMainContent(div("Two")).setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
@@ -67,15 +67,8 @@ public class HtmlBundleTest extends ResetPostgres {
   }
 
   @Test
-  public void renderWithJsBundlesDisabled() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ false);
-    Content content = bundle.setJsBundle(JsBundle.APPLICANT).render();
-    assertThat(content.body()).doesNotContain("applicant.bundle.js");
-  }
-
-  @Test
-  public void renderWithJsBundlesEnabled() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils, /* enableJsBundles= */ true);
+  public void rendersBundle() {
+    HtmlBundle bundle = new HtmlBundle(viewUtils);
     Content content = bundle.setJsBundle(JsBundle.APPLICANT).render();
     assertThat(content.body()).contains("applicant.bundle.js");
   }

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -51,7 +51,7 @@ public class HtmlBundleTest extends ResetPostgres {
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
     assertThat(content.body())
-        .matches(
+        .containsPattern(
             "<body><header></header><main></main><div id=\"modal-container\" class=\"hidden fixed"
                 + " h-screen w-screen z-20\"><div id=\"modal-glass-pane\" class=\"fixed h-screen"
                 + " w-screen bg-gray-400 opacity-75\"></div></div><footer><script src=\"/assets/"

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -51,10 +51,12 @@ public class HtmlBundleTest extends ResetPostgres {
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
     assertThat(content.body())
-        .contains(
+        .matches(
             "<body><header></header><main></main><div id=\"modal-container\" class=\"hidden fixed"
                 + " h-screen w-screen z-20\"><div id=\"modal-glass-pane\" class=\"fixed h-screen"
-                + " w-screen bg-gray-400 opacity-75\"></div></div><footer></footer></body>");
+                + " w-screen bg-gray-400 opacity-75\"></div></div><footer><script src=\"/assets/"
+                + "javascripts/[a-z0-9]+-applicant.bundle.js\" type=\"text/javascript\"></script>"
+                + "</footer></body>");
   }
 
   @Test
@@ -64,12 +66,5 @@ public class HtmlBundleTest extends ResetPostgres {
 
     Content content = bundle.render();
     assertThat(content.body()).contains("<main><div>One</div><div>Two</div></main>");
-  }
-
-  @Test
-  public void rendersBundle() {
-    HtmlBundle bundle = new HtmlBundle(viewUtils);
-    Content content = bundle.setJsBundle(JsBundle.APPLICANT).render();
-    assertThat(content.body()).contains("applicant.bundle.js");
   }
 }


### PR DESCRIPTION
### Description

Its default value was set to true and ran for a week in production (Seattle). No issues were raised so I consider it to be safe for the cleanup. 

## Release notes

Clean up USE_JS_BUNDLES flags since JS bundles have been launched. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Issue #3864
