### PR TITLE
Explicitly disable the multiple predicates experiment for legacy tests

### DIFF
--- a/browser-test/src/admin_legacy_predicates.test.ts
+++ b/browser-test/src/admin_legacy_predicates.test.ts
@@ -1,5 +1,6 @@
 import {
   createTestContext,
+  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   loginAsProgramAdmin,
@@ -25,6 +26,7 @@ describe('create and edit predicates', () => {
     } = ctx
 
     await loginAsAdmin(page)
+    await disableFeatureFlag(page, 'predicates_multiple_questions_enabled')
 
     // Add a program with two screens
     await adminQuestions.addTextQuestion({questionName: 'hide-predicate-q'})
@@ -118,6 +120,7 @@ describe('create and edit predicates', () => {
     } = ctx
 
     await loginAsAdmin(page)
+    await disableFeatureFlag(page, 'predicates_multiple_questions_enabled')
 
     // Add a program with two screens
     await adminQuestions.addTextQuestion({questionName: 'show-predicate-q'})
@@ -296,6 +299,7 @@ describe('create and edit predicates', () => {
       const {page, adminQuestions} = ctx
 
       await loginAsAdmin(page)
+      await disableFeatureFlag(page, 'predicates_multiple_questions_enabled')
 
       // DATE, STRING, LONG, LIST_OF_STRINGS, LIST_OF_LONGS
       await adminQuestions.addNameQuestion({questionName: 'single-string'})
@@ -321,6 +325,7 @@ describe('create and edit predicates', () => {
       const {page, adminPrograms, applicantQuestions, adminPredicates} = ctx
 
       await loginAsAdmin(page)
+      await disableFeatureFlag(page, 'predicates_multiple_questions_enabled')
 
       const programName = 'Test all visibility predicate types'
       await adminPrograms.addProgram(programName)
@@ -521,6 +526,7 @@ describe('create and edit predicates', () => {
       const {page, adminPrograms, applicantQuestions, adminPredicates} = ctx
 
       await loginAsAdmin(page)
+      await disableFeatureFlag(page, 'predicates_multiple_questions_enabled')
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
 
       const programName = 'Test all eligibility predicate types'

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -446,6 +446,10 @@ export const seedCanonicalQuestions = async (page: Page) => {
   await page.click('#canonical-questions')
 }
 
+export const disableFeatureFlag = async (page: Page, flag: string) => {
+  await page.goto(BASE_URL + `/dev/feature/${flag}/disable`)
+}
+
 export const enableFeatureFlag = async (page: Page, flag: string) => {
   await page.goto(BASE_URL + `/dev/feature/${flag}/enable`)
 }


### PR DESCRIPTION
### Description

The multiple predicates experiment changes the legacy UI in a way that fails the tests, so explicitly disable it for environments where the experiment has been enabled.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
