### PR TITLE
Add LeafAddressServiceAreaExpressionNode

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -29,6 +29,7 @@ import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.predicate.AndNode;
+import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.OrNode;
 import services.program.predicate.PredicateDefinition;
@@ -340,6 +341,11 @@ public final class VersionRepository {
         Optional<Question> updated = getLatestVersionOfQuestion(leaf.questionId());
         return PredicateExpressionNode.create(
             leaf.toBuilder().setQuestionId(updated.orElseThrow().id).build());
+      case LEAF_ADDRESS_SERVICE_AREA:
+        LeafAddressServiceAreaExpressionNode leafAddress = node.getLeafAddressNode();
+        Optional<Question> updatedQuestion = getLatestVersionOfQuestion(leafAddress.questionId());
+        return PredicateExpressionNode.create(
+            leafAddress.toBuilder().setQuestionId(updatedQuestion.orElseThrow().id).build());
     }
     // ErrorProne will require the switch handle all types since there isn't a default, we should
     // never get here.

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -28,6 +28,9 @@ public final class PredicateEvaluator {
     switch (node.getType()) {
       case LEAF_OPERATION:
         return evaluateLeafNode(node.getLeafNode());
+      case LEAF_ADDRESS_SERVICE_AREA:
+        // TODO(https://github.com/civiform/civiform/issues/4048): check if address in service area
+        return true;
       case AND:
         return evaluateAndNode(node.getAndNode());
       case OR:

--- a/server/app/services/program/predicate/AndNode.java
+++ b/server/app/services/program/predicate/AndNode.java
@@ -34,6 +34,13 @@ public abstract class AndNode implements ConcretePredicateExpressionNode {
   }
 
   @Override
+  @JsonIgnore
+  public void accept(PredicateExpressionNodeVisitor visitor) {
+    children().stream().forEach(child -> child.accept(visitor));
+    visitor.visit(this);
+  }
+
+  @Override
   public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     return Joiner.on(" and ")
         .join(children().stream().map(c -> c.node().toDisplayString(questions)).toArray());

--- a/server/app/services/program/predicate/ConcretePredicateExpressionNode.java
+++ b/server/app/services/program/predicate/ConcretePredicateExpressionNode.java
@@ -33,4 +33,6 @@ public interface ConcretePredicateExpressionNode {
    * @return a human-readable representation of this node
    */
   String toDisplayString(ImmutableList<QuestionDefinition> questions);
+
+  void accept(PredicateExpressionNodeVisitor v);
 }

--- a/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
+++ b/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
@@ -26,7 +26,7 @@ public abstract class LeafAddressServiceAreaExpressionNode
   @JsonProperty("questionId")
   public abstract long questionId();
 
-  /** The string label of the service area the address should be checked for inclusion in. */
+  /** The string ID of the service area the address should be checked for inclusion in. */
   @JsonProperty("serviceAreaId")
   public abstract String serviceAreaId();
 
@@ -44,7 +44,7 @@ public abstract class LeafAddressServiceAreaExpressionNode
 
   /**
    * Displays a human-readable representation of the assertion in the format "[question name] is in
-   * service area [service area label]".
+   * service area [service area ID]".
    */
   @Override
   public String toDisplayString(ImmutableList<QuestionDefinition> questions) {

--- a/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
+++ b/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
@@ -18,8 +18,8 @@ public abstract class LeafAddressServiceAreaExpressionNode
   @JsonCreator
   public static LeafAddressServiceAreaExpressionNode create(
       @JsonProperty("questionId") long questionId,
-      @JsonProperty("serviceAreaLabel") String serviceAreaLabel) {
-    return builder().setQuestionId(questionId).setServiceAreaLabel(serviceAreaLabel).build();
+      @JsonProperty("serviceAreaId") String serviceAreaId) {
+    return builder().setQuestionId(questionId).setServiceAreaId(serviceAreaId).build();
   }
 
   /** The ID of the address {@link services.question.types.QuestionDefinition} this node checks. */
@@ -27,8 +27,8 @@ public abstract class LeafAddressServiceAreaExpressionNode
   public abstract long questionId();
 
   /** The string label of the service area the address should be checked for inclusion in. */
-  @JsonProperty("serviceAreaLabel")
-  public abstract String serviceAreaLabel();
+  @JsonProperty("serviceAreaId")
+  public abstract String serviceAreaId();
 
   @Override
   @JsonIgnore
@@ -57,7 +57,7 @@ public abstract class LeafAddressServiceAreaExpressionNode
             .map(addressName -> String.format("\"%s\"", addressName))
             .orElse("address");
 
-    return String.format("%s is in service area \"%s\"", addressLabel, serviceAreaLabel());
+    return String.format("%s is in service area \"%s\"", addressLabel, serviceAreaId());
   }
 
   public static Builder builder() {
@@ -71,7 +71,7 @@ public abstract class LeafAddressServiceAreaExpressionNode
 
     public abstract Builder setQuestionId(long questionId);
 
-    public abstract Builder setServiceAreaLabel(String serviceAreaLabel);
+    public abstract Builder setServiceAreaId(String serviceAreaId);
 
     public abstract LeafAddressServiceAreaExpressionNode build();
   }

--- a/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
+++ b/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
@@ -1,0 +1,78 @@
+package services.program.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import services.question.types.QuestionDefinition;
+
+/** Represents an assertion that an address question is within a given service area. */
+@JsonTypeName("leafAddressServiceArea")
+@AutoValue
+public abstract class LeafAddressServiceAreaExpressionNode
+    implements ConcretePredicateExpressionNode {
+
+  @JsonCreator
+  public static LeafAddressServiceAreaExpressionNode create(
+      @JsonProperty("questionId") long questionId,
+      @JsonProperty("serviceAreaLabel") String serviceAreaLabel) {
+    return builder().setQuestionId(questionId).setServiceAreaLabel(serviceAreaLabel).build();
+  }
+
+  /** The ID of the address {@link services.question.types.QuestionDefinition} this node checks. */
+  @JsonProperty("questionId")
+  public abstract long questionId();
+
+  /** The string label of the service area the address should be checked for inclusion in. */
+  @JsonProperty("serviceAreaLabel")
+  public abstract String serviceAreaLabel();
+
+  @Override
+  @JsonIgnore
+  public PredicateExpressionNodeType getType() {
+    return PredicateExpressionNodeType.LEAF_ADDRESS_SERVICE_AREA;
+  }
+
+  @Override
+  @JsonIgnore
+  public void accept(PredicateExpressionNodeVisitor visitor) {
+    visitor.visit(this);
+  }
+
+  /**
+   * Displays a human-readable representation of the assertion in the format "[question name] is in
+   * service area [service area label]".
+   */
+  @Override
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
+    Optional<QuestionDefinition> maybeQuestionDefinition =
+        questions.stream().filter(q -> q.getId() == questionId()).findFirst();
+
+    String addressLabel =
+        maybeQuestionDefinition
+            .map(QuestionDefinition::getName)
+            .map(addressName -> String.format("\"%s\"", addressName))
+            .orElse("address");
+
+    return String.format("%s is in service area \"%s\"", addressLabel, serviceAreaLabel());
+  }
+
+  public static Builder builder() {
+    return new AutoValue_LeafAddressServiceAreaExpressionNode.Builder();
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setQuestionId(long questionId);
+
+    public abstract Builder setServiceAreaLabel(String serviceAreaLabel);
+
+    public abstract LeafAddressServiceAreaExpressionNode build();
+  }
+}

--- a/server/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/server/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -58,6 +58,12 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
     return PredicateExpressionNodeType.LEAF_OPERATION;
   }
 
+  @Override
+  @JsonIgnore
+  public void accept(PredicateExpressionNodeVisitor visitor) {
+    visitor.visit(this);
+  }
+
   /**
    * Displays a human-readable representation of this expression, in the format "[question name]'s
    * [scalar] [operator] [value]". For example: "home address's city is one of ["Seattle",

--- a/server/app/services/program/predicate/OrNode.java
+++ b/server/app/services/program/predicate/OrNode.java
@@ -34,6 +34,13 @@ public abstract class OrNode implements ConcretePredicateExpressionNode {
   }
 
   @Override
+  @JsonIgnore
+  public void accept(PredicateExpressionNodeVisitor visitor) {
+    children().stream().forEach(child -> child.accept(visitor));
+    visitor.visit(this);
+  }
+
+  @Override
   public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     return Joiner.on(" or ")
         .join(children().stream().map(c -> c.node().toDisplayString(questions)).toArray());

--- a/server/app/services/program/predicate/PredicateAddressServiceAreaNodeExtractor.java
+++ b/server/app/services/program/predicate/PredicateAddressServiceAreaNodeExtractor.java
@@ -3,8 +3,7 @@ package services.program.predicate;
 import com.google.common.collect.ImmutableList;
 
 /** Extracts {@link LeafAddressServiceAreaExpressionNode}s from a {@link PredicateDefinition}. */
-public final class PredicateAddressServiceAreaNodeExtractor
-    implements PredicateExpressionNodeVisitor {
+public final class PredicateAddressServiceAreaNodeExtractor extends PredicateExpressionNodeVisitor {
 
   private ImmutableList.Builder<LeafAddressServiceAreaExpressionNode> nodes =
       ImmutableList.builder();
@@ -25,13 +24,4 @@ public final class PredicateAddressServiceAreaNodeExtractor
   public void visit(LeafAddressServiceAreaExpressionNode leafAddressServiceAreaExpressionNode) {
     this.nodes.add(leafAddressServiceAreaExpressionNode);
   }
-
-  @Override
-  public void visit(AndNode andNode) {}
-
-  @Override
-  public void visit(OrNode orNode) {}
-
-  @Override
-  public void visit(LeafOperationExpressionNode leafOperationExpressionNode) {}
 }

--- a/server/app/services/program/predicate/PredicateAddressServiceAreaNodeExtractor.java
+++ b/server/app/services/program/predicate/PredicateAddressServiceAreaNodeExtractor.java
@@ -1,0 +1,37 @@
+package services.program.predicate;
+
+import com.google.common.collect.ImmutableList;
+
+/** Extracts {@link LeafAddressServiceAreaExpressionNode}s from a {@link PredicateDefinition}. */
+public final class PredicateAddressServiceAreaNodeExtractor
+    implements PredicateExpressionNodeVisitor {
+
+  private ImmutableList.Builder<LeafAddressServiceAreaExpressionNode> nodes =
+      ImmutableList.builder();
+
+  /** Extracts {@link LeafAddressServiceAreaExpressionNode}s from a {@link PredicateDefinition}. */
+  public static ImmutableList<LeafAddressServiceAreaExpressionNode> extract(
+      PredicateDefinition predicateDefinition) {
+    return new PredicateAddressServiceAreaNodeExtractor().extractInternal(predicateDefinition);
+  }
+
+  private ImmutableList<LeafAddressServiceAreaExpressionNode> extractInternal(
+      PredicateDefinition predicateDefinition) {
+    predicateDefinition.rootNode().accept(this);
+    return nodes.build();
+  }
+
+  @Override
+  public void visit(LeafAddressServiceAreaExpressionNode leafAddressServiceAreaExpressionNode) {
+    this.nodes.add(leafAddressServiceAreaExpressionNode);
+  }
+
+  @Override
+  public void visit(AndNode andNode) {}
+
+  @Override
+  public void visit(OrNode orNode) {}
+
+  @Override
+  public void visit(LeafOperationExpressionNode leafOperationExpressionNode) {}
+}

--- a/server/app/services/program/predicate/PredicateExpressionNode.java
+++ b/server/app/services/program/predicate/PredicateExpressionNode.java
@@ -30,7 +30,12 @@ public abstract class PredicateExpressionNode {
     return node().getType();
   }
 
-  /** Get a leaf node if it exists, or throw if this is not a leaf node. */
+  @JsonIgnore
+  public void accept(PredicateExpressionNodeVisitor predicateExpressionNodeVisitor) {
+    node().accept(predicateExpressionNodeVisitor);
+  }
+
+  /** Get a leaf operation node if it exists, or throw if this is not a leaf operation node. */
   @JsonIgnore
   @Memoized
   public LeafOperationExpressionNode getLeafNode() {
@@ -39,6 +44,18 @@ public abstract class PredicateExpressionNode {
           String.format("Expected a LEAF node but received %s node", getType()));
     }
     return (LeafOperationExpressionNode) node();
+  }
+
+  /** Get a leaf address node if it exists, or throw if this is not a leaf address node. */
+  @JsonIgnore
+  @Memoized
+  public LeafAddressServiceAreaExpressionNode getLeafAddressNode() {
+    if (!(node() instanceof LeafAddressServiceAreaExpressionNode)) {
+      throw new RuntimeException(
+          String.format(
+              "Expected a LEAF_ADDRESS_SERVICE_AREA node but received %s node", getType()));
+    }
+    return (LeafAddressServiceAreaExpressionNode) node();
   }
 
   /** Get an and node if it exists, or throw if this is not an and node. */

--- a/server/app/services/program/predicate/PredicateExpressionNodeType.java
+++ b/server/app/services/program/predicate/PredicateExpressionNodeType.java
@@ -8,5 +8,6 @@ package services.program.predicate;
 public enum PredicateExpressionNodeType {
   AND,
   OR,
-  LEAF_OPERATION
+  LEAF_OPERATION,
+  LEAF_ADDRESS_SERVICE_AREA
 }

--- a/server/app/services/program/predicate/PredicateExpressionNodeVisitor.java
+++ b/server/app/services/program/predicate/PredicateExpressionNodeVisitor.java
@@ -1,0 +1,15 @@
+package services.program.predicate;
+
+/**
+ * Visitor pattern (https://en.wikipedia.org/wiki/Visitor_pattern) for traversing predicate ASTs.
+ */
+public interface PredicateExpressionNodeVisitor {
+
+  void visit(AndNode andNode);
+
+  void visit(OrNode orNode);
+
+  void visit(LeafOperationExpressionNode leafOperationExpressionNode);
+
+  void visit(LeafAddressServiceAreaExpressionNode leafAddressServiceAreaExpressionNode);
+}

--- a/server/app/services/program/predicate/PredicateExpressionNodeVisitor.java
+++ b/server/app/services/program/predicate/PredicateExpressionNodeVisitor.java
@@ -3,13 +3,13 @@ package services.program.predicate;
 /**
  * Visitor pattern (https://en.wikipedia.org/wiki/Visitor_pattern) for traversing predicate ASTs.
  */
-public interface PredicateExpressionNodeVisitor {
+public abstract class PredicateExpressionNodeVisitor {
 
-  void visit(AndNode andNode);
+  public void visit(AndNode andNode) {}
 
-  void visit(OrNode orNode);
+  public void visit(OrNode orNode) {}
 
-  void visit(LeafOperationExpressionNode leafOperationExpressionNode);
+  public void visit(LeafOperationExpressionNode leafOperationExpressionNode) {}
 
-  void visit(LeafAddressServiceAreaExpressionNode leafAddressServiceAreaExpressionNode);
+  public void visit(LeafAddressServiceAreaExpressionNode leafAddressServiceAreaExpressionNode) {}
 }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
 import services.program.predicate.AndNode;
+import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.Operator;
 import services.program.predicate.OrNode;
@@ -301,7 +302,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     //      /     \
     //   LEAF1    OR
     //          /    \
-    //       LEAF2   LEAF3
+    //       LEAF2   LEAF_ADDRESS
     PredicateExpressionNode leafOne =
         PredicateExpressionNode.create(
             LeafOperationExpressionNode.create(
@@ -310,12 +311,10 @@ public class VersionRepositoryTest extends ResetPostgres {
         PredicateExpressionNode.create(
             LeafOperationExpressionNode.create(
                 oldTwo.id, Scalar.TEXT, Operator.EQUAL_TO, PredicateValue.of("")));
-    PredicateExpressionNode leafThree =
-        PredicateExpressionNode.create(
-            LeafOperationExpressionNode.create(
-                oldOne.id, Scalar.NUMBER, Operator.LESS_THAN, PredicateValue.of(12)));
+    PredicateExpressionNode leafAddress =
+        PredicateExpressionNode.create(LeafAddressServiceAreaExpressionNode.create(oldOne.id, ""));
     PredicateExpressionNode or =
-        PredicateExpressionNode.create(OrNode.create(ImmutableSet.of(leafTwo, leafThree)));
+        PredicateExpressionNode.create(OrNode.create(ImmutableSet.of(leafTwo, leafAddress)));
     PredicateExpressionNode and =
         PredicateExpressionNode.create(AndNode.create(ImmutableSet.of(leafOne, or)));
 
@@ -330,7 +329,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             leafTwo.getLeafNode().toBuilder().setQuestionId(newTwo.id).build());
     PredicateExpressionNode expectedLeafThree =
         PredicateExpressionNode.create(
-            leafThree.getLeafNode().toBuilder().setQuestionId(newOne.id).build());
+            leafAddress.getLeafAddressNode().toBuilder().setQuestionId(newOne.id).build());
     PredicateExpressionNode expectedOr =
         PredicateExpressionNode.create(
             OrNode.create(ImmutableSet.of(expectedLeafTwo, expectedLeafThree)));

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import org.junit.Test;
 import services.applicant.question.Scalar;
+import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.Operator;
 import services.program.predicate.PredicateAction;
@@ -106,6 +107,31 @@ public class BlockDefinitionTest {
 
   @Test
   public void setAndGetEligibilityDefinition() {
+    var visibilityAddress = LeafAddressServiceAreaExpressionNode.create(1L, "");
+    PredicateDefinition visibilityPredicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(visibilityAddress), PredicateAction.HIDE_BLOCK);
+
+    var eligibilityAddress = LeafAddressServiceAreaExpressionNode.create(2L, "");
+    PredicateDefinition eligibilityPredicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(eligibilityAddress), PredicateAction.HIDE_BLOCK);
+    EligibilityDefinition eligibility =
+        EligibilityDefinition.builder().setPredicate(eligibilityPredicate).build();
+
+    BlockDefinition blockDefinition =
+        makeBlockDefinitionWithQuestions().toBuilder()
+            .setEligibilityDefinition(eligibility)
+            .setVisibilityPredicate(visibilityPredicate)
+            .build();
+
+    assertThat(blockDefinition.getAddressServiceAreaPredicateNodes())
+        .containsExactlyInAnyOrder(visibilityAddress, eligibilityAddress);
+    assertThat(blockDefinition.hasAddressServiceAreaPredicateNodes()).isTrue();
+  }
+
+  @Test
+  public void getAddressServiceAreaPredicateNodes() {
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(

--- a/server/test/services/program/predicate/PredicateAddressServiceAreaNodeExtractorTest.java
+++ b/server/test/services/program/predicate/PredicateAddressServiceAreaNodeExtractorTest.java
@@ -1,0 +1,55 @@
+package services.program.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import services.applicant.question.Scalar;
+
+public class PredicateAddressServiceAreaNodeExtractorTest {
+
+  @Test
+  public void run_addressServiceAreaNodeExists_returnsTheAddressNodes() {
+    var leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    var addressNode = LeafAddressServiceAreaExpressionNode.create(456L, "Seattle");
+    var rootNode =
+        PredicateExpressionNode.create(
+            OrNode.create(
+                ImmutableSet.of(
+                    PredicateExpressionNode.create(
+                        AndNode.create(
+                            ImmutableSet.of(
+                                PredicateExpressionNode.create(leaf1),
+                                PredicateExpressionNode.create(addressNode)))))));
+    var predicateDefinition = PredicateDefinition.create(rootNode, PredicateAction.HIDE_BLOCK);
+
+    assertThat(PredicateAddressServiceAreaNodeExtractor.extract(predicateDefinition))
+        .isEqualTo(ImmutableList.of(addressNode));
+  }
+
+  @Test
+  public void run_addressServiceAreaNodeDoesNotExist_returnsEmpty() {
+    var leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    var leaf2 =
+        LeafOperationExpressionNode.create(
+            456L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("goodbye"));
+    var rootNode =
+        PredicateExpressionNode.create(
+            OrNode.create(
+                ImmutableSet.of(
+                    PredicateExpressionNode.create(
+                        AndNode.create(
+                            ImmutableSet.of(
+                                PredicateExpressionNode.create(leaf1),
+                                PredicateExpressionNode.create(leaf2)))))));
+    var predicateDefinition = PredicateDefinition.create(rootNode, PredicateAction.HIDE_BLOCK);
+
+    assertThat(PredicateAddressServiceAreaNodeExtractor.extract(predicateDefinition))
+        .isEqualTo(ImmutableList.of());
+  }
+}

--- a/server/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/server/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -77,6 +77,26 @@ public class PredicateExpressionNodeTest {
   }
 
   @Test
+  public void toDisplayString_addressServiceAreaNodeOnly_questionIsPresent() {
+    QuestionDefinition question = testQuestionBank.applicantAddress().getQuestionDefinition();
+    LeafAddressServiceAreaExpressionNode leaf =
+        LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
+
+    assertThat(PredicateExpressionNode.create(leaf).toDisplayString(ImmutableList.of(question)))
+        .isEqualTo(String.format("\"%s\" is in service area \"Seattle\"", question.getName()));
+  }
+
+  @Test
+  public void toDisplayString_addressServiceAreaNodeOnly_questionIsNotPresent() {
+    QuestionDefinition question = testQuestionBank.applicantAddress().getQuestionDefinition();
+    LeafAddressServiceAreaExpressionNode leaf =
+        LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
+
+    assertThat(PredicateExpressionNode.create(leaf).toDisplayString(ImmutableList.of()))
+        .isEqualTo(String.format("address is in service area \"Seattle\""));
+  }
+
+  @Test
   public void toDisplayString_andNode() {
     QuestionDefinition question =
         testQuestionBank.applicantJugglingNumber().getQuestionDefinition();


### PR DESCRIPTION
### Description

Adds `LeafAddressServiceAreaExpressionNode` along with `BlockDefinition` methods for retrieving them.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Closes https://github.com/civiform/civiform/issues/4047 https://github.com/civiform/civiform/issues/4045