### PR TITLE
Replace abandoned file-changes-action with one that is still maintained

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -86,18 +86,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@v35
+        with:
+          json: 'true'
         if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Check build & push
         id: check_build
         if: >
           ${{ (github.event_name == 'workflow_dispatch') ||
-            contains(toJSON(steps.file_changes.outputs.files), matrix.file_pattern) ||
-            contains(toJSON(steps.file_changes.outputs.files), matrix.script) ||
-            contains(toJSON(steps.file_changes.outputs.files), '.github') }}
+            contains(toJSON(steps.file_changes.outputs.all_changed_files), matrix.file_pattern) ||
+            contains(toJSON(steps.file_changes.outputs.all_changed_files), matrix.script) ||
+            contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github') }}
         run: echo "Build & push ${{ matrix.image }} due to event ${{github.event_name}}" && echo "build=build" >> $GITHUB_OUTPUT
 
       - name: Skip build & push

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@v3
         with:
@@ -28,9 +30,10 @@ jobs:
           distribution: 'zulu'
 
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@v35
         with:
-          output: 'json'
+          json: 'true'
+
       - uses: axel-op/googlejavaformat-action@v3
         with:
           version: 1.9
@@ -63,7 +66,7 @@ jobs:
         run: git add .; git diff --exit-code HEAD
 
       - name: Check bin scripts have docstrings.
-        if: contains(toJSON(steps.file_changes.outputs.files), 'bin/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
+        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'bin/') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github/workflows/format.yaml')
         id: check_bin_script_docs
         run: bin/help
 
@@ -79,9 +82,9 @@ jobs:
         with:
           fetch-depth: 0 # get main
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@v35
         with:
-          output: 'json'
+          json: 'true'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build formatter
@@ -94,7 +97,7 @@ jobs:
           cache-from: |
             civiform/formatter:latest
       - name: Run Browsertest formatter
-        if: contains(toJSON(steps.file_changes.outputs.files), 'browser-test/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.files), 'formatter')
+        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'browser-test/') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.all_changed_files), 'formatter')
         run: browser-test/bin/fmt
       - name: show Browsertest diff
         run: git add .; git diff --exit-code HEAD
@@ -110,15 +113,15 @@ jobs:
         with:
           fetch-depth: 0 # get main
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@v35
         with:
-          output: 'json'
+          json: 'true'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Run bin/fmt-sbt
         env:
           DOCKER_BUILDKIT: 1
-        if: contains(toJSON(steps.file_changes.outputs.files), '.sbt') || contains(toJSON(steps.file_changes.outputs.files), '.scala') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.files), 'fmt-sbt')
+        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), '.sbt') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.scala') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.all_changed_files), 'fmt-sbt')
         run: bin/fmt-sbt
       - name: show bin/fmt-sbt diff
         run: git add .; git diff --exit-code HEAD


### PR DESCRIPTION
### Description

The [trilom/file-changes-action](https://github.com/trilom/file-changes-action) hasn't been updated in years. It now uses deprecated github features that will be sunset later this spring. This replaces it with [tj-actions/changed-files](https://github.com/tj-actions/changed-files) which has a thriving community around it and is being maintained.

The only difference I see in output is that each file is surrounded by double-quotes in the new action. 

**Examples**
Before with _Trilom_ `[bin/bin0341_1.txt,bin/bin0341_2.txt,bin/bin1.txt]`
After with _tj-actions_ `["bin/bin0341_1.txt","bin/bin0341_2.txt","bin/bin1.txt"]`

I've tried simple examples in an empty repository similar to how we use the list of changed files. This looks like it should do the job, but it needs to be tested in our full actions to be certain at this point.

When format.yaml looks for files changes one of the triggers is changes to itself. Recommend reviewing the action results post merge with main with a commit that doesn't affect format.yaml.

Finally, push_build_ci only triggers when main is pushed so precheck tests won't be able to check it.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary



### Issue(s) this completes

Fixes #3810 