### PR TITLE
Fix webpack error output

### DIFF
--- a/server/project/TypescriptBuilder.scala
+++ b/server/project/TypescriptBuilder.scala
@@ -126,7 +126,7 @@ object TypescriptBuilder extends AutoPlugin {
 
   def runWebpack(targetDir: File, log: ManagedLogger) = {
     val compilationCommand =
-      "npx webpack --no-stats --config webpack.config.js --output-path " + targetDir
+      "npx webpack --config webpack.config.js --output-path " + targetDir
     val res = Process(compilationCommand) ! ProcessLogger(
       line => log.error(line),
       line => log.error(line)

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
+  stats: 'errors-only',
   module: {
     rules: [
       {


### PR DESCRIPTION
We want webpack to only print errors skipping all other stats info. Having `--no-stats` hides all webpack output including error. Instead we set stats to output only errors.