### PR TITLE
Use commit sha for prettier action version

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -46,7 +46,7 @@ jobs:
           rm package*.json
 
       - name: Prettier diff
-        uses: actionsx/prettier@v2
+        uses: actionsx/prettier@e90ec5455552f0f640781bdd5f5d2415acb52f1a
         with:
           # prettier CLI arguments.
           args: --check .


### PR DESCRIPTION
### Description

Currently we use actionsx/prettier@v2 to do some formatting. The v2 release is very old and uses the deprecated node12. The action has been updated to use node16 however there is no tagged release version. Setting to the [specific commit hash](https://github.com/actionsx/prettier/commit/e90ec5455552f0f640781bdd5f5d2415acb52f1a) here so we can keep using the action.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
