### PR TITLE
Enable typescript strict checks on server code

### DIFF
--- a/browser-test/.eslintrc.json
+++ b/browser-test/.eslintrc.json
@@ -2,7 +2,6 @@
   "root": true,
   "extends": "../formatter/eslintrc_base.json",
   "rules": {
-    "valid-jsdoc": "off",
     "@typescript-eslint/no-non-null-assertion": "off" // this is test code.
   },
   "parserOptions": {

--- a/formatter/eslintrc_base.json
+++ b/formatter/eslintrc_base.json
@@ -16,7 +16,9 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "require-jsdoc": "off",
-    "valid-jsdoc": "warn",
+    // valid-jsdoc is deprecated. If we want JSdoc checks we should use
+    // https://github.com/gajus/eslint-plugin-jsdoc with TS-specific settings.
+    "valid-jsdoc": "off",
     // default JS no-unused-vars causes false-positives on TS code. For example
     // enums.
     "no-unused-vars": "off",

--- a/formatter/eslintrc_base.json
+++ b/formatter/eslintrc_base.json
@@ -23,7 +23,10 @@
     // enums.
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/unbound-method": ["error", {"ignoreStatic": true}]
+    "@typescript-eslint/unbound-method": ["error", {"ignoreStatic": true}],
+    // See TypeScript best practices in
+    // https://docs.civiform.us/contributor-guide/developer-guide/development-standards
+    "@typescript-eslint/no-non-null-assertion": "off"
   },
   "parserOptions": {
     "project": ["../server/tsconfig.json", "../browser-test/src/tsconfig.json"]

--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -1,4 +1,4 @@
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 class AdminApplicationView {
   private static APPLICATION_STATUS_SELECTOR =
@@ -37,7 +37,7 @@ class AdminApplicationView {
       // within the IFrame.
       statusUpdateForm.addEventListener('submit', (ev) => {
         ev.preventDefault()
-        const formEl = assert(ev.target as HTMLFormElement)
+        const formEl = assertNotNull(ev.target as HTMLFormElement)
         window.parent.postMessage(
           {
             messageType: 'UPDATE_STATUS',
@@ -88,7 +88,7 @@ class AdminApplicationView {
     // list of applications to reflect the note change.
     editNoteForm.addEventListener('submit', (ev) => {
       ev.preventDefault()
-      const formEl = assert(ev.target as HTMLFormElement)
+      const formEl = assertNotNull(ev.target as HTMLFormElement)
       window.parent.postMessage(
         {
           messageType: 'EDIT_NOTE',
@@ -122,7 +122,7 @@ class AdminApplicationView {
     formEl: HTMLFormElement,
     inputName: string,
   ): string {
-    return assert(
+    return assertNotNull(
       formEl.querySelector<HTMLInputElement>(`[name=${inputName}]`),
       inputName,
     ).value
@@ -132,7 +132,7 @@ class AdminApplicationView {
     formEl: HTMLFormElement,
     inputName: string,
   ): string {
-    const checkbox = assert(
+    const checkbox = assertNotNull(
       formEl.querySelector<HTMLInputElement>(`[name=${inputName}]`),
       inputName,
     )
@@ -147,7 +147,7 @@ class AdminApplicationView {
       // If status tracking isn't enabled, there's nothing to do.
       return
     }
-    const statusSelector = assert(
+    const statusSelector = assertNotNull(
       statusSelectForm.querySelector<HTMLSelectElement>('select'),
     )
 
@@ -170,7 +170,7 @@ class AdminApplicationView {
         `[${AdminApplicationView.CONFIRM_MODAL_FOR_DATA_ATTRIBUTE}]`,
       ),
     )
-    const relevantStatusModalTrigger = assert(
+    const relevantStatusModalTrigger = assertNotNull(
       statusModalTriggers.find((statusModalTrigger) => {
         return (
           selectedStatus ===

--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -1,3 +1,5 @@
+import {assert} from './util'
+
 class AdminApplicationView {
   private static APPLICATION_STATUS_SELECTOR =
     '.cf-program-admin-status-selector'
@@ -35,10 +37,7 @@ class AdminApplicationView {
       // within the IFrame.
       statusUpdateForm.addEventListener('submit', (ev) => {
         ev.preventDefault()
-        const formEl = this._assertNotNull(
-          ev.target as HTMLFormElement,
-          'form element',
-        )
+        const formEl = assert(ev.target as HTMLFormElement)
         window.parent.postMessage(
           {
             messageType: 'UPDATE_STATUS',
@@ -89,10 +88,7 @@ class AdminApplicationView {
     // list of applications to reflect the note change.
     editNoteForm.addEventListener('submit', (ev) => {
       ev.preventDefault()
-      const formEl = this._assertNotNull(
-        ev.target as HTMLFormElement,
-        'form element',
-      )
+      const formEl = assert(ev.target as HTMLFormElement)
       window.parent.postMessage(
         {
           messageType: 'EDIT_NOTE',
@@ -126,7 +122,7 @@ class AdminApplicationView {
     formEl: HTMLFormElement,
     inputName: string,
   ): string {
-    return this._assertNotNull(
+    return assert(
       formEl.querySelector<HTMLInputElement>(`[name=${inputName}]`),
       inputName,
     ).value
@@ -136,7 +132,7 @@ class AdminApplicationView {
     formEl: HTMLFormElement,
     inputName: string,
   ): string {
-    const checkbox = this._assertNotNull(
+    const checkbox = assert(
       formEl.querySelector<HTMLInputElement>(`[name=${inputName}]`),
       inputName,
     )
@@ -151,9 +147,8 @@ class AdminApplicationView {
       // If status tracking isn't enabled, there's nothing to do.
       return
     }
-    const statusSelector = this._assertNotNull(
+    const statusSelector = assert(
       statusSelectForm.querySelector<HTMLSelectElement>('select'),
-      'status selector',
     )
 
     // Remember the original value here since neither the 'change/input' events provide the
@@ -175,7 +170,7 @@ class AdminApplicationView {
         `[${AdminApplicationView.CONFIRM_MODAL_FOR_DATA_ATTRIBUTE}]`,
       ),
     )
-    const relevantStatusModalTrigger = this._assertNotNull(
+    const relevantStatusModalTrigger = assert(
       statusModalTriggers.find((statusModalTrigger) => {
         return (
           selectedStatus ===
@@ -184,17 +179,8 @@ class AdminApplicationView {
           )
         )
       }) as HTMLButtonElement | null,
-      'confirmation modal button',
     )
     relevantStatusModalTrigger.click()
-  }
-
-  _assertNotNull<T>(value: T | null | undefined, description: string): T {
-    if (value == null) {
-      throw new Error(`Expected ${description} not to be null.`)
-    }
-
-    return value
   }
 }
 

--- a/server/app/assets/javascripts/admin_applications.ts
+++ b/server/app/assets/javascripts/admin_applications.ts
@@ -2,8 +2,7 @@ class AdminApplications {
   private static BACKGROUND_GRAY_CLASS = 'bg-gray-200'
   private static BACKGROUND_WHITE_CLASS = 'bg-white'
   private static CARD_SELECTOR = '.cf-admin-application-card'
-  private static DISPLAY_FRAME_SELECTOR =
-    'iframe[name="application-display-frame"]'
+  static DISPLAY_FRAME_SELECTOR = 'iframe[name="application-display-frame"]'
 
   // This value should be kept in sync with that in AdminApplicationController.java.
   private static SELECTED_APPLICATION_URI_PARAM_NAME = 'selectedApplicationUri'
@@ -17,19 +16,9 @@ class AdminApplications {
   private static SEND_EMAIL_INPUT_NAME = 'sendEmail'
   private static NOTE_INPUT_NAME = 'note'
 
-  private displayFrame: Element
   private cards: Array<HTMLElement>
 
-  constructor() {
-    const frame = document.querySelector(
-      AdminApplications.DISPLAY_FRAME_SELECTOR,
-    )
-
-    if (frame == null) {
-      return
-    }
-
-    this.displayFrame = frame
+  constructor(private readonly displayFrame: Element) {
     this.cards = Array.from(
       document.querySelectorAll(AdminApplications.CARD_SELECTOR),
     )
@@ -241,5 +230,8 @@ interface EditNoteData {
 }
 
 export function init() {
-  new AdminApplications()
+  const frame = document.querySelector(AdminApplications.DISPLAY_FRAME_SELECTOR)
+  if (frame) {
+    new AdminApplications(frame)
+  }
 }

--- a/server/app/assets/javascripts/admin_validation.ts
+++ b/server/app/assets/javascripts/admin_validation.ts
@@ -1,4 +1,6 @@
 /** The validation controller provides basic client-side validation of admin form fields. */
+import {assert} from './util'
+
 class AdminValidationController {
   static readonly MULTI_OPTION_QUESTION_FIELD_NAME_CREATE =
     '#question-settings input[name="newOptions[]"]'
@@ -35,13 +37,13 @@ class AdminValidationController {
     fieldErrorName: string,
     isValid: boolean,
   ) {
-    const errorDiv = element.parentElement.querySelector(fieldErrorName)
+    const errorDiv = assert(element.parentElement).querySelector(fieldErrorName)
     if (errorDiv) {
       errorDiv.classList.toggle('hidden', isValid)
     }
 
     // Also toggle the border on error inputs (if applicable).
-    const field = element.parentElement.querySelector('input')
+    const field = assert(element.parentElement).querySelector('input')
     if (field) {
       field.classList.toggle('border-red-600', !isValid)
     }

--- a/server/app/assets/javascripts/admin_validation.ts
+++ b/server/app/assets/javascripts/admin_validation.ts
@@ -1,5 +1,4 @@
 /** The validation controller provides basic client-side validation of admin form fields. */
-import {assert} from './util'
 
 class AdminValidationController {
   static readonly MULTI_OPTION_QUESTION_FIELD_NAME_CREATE =
@@ -37,13 +36,13 @@ class AdminValidationController {
     fieldErrorName: string,
     isValid: boolean,
   ) {
-    const errorDiv = assert(element.parentElement).querySelector(fieldErrorName)
+    const errorDiv = element.parentElement!.querySelector(fieldErrorName)
     if (errorDiv) {
       errorDiv.classList.toggle('hidden', isValid)
     }
 
     // Also toggle the border on error inputs (if applicable).
-    const field = assert(element.parentElement).querySelector('input')
+    const field = element.parentElement!.querySelector('input')
     if (field) {
       field.classList.toggle('border-red-600', !isValid)
     }

--- a/server/app/assets/javascripts/azure_delete.ts
+++ b/server/app/assets/javascripts/azure_delete.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * This is responsible for deleting a file that was uploaded to Azure blob storage.
@@ -23,7 +24,7 @@ class AzureDeleteController {
       AzureDeleteController.FILEUPLOAD_DELETE_ID,
     )
     if (deleteContainer) {
-      const azblob = window['azblob']
+      const azblob = (window as {[key: string]: any})['azblob']
       deleteContainer.addEventListener('click', () =>
         this.attemptDelete(azblob),
       )

--- a/server/app/assets/javascripts/azure_upload.ts
+++ b/server/app/assets/javascripts/azure_upload.ts
@@ -9,7 +9,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 class AzureUploadController {
   private static FILEUPLOAD_FORM_ID = 'cf-block-form'
@@ -22,7 +22,7 @@ class AzureUploadController {
     ) {
       return
     }
-    const blockForm = assert(
+    const blockForm = assertNotNull(
       document.getElementById(AzureUploadController.FILEUPLOAD_FORM_ID),
     )
     blockForm.addEventListener('submit', (event) => {
@@ -89,7 +89,7 @@ class AzureUploadController {
   }
 
   private getAzureUploadProps(uploadContainer: HTMLElement) {
-    const files = assert(
+    const files = assertNotNull(
       uploadContainer.querySelector<HTMLInputElement>('input[type=file]')
         ?.files,
     )

--- a/server/app/assets/javascripts/azure_upload.ts
+++ b/server/app/assets/javascripts/azure_upload.ts
@@ -90,10 +90,9 @@ class AzureUploadController {
 
   private getAzureUploadProps(uploadContainer: HTMLElement) {
     const files = assert(
-      assert(
-        uploadContainer.querySelector<HTMLInputElement>('input[type=file]'),
-      ),
-    ).files
+      uploadContainer.querySelector<HTMLInputElement>('input[type=file]')
+        ?.files,
+    )
     return {
       sasToken: this.getValueFromInputLabel('sasToken'),
       blobUrl: this.getValueFromInputLabel('blobUrl'),
@@ -101,7 +100,7 @@ class AzureUploadController {
         'successActionRedirect',
       ),
       containerName: this.getValueFromInputLabel('containerName'),
-      file: assert(files)[0],
+      file: files[0],
       fileName: this.getValueFromInputLabel('fileName'),
     }
   }

--- a/server/app/assets/javascripts/azure_upload.ts
+++ b/server/app/assets/javascripts/azure_upload.ts
@@ -7,6 +7,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {assert} from './util'
 
 class AzureUploadController {
   private static FILEUPLOAD_FORM_ID = 'cf-block-form'
@@ -19,8 +22,8 @@ class AzureUploadController {
     ) {
       return
     }
-    const blockForm = document.getElementById(
-      AzureUploadController.FILEUPLOAD_FORM_ID,
+    const blockForm = assert(
+      document.getElementById(AzureUploadController.FILEUPLOAD_FORM_ID),
     )
     blockForm.addEventListener('submit', (event) => {
       this.attemptUpload(event, blockForm)
@@ -36,7 +39,7 @@ class AzureUploadController {
     // This is set by an imported JavaScript Azure blob client.
     // window["azblob"] was used because the TS compiler complained about using
     // window.azblob.
-    const azblob = window['azblob']
+    const azblob = (window as {[key: string]: any})['azblob']
 
     if (uploadContainer == null) {
       throw new Error('Attempted to upload to null container')
@@ -71,7 +74,7 @@ class AzureUploadController {
         blockBlobUrl,
         options,
       )
-      .then((resp, err) => {
+      .then((resp: any, err: any) => {
         if (err) {
           throw err
         }
@@ -86,6 +89,11 @@ class AzureUploadController {
   }
 
   private getAzureUploadProps(uploadContainer: HTMLElement) {
+    const files = assert(
+      assert(
+        uploadContainer.querySelector<HTMLInputElement>('input[type=file]'),
+      ),
+    ).files
     return {
       sasToken: this.getValueFromInputLabel('sasToken'),
       blobUrl: this.getValueFromInputLabel('blobUrl'),
@@ -93,8 +101,7 @@ class AzureUploadController {
         'successActionRedirect',
       ),
       containerName: this.getValueFromInputLabel('containerName'),
-      file: uploadContainer.querySelector<HTMLInputElement>('input[type=file]')
-        .files[0],
+      file: assert(files)[0],
       fileName: this.getValueFromInputLabel('fileName'),
     }
   }

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -1,7 +1,7 @@
 // Javascript handling for enumerators
 // This file requires that main.ts is also added to the page.
 
-import {addEventListenerToElements, assert} from './util'
+import {addEventListenerToElements, assertNotNull} from './util'
 
 export function init() {
   // Configure the button on the enumerator question form to add more enumerator field options
@@ -29,35 +29,36 @@ let enumeratorCounter = 0
 /** In the enumerator form - add a new input field for a repeated entity. */
 function addNewEnumeratorField() {
   // Copy the enumerator field template
-  const newField = assert(
+  const newField = assertNotNull(
     document.getElementById('enumerator-field-template'),
   ).cloneNode(true) as HTMLElement
   newField.classList.remove('hidden')
   newField.removeAttribute('id')
 
   // Add the remove enumerator field event listener to the delete button
-  assert(newField.querySelector('[type=button]')).addEventListener(
-    'click',
-    removeEnumeratorField,
-  )
+  newField
+    .querySelector('[type=button]')!
+    .addEventListener('click', removeEnumeratorField)
 
   // Update IDs from the template element so that they are unique.
-  const inputElement = assert(
+  const inputElement = assertNotNull(
     newField.querySelector('#enumerator-field-template-input'),
   )
   enumeratorCounter++
   inputElement.id = `${inputElement.id}-${enumeratorCounter}`
-  const labelElement = assert(
+  const labelElement = assertNotNull(
     newField.querySelector('label[for="enumerator-field-template-input"]'),
   )
   labelElement.setAttribute('for', inputElement.id)
-  const errorsElement = assert(
+  const errorsElement = assertNotNull(
     newField.querySelector('#enumerator-field-template-input-errors'),
   )
   errorsElement.id = `enumerator-field-template-input-${enumeratorCounter}-errors`
 
   // Add to the end of enumerator-fields div.
-  const enumeratorFields = assert(document.getElementById('enumerator-fields'))
+  const enumeratorFields = assertNotNull(
+    document.getElementById('enumerator-fields'),
+  )
   enumeratorFields.appendChild(newField)
 
   // Set focus to the new input
@@ -79,7 +80,7 @@ function addNewEnumeratorField() {
  */
 function removeEnumeratorField(event: Event) {
   // Get the parent div, which contains the input field and remove button, and remove it.
-  const enumeratorFieldDiv = assert(
+  const enumeratorFieldDiv = assertNotNull(
     (event.currentTarget as HTMLElement).parentNode,
   ) as HTMLElement
   enumeratorFieldDiv.remove()
@@ -96,18 +97,20 @@ function removeExistingEnumeratorField(event: Event) {
 
   // Hide the field that was removed. We cannot remove it completely, as we need to
   // submit the input to maintain entity ordering.
-  const enumeratorFieldDiv = assert(removeButton.parentElement)
+  const enumeratorFieldDiv = assertNotNull(removeButton.parentElement)
   enumeratorFieldDiv.classList.add('hidden')
   // We must hide the child in addition to the parent since we
   // want to prevent this input from being considered when
   // toggling whether the "Add" button is enabled (especially if
   // the applicant were removing a blank input).
-  const enumeratorInput = assert(enumeratorFieldDiv.querySelector('input'))
+  const enumeratorInput = assertNotNull(
+    enumeratorFieldDiv.querySelector('input'),
+  )
   enumeratorInput.classList.add('hidden')
 
   // Create a copy of the hidden deleted entity template. Set the value to this
   // button's ID, and set disabled to false so the data is submitted with the form.
-  const deletedEntityInput = assert(
+  const deletedEntityInput = assertNotNull(
     document.getElementById('enumerator-delete-template'),
   ).cloneNode(true) as HTMLInputElement
   deletedEntityInput.disabled = false

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -1,7 +1,7 @@
 // Javascript handling for enumerators
 // This file requires that main.ts is also added to the page.
 
-import {addEventListenerToElements} from './util'
+import {addEventListenerToElements, assert} from './util'
 
 export function init() {
   // Configure the button on the enumerator question form to add more enumerator field options
@@ -29,34 +29,35 @@ let enumeratorCounter = 0
 /** In the enumerator form - add a new input field for a repeated entity. */
 function addNewEnumeratorField() {
   // Copy the enumerator field template
-  const newField = document
-    .getElementById('enumerator-field-template')
-    .cloneNode(true) as HTMLElement
+  const newField = assert(
+    document.getElementById('enumerator-field-template'),
+  ).cloneNode(true) as HTMLElement
   newField.classList.remove('hidden')
   newField.removeAttribute('id')
 
   // Add the remove enumerator field event listener to the delete button
-  newField
-    .querySelector('[type=button]')
-    .addEventListener('click', removeEnumeratorField)
+  assert(newField.querySelector('[type=button]')).addEventListener(
+    'click',
+    removeEnumeratorField,
+  )
 
   // Update IDs from the template element so that they are unique.
-  const inputElement = newField.querySelector(
-    '#enumerator-field-template-input',
+  const inputElement = assert(
+    newField.querySelector('#enumerator-field-template-input'),
   )
   enumeratorCounter++
   inputElement.id = `${inputElement.id}-${enumeratorCounter}`
-  const labelElement = newField.querySelector(
-    'label[for="enumerator-field-template-input"]',
+  const labelElement = assert(
+    newField.querySelector('label[for="enumerator-field-template-input"]'),
   )
   labelElement.setAttribute('for', inputElement.id)
-  const errorsElement = newField.querySelector(
-    '#enumerator-field-template-input-errors',
+  const errorsElement = assert(
+    newField.querySelector('#enumerator-field-template-input-errors'),
   )
   errorsElement.id = `enumerator-field-template-input-${enumeratorCounter}-errors`
 
   // Add to the end of enumerator-fields div.
-  const enumeratorFields = document.getElementById('enumerator-fields')
+  const enumeratorFields = assert(document.getElementById('enumerator-fields'))
   enumeratorFields.appendChild(newField)
 
   // Set focus to the new input
@@ -78,8 +79,10 @@ function addNewEnumeratorField() {
  */
 function removeEnumeratorField(event: Event) {
   // Get the parent div, which contains the input field and remove button, and remove it.
-  const enumeratorFieldDiv = (event.currentTarget as HTMLElement).parentNode
-  enumeratorFieldDiv.parentNode.removeChild(enumeratorFieldDiv)
+  const enumeratorFieldDiv = assert(
+    (event.currentTarget as HTMLElement).parentNode,
+  ) as HTMLElement
+  enumeratorFieldDiv.remove()
 }
 
 /**
@@ -93,20 +96,20 @@ function removeExistingEnumeratorField(event: Event) {
 
   // Hide the field that was removed. We cannot remove it completely, as we need to
   // submit the input to maintain entity ordering.
-  const enumeratorFieldDiv = removeButton.parentElement
+  const enumeratorFieldDiv = assert(removeButton.parentElement)
   enumeratorFieldDiv.classList.add('hidden')
   // We must hide the child in addition to the parent since we
   // want to prevent this input from being considered when
   // toggling whether the "Add" button is enabled (especially if
   // the applicant were removing a blank input).
-  const enumeratorInput = enumeratorFieldDiv.querySelector('input')
+  const enumeratorInput = assert(enumeratorFieldDiv.querySelector('input'))
   enumeratorInput.classList.add('hidden')
 
   // Create a copy of the hidden deleted entity template. Set the value to this
   // button's ID, and set disabled to false so the data is submitted with the form.
-  const deletedEntityInput = document
-    .getElementById('enumerator-delete-template')
-    .cloneNode(true) as HTMLInputElement
+  const deletedEntityInput = assert(
+    document.getElementById('enumerator-delete-template'),
+  ).cloneNode(true) as HTMLInputElement
   deletedEntityInput.disabled = false
   deletedEntityInput.setAttribute('value', removeButton.id)
   deletedEntityInput.removeAttribute('id')

--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -1,3 +1,5 @@
+import {assert} from './util'
+
 const UPLOAD_ATTR = 'data-upload-text'
 
 export function init() {
@@ -19,11 +21,12 @@ export function init() {
 
     if (uploadedDivs.length) {
       const uploadedDiv = uploadedDivs[0]
-      const uploadText = uploadedDiv.getAttribute(UPLOAD_ATTR)
+      const uploadText = assert(uploadedDiv.getAttribute(UPLOAD_ATTR))
 
       blockForm.addEventListener('change', (event) => {
         if (uploadedDiv.innerHTML) return
-        const file = (<HTMLInputElement>event.target).files[0]
+        const files = (assert(event.target) as HTMLInputElement).files
+        const file = assert(files)[0]
         uploadedDiv.innerHTML = uploadText.replace('{0}', file.name)
       })
     }
@@ -39,8 +42,9 @@ function validateFileUploadQuestions(formEl: Element): boolean {
   )
   for (const question of questions) {
     // validate a file is selected.
-    const fileInput =
-      question.querySelector<HTMLInputElement>('input[type=file]')
+    const fileInput = assert(
+      question.querySelector<HTMLInputElement>('input[type=file]'),
+    )
 
     const isValid = fileInput.value != ''
 
@@ -60,7 +64,7 @@ function validateFileUploadQuestions(formEl: Element): boolean {
         // Only allow this to be done once so we don't repeatedly append the error id.
         wasSetInvalid = true
         fileInput.setAttribute('aria-invalid', 'true')
-        const ariaDescribedBy = fileInput.getAttribute('aria-describedby')
+        const ariaDescribedBy = fileInput.getAttribute('aria-describedby') ?? ''
         fileInput.setAttribute(
           'aria-describedby',
           `${errorId} ${ariaDescribedBy}`,

--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -1,4 +1,4 @@
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 const UPLOAD_ATTR = 'data-upload-text'
 
@@ -21,12 +21,12 @@ export function init() {
 
     if (uploadedDivs.length) {
       const uploadedDiv = uploadedDivs[0]
-      const uploadText = assert(uploadedDiv.getAttribute(UPLOAD_ATTR))
+      const uploadText = assertNotNull(uploadedDiv.getAttribute(UPLOAD_ATTR))
 
       blockForm.addEventListener('change', (event) => {
         if (uploadedDiv.innerHTML) return
-        const files = (assert(event.target) as HTMLInputElement).files
-        const file = assert(files)[0]
+        const files = (event.target! as HTMLInputElement).files
+        const file = assertNotNull(files)[0]
         uploadedDiv.innerHTML = uploadText.replace('{0}', file.name)
       })
     }
@@ -42,7 +42,7 @@ function validateFileUploadQuestions(formEl: Element): boolean {
   )
   for (const question of questions) {
     // validate a file is selected.
-    const fileInput = assert(
+    const fileInput = assertNotNull(
       question.querySelector<HTMLInputElement>('input[type=file]'),
     )
 

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -1,4 +1,4 @@
-import {addEventListenerToElements} from './util'
+import {addEventListenerToElements, assert} from './util'
 
 /**
  * We're trying to keep the JS pretty minimal for CiviForm, so we're only using it
@@ -51,13 +51,16 @@ function maybeHideElement(e: Event, id: string, parentId: string) {
  * In admin program block edit form - enabling submit button when form is changed or if not empty
  */
 function changeUpdateBlockButtonState() {
-  const blockEditForm = document.getElementById('block-edit-form')
-  const submitButton = document.getElementById('update-block-button')
+  const blockEditForm = assert(document.getElementById('block-edit-form'))
+  const submitButton = assert(document.getElementById('update-block-button'))
 
-  const formNameInput =
-    blockEditForm.querySelector<HTMLInputElement>('#block-name-input')
-  const formDescriptionText = blockEditForm.querySelector<HTMLTextAreaElement>(
-    '#block-description-textarea',
+  const formNameInput = assert(
+    blockEditForm.querySelector<HTMLInputElement>('#block-name-input'),
+  )
+  const formDescriptionText = assert(
+    blockEditForm.querySelector<HTMLTextAreaElement>(
+      '#block-description-textarea',
+    ),
   )
 
   if (
@@ -86,18 +89,21 @@ function addNewInput(
   divContainerId: string,
 ) {
   // Copy the answer template and remove ID and hidden properties.
-  const newField = document
-    .getElementById(inputTemplateId)
-    .cloneNode(true) as HTMLElement
+  const newField = assert(document.getElementById(inputTemplateId)).cloneNode(
+    true,
+  ) as HTMLElement
   newField.classList.remove('hidden')
   newField.removeAttribute('id')
 
   // Register the click event handler for the remove button.
-  newField.querySelector('[type=button]').addEventListener('click', removeInput)
+  assert(newField.querySelector('[type=button]')).addEventListener(
+    'click',
+    removeInput,
+  )
 
   // Find the add option button and insert the new option input field before it.
   const button = document.getElementById(addButtonId)
-  document.getElementById(divContainerId).insertBefore(newField, button)
+  assert(document.getElementById(divContainerId)).insertBefore(newField, button)
 }
 
 /**
@@ -107,8 +113,10 @@ function addNewInput(
  */
 function removeInput(event: Event) {
   // Get the parent div, which contains the input field and remove button, and remove it.
-  const optionDiv = (event.currentTarget as Element).parentNode
-  optionDiv.parentNode.removeChild(optionDiv)
+  const optionDiv = assert(
+    (event.currentTarget as Element).parentNode,
+  ) as HTMLElement
+  optionDiv.remove()
 }
 
 /**
@@ -117,9 +125,9 @@ function removeInput(event: Event) {
  * @param {Event} event The event that triggered this action.
  */
 function hideInput(event: Event) {
-  const inputDiv = (event.currentTarget as Element).parentElement
+  const inputDiv = assert((event.currentTarget as Element).parentElement)
   // Remove 'disabled' so the field is submitted with the form
-  inputDiv.querySelector('input').disabled = false
+  assert(inputDiv.querySelector('input')).disabled = false
   // Hide the entire div from the user
   inputDiv.classList.add('hidden')
 }
@@ -148,8 +156,9 @@ function attachLineClampListeners() {
 function configurePredicateFormOnScalarChange(event: Event) {
   // Get the type of scalar currently selected.
   const scalarDropdown = event.target as HTMLSelectElement
-  const selectedScalarType =
-    scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type
+  const selectedScalarType = assert(
+    scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type,
+  )
   const selectedScalarValue =
     scalarDropdown.options[scalarDropdown.options.selectedIndex].value
 
@@ -173,9 +182,11 @@ function filterOperators(
   selectedScalarValue: string,
 ) {
   // Filter the operators available for the given selected scalar type.
-  const operatorDropdown = scalarDropdown
-    .closest('.cf-predicate-options') // div containing all predicate builder form fields
-    .querySelector<HTMLSelectElement>('.cf-operator-select select')
+  const operatorDropdown = assert(
+    scalarDropdown
+      ?.closest('.cf-predicate-options') // div containing all predicate builder form fields
+      ?.querySelector<HTMLSelectElement>('.cf-operator-select select'),
+  )
 
   Array.from(operatorDropdown.options).forEach((operatorOption) => {
     // Remove any existing hidden class from previous filtering.
@@ -242,17 +253,19 @@ function configurePredicateValueInput(
     return
   }
 
-  const operatorDropdown = scalarDropdown
-    .closest('.cf-predicate-options') // div containing all predicate builder form fields
-    .querySelector('.cf-operator-select') // div containing the operator dropdown
-    .querySelector('select')
+  const operatorDropdown = assert(
+    scalarDropdown
+      .closest('.cf-predicate-options') // div containing all predicate builder form fields
+      ?.querySelector<HTMLSelectElement>('.cf-operator-select select'),
+  )
   const operatorValue =
     operatorDropdown.options[operatorDropdown.options.selectedIndex].value
 
-  const valueInput = scalarDropdown
-    .closest('.cf-predicate-options') // div containing all predicate builder form fields
-    .querySelector('.cf-predicate-value-input') // div containing the predicate value input
-    .querySelector('input')
+  const valueInput = assert(
+    scalarDropdown
+      .closest('.cf-predicate-options') // div containing all predicate builder form fields
+      ?.querySelector<HTMLInputElement>('.cf-predicate-value-input input'),
+  )
 
   switch (selectedScalarType.toUpperCase()) {
     case 'STRING':
@@ -290,7 +303,7 @@ function configurePredicateFormOnOperatorChange(event: Event) {
 
   const commaSeparatedHelpText = operatorDropdown
     .closest('.cf-predicate-options')
-    .querySelector('.cf-predicate-value-comma-help-text')
+    ?.querySelector('.cf-predicate-value-comma-help-text')
 
   // This help text div isn't present at all in some cases.
   if (!commaSeparatedHelpText) {
@@ -308,12 +321,14 @@ function configurePredicateFormOnOperatorChange(event: Event) {
   }
 
   // The type of the value field may need to change based on the current operator
-  const scalarDropdown = operatorDropdown
-    .closest('.cf-predicate-options') // div containing all predicate builder form fields
-    .querySelector('.cf-scalar-select') // div containing the scalar dropdown
-    .querySelector('select')
-  const selectedScalarType =
-    scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type
+  const scalarDropdown = assert(
+    operatorDropdown
+      .closest('.cf-predicate-options') // div containing all predicate builder form fields
+      ?.querySelector<HTMLSelectElement>('.cf-scalar-select select'),
+  )
+  const selectedScalarType = assert(
+    scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type,
+  )
   const selectedScalarValue =
     scalarDropdown.options[scalarDropdown.options.selectedIndex].value
   configurePredicateValueInput(
@@ -346,7 +361,9 @@ function attachFormDebouncers() {
 function attachRedirectToPageListeners() {
   addEventListenerToElements('[data-redirect-to]', 'click', (e: Event) => {
     e.stopPropagation()
-    window.location.href = (e.currentTarget as HTMLElement).dataset.redirectTo
+    window.location.href = assert(
+      (e.currentTarget as HTMLElement).dataset.redirectTo,
+    )
   })
 }
 

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -1,4 +1,4 @@
-import {addEventListenerToElements, assert} from './util'
+import {addEventListenerToElements, assertNotNull} from './util'
 
 /**
  * We're trying to keep the JS pretty minimal for CiviForm, so we're only using it
@@ -51,13 +51,17 @@ function maybeHideElement(e: Event, id: string, parentId: string) {
  * In admin program block edit form - enabling submit button when form is changed or if not empty
  */
 function changeUpdateBlockButtonState() {
-  const blockEditForm = assert(document.getElementById('block-edit-form'))
-  const submitButton = assert(document.getElementById('update-block-button'))
+  const blockEditForm = assertNotNull(
+    document.getElementById('block-edit-form'),
+  )
+  const submitButton = assertNotNull(
+    document.getElementById('update-block-button'),
+  )
 
-  const formNameInput = assert(
+  const formNameInput = assertNotNull(
     blockEditForm.querySelector<HTMLInputElement>('#block-name-input'),
   )
-  const formDescriptionText = assert(
+  const formDescriptionText = assertNotNull(
     blockEditForm.querySelector<HTMLTextAreaElement>(
       '#block-description-textarea',
     ),
@@ -89,21 +93,20 @@ function addNewInput(
   divContainerId: string,
 ) {
   // Copy the answer template and remove ID and hidden properties.
-  const newField = assert(document.getElementById(inputTemplateId)).cloneNode(
-    true,
-  ) as HTMLElement
+  const newField = assertNotNull(
+    document.getElementById(inputTemplateId),
+  ).cloneNode(true) as HTMLElement
   newField.classList.remove('hidden')
   newField.removeAttribute('id')
 
   // Register the click event handler for the remove button.
-  assert(newField.querySelector('[type=button]')).addEventListener(
-    'click',
-    removeInput,
-  )
+  newField
+    .querySelector('[type=button]')!
+    .addEventListener('click', removeInput)
 
   // Find the add option button and insert the new option input field before it.
   const button = document.getElementById(addButtonId)
-  assert(document.getElementById(divContainerId)).insertBefore(newField, button)
+  document.getElementById(divContainerId)!.insertBefore(newField, button)
 }
 
 /**
@@ -113,7 +116,7 @@ function addNewInput(
  */
 function removeInput(event: Event) {
   // Get the parent div, which contains the input field and remove button, and remove it.
-  const optionDiv = assert(
+  const optionDiv = assertNotNull(
     (event.currentTarget as Element).parentNode,
   ) as HTMLElement
   optionDiv.remove()
@@ -125,9 +128,9 @@ function removeInput(event: Event) {
  * @param {Event} event The event that triggered this action.
  */
 function hideInput(event: Event) {
-  const inputDiv = assert((event.currentTarget as Element).parentElement)
+  const inputDiv = assertNotNull((event.currentTarget as Element).parentElement)
   // Remove 'disabled' so the field is submitted with the form
-  assert(inputDiv.querySelector('input')).disabled = false
+  inputDiv.querySelector('input')!.disabled = false
   // Hide the entire div from the user
   inputDiv.classList.add('hidden')
 }
@@ -156,7 +159,7 @@ function attachLineClampListeners() {
 function configurePredicateFormOnScalarChange(event: Event) {
   // Get the type of scalar currently selected.
   const scalarDropdown = event.target as HTMLSelectElement
-  const selectedScalarType = assert(
+  const selectedScalarType = assertNotNull(
     scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type,
   )
   const selectedScalarValue =
@@ -182,7 +185,7 @@ function filterOperators(
   selectedScalarValue: string,
 ) {
   // Filter the operators available for the given selected scalar type.
-  const operatorDropdown = assert(
+  const operatorDropdown = assertNotNull(
     scalarDropdown
       .closest('.cf-predicate-options') // div containing all predicate builder form fields
       ?.querySelector<HTMLSelectElement>('.cf-operator-select select'),
@@ -253,7 +256,7 @@ function configurePredicateValueInput(
     return
   }
 
-  const operatorDropdown = assert(
+  const operatorDropdown = assertNotNull(
     scalarDropdown
       .closest('.cf-predicate-options') // div containing all predicate builder form fields
       ?.querySelector<HTMLSelectElement>('.cf-operator-select select'),
@@ -261,7 +264,7 @@ function configurePredicateValueInput(
   const operatorValue =
     operatorDropdown.options[operatorDropdown.options.selectedIndex].value
 
-  const valueInput = assert(
+  const valueInput = assertNotNull(
     scalarDropdown
       .closest('.cf-predicate-options') // div containing all predicate builder form fields
       ?.querySelector<HTMLInputElement>('.cf-predicate-value-input input'),
@@ -321,12 +324,12 @@ function configurePredicateFormOnOperatorChange(event: Event) {
   }
 
   // The type of the value field may need to change based on the current operator
-  const scalarDropdown = assert(
+  const scalarDropdown = assertNotNull(
     operatorDropdown
       .closest('.cf-predicate-options') // div containing all predicate builder form fields
       ?.querySelector<HTMLSelectElement>('.cf-scalar-select select'),
   )
-  const selectedScalarType = assert(
+  const selectedScalarType = assertNotNull(
     scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type,
   )
   const selectedScalarValue =
@@ -361,7 +364,7 @@ function attachFormDebouncers() {
 function attachRedirectToPageListeners() {
   addEventListenerToElements('[data-redirect-to]', 'click', (e: Event) => {
     e.stopPropagation()
-    window.location.href = assert(
+    window.location.href = assertNotNull(
       (e.currentTarget as HTMLElement).dataset.redirectTo,
     )
   })

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -93,9 +93,9 @@ function addNewInput(
   divContainerId: string,
 ) {
   // Copy the answer template and remove ID and hidden properties.
-  const newField = assertNotNull(
-    document.getElementById(inputTemplateId),
-  ).cloneNode(true) as HTMLElement
+  const newField = document
+    .getElementById(inputTemplateId)!
+    .cloneNode(true) as HTMLElement
   newField.classList.remove('hidden')
   newField.removeAttribute('id')
 
@@ -128,7 +128,9 @@ function removeInput(event: Event) {
  * @param {Event} event The event that triggered this action.
  */
 function hideInput(event: Event) {
-  const inputDiv = assertNotNull((event.currentTarget as Element).parentElement)
+  const inputDiv = assertNotNull(
+    (event.currentTarget as Element)!.parentElement,
+  )
   // Remove 'disabled' so the field is submitted with the form
   inputDiv.querySelector('input')!.disabled = false
   // Hide the entire div from the user

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -184,7 +184,7 @@ function filterOperators(
   // Filter the operators available for the given selected scalar type.
   const operatorDropdown = assert(
     scalarDropdown
-      ?.closest('.cf-predicate-options') // div containing all predicate builder form fields
+      .closest('.cf-predicate-options') // div containing all predicate builder form fields
       ?.querySelector<HTMLSelectElement>('.cf-operator-select select'),
   )
 

--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -1,4 +1,6 @@
 /** The preview controller is responsible for updating question preview text in the question builder. */
+import {assert} from './util'
+
 class PreviewController {
   private static readonly QUESTION_TEXT_INPUT_ID = 'question-text-textarea'
   private static readonly QUESTION_HELP_TEXT_INPUT_ID =
@@ -224,8 +226,10 @@ class PreviewController {
         PreviewController.QUESTION_MULTI_OPTION_VALUE_CLASS,
       )
         ? newPreviewOption
-        : newPreviewOption.querySelector<HTMLElement>(
-            `.${PreviewController.QUESTION_MULTI_OPTION_VALUE_CLASS}`,
+        : assert(
+            newPreviewOption.querySelector<HTMLElement>(
+              `.${PreviewController.QUESTION_MULTI_OPTION_VALUE_CLASS}`,
+            ),
           )
       optionText.innerText = configuredOption
       previewQuestionOptionContainer.appendChild(newPreviewOption)
@@ -268,8 +272,10 @@ class PreviewController {
   private static updateFromNewEnumeratorSelector(
     enumeratorSelectorValue: string,
   ) {
-    const repeatedQuestionInformation = document.getElementById(
-      PreviewController.REPEATED_QUESTION_INFORMATION_ID,
+    const repeatedQuestionInformation = assert(
+      document.getElementById(
+        PreviewController.REPEATED_QUESTION_INFORMATION_ID,
+      ),
     )
     repeatedQuestionInformation.classList.toggle(
       'hidden',
@@ -308,7 +314,7 @@ class PreviewController {
     selector: string,
     text: string,
   ) {
-    const previewDiv = document.querySelector(selector)
+    const previewDiv = assert(document.querySelector(selector))
     const pieces = text.split(PreviewController.THIS_REGEX)
 
     previewDiv.innerHTML = ''

--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -1,5 +1,5 @@
 /** The preview controller is responsible for updating question preview text in the question builder. */
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 class PreviewController {
   private static readonly QUESTION_TEXT_INPUT_ID = 'question-text-textarea'
@@ -226,7 +226,7 @@ class PreviewController {
         PreviewController.QUESTION_MULTI_OPTION_VALUE_CLASS,
       )
         ? newPreviewOption
-        : assert(
+        : assertNotNull(
             newPreviewOption.querySelector<HTMLElement>(
               `.${PreviewController.QUESTION_MULTI_OPTION_VALUE_CLASS}`,
             ),
@@ -272,7 +272,7 @@ class PreviewController {
   private static updateFromNewEnumeratorSelector(
     enumeratorSelectorValue: string,
   ) {
-    const repeatedQuestionInformation = assert(
+    const repeatedQuestionInformation = assertNotNull(
       document.getElementById(
         PreviewController.REPEATED_QUESTION_INFORMATION_ID,
       ),
@@ -314,7 +314,7 @@ class PreviewController {
     selector: string,
     text: string,
   ) {
-    const previewDiv = assert(document.querySelector(selector))
+    const previewDiv = assertNotNull(document.querySelector(selector))
     const pieces = text.split(PreviewController.THIS_REGEX)
 
     previewDiv.innerHTML = ''

--- a/server/app/assets/javascripts/questionBank.ts
+++ b/server/app/assets/javascripts/questionBank.ts
@@ -1,5 +1,5 @@
 /** The question bank controller is responsible for manipulating the question bank. */
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 class QuestionBankController {
   static readonly FILTER_ID = 'question-bank-filter'
@@ -83,7 +83,9 @@ class QuestionBankController {
   }
 
   static hideQuestionBank(container: HTMLElement) {
-    const panel = assert(container.querySelector('.cf-question-bank-panel'))
+    const panel = assertNotNull(
+      container.querySelector('.cf-question-bank-panel'),
+    )
     panel.addEventListener(
       'transitionend',
       () => {

--- a/server/app/assets/javascripts/questionBank.ts
+++ b/server/app/assets/javascripts/questionBank.ts
@@ -1,4 +1,5 @@
 /** The question bank controller is responsible for manipulating the question bank. */
+import {assert} from './util'
 
 class QuestionBankController {
   static readonly FILTER_ID = 'question-bank-filter'
@@ -82,7 +83,8 @@ class QuestionBankController {
   }
 
   static hideQuestionBank(container: HTMLElement) {
-    container.querySelector('.cf-question-bank-panel').addEventListener(
+    const panel = assert(container.querySelector('.cf-question-bank-panel'))
+    panel.addEventListener(
       'transitionend',
       () => {
         container.classList.add('hidden')
@@ -125,7 +127,7 @@ class QuestionBankController {
       const questionContents = questionElement.innerText
       questionElement.classList.toggle(
         'hidden',
-        filterString.length &&
+        filterString.length > 0 &&
           !questionContents.toUpperCase().includes(filterString),
       )
     })

--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -1,4 +1,6 @@
 /** This class controls the style of selected radio buttons. */
+import {assert} from './util'
+
 class RadioController {
   static radioDefaultClass = '.cf-radio-default'
   static radioInputClass = '.cf-radio-input'
@@ -41,7 +43,7 @@ class RadioController {
       // Add listener to radio button.
       radio.addEventListener('change', (e) => {
         const targetElement = e.target as HTMLInputElement
-        const radioName = targetElement.getAttribute('name')
+        const radioName = assert(targetElement.getAttribute('name'))
         let checkCount = 0
         const buttons = Array.from(
           document.querySelectorAll(

--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -1,5 +1,5 @@
 /** This class controls the style of selected radio buttons. */
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 class RadioController {
   static radioDefaultClass = '.cf-radio-default'
@@ -43,7 +43,7 @@ class RadioController {
       // Add listener to radio button.
       radio.addEventListener('change', (e) => {
         const targetElement = e.target as HTMLInputElement
-        const radioName = assert(targetElement.getAttribute('name'))
+        const radioName = assertNotNull(targetElement.getAttribute('name'))
         let checkCount = 0
         const buttons = Array.from(
           document.querySelectorAll(

--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -6,6 +6,8 @@
  *  - dismiss a toast messages based on a user action or after a specified timeout.
  *  - permanently dismiss toast messags (using localStorage)
  */
+import {assert} from './util'
+
 export class ToastController {
   private static readonly CONTAINER_ID = 'toast-container'
   private static readonly MESSAGE_CLASS = 'cf-toast'
@@ -159,13 +161,12 @@ export class ToastController {
     )
     messages.forEach((element) => {
       const message: ToastMessage = {
-        id: element.getAttribute('id'),
+        id: element.id,
         canDismiss: element.getAttribute('canDismiss') === 'true',
         canIgnore: element.getAttribute('canIgnore') === 'true',
-        content: element.textContent,
+        content: assert(element.textContent),
         duration: Number(element.getAttribute('toastDuration')),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        type: element.getAttribute('toastType')!.toLowerCase(),
+        type: assert(element.getAttribute('toastType')).toLowerCase(),
       }
       element.remove()
       ToastController.showToastMessage(message)
@@ -179,9 +180,8 @@ export class ToastController {
   private static dismissClicked(event: Event) {
     const target = event.target as Element
     const toast = target.closest('.' + ToastController.MESSAGE_CLASS)
-    if (toast && toast.hasAttribute('id')) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const toastId = toast.getAttribute('id')!
+    if (toast && toast.id) {
+      const toastId = toast.id
       ToastController.dismissToast(toastId, /* dismissClicked = */ true)
     }
   }

--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -6,7 +6,7 @@
  *  - dismiss a toast messages based on a user action or after a specified timeout.
  *  - permanently dismiss toast messags (using localStorage)
  */
-import {assert} from './util'
+import {assertNotNull} from './util'
 
 export class ToastController {
   private static readonly CONTAINER_ID = 'toast-container'
@@ -164,9 +164,9 @@ export class ToastController {
         id: element.id,
         canDismiss: element.getAttribute('canDismiss') === 'true',
         canIgnore: element.getAttribute('canIgnore') === 'true',
-        content: assert(element.textContent),
+        content: assertNotNull(element.textContent),
         duration: Number(element.getAttribute('toastDuration')),
-        type: assert(element.getAttribute('toastType')).toLowerCase(),
+        type: element.getAttribute('toastType')!.toLowerCase(),
       }
       element.remove()
       ToastController.showToastMessage(message)

--- a/server/app/assets/javascripts/util.test.ts
+++ b/server/app/assets/javascripts/util.test.ts
@@ -1,4 +1,4 @@
-import {addEventListenerToElements} from './util'
+import {addEventListenerToElements, assert} from './util'
 
 describe('addEventListenerToElements', () => {
   let container: HTMLElement
@@ -22,18 +22,44 @@ describe('addEventListenerToElements', () => {
     container.appendChild(thirdDiv)
 
     let listenerCalled = 0
-    addEventListenerToElements('.marked', 'my-event', () => {
+    addEventListenerToElements('.marked', 'click', () => {
       listenerCalled++
     })
 
-    firstDiv.dispatchEvent(new CustomEvent('my-event'))
+    firstDiv.dispatchEvent(new CustomEvent('click'))
     expect(listenerCalled).toBe(1)
 
-    secondDiv.dispatchEvent(new CustomEvent('my-event'))
+    secondDiv.dispatchEvent(new CustomEvent('click'))
     // Second div should not have the listener registered and invoked.
     expect(listenerCalled).toBe(1)
 
-    thirdDiv.dispatchEvent(new CustomEvent('my-event'))
+    thirdDiv.dispatchEvent(new CustomEvent('click'))
     expect(listenerCalled).toBe(2)
+  })
+})
+
+describe('assert', () => {
+  it('does not throw on non-null values', () => {
+    expect(assert('')).toEqual('')
+    expect(assert(false)).toEqual(false)
+    expect(assert([])).toEqual([])
+    expect(assert(0)).toEqual(0)
+    const val = {}
+    expect(assert(val)).toEqual(val)
+  })
+
+  it('throws errors on null and undefined', () => {
+    expect(() => {
+      assert(null)
+    }).toThrow('Provided value is null.')
+    expect(() => {
+      assert(undefined)
+    }).toThrow('Provided value is undefined.')
+  })
+
+  it('adds extra info to error if passed', () => {
+    expect(() => {
+      assert(null, 'foobar')
+    }).toThrow('Provided value is null. Extra info: foobar')
   })
 })

--- a/server/app/assets/javascripts/util.test.ts
+++ b/server/app/assets/javascripts/util.test.ts
@@ -1,4 +1,4 @@
-import {addEventListenerToElements, assert} from './util'
+import {addEventListenerToElements, assertNotNull} from './util'
 
 describe('addEventListenerToElements', () => {
   let container: HTMLElement
@@ -40,26 +40,26 @@ describe('addEventListenerToElements', () => {
 
 describe('assert', () => {
   it('does not throw on non-null values', () => {
-    expect(assert('')).toEqual('')
-    expect(assert(false)).toEqual(false)
-    expect(assert([])).toEqual([])
-    expect(assert(0)).toEqual(0)
+    expect(assertNotNull('')).toEqual('')
+    expect(assertNotNull(false)).toEqual(false)
+    expect(assertNotNull([])).toEqual([])
+    expect(assertNotNull(0)).toEqual(0)
     const val = {}
-    expect(assert(val)).toEqual(val)
+    expect(assertNotNull(val)).toEqual(val)
   })
 
   it('throws errors on null and undefined', () => {
     expect(() => {
-      assert(null)
+      assertNotNull(null)
     }).toThrow('Provided value is null.')
     expect(() => {
-      assert(undefined)
+      assertNotNull(undefined)
     }).toThrow('Provided value is undefined.')
   })
 
   it('adds extra info to error if passed', () => {
     expect(() => {
-      assert(null, 'foobar')
+      assertNotNull(null, 'foobar')
     }).toThrow('Provided value is null. Extra info: foobar')
   })
 })

--- a/server/app/assets/javascripts/util.ts
+++ b/server/app/assets/javascripts/util.ts
@@ -42,8 +42,8 @@ export function assertNotNull<T>(
   extraInfo = '',
 ): T {
   if (value == null) {
-    const extra = extraInfo !== '' ? ' Extra info: ' + extraInfo : ''
-    throw new Error(`Provided value is ${String(value)}.${extra}`)
+    const extra = extraInfo !== '' ? `Extra info: ${extraInfo}` : ''
+    throw new Error(`Provided value is ${String(value)}. ${extra}`)
   }
   return value
 }

--- a/server/app/assets/javascripts/util.ts
+++ b/server/app/assets/javascripts/util.ts
@@ -28,6 +28,7 @@ export function addEventListenerToElements<K extends keyof HTMLElementEventMap>(
  *
  * This is preferred way of asserting values over using assertion `value!` as
  * latter doesn't throw error immediately and instead value can be dereferenced later in the code flow making root cause of the error harder to track.
+ *
  * @param value
  * @param extraInfo Additional info to add to the error if provided value is null. In most cases it's not needed as stack trace is enough to identify the location of the error.
  */

--- a/server/app/assets/javascripts/util.ts
+++ b/server/app/assets/javascripts/util.ts
@@ -5,16 +5,36 @@
 /**
  * Adds event listener to all elements on a page that match given selector.
  * This function doesn't handle elements added dynamically after the function was invoked.
- * @param {string} selector CSS selector that will be used to retrieve list of elements.
- * @param {string} event Browser event. For example 'click'
- * @param {Function} listener Listener that will be registered on all matching elements.
+ * @param selector CSS selector that will be used to retrieve list of elements.
+ * @param event Browser event. For example 'click'
+ * @param listener Listener that will be registered on all matching elements.
  */
-export function addEventListenerToElements(
+export function addEventListenerToElements<K extends keyof HTMLElementEventMap>(
   selector: string,
-  event: string,
-  listener: (e: Event) => void,
+  event: K,
+  listener: (ev: HTMLElementEventMap[K]) => void,
 ) {
-  Array.from(document.querySelectorAll(selector)).forEach((el) =>
+  Array.from(document.querySelectorAll<HTMLElement>(selector)).forEach((el) =>
     el.addEventListener(event, listener),
   )
+}
+
+/**
+ * Asserts that passed value is not null. This method is used when working with
+ * various APIs that often return nullable values and often developers know
+ * that value is not-null. For example using document.querySelector on elements
+ * that 100% should be there. This function helps to assert that value is not
+ * null or fail quickly if those expectations are false.
+ *
+ * This is preferred way of asserting values over using assertion `value!` as
+ * latter doesn't throw error immediately and instead value can be dereferenced later in the code flow making root cause of the error harder to track.
+ * @param value
+ * @param extraInfo Additional info to add to the error if provided value is null. In most cases it's not needed as stack trace is enough to identify the location of the error.
+ */
+export function assert<T>(value: T | null | undefined, extraInfo = ''): T {
+  if (value == null) {
+    const extra = extraInfo !== '' ? ' Extra info: ' + extraInfo : ''
+    throw new Error(`Provided value is ${String(value)}.${extra}`)
+  }
+  return value
 }

--- a/server/app/assets/javascripts/util.ts
+++ b/server/app/assets/javascripts/util.ts
@@ -4,7 +4,9 @@
 
 /**
  * Adds event listener to all elements on a page that match given selector.
- * This function doesn't handle elements added dynamically after the function was invoked.
+ * This function doesn't handle elements added dynamically after the function
+ * was invoked.
+ *
  * @param selector CSS selector that will be used to retrieve list of elements.
  * @param event Browser event. For example 'click'
  * @param listener Listener that will be registered on all matching elements.
@@ -26,13 +28,19 @@ export function addEventListenerToElements<K extends keyof HTMLElementEventMap>(
  * that 100% should be there. This function helps to assert that value is not
  * null or fail quickly if those expectations are false.
  *
- * This is preferred way of asserting values over using assertion `value!` as
- * latter doesn't throw error immediately and instead value can be dereferenced later in the code flow making root cause of the error harder to track.
+ * See TypeScirpt best practices for recommendations for when to use
+ * assertNotNull vs non-null operator `!`:
+ * https://docs.civiform.us/contributor-guide/developer-guide/development-standards
  *
  * @param value
- * @param extraInfo Additional info to add to the error if provided value is null. In most cases it's not needed as stack trace is enough to identify the location of the error.
+ * @param extraInfo Additional info to add to the error if provided value is
+ *     null. In most cases it's not needed as stack trace is enough to identify
+ *     the location of the error.
  */
-export function assert<T>(value: T | null | undefined, extraInfo = ''): T {
+export function assertNotNull<T>(
+  value: T | null | undefined,
+  extraInfo = '',
+): T {
   if (value == null) {
     const extra = extraInfo !== '' ? ' Extra info: ' + extraInfo : ''
     throw new Error(`Provided value is ${String(value)}.${extra}`)

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testMatch: ['**/*.test.ts'],
+  testMatch: ['<rootDir>/app/**/*.test.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,7 +11,6 @@
     "mapRoot": "/assets/javascripts",
     "sourceRoot": "/assets/javascripts",
     "baseUrl": "./",
-    // TODO(#3361): fix and reenable strict checks.
     "strict": true
   },
   "include": ["app/assets/javascripts/*"]

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceRoot": "/assets/javascripts",
     "baseUrl": "./",
     // TODO(#3361): fix and reenable strict checks.
-    "strict": false
+    "strict": true
   },
   "include": ["app/assets/javascripts/*"]
 }


### PR DESCRIPTION
### Description

The main change is that accessing (calling methods or accessing properties) on nullable variables is now an error. Developer either have to explicitly check that value is not-null or add non-null assertion. For that I introduced `assert()` helper function that ensures that provided value is non-null and throws error otherwise. It required me to add it in a lot of places, mainly around `querySelector()` and `getElementById()` calls. It's quite annoying but provides extra safety. 

We can also implement something like `safeQuerySelector` described here: https://effectivetypescript.com/2020/07/27/safe-queryselector/ But I decided to go simpler, more universal approach (we'd need to have `assert()` for other cases as well).  


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
