### PR TITLE
Fix editing published program with screen ID 1 removed

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -141,7 +141,7 @@ public final class AdminProgramController extends CiviFormController {
         // Make a new draft from the provided id.
         idToEdit = programService.newDraftOf(id).id();
       }
-      return redirect(controllers.admin.routes.AdminProgramBlocksController.edit(idToEdit, 1));
+      return redirect(controllers.admin.routes.AdminProgramBlocksController.index(idToEdit).url());
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
     } catch (Exception e) {


### PR DESCRIPTION
### Description

This fixes a bug with removing a screen with id 1 and editing the publish draft.

Browser tests are still needed.

## Release notes

This fixes a bug with published programs where the first screen was deleted.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #4029 
