### PR TITLE
Explicitly name Visibility predicate routes

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -69,7 +69,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
    * configurations.
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public Result edit(Request request, long programId, long blockDefinitionId) {
+  public Result editVisibility(Request request, long programId, long blockDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
@@ -119,7 +119,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   }
   /** POST endpoint for updating show-hide configurations. */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public Result update(Request request, long programId, long blockDefinitionId) {
+  public Result updateVisibility(Request request, long programId, long blockDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
     Form<BlockVisibilityPredicateForm> predicateFormWrapper =
@@ -132,7 +132,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           .forEach(error -> errorMessageBuilder.append(String.format("\n• %s", error.message())));
 
       return redirect(
-              routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+              routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
           .flashing("error", errorMessageBuilder.toString());
     }
 
@@ -159,7 +159,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
         PredicateDefinition.create(PredicateExpressionNode.create(leafExpression), action);
 
     try {
-      programService.setBlockPredicate(
+      programService.setBlockVisibilityPredicate(
           programId, blockDefinitionId, Optional.of(predicateDefinition));
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
@@ -168,14 +168,14 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     } catch (IllegalPredicateOrderingException e) {
       return redirect(
-              routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+              routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
           .flashing("error", e.getLocalizedMessage());
     }
 
     ReadOnlyQuestionService roQuestionService =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join();
 
-    return redirect(routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+    return redirect(routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
         .flashing(
             "success",
             String.format(
@@ -259,7 +259,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
 
   /** POST endpoint for deleting show-hide configurations. */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public Result destroy(long programId, long blockDefinitionId) {
+  public Result destroyVisibility(long programId, long blockDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
@@ -271,7 +271,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     }
 
-    return redirect(routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+    return redirect(routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
         .flashing("success", "Removed the visibility condition for this screen.");
   }
 

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -132,7 +132,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           .forEach(error -> errorMessageBuilder.append(String.format("\n• %s", error.message())));
 
       return redirect(
-              routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
+              routes.AdminProgramBlockPredicatesController.editVisibility(
+                  programId, blockDefinitionId))
           .flashing("error", errorMessageBuilder.toString());
     }
 
@@ -168,14 +169,17 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     } catch (IllegalPredicateOrderingException e) {
       return redirect(
-              routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
+              routes.AdminProgramBlockPredicatesController.editVisibility(
+                  programId, blockDefinitionId))
           .flashing("error", e.getLocalizedMessage());
     }
 
     ReadOnlyQuestionService roQuestionService =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join();
 
-    return redirect(routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
+    return redirect(
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                programId, blockDefinitionId))
         .flashing(
             "success",
             String.format(
@@ -271,7 +275,9 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     }
 
-    return redirect(routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockDefinitionId))
+    return redirect(
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                programId, blockDefinitionId))
         .flashing("success", "Removed the visibility condition for this screen.");
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -424,7 +424,7 @@ public class DatabaseSeedController extends DevController {
           PredicateDefinition.create(
               PredicateExpressionNode.create(operation), PredicateAction.SHOW_BLOCK);
       programDefinition =
-          programService.setBlockPredicate(programId, blockId, Optional.of(predicate));
+          programService.setBlockVisibilityPredicate(programId, blockId, Optional.of(predicate));
 
       // Add file upload as optional to make local testing easier.
       blockId =

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -264,7 +264,7 @@ public interface ProgramService {
    *     real Block.
    * @throws IllegalPredicateOrderingException if this predicate cannot be added to this block
    */
-  ProgramDefinition setBlockPredicate(
+  ProgramDefinition setBlockVisibilityPredicate(
       long programId, long blockDefinitionId, Optional<PredicateDefinition> predicate)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
           IllegalPredicateOrderingException;

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -710,7 +710,8 @@ public final class ProgramServiceImpl implements ProgramService {
   public ProgramDefinition removeBlockPredicate(long programId, long blockDefinitionId)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     try {
-      return setBlockVisibilityPredicate(programId, blockDefinitionId, /* predicate= */ Optional.empty());
+      return setBlockVisibilityPredicate(
+          programId, blockDefinitionId, /* predicate= */ Optional.empty());
     } catch (IllegalPredicateOrderingException e) {
       // Removing a predicate should never invalidate another.
       throw new RuntimeException("Unexpected error: removing this predicate invalidates another");

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -675,7 +675,7 @@ public final class ProgramServiceImpl implements ProgramService {
 
   @Override
   @Transactional
-  public ProgramDefinition setBlockPredicate(
+  public ProgramDefinition setBlockVisibilityPredicate(
       long programId, long blockDefinitionId, Optional<PredicateDefinition> predicate)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
           IllegalPredicateOrderingException {
@@ -710,7 +710,7 @@ public final class ProgramServiceImpl implements ProgramService {
   public ProgramDefinition removeBlockPredicate(long programId, long blockDefinitionId)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     try {
-      return setBlockPredicate(programId, blockDefinitionId, /* predicate= */ Optional.empty());
+      return setBlockVisibilityPredicate(programId, blockDefinitionId, /* predicate= */ Optional.empty());
     } catch (IllegalPredicateOrderingException e) {
       // Removing a predicate should never invalidate another.
       throw new RuntimeException("Unexpected error: removing this predicate invalidates another");

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -435,7 +435,7 @@ public final class ProgramBlockEditView extends ProgramBlockView {
         .with(
             asRedirectElement(
                 editScreenButton,
-                routes.AdminProgramBlockPredicatesController.edit(programId, blockId).url()));
+                routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockId).url()));
   }
 
   private DivTag renderEligibilityPredicate(

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -435,7 +435,8 @@ public final class ProgramBlockEditView extends ProgramBlockView {
         .with(
             asRedirectElement(
                 editScreenButton,
-                routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockId).url()));
+                routes.AdminProgramBlockPredicatesController.editVisibility(programId, blockId)
+                    .url()));
   }
 
   private DivTag renderEligibilityPredicate(

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -146,11 +146,11 @@ public final class ProgramBlockPredicatesEditView extends ProgramBlockView {
             "There are no available questions with which to set a visibility condition for this"
                 + " screen.";
         predicateUpdateUrl =
-            routes.AdminProgramBlockPredicatesController.update(
+            routes.AdminProgramBlockPredicatesController.updateVisibility(
                     programDefinition.id(), blockDefinition.id())
                 .url();
         removePredicateUrl =
-            routes.AdminProgramBlockPredicatesController.destroy(
+            routes.AdminProgramBlockPredicatesController.destroyVisibility(
                     programDefinition.id(), blockDefinition.id())
                 .url();
         break;

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -47,12 +47,12 @@ POST    /admin/programs/:programId/blocks/:blockDefinitionId/move      controlle
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/delete    controllers.admin.AdminProgramBlocksController.destroy(programId: Long, blockDefinitionId: Long)
 
 # A controller for pages for an admin to configure show/hide logic on blocks for a program
-GET     /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/edit    controllers.admin.AdminProgramBlockPredicatesController.edit(request: Request, programId: Long, blockDefinitionId: Long)
-GET     /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/editEligibility    controllers.admin.AdminProgramBlockPredicatesController.editEligibility(request: Request, programId: Long, blockDefinitionId: Long)
-POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates         controllers.admin.AdminProgramBlockPredicatesController.update(request: Request, programId: Long, blockDefinitionId: Long)
-POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/eligibilityPredicates         controllers.admin.AdminProgramBlockPredicatesController.updateEligibility(request: Request, programId: Long, blockDefinitionId: Long)
-POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/delete  controllers.admin.AdminProgramBlockPredicatesController.destroy(programId: Long, blockDefinitionId: Long)
-POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/deleteEligibility  controllers.admin.AdminProgramBlockPredicatesController.destroyEligibility(programId: Long, blockDefinitionId: Long)
+GET     /admin/programs/:programId/blocks/:blockDefinitionId/visibilityPredicates/edit    controllers.admin.AdminProgramBlockPredicatesController.editVisibility(request: Request, programId: Long, blockDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/visibilityPredicates         controllers.admin.AdminProgramBlockPredicatesController.updateVisibility(request: Request, programId: Long, blockDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/visibilityPredicates/delete  controllers.admin.AdminProgramBlockPredicatesController.destroyVisibility(programId: Long, blockDefinitionId: Long)
+GET     /admin/programs/:programId/blocks/:blockDefinitionId/eligibilityPredicates/edit   controllers.admin.AdminProgramBlockPredicatesController.editEligibility(request: Request, programId: Long, blockDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/eligibilityPredicates        controllers.admin.AdminProgramBlockPredicatesController.updateEligibility(request: Request, programId: Long, blockDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/eligibilityPredicates/delete controllers.admin.AdminProgramBlockPredicatesController.destroyEligibility(programId: Long, blockDefinitionId: Long)
 
 # A controller for adding and removing questions from program blocks
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions                                     controllers.admin.AdminProgramBlockQuestionsController.create(request: Request, programId: Long, blockDefinitionId: Long)

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -47,7 +47,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withNonExistantProgram_notFound() {
     assertThatThrownBy(
             () ->
-                controller.edit(
+                controller.editVisibility(
                     fakeRequest().build(), /* programId= */ 1, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
@@ -85,7 +85,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () -> controller.edit(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+            () -> controller.editVisibility(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -103,7 +103,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withFirstBlock_displaysEmptyList() {
     Http.Request request = addCSRFToken(fakeRequest()).build();
 
-    Result result = controller.edit(request, programWithThreeBlocks.id, 1L);
+    Result result = controller.editVisibility(request, programWithThreeBlocks.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -133,7 +133,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withThirdBlock_displaysQuestionsFromFirstAndSecondBlock() {
     Http.Request request = addCSRFToken(fakeRequest()).build();
 
-    Result result = controller.edit(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.editVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -152,7 +152,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void update_withValidFormData_savesNewPredicate() {
     // Test that the edit page does not display a saved predicate beforehand.
     Result editBeforeResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(editBeforeResult)).contains("This screen is always shown.");
 
     Http.Request request =
@@ -171,19 +171,19 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "Hello"))
             .build();
 
-    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult))
         .doesNotContain("This screen is always shown.");
   }
@@ -251,12 +251,12 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "1"))
             .build();
 
-    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
   }
@@ -279,19 +279,19 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "1"))
             .build();
 
-    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult))
         .doesNotContain("This screen is always shown.");
   }
@@ -314,19 +314,19 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     ""))
             .build();
 
-    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error").get()).contains("Did not save visibility condition");
     assertThat(result.flash().get("success")).isEmpty();
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 
@@ -385,12 +385,12 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "Hello"))
             .build();
 
-    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error").get()).contains("Did not save visibility condition");
     assertThat(result.flash().get("error").get())
         .contains("Cannot use operator \"is greater than\" on scalar \"first name\".");
@@ -399,7 +399,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 
@@ -446,7 +446,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void update_activeProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () -> controller.update(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+            () -> controller.updateVisibility(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -463,7 +463,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   @Test
   public void destroy_activeProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThatThrownBy(() -> controller.destroy(programId, /* blockDefinitionId= */ 1))
+    assertThatThrownBy(() -> controller.destroyVisibility(programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -492,12 +492,12 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "predicateValue",
                     "Hello"))
             .build();
-    Result resultWithPredicate = controller.update(request, programWithThreeBlocks.id, 3L);
+    Result resultWithPredicate = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
     assertThat(resultWithPredicate.flash().get("success").get())
         .contains("Saved visibility condition");
 
     // Then use the destroy endpoint and confirm the predicate's absence.
-    Result resultWithoutPredicate = controller.destroy(programWithThreeBlocks.id, 3L);
+    Result resultWithoutPredicate = controller.destroyVisibility(programWithThreeBlocks.id, 3L);
 
     assertThat(resultWithoutPredicate.status()).isEqualTo(SEE_OTHER);
     assertThat(resultWithoutPredicate.flash().get("success").get())
@@ -506,7 +506,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -85,7 +85,9 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () -> controller.editVisibility(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+            () ->
+                controller.editVisibility(
+                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -152,7 +154,8 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void update_withValidFormData_savesNewPredicate() {
     // Test that the edit page does not display a saved predicate beforehand.
     Result editBeforeResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(editBeforeResult)).contains("This screen is always shown.");
 
     Http.Request request =
@@ -176,14 +179,17 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                    programWithThreeBlocks.id, 3L)
+                .url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult))
         .doesNotContain("This screen is always shown.");
   }
@@ -256,7 +262,9 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                    programWithThreeBlocks.id, 3L)
+                .url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
   }
@@ -284,14 +292,17 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                    programWithThreeBlocks.id, 3L)
+                .url());
     assertThat(result.flash().get("error")).isEmpty();
     assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult))
         .doesNotContain("This screen is always shown.");
   }
@@ -319,14 +330,17 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                    programWithThreeBlocks.id, 3L)
+                .url());
     assertThat(result.flash().get("error").get()).contains("Did not save visibility condition");
     assertThat(result.flash().get("success")).isEmpty();
 
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 
@@ -390,7 +404,9 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlockPredicatesController.editVisibility(programWithThreeBlocks.id, 3L).url());
+            routes.AdminProgramBlockPredicatesController.editVisibility(
+                    programWithThreeBlocks.id, 3L)
+                .url());
     assertThat(result.flash().get("error").get()).contains("Did not save visibility condition");
     assertThat(result.flash().get("error").get())
         .contains("Cannot use operator \"is greater than\" on scalar \"first name\".");
@@ -399,7 +415,8 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 
@@ -446,7 +463,9 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void update_activeProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () -> controller.updateVisibility(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+            () ->
+                controller.updateVisibility(
+                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -492,7 +511,8 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
                     "predicateValue",
                     "Hello"))
             .build();
-    Result resultWithPredicate = controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
+    Result resultWithPredicate =
+        controller.updateVisibility(request, programWithThreeBlocks.id, 3L);
     assertThat(resultWithPredicate.flash().get("success").get())
         .contains("Saved visibility condition");
 
@@ -506,7 +526,8 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     // For some reason the above result has an empty contents. So we test the new content of the
     // edit page manually.
     Result redirectResult =
-        controller.editVisibility(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+        controller.editVisibility(
+            addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This screen is always shown.");
   }
 

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -820,7 +820,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
                             AndNode.create(ImmutableSet.of(statePredicate, zipPredicate)))))),
             PredicateAction.HIDE_BLOCK);
 
-    ps.setBlockPredicate(program.id, 2L, Optional.of(predicate));
+    ps.setBlockVisibilityPredicate(program.id, 2L, Optional.of(predicate));
 
     ProgramDefinition found = ps.getProgramDefinition(program.id);
 
@@ -833,7 +833,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     ProgramDefinition p = ProgramBuilder.newDraftProgram().buildDefinition();
     assertThatThrownBy(
             () ->
-                ps.setBlockPredicate(
+                ps.setBlockVisibilityPredicate(
                     p.id(),
                     100L,
                     Optional.of(
@@ -860,7 +860,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     Long programId = programDefinition.id();
 
     ProgramDefinition found =
-        ps.setBlockPredicate(
+        ps.setBlockVisibilityPredicate(
             programId,
             2L,
             Optional.of(
@@ -896,7 +896,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
     // This predicate depends on a question that doesn't exist in a prior block.
     assertThatExceptionOfType(IllegalPredicateOrderingException.class)
-        .isThrownBy(() -> ps.setBlockPredicate(program.id(), 2L, Optional.of(predicate)))
+        .isThrownBy(() -> ps.setBlockVisibilityPredicate(program.id(), 2L, Optional.of(predicate)))
         .withMessage("This action would invalidate a block condition");
   }
 
@@ -919,7 +919,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
                     Operator.EQUAL_TO,
                     PredicateValue.of(""))),
             PredicateAction.HIDE_BLOCK);
-    ps.setBlockPredicate(program.id, 2L, Optional.of(predicate));
+    ps.setBlockVisibilityPredicate(program.id, 2L, Optional.of(predicate));
 
     ProgramDefinition foundWithPredicate = ps.getProgramDefinition(program.id);
     assertThat(foundWithPredicate.blockDefinitions().get(1).visibilityPredicate())


### PR DESCRIPTION
### Description

'Visibility' was the implicit value for these routes, and when 'Eligibility' was added we created similar paths with explicit naming for those.  This makes the implicit Visibility paths explicit.

Cleaned up the edit/predicate/edit pattern in the routes too.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
