### PR TITLE
Add feature flag

### DIFF
--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -32,7 +32,7 @@ public final class FeatureFlags {
       "program_eligibility_conditions_enabled";
   public static final String PROGRAM_READ_ONLY_VIEW_ENABLED = "program_read_only_view_enabled";
   public static final String PREDICATES_MULTIPLE_QUESTIONS_ENABLED =
-    "predicates_multiple_questions_enabled";
+      "predicates_multiple_questions_enabled";
 
   private final Config config;
 

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -31,6 +31,8 @@ public final class FeatureFlags {
   public static final String PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED =
       "program_eligibility_conditions_enabled";
   public static final String PROGRAM_READ_ONLY_VIEW_ENABLED = "program_read_only_view_enabled";
+  public static final String PREDICATES_MULTIPLE_QUESTIONS_ENABLED =
+    "predicates_multiple_questions_enabled";
 
   private final Config config;
 
@@ -56,6 +58,15 @@ public final class FeatureFlags {
   /** If the Eligibility Conditions feature is enabled in the system configuration. */
   public boolean isProgramEligibilityConditionsEnabled() {
     return config.getBoolean(PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED);
+  }
+
+  /**
+   * If specifying multiple questions in a predicate is enabled.
+   *
+   * <p>Allows for overrides set in {@code request}.
+   */
+  public boolean isPredicatesMultipleQuestionsEnabled(Request request) {
+    return getFlagEnabled(request, PREDICATES_MULTIPLE_QUESTIONS_ENABLED);
   }
 
   /**

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -663,6 +663,9 @@ program_read_only_view_enabled = ${?PROGRAM_READ_ONLY_VIEW_ENABLED}
 program_eligibility_conditions_enabled = false
 program_eligibility_conditions_enabled = ${?PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED}
 
+predicates_multiple_questions_enabled = false
+predicates_multiple_questions_enabled = ${?PREDICATES_MULTIPLE_QUESTIONS_ENABLED}
+
 # If enabled allows for setting of feature flags via HTTP.
 # This is explicitly not recommended for production and intended to aid
 # development and pre-release evaluation of features. In fact it is unlikely to

--- a/server/test/featureflags/FeatureFlagsTest.java
+++ b/server/test/featureflags/FeatureFlagsTest.java
@@ -25,6 +25,8 @@ public class FeatureFlagsTest {
               "true",
               FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
               "true",
+              FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
+              "true",
               FeatureFlags.PROGRAM_READ_ONLY_VIEW_ENABLED,
               "true"));
 
@@ -35,6 +37,8 @@ public class FeatureFlagsTest {
               "true",
               FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
               "true",
+              FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
+              "true",
               FeatureFlags.PROGRAM_READ_ONLY_VIEW_ENABLED,
               "true"));
   private static final Map<String, String> allFeaturesEnabledMap =
@@ -42,6 +46,8 @@ public class FeatureFlagsTest {
           FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
           "true",
           FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
+          "true",
+          FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
           "true",
           FeatureFlags.PROGRAM_READ_ONLY_VIEW_ENABLED,
           "true");
@@ -53,6 +59,8 @@ public class FeatureFlagsTest {
           FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
           "false",
           FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
+          "false",
+          FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
           "false",
           FeatureFlags.PROGRAM_READ_ONLY_VIEW_ENABLED,
           "false");
@@ -67,6 +75,7 @@ public class FeatureFlagsTest {
 
     assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
+    assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isFalse();
   }
 
   @Test
@@ -77,6 +86,8 @@ public class FeatureFlagsTest {
     assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesEnabledRequest)).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesEnabledRequest))
         .isFalse();
+    assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(allFeaturesEnabledRequest))
+        .isFalse();
   }
 
   @Test
@@ -85,6 +96,7 @@ public class FeatureFlagsTest {
 
     assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
+    assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isFalse();
   }
 
   @Test
@@ -93,6 +105,7 @@ public class FeatureFlagsTest {
 
     assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isTrue();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isTrue();
+    assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Add `PREDICATES_MULTIPLE_QUESTIONS_ENABLED` feature flag for admin multi-question predicate UI, default to `false`.