### PR TITLE
Set focus after removing an enumerator for applicant view

### DIFF
--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -149,7 +149,7 @@ function setFocusAfterEnumeratorRemoval() {
     addButton.focus()
   } else {
     // Other entries, set to last remove button.
-    (deleteButtons[deleteButtons.length - 1] as HTMLElement).focus()
+    ;(deleteButtons[deleteButtons.length - 1] as HTMLElement).focus()
   }
 }
 

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -149,7 +149,7 @@ function setFocusAfterEnumeratorRemoval() {
     addButton.focus()
   } else {
     // Other entries, set to last remove button.
-    ;(deleteButtons[deleteButtons.length - 1] as HTMLElement).focus()
+    (deleteButtons[deleteButtons.length - 1] as HTMLElement).focus()
   }
 }
 

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -135,7 +135,7 @@ function setFocusAfterEnumeratorRemoval() {
   const deleteButtons = document.querySelectorAll(
     '.cf-enumerator-field:not(.hidden) .cf-enumerator-delete-button',
   )
-  if (deleteButtons.length == 0) {
+  if (deleteButtons.length === 0) {
     // No entries, set focus to add button.
     const enumeratorQuestion = assertNotNull(
       document.querySelector('.cf-question-enumerator'),


### PR DESCRIPTION
### Description

Set focus to add button or remove button for enumerators after an enumerator entity is removed. Setting focus is important for keyboard only / screenreader users.

## Release notes
Accessibility - Set focus to add button or remove button for enumerators after an enumerator entity is removed.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3566
