### PR TITLE
Add missing ariaLabel.begin to default language file

### DIFF
--- a/server/conf/messages
+++ b/server/conf/messages
@@ -193,12 +193,16 @@ link.edit=Edit
 link.answer=Answer
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
-ariaLabel.edit=Edit {0}
+# question, so this might say "Answer What is your name?". The {0} variable is the question text.
+ariaLabel.answer=Answer {0}
+
+# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
+# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
+ariaLabel.begin=Start here. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
-ariaLabel.answer=Answer {0}
+ariaLabel.edit=Edit {0}
 
 # Program Summary Title
 title.programSummary=Program application summary

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -190,7 +190,7 @@ link.edit=Edit
 link.answer=Answer
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
+# question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Answer {0}
 
 # An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific


### PR DESCRIPTION
### Description

Add missing label and fix ordering/comment on others.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
