### PR TITLE
Refactor admin_programs.ts and toast.ts

### DIFF
--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -1,3 +1,5 @@
+import {ToastController} from './toast'
+
 class AdminPrograms {
   private static PROGRAM_CARDS_SELECTOR = '.cf-admin-program-card'
   private static PROGRAM_LINK_ATTRIBUTE = 'data-copyable-program-link'
@@ -41,10 +43,8 @@ class AdminPrograms {
 
   static async copyProgramLinkToClipboard(programLink: string) {
     const succeeded = await AdminPrograms.tryCopyToClipboard(programLink)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const toastController = window['toastController'] as any
     if (succeeded) {
-      toastController.showToastMessage({
+      ToastController.showToastMessage({
         id: `program-link-${Math.random()}`,
         content: 'Program link copied to clipboard',
         duration: 3000,
@@ -53,7 +53,7 @@ class AdminPrograms {
         canIgnore: false,
       })
     } else {
-      toastController.showToastMessage({
+      ToastController.showToastMessage({
         id: `program-link-${Math.random()}`,
         content: `Could not copy program link to clipboard: ${programLink}`,
         duration: -1,

--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -7,18 +7,18 @@
  *  - permanently dismiss toast messags (using localStorage)
  */
 export class ToastController {
-  static CONTAINER_ID = 'toast-container'
-  static MESSAGE_CLASS = 'cf-toast'
-  static MESSAGE_DATA_CLASS = 'cf-toast-data'
+  private static readonly CONTAINER_ID = 'toast-container'
+  private static readonly MESSAGE_CLASS = 'cf-toast'
+  private static readonly MESSAGE_DATA_CLASS = 'cf-toast-data'
 
-  static INFO_SVG_PATH =
+  private static readonly INFO_SVG_PATH =
     'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0' +
     ' 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z'
-  static ERROR_SVG_PATH =
+  private static readonly ERROR_SVG_PATH =
     'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0' +
     ' 102 0V6a1 1 0 00-1-1z'
-  static SUCCESS_SVG_PATH = 'M5 13l4 4L19 7'
-  static WARNING_SVG_PATH =
+  private static readonly SUCCESS_SVG_PATH = 'M5 13l4 4L19 7'
+  private static readonly WARNING_SVG_PATH =
     'M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742' +
     ' 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012' +
     ' 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z'

--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -6,29 +6,27 @@
  *  - dismiss a toast messages based on a user action or after a specified timeout.
  *  - permanently dismiss toast messags (using localStorage)
  */
-class ToastController {
-  static containerId = 'toast-container'
-  static messageClass = 'cf-toast'
-  static messageDataClass = 'cf-toast-data'
+export class ToastController {
+  static CONTAINER_ID = 'toast-container'
+  static MESSAGE_CLASS = 'cf-toast'
+  static MESSAGE_DATA_CLASS = 'cf-toast-data'
 
-  static infoSvgPath =
+  static INFO_SVG_PATH =
     'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0' +
     ' 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z'
-  static errorSvgPath =
+  static ERROR_SVG_PATH =
     'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0' +
     ' 102 0V6a1 1 0 00-1-1z'
-  static successSvgPath = 'M5 13l4 4L19 7'
-  static warningSvgPath =
+  static SUCCESS_SVG_PATH = 'M5 13l4 4L19 7'
+  static WARNING_SVG_PATH =
     'M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742' +
     ' 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012' +
     ' 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z'
 
-  toastContainer: Element
-
   constructor() {
-    this.toastContainer = document.createElement('div')
-    this.toastContainer.setAttribute('id', ToastController.containerId)
-    this.toastContainer.classList.add(
+    const toastContainer = document.createElement('div')
+    toastContainer.setAttribute('id', ToastController.CONTAINER_ID)
+    toastContainer.classList.add(
       'absolute',
       'hidden',
       'left-1/2',
@@ -37,12 +35,12 @@ class ToastController {
       '-translate-x-1/2',
       'z-20',
     )
-    document.body.appendChild(this.toastContainer)
+    document.body.appendChild(toastContainer)
 
-    this.maybeShowToasts()
+    ToastController.maybeShowToasts()
   }
 
-  showToastMessage(message: ToastMessage) {
+  static showToastMessage(message: ToastMessage) {
     const inIgnoreList = localStorage.getItem(message.id + '-dismissed')
     if (message.canIgnore && inIgnoreList) {
       return
@@ -51,7 +49,7 @@ class ToastController {
     const toastMessage = document.createElement('div')
     toastMessage.setAttribute('id', message.id)
     toastMessage.setAttribute('ignorable', String(message.canIgnore))
-    toastMessage.classList.add(ToastController.messageClass)
+    toastMessage.classList.add(ToastController.MESSAGE_CLASS)
     toastMessage.classList.add(
       'bg-opacity-90',
       'duration-300',
@@ -79,7 +77,7 @@ class ToastController {
       toastMessage.classList.add('bg-amber-200', 'border-amber-300')
     }
 
-    toastMessage.appendChild(this.getToastIcon(message.type))
+    toastMessage.appendChild(ToastController.getToastIcon(message.type))
 
     // Add the content string.
     const contentContainer = document.createElement('span')
@@ -101,12 +99,12 @@ class ToastController {
         'hover:opacity-100',
       )
       dismissButton.textContent = 'x'
-      dismissButton.addEventListener('click', this.dismissClicked)
+      dismissButton.addEventListener('click', ToastController.dismissClicked)
       toastMessage.appendChild(dismissButton)
       toastMessage.classList.add('pr-8')
     }
 
-    const toastContainer = document.getElementById(ToastController.containerId)
+    const toastContainer = document.getElementById(ToastController.CONTAINER_ID)
     if (toastContainer) {
       toastContainer.appendChild(toastMessage)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -122,7 +120,7 @@ class ToastController {
     }
   }
 
-  private getToastIcon(type: string): Element {
+  private static getToastIcon(type: string): Element {
     const svgContainer = document.createElement('div')
     svgContainer.classList.add('flex-none', 'pr-2')
 
@@ -141,24 +139,24 @@ class ToastController {
     svg.appendChild(svgPath)
 
     if (type === 'alert') {
-      svgPath.setAttribute('d', ToastController.infoSvgPath)
+      svgPath.setAttribute('d', ToastController.INFO_SVG_PATH)
     } else if (type === 'error') {
-      svgPath.setAttribute('d', ToastController.errorSvgPath)
+      svgPath.setAttribute('d', ToastController.ERROR_SVG_PATH)
     } else if (type === 'success') {
       svg.setAttribute('fill', 'none')
       svg.setAttribute('stroke', 'currentColor')
       svg.setAttribute('stroke-width', '2')
-      svgPath.setAttribute('d', ToastController.successSvgPath)
+      svgPath.setAttribute('d', ToastController.SUCCESS_SVG_PATH)
     } else if (type === 'warning') {
-      svgPath.setAttribute('d', ToastController.warningSvgPath)
+      svgPath.setAttribute('d', ToastController.WARNING_SVG_PATH)
     }
     return svgContainer
   }
 
   /** If a toast message is present, create it and add it to the container. */
-  maybeShowToasts() {
+  private static maybeShowToasts() {
     const messages = Array.from(
-      document.querySelectorAll('.' + ToastController.messageDataClass),
+      document.querySelectorAll('.' + ToastController.MESSAGE_DATA_CLASS),
     )
     messages.forEach((element) => {
       const message: ToastMessage = {
@@ -173,7 +171,7 @@ class ToastController {
         type: element.getAttribute('toastType')!.toLowerCase(),
       }
       element.remove()
-      this.showToastMessage(message)
+      ToastController.showToastMessage(message)
     })
   }
 
@@ -181,9 +179,9 @@ class ToastController {
    *  Hide warning message and throw an indicator in local storage to not show.
    *  @param {Event} event The event that triggered this action.
    *  */
-  dismissClicked(event: Event) {
+  private static dismissClicked(event: Event) {
     const target = event.target as Element
-    const toast = target.closest('.' + ToastController.messageClass)
+    const toast = target.closest('.' + ToastController.MESSAGE_CLASS)
     if (toast && toast.hasAttribute('id')) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const toastId = toast.getAttribute('id')!
@@ -197,7 +195,7 @@ class ToastController {
    * @param {string} toastId The html id of the toast message
    * @param {boolean} dismissClicked Whether to add indicator in local storage to not show
    *  */
-  static dismissToast(toastId: string, dismissClicked: boolean) {
+  private static dismissToast(toastId: string, dismissClicked: boolean) {
     const toastMessage = document.getElementById(toastId)
     if (toastMessage) {
       if (dismissClicked && toastMessage.getAttribute('ignorable')) {
@@ -214,7 +212,7 @@ class ToastController {
    * Removes a toast from the DOM and hides the toast container if it is now empty.
    * @param {string} toastId The html id of the toast message
    * */
-  static cleanupToast(toastId: string) {
+  private static cleanupToast(toastId: string) {
     const toastMessage = document.getElementById(toastId)
     if (toastMessage) {
       // Remove toast message.
@@ -222,7 +220,7 @@ class ToastController {
     }
 
     /** Hide toast container if there are no toast messages active. */
-    const toastContainer = document.getElementById(this.containerId)
+    const toastContainer = document.getElementById(ToastController.CONTAINER_ID)
     if (toastContainer && toastContainer.children.length == 0) {
       toastContainer.classList.add('hidden')
     }
@@ -239,8 +237,5 @@ type ToastMessage = {
 }
 
 export function init() {
-  // toastController is used from other JS files. They read it from the window object.
-  // TODO(#3864): refactor to export instance of controller instead of setting
-  // it on window object.
-  window['toastController'] = new ToastController()
+  new ToastController()
 }


### PR DESCRIPTION
### Description

1. Remove instance variables and methods from ToastController class. All methods can be static as they don't use any state stored in class instance.
2. Change admin_programs.ts to call `ToastController.showToastMessage` static method rather than getting untyped instance from window object. 
3. Rename static variables to use UPPER_CASE as they are const.
4. Add `private` modifiers to most methods/variables. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
