### PR TITLE
Update timezone of previously answered on text

### DIFF
--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -85,4 +85,9 @@ public final class DateConverter {
   public String formatIso8601Date(LocalDate date) {
     return date.format(DATE_TIME_FORMATTER_WITH_DASH);
   }
+
+  /** Formats a {@link Long} timestamp to a {@link LocalDate}. */
+  public LocalDate renderLocalDate(Long timestamp) {
+    return Instant.ofEpochMilli(timestamp).atZone(this.zoneId).toLocalDate();
+  }
 }

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import play.i18n.Messages;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.DateConverter;
 import services.MessageKey;
 import services.applicant.AnswerData;
 import services.applicant.RepeatedEntity;
@@ -40,12 +41,12 @@ import views.style.StyleUtils;
 public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
   private final ApplicantLayout layout;
-  private final ZoneId zoneId;
+  private final DateConverter dateConverter;
 
   @Inject
-  public ApplicantProgramSummaryView(ApplicantLayout layout, ZoneId zoneId) {
+  public ApplicantProgramSummaryView(ApplicantLayout layout,  DateConverter dateConverter) {
     this.layout = checkNotNull(layout);
-    this.zoneId = checkNotNull(zoneId);
+    this.dateConverter = checkNotNull(dateConverter);
   }
 
   /**
@@ -163,7 +164,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     DivTag actionAndTimestampDiv = div().withClasses("pr-2", "flex", "flex-col", "text-right");
     // Show timestamp if answered elsewhere.
     if (data.isPreviousResponse()) {
-      LocalDate date = Instant.ofEpochMilli(data.timestamp()).atZone(this.zoneId).toLocalDate();
+      LocalDate date = this.dateConverter.renderLocalDate(data.timestamp());
       // TODO(#4003): Translate this text.
       DivTag timestampContent =
           div("Previously answered on " + date)

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -163,8 +163,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     DivTag actionAndTimestampDiv = div().withClasses("pr-2", "flex", "flex-col", "text-right");
     // Show timestamp if answered elsewhere.
     if (data.isPreviousResponse()) {
-      LocalDate date =
-          Instant.ofEpochMilli(data.timestamp()).atZone(this.zoneId).toLocalDate();
+      LocalDate date = Instant.ofEpochMilli(data.timestamp()).atZone(this.zoneId).toLocalDate();
       // TODO(#4003): Translate this text.
       DivTag timestampContent =
           div("Previously answered on " + date)

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -15,9 +15,7 @@ import com.google.inject.Inject;
 import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Optional;
 import play.i18n.Messages;
@@ -44,7 +42,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
   private final DateConverter dateConverter;
 
   @Inject
-  public ApplicantProgramSummaryView(ApplicantLayout layout,  DateConverter dateConverter) {
+  public ApplicantProgramSummaryView(ApplicantLayout layout, DateConverter dateConverter) {
     this.layout = checkNotNull(layout);
     this.dateConverter = checkNotNull(dateConverter);
   }

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -40,10 +40,12 @@ import views.style.StyleUtils;
 public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
   private final ApplicantLayout layout;
+  private final ZoneId zoneId;
 
   @Inject
-  public ApplicantProgramSummaryView(ApplicantLayout layout) {
+  public ApplicantProgramSummaryView(ApplicantLayout layout, ZoneId zoneId) {
     this.layout = checkNotNull(layout);
+    this.zoneId = checkNotNull(zoneId);
   }
 
   /**
@@ -162,7 +164,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     // Show timestamp if answered elsewhere.
     if (data.isPreviousResponse()) {
       LocalDate date =
-          Instant.ofEpochMilli(data.timestamp()).atZone(ZoneId.systemDefault()).toLocalDate();
+          Instant.ofEpochMilli(data.timestamp()).atZone(this.zoneId).toLocalDate();
       // TODO(#4003): Translate this text.
       DivTag timestampContent =
           div("Previously answered on " + date)

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -60,7 +60,6 @@ public class DateConverterTest {
   @Test
   public void renderLocalDate_isCorrect() {
     Long timestamp = 1673453292339L;
-    assertThat(dateConverter.renderLocalDate(timestamp))
-      .isEqualTo(LocalDate.of(2023,1,11));
+    assertThat(dateConverter.renderLocalDate(timestamp)).isEqualTo(LocalDate.of(2023, 1, 11));
   }
 }

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -56,4 +56,11 @@ public class DateConverterTest {
     assertThat(dateConverter.renderDateTimeDataOnly(instant))
         .isEqualTo("2022/04/09 10:07:03 AM UTC");
   }
+
+  @Test
+  public void renderLocalDate_isCorrect() {
+    Long timestamp = 1673453292339L;
+    assertThat(dateConverter.renderLocalDate(timestamp))
+      .isEqualTo(LocalDate.of(2023,1,11));
+  }
 }


### PR DESCRIPTION
### Description

Using ZoneId.systemDefault() will show the timezone as GMT. By initializing the View with ZoneId and then calling this.zoneId, the zone is "America/Los_Angeles". This also seems to be how this is done in other files, so this seems consistent with other places where we localize a timestamp or date. 

It doesn't seem like there is currently a browser test that checks whether "previously answered state" is set correctly. I was thinking of filing a separate bug for that, but let me know if this seems in scope for this bug. 

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

#3379
