### PR TITLE
Rework handling of errors in BrowserErrorWatcher

### DIFF
--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -39,8 +39,8 @@ export class BrowserErrorWatcher {
 
     // Catch requests failed due to 4xx or 5xx responses.
     page.on('requestfinished', (request) => {
-      try {
-        void request.response().then((response) => {
+      void request.response().then(
+        (response) => {
           if (response == null) return
           const statusCode = response.status()
           if (statusCode >= 400 && statusCode < 600) {
@@ -49,11 +49,12 @@ export class BrowserErrorWatcher {
               url: request.url(),
             })
           }
-        })
-      } catch (e) {
-        // do nothing. Sometimes we are getting error like:
-        // request.response: Target page, context or browser has been closed
-      }
+        },
+        () => {
+          // do nothing. Sometimes we are getting error like:
+          // request.response: Target page, context or browser has been closed
+        },
+      )
     })
   }
 


### PR DESCRIPTION
Adding `try/catch` around `request.response()` didn't help. I still see errors locally sometimes and in staging prober tests. I think the reason is that the error is thrown as inside promise: the promise is rejected and that rejection is failing the tests. Promise rejections can't be caught by try/catch, instead they need to be handled in `.then()` or `.catch()`.

Ran all tests locally and nothing failed.