### PR TITLE
Update set-output in github action to new format

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -98,7 +98,7 @@ jobs:
             contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) ||
             contains(toJSON(steps.file_changes.outputs.files), matrix.script) ||
             contains(toJSON(steps.file_changes.outputs.files), '.github') }}
-        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "::set-output name=build::build"
+        run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "build=build" >> $GITHUB_OUTPUT
 
       - name: Skip build & push
         if: ${{ steps.check_build.outputs.build != 'build' }}


### PR DESCRIPTION
### Description

Use of set-output in github action is deprecated. Updating to new format. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

