### PR TITLE
Promote status tracking to a default feature.

### DIFF
--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -2,7 +2,6 @@ import {
   AdminPrograms,
   createTestContext,
   dismissModal,
-  enableFeatureFlag,
   loginAsAdmin,
   loginAsGuest,
   loginAsProgramAdmin,
@@ -75,7 +74,6 @@ describe('view program statuses', () => {
       const {page, adminPrograms, applicantQuestions, adminProgramStatuses} =
         ctx
       await loginAsAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
 
       // Add a program, no questions are needed.
       await adminPrograms.addProgram(programWithStatusesName)
@@ -108,7 +106,6 @@ describe('view program statuses', () => {
     beforeEach(async () => {
       const {page, adminPrograms} = ctx
       await loginAsProgramAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
       await adminPrograms.viewApplications(programWithStatusesName)
       await adminPrograms.viewApplicationForApplicant('Guest')
     })
@@ -366,7 +363,6 @@ describe('view program statuses', () => {
         adminProgramStatuses,
       } = ctx
       await loginAsAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
 
       // Add a program with a single question that is used for asserting downloaded content.
       await adminPrograms.addProgram(programForFilteringName)
@@ -399,7 +395,6 @@ describe('view program statuses', () => {
     beforeEach(async () => {
       const {page} = ctx
       await loginAsProgramAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
     })
 
     it('application without status appears in default filter and without statuses filter', async () => {

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -1,6 +1,5 @@
 import {
   createTestContext,
-  enableFeatureFlag,
   loginAsAdmin,
   loginAsGuest,
   logout,
@@ -61,7 +60,6 @@ describe('Admin can manage translations', () => {
     const {page, adminPrograms, adminProgramStatuses, adminTranslations} = ctx
 
     await loginAsAdmin(page)
-    await enableFeatureFlag(page, 'application_status_tracking_enabled')
 
     const programName = 'Program to be translated with statuses'
     await adminPrograms.addProgram(programName)

--- a/browser-test/src/applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant_application_statuses.test.ts
@@ -1,6 +1,5 @@
 import {
   createTestContext,
-  enableFeatureFlag,
   loginAsAdmin,
   loginAsProgramAdmin,
   loginAsTestUser,
@@ -21,7 +20,6 @@ describe('with program statuses', () => {
     const {page, adminPrograms, adminProgramStatuses, applicantQuestions} = ctx
     await loginAsAdmin(page)
 
-    await enableFeatureFlag(page, 'application_status_tracking_enabled')
     await adminPrograms.addProgram(programName)
     await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
     await adminProgramStatuses.createStatus(approvedStatusName)

--- a/browser-test/src/civiform_admin_program_statuses.test.ts
+++ b/browser-test/src/civiform_admin_program_statuses.test.ts
@@ -1,7 +1,6 @@
 import {
   createTestContext,
   dismissModal,
-  enableFeatureFlag,
   loginAsAdmin,
   validateScreenshot,
 } from './support'
@@ -13,7 +12,6 @@ describe('modify program statuses', () => {
   beforeEach(async () => {
     const {page} = ctx
     await loginAsAdmin(page)
-    await enableFeatureFlag(page, 'application_status_tracking_enabled')
   })
 
   describe('statuses list', () => {
@@ -104,7 +102,6 @@ describe('modify program statuses', () => {
     beforeAll(async () => {
       const {page, adminPrograms, adminProgramStatuses} = ctx
       await loginAsAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
       await adminPrograms.addProgram(programName)
       await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
 
@@ -235,7 +232,6 @@ describe('modify program statuses', () => {
     beforeAll(async () => {
       const {page, adminPrograms, adminProgramStatuses} = ctx
       await loginAsAdmin(page)
-      await enableFeatureFlag(page, 'application_status_tracking_enabled')
       await adminPrograms.addProgram(programName)
       await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
 

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -14,7 +14,6 @@ import com.google.inject.Provider;
 import com.itextpdf.text.DocumentException;
 import controllers.BadRequestException;
 import controllers.CiviFormController;
-import featureflags.FeatureFlags;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -79,7 +78,6 @@ public final class AdminApplicationController extends CiviFormController {
   private final Provider<LocalDateTime> nowProvider;
   private final MessagesApi messagesApi;
   private final DateConverter dateConverter;
-  private final FeatureFlags featureFlags;
 
   @Inject
   public AdminApplicationController(
@@ -95,8 +93,7 @@ public final class AdminApplicationController extends CiviFormController {
       ProfileUtils profileUtils,
       MessagesApi messagesApi,
       DateConverter dateConverter,
-      @Now Provider<LocalDateTime> nowProvider,
-      FeatureFlags featureFlags) {
+      @Now Provider<LocalDateTime> nowProvider) {
     this.programService = checkNotNull(programService);
     this.applicantService = checkNotNull(applicantService);
     this.applicationListView = checkNotNull(applicationListView);
@@ -110,7 +107,6 @@ public final class AdminApplicationController extends CiviFormController {
     this.pdfExporter = checkNotNull(pdfExporter);
     this.messagesApi = checkNotNull(messagesApi);
     this.dateConverter = checkNotNull(dateConverter);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   /** Download a JSON file containing all applications to all versions of the specified program. */
@@ -345,9 +341,6 @@ public final class AdminApplicationController extends CiviFormController {
   public Result updateStatus(Http.Request request, long programId, long applicationId)
       throws ProgramNotFoundException, StatusEmailNotFoundException, StatusNotFoundException,
           AccountHasNoEmailException {
-    if (!featureFlags.isStatusTrackingEnabled(request)) {
-      return notFound("status tracking is not enabled");
-    }
     ProgramDefinition program = programService.getProgramDefinition(programId);
     String programName = program.adminName();
 
@@ -426,9 +419,6 @@ public final class AdminApplicationController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result updateNote(Http.Request request, long programId, long applicationId)
       throws ProgramNotFoundException {
-    if (!featureFlags.isStatusTrackingEnabled(request)) {
-      return notFound("status tracking is not enabled");
-    }
     ProgramDefinition program = programService.getProgramDefinition(programId);
     String programName = program.adminName();
 

--- a/server/app/controllers/admin/AdminProgramStatusesController.java
+++ b/server/app/controllers/admin/AdminProgramStatusesController.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import auth.Authorizers;
 import com.google.inject.Inject;
 import controllers.CiviFormController;
-import featureflags.FeatureFlags;
 import forms.admin.ProgramStatusesForm;
 import java.util.Optional;
 import org.pac4j.play.java.Secure;
@@ -34,28 +33,22 @@ public final class AdminProgramStatusesController extends CiviFormController {
   private final ProgramStatusesView statusesView;
   private final RequestChecker requestChecker;
   private final FormFactory formFactory;
-  private final FeatureFlags featureFlags;
 
   @Inject
   public AdminProgramStatusesController(
       ProgramService service,
       ProgramStatusesView statusesView,
       RequestChecker requestChecker,
-      FormFactory formFactory,
-      FeatureFlags featureFlags) {
+      FormFactory formFactory) {
     this.service = checkNotNull(service);
     this.statusesView = checkNotNull(statusesView);
     this.requestChecker = checkNotNull(requestChecker);
     this.formFactory = checkNotNull(formFactory);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   /** Displays the list of {@link StatusDefinitions} associated with the program. */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Http.Request request, long programId) throws ProgramNotFoundException {
-    if (!featureFlags.isStatusTrackingEnabled(request)) {
-      return notFound("status tracking is not enabled");
-    }
     requestChecker.throwIfProgramNotDraft(programId);
 
     return ok(
@@ -78,9 +71,6 @@ public final class AdminProgramStatusesController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result createOrUpdate(Http.Request request, long programId)
       throws ProgramNotFoundException {
-    if (!featureFlags.isStatusTrackingEnabled(request)) {
-      return notFound("status tracking is not enabled");
-    }
     requestChecker.throwIfProgramNotDraft(programId);
     ProgramDefinition program = service.getProgramDefinition(programId);
     int previousStatusCount = program.statusDefinitions().getStatuses().size();
@@ -172,9 +162,6 @@ public final class AdminProgramStatusesController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result delete(Http.Request request, long programId) throws ProgramNotFoundException {
-    if (!featureFlags.isStatusTrackingEnabled(request)) {
-      return notFound("status tracking is not enabled");
-    }
     requestChecker.throwIfProgramNotDraft(programId);
     ProgramDefinition program = service.getProgramDefinition(programId);
 

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -26,8 +26,6 @@ public final class FeatureFlags {
       "allow_civiform_admin_access_programs";
 
   // Launch Flags, these will eventually be removed.
-  public static final String APPLICATION_STATUS_TRACKING_ENABLED =
-      "application_status_tracking_enabled";
   public static final String PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED =
       "program_eligibility_conditions_enabled";
   public static final String PROGRAM_READ_ONLY_VIEW_ENABLED = "program_read_only_view_enabled";
@@ -74,20 +72,6 @@ public final class FeatureFlags {
     return getFlagEnabled(request, PREDICATES_MULTIPLE_QUESTIONS_ENABLED);
   }
 
-  /**
-   * If the Status Tracking feature is enabled.
-   *
-   * <p>Allows for overrides set in {@code request}.
-   */
-  public boolean isStatusTrackingEnabled(Request request) {
-    return getFlagEnabled(request, APPLICATION_STATUS_TRACKING_ENABLED);
-  }
-
-  /** If the Status Tracking feature is enabled in the system configuration. */
-  public boolean isStatusTrackingEnabled() {
-    return config.getBoolean(APPLICATION_STATUS_TRACKING_ENABLED);
-  }
-
   public boolean allowCiviformAdminAccessPrograms(Request request) {
     return getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS);
   }
@@ -114,8 +98,6 @@ public final class FeatureFlags {
     return ImmutableMap.of(
         ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS,
         allowCiviformAdminAccessPrograms(request),
-        APPLICATION_STATUS_TRACKING_ENABLED,
-        isStatusTrackingEnabled(request),
         PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
         isProgramEligibilityConditionsEnabled(request),
         PREDICATES_MULTIPLE_QUESTIONS_ENABLED,

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -6,7 +6,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
-import featureflags.FeatureFlags;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -56,7 +55,6 @@ public final class CsvExporterService {
   private final ProgramService programService;
   private final QuestionService questionService;
   private final ApplicantService applicantService;
-  private final FeatureFlags featureFlags;
   private final Config config;
   private final DateConverter dateConverter;
 
@@ -74,13 +72,11 @@ public final class CsvExporterService {
       ProgramService programService,
       QuestionService questionService,
       ApplicantService applicantService,
-      FeatureFlags featureFlags,
       Config config,
       DateConverter dateConverter) {
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
     this.applicantService = checkNotNull(applicantService);
-    this.featureFlags = checkNotNull(featureFlags);
     this.config = checkNotNull(config);
     this.dateConverter = dateConverter;
   }
@@ -247,11 +243,8 @@ public final class CsvExporterService {
             .setHeader("Submitted by")
             .setColumnType(ColumnType.SUBMITTER_EMAIL)
             .build());
-
-    if (featureFlags.isStatusTrackingEnabled()) {
-      columnsBuilder.add(
-          Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
-    }
+    columnsBuilder.add(
+        Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
 
     // Add columns for each path to an answer.
     for (AnswerData answerData : answerDataList) {
@@ -355,10 +348,8 @@ public final class CsvExporterService {
         Column.builder().setHeader("Create time").setColumnType(ColumnType.CREATE_TIME).build());
     columnsBuilder.add(
         Column.builder().setHeader("Submit time").setColumnType(ColumnType.SUBMIT_TIME).build());
-    if (featureFlags.isStatusTrackingEnabled()) {
-      columnsBuilder.add(
-          Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
-    }
+    columnsBuilder.add(
+        Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
 
     for (QuestionTag tagType :
         ImmutableList.of(QuestionTag.DEMOGRAPHIC, QuestionTag.DEMOGRAPHIC_PII)) {

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.DocumentContext;
-import featureflags.FeatureFlags;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -37,18 +36,15 @@ public final class JsonExporter {
 
   private final ApplicantService applicantService;
   private final ProgramService programService;
-  private final FeatureFlags featureFlags;
   private final DateConverter dateConverter;
 
   @Inject
   JsonExporter(
       ApplicantService applicantService,
       ProgramService programService,
-      FeatureFlags featureFlags,
       DateConverter dateConverter) {
     this.applicantService = checkNotNull(applicantService);
     this.programService = checkNotNull(programService);
-    this.featureFlags = checkNotNull(featureFlags);
     this.dateConverter = dateConverter;
   }
 
@@ -110,14 +106,12 @@ public final class JsonExporter {
                     submitTimePath, dateConverter.renderDateTimeDataOnly(submitTime)),
             () -> jsonApplication.putNull(submitTimePath));
 
-    if (featureFlags.isStatusTrackingEnabled()) {
-      Path statusPath = Path.create("status");
-      application
-          .getLatestStatus()
-          .ifPresentOrElse(
-              status -> jsonApplication.putString(statusPath, status),
-              () -> jsonApplication.putNull(statusPath));
-    }
+    Path statusPath = Path.create("status");
+    application
+        .getLatestStatus()
+        .ifPresentOrElse(
+            status -> jsonApplication.putString(statusPath, status),
+            () -> jsonApplication.putNull(statusPath));
 
     for (AnswerData answerData : roApplicantProgramService.getSummaryData()) {
       // Answers to enumerator questions should not be included because the path is incompatible

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -13,7 +13,6 @@ import com.itextpdf.text.FontFactory;
 import com.itextpdf.text.Paragraph;
 import com.itextpdf.text.pdf.PdfWriter;
 import com.typesafe.config.Config;
-import featureflags.FeatureFlags;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
@@ -32,18 +31,15 @@ public final class PdfExporter {
   private final ApplicantService applicantService;
   private final Provider<LocalDateTime> nowProvider;
   private final String baseUrl;
-  private final FeatureFlags featureFlags;
 
   @Inject
   PdfExporter(
       ApplicantService applicantService,
       @Now Provider<LocalDateTime> nowProvider,
-      Config configuration,
-      FeatureFlags featureFlags) {
+      Config configuration) {
     this.applicantService = checkNotNull(applicantService);
     this.nowProvider = checkNotNull(nowProvider);
     this.baseUrl = checkNotNull(configuration).getString("base_url");
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   /**
@@ -98,13 +94,11 @@ public final class PdfExporter {
               "Program Name : " + programName, FontFactory.getFont(FontFactory.HELVETICA_BOLD, 15));
       document.add(applicant);
       document.add(program);
-      if (featureFlags.isStatusTrackingEnabled()) {
-        Paragraph status =
-            new Paragraph(
-                "Status: " + statusValue.orElse("none"),
-                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
-        document.add(status);
-      }
+      Paragraph status =
+          new Paragraph(
+              "Status: " + statusValue.orElse("none"),
+              FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
+      document.add(status);
       document.add(Chunk.NEWLINE);
       for (AnswerData answerData : answers) {
         Paragraph question =

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import controllers.admin.routes;
-import featureflags.FeatureFlags;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.LiTag;
@@ -54,7 +53,6 @@ public final class ProgramIndexView extends BaseHtmlView {
   private final String baseUrl;
   private final TranslationLocales translationLocales;
   private final ProgramCardFactory programCardFactory;
-  private final FeatureFlags featureFlags;
   private final String civicEntityShortName;
 
   @Inject
@@ -62,13 +60,11 @@ public final class ProgramIndexView extends BaseHtmlView {
       AdminLayoutFactory layoutFactory,
       Config config,
       TranslationLocales translationLocales,
-      ProgramCardFactory programCardFactory,
-      FeatureFlags featureFlags) {
+      ProgramCardFactory programCardFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
     this.translationLocales = checkNotNull(translationLocales);
     this.programCardFactory = checkNotNull(programCardFactory);
-    this.featureFlags = checkNotNull(featureFlags);
     this.civicEntityShortName = config.getString("whitelabel.civic_entity_short_name");
   }
 
@@ -316,9 +312,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       if (maybeManageTranslationsLink.isPresent()) {
         draftRowExtraActions.add(maybeManageTranslationsLink.get());
       }
-      if (featureFlags.isStatusTrackingEnabled(request)) {
-        draftRowExtraActions.add(renderEditStatusesLink(draftProgram.get()));
-      }
+      draftRowExtraActions.add(renderEditStatusesLink(draftProgram.get()));
       draftRow =
           Optional.of(
               ProgramCardFactory.ProgramCardData.ProgramRow.builder()

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -8,7 +8,6 @@ import static j2html.TagCreator.span;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
-import featureflags.FeatureFlags;
 import forms.translation.ProgramTranslationForm;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.FormTag;
@@ -34,16 +33,12 @@ import views.components.ToastMessage;
 /** Renders a list of languages to select from, and a form for updating program information. */
 public final class ProgramTranslationView extends TranslationFormView {
   private final AdminLayout layout;
-  private final FeatureFlags featureFlags;
 
   @Inject
   public ProgramTranslationView(
-      AdminLayoutFactory layoutFactory,
-      TranslationLocales translationLocales,
-      FeatureFlags featureFlags) {
+      AdminLayoutFactory layoutFactory, TranslationLocales translationLocales) {
     super(translationLocales);
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
-    this.featureFlags = checkNotNull(featureFlags);
   }
 
   public Content render(
@@ -57,8 +52,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                 program.id(), locale.toLanguageTag())
             .url();
     FormTag form =
-        renderTranslationForm(
-            request, locale, formAction, formFields(request, program, translationForm));
+        renderTranslationForm(request, locale, formAction, formFields(program, translationForm));
 
     String title =
         String.format("Manage program translations: %s", program.localizedName().getDefault());
@@ -80,7 +74,7 @@ public final class ProgramTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<DomContent> formFields(
-      Http.Request request, ProgramDefinition program, ProgramTranslationForm translationForm) {
+      ProgramDefinition program, ProgramTranslationForm translationForm) {
     LocalizationUpdate updateData = translationForm.getUpdateData();
     String programDetailsLink =
         controllers.admin.routes.AdminProgramController.edit(program.id()).url();
@@ -111,62 +105,59 @@ public final class ProgramTranslationView extends TranslationFormView {
                                 .setValue(updateData.localizedDisplayDescription())
                                 .getInputTag(),
                             program.localizedDescription()))));
-    if (featureFlags.isStatusTrackingEnabled(request)) {
-      String programStatusesLink =
-          controllers.admin.routes.AdminProgramStatusesController.index(program.id()).url();
+    // Add Status Tracking messages.
+    String programStatusesLink =
+        controllers.admin.routes.AdminProgramStatusesController.index(program.id()).url();
 
-      Preconditions.checkState(
-          updateData.statuses().size() == program.statusDefinitions().getStatuses().size());
-      for (int statusIdx = 0; statusIdx < updateData.statuses().size(); statusIdx++) {
-        StatusDefinitions.Status configuredStatus =
-            program.statusDefinitions().getStatuses().get(statusIdx);
-        LocalizationUpdate.StatusUpdate statusUpdateData = updateData.statuses().get(statusIdx);
-        // Note: While displayed as siblings, fields are logically grouped together by sharing a
-        // common index in their field names. These are dynamically generated via helper methods
-        // within ProgramTranslationForm (e.g. statusKeyToUpdateFieldName).
-        ImmutableList.Builder<DomContent> fieldsBuilder =
-            ImmutableList.<DomContent>builder()
-                .add(
-                    // This input serves as the key indicating which status to update translations
-                    // for and isn't configurable.
-                    input()
-                        .isHidden()
-                        .withName(ProgramTranslationForm.statusKeyToUpdateFieldName(statusIdx))
-                        .withValue(configuredStatus.statusText()),
-                    fieldWithDefaultLocaleTextHint(
-                        FieldWithLabel.input()
-                            .setFieldName(
-                                ProgramTranslationForm.localizedStatusFieldName(statusIdx))
-                            .setLabelText("Status name")
-                            .setScreenReaderText("Status name")
-                            .setValue(statusUpdateData.localizedStatusText())
-                            .getInputTag(),
-                        configuredStatus.localizedStatusText()));
-        if (configuredStatus.localizedEmailBodyText().isPresent()) {
-          fieldsBuilder.add(
-              fieldWithDefaultLocaleTextHint(
-                  FieldWithLabel.textArea()
-                      .setFieldName(ProgramTranslationForm.localizedEmailFieldName(statusIdx))
-                      .setLabelText("Email content")
-                      .setScreenReaderText("Email content")
-                      .setValue(statusUpdateData.localizedEmailBody())
-                      .setRows(OptionalLong.of(8))
-                      .getTextareaTag(),
-                  configuredStatus.localizedEmailBodyText().get()));
-        }
-        result.add(
-            fieldSetForFields(
-                legend()
-                    .with(
-                        span(
-                            String.format("Application status: %s", configuredStatus.statusText())),
-                        new LinkElement()
-                            .setText("(edit default)")
-                            .setHref(programStatusesLink)
-                            .setStyles("ml-2")
-                            .asAnchorText()),
-                fieldsBuilder.build()));
+    Preconditions.checkState(
+        updateData.statuses().size() == program.statusDefinitions().getStatuses().size());
+    for (int statusIdx = 0; statusIdx < updateData.statuses().size(); statusIdx++) {
+      StatusDefinitions.Status configuredStatus =
+          program.statusDefinitions().getStatuses().get(statusIdx);
+      LocalizationUpdate.StatusUpdate statusUpdateData = updateData.statuses().get(statusIdx);
+      // Note: While displayed as siblings, fields are logically grouped together by sharing a
+      // common index in their field names. These are dynamically generated via helper methods
+      // within ProgramTranslationForm (e.g. statusKeyToUpdateFieldName).
+      ImmutableList.Builder<DomContent> fieldsBuilder =
+          ImmutableList.<DomContent>builder()
+              .add(
+                  // This input serves as the key indicating which status to update translations
+                  // for and isn't configurable.
+                  input()
+                      .isHidden()
+                      .withName(ProgramTranslationForm.statusKeyToUpdateFieldName(statusIdx))
+                      .withValue(configuredStatus.statusText()),
+                  fieldWithDefaultLocaleTextHint(
+                      FieldWithLabel.input()
+                          .setFieldName(ProgramTranslationForm.localizedStatusFieldName(statusIdx))
+                          .setLabelText("Status name")
+                          .setScreenReaderText("Status name")
+                          .setValue(statusUpdateData.localizedStatusText())
+                          .getInputTag(),
+                      configuredStatus.localizedStatusText()));
+      if (configuredStatus.localizedEmailBodyText().isPresent()) {
+        fieldsBuilder.add(
+            fieldWithDefaultLocaleTextHint(
+                FieldWithLabel.textArea()
+                    .setFieldName(ProgramTranslationForm.localizedEmailFieldName(statusIdx))
+                    .setLabelText("Email content")
+                    .setScreenReaderText("Email content")
+                    .setValue(statusUpdateData.localizedEmailBody())
+                    .setRows(OptionalLong.of(8))
+                    .getTextareaTag(),
+                configuredStatus.localizedEmailBodyText().get()));
       }
+      result.add(
+          fieldSetForFields(
+              legend()
+                  .with(
+                      span(String.format("Application status: %s", configuredStatus.statusText())),
+                      new LinkElement()
+                          .setText("(edit default)")
+                          .setHref(programStatusesLink)
+                          .setStyles("ml-2")
+                          .asAnchorText()),
+              fieldsBuilder.build()));
     }
     return result.build();
   }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -655,6 +655,7 @@ allow_civiform_admin_access_programs = ${?ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS}
 # Preview features.
 
 # In development features.
+# Deprecated Jan 2023, this is a default feature.
 application_status_tracking_enabled = false
 application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED}
 program_read_only_view_enabled = false

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -655,8 +655,8 @@ allow_civiform_admin_access_programs = ${?ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS}
 # Preview features.
 
 # In development features.
-# Deprecated Jan 2023, this is a default feature.
-application_status_tracking_enabled = false
+# Status Tracking is a default feature as of Jan 2023, this control is deprecated.
+application_status_tracking_enabled = true
 application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED}
 program_read_only_view_enabled = false
 program_read_only_view_enabled = ${?PROGRAM_READ_ONLY_VIEW_ENABLED}

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -11,7 +11,6 @@ db {
 # Browser tests shouldn't turn features on by default,
 # they should enable them via the Feature Flags HTTP
 # handler as needed.
-application_status_tracking_enabled = false
 program_eligibility_conditions_enabled = false
 program_read_only_view_enabled = false
 esri_address_correction_enabled = false

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -28,7 +28,6 @@ play.filters {
 
 # Feature flags.
 # These should be set to the system default in application.dev-browser-tests.conf
-application_status_tracking_enabled = true
 program_eligibility_conditions_enabled = true
 program_read_only_view_enabled = true
 feature_flag_overrides_enabled = true

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -19,7 +19,6 @@ azure.blob.account = "my awesome azure account name"
 auth.applicant_idp = "disabled"
 
 # Feature flags.
-application_status_tracking_enabled = true
 program_read_only_view_enabled = true
 feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertThrows;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
@@ -147,22 +146,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             /* applicationStatus= */ Optional.empty(),
             /* selectedApplicationUri= */ Optional.empty());
     assertThat(result.status()).isEqualTo(OK);
-  }
-
-  @Test
-  public void updateStatus_flagDisabled() throws Exception {
-    Program program = ProgramBuilder.newActiveProgram("test name", "test description").build();
-    Applicant applicant = resourceCreator.insertApplicantWithAccount();
-    Application application =
-        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
-
-    Request request =
-        addCSRFToken(
-                Helpers.fakeRequest()
-                    .session(FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED, "false"))
-            .build();
-    Result result = controller.updateStatus(request, program.id, application.id);
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test
@@ -494,22 +477,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void updateNote_flagDisabled() throws Exception {
-    Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
-    Applicant applicant = resourceCreator.insertApplicantWithAccount();
-    Application application =
-        Application.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
-
-    Request request =
-        addCSRFToken(
-                Helpers.fakeRequest()
-                    .session(FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED, "false"))
-            .build();
-    Result result = controller.updateNote(request, program.id, application.id);
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
   public void updateNote_programNotFound() {
     Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
     Applicant applicant = resourceCreator.insertApplicantWithAccount();
@@ -635,8 +602,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         profileUtilsNoOpTester,
         instanceOf(MessagesApi.class),
         instanceOf(DateConverter.class),
-        Providers.of(LocalDateTime.now(ZoneId.systemDefault())),
-        instanceOf(FeatureFlags.class));
+        Providers.of(LocalDateTime.now(ZoneId.systemDefault())));
   }
 
   // A test version of ProfileUtils that disable functionality that is hard

--- a/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -12,7 +11,6 @@ import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import featureflags.FeatureFlags;
 import java.util.Locale;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
@@ -78,22 +76,6 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   public void setup() {
     programService = instanceOf(ProgramService.class);
     controller = instanceOf(AdminProgramStatusesController.class);
-  }
-
-  @Test
-  @Parameters({"GET", "POST"})
-  public void index_flagDisabled(String httpMethod) throws ProgramNotFoundException {
-    Program program = ProgramBuilder.newDraftProgram("test name", "test description").build();
-
-    Result result =
-        controller.index(
-            addCSRFToken(
-                    fakeRequest()
-                        .method(httpMethod)
-                        .session(FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED, "false"))
-                .build(),
-            program.id);
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test

--- a/server/test/featureflags/FeatureFlagsTest.java
+++ b/server/test/featureflags/FeatureFlagsTest.java
@@ -19,8 +19,6 @@ public class FeatureFlagsTest {
           ImmutableMap.of(
               "feature_flag_overrides_enabled",
               "true",
-              FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
-              "true",
               FeatureFlags.ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS,
               "true",
               FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
@@ -33,8 +31,6 @@ public class FeatureFlagsTest {
   private static final Config featuresEnabledConfig =
       ConfigFactory.parseMap(
           ImmutableMap.of(
-              FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
-              "true",
               FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
               "true",
               FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
@@ -43,8 +39,6 @@ public class FeatureFlagsTest {
               "true"));
   private static final Map<String, String> allFeaturesEnabledMap =
       Map.of(
-          FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
-          "true",
           FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
           "true",
           FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
@@ -56,8 +50,6 @@ public class FeatureFlagsTest {
 
   private static final Map<String, String> allFeaturesDisabledMap =
       Map.of(
-          FeatureFlags.APPLICATION_STATUS_TRACKING_ENABLED,
-          "false",
           FeatureFlags.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED,
           "false",
           FeatureFlags.PREDICATES_MULTIPLE_QUESTIONS_ENABLED,
@@ -73,7 +65,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withNoConfig_withNoOverride_isNotEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.empty());
 
-    assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isFalse();
   }
@@ -83,7 +74,6 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.empty());
 
     // Overrides only apply if the config is present.
-    assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesEnabledRequest)).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesEnabledRequest))
         .isFalse();
     assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(allFeaturesEnabledRequest))
@@ -94,7 +84,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureDisabled_withNoOverride_isDisables() {
     FeatureFlags featureFlags = new FeatureFlags(featuresDisabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
     assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isFalse();
   }
@@ -103,7 +92,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureEnabled_withNoOverride_isEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(featuresEnabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(fakeRequest().build())).isTrue();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isTrue();
     assertThat(featureFlags.isPredicatesMultipleQuestionsEnabled(fakeRequest().build())).isTrue();
   }
@@ -113,7 +101,6 @@ public class FeatureFlagsTest {
     // A flag not in the config can not be overriden.
     FeatureFlags featureFlags = new FeatureFlags(overridesEnabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesEnabledRequest)).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesEnabledRequest))
         .isFalse();
   }
@@ -122,7 +109,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureEnabled_withOverridesDisabled_withDisabledOverride_isEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(featuresEnabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesDisabledRequest)).isTrue();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesDisabledRequest))
         .isTrue();
   }
@@ -131,7 +117,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureEnabled_withOverridesEnabled_withOverrideFalse_isNotEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(everythingEnabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesDisabledRequest)).isFalse();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesDisabledRequest))
         .isFalse();
   }
@@ -140,7 +125,6 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureEnabled_withOverridesEnabled_withOverrideTrue_isTrue() {
     FeatureFlags featureFlags = new FeatureFlags(everythingEnabledConfig);
 
-    assertThat(featureFlags.isStatusTrackingEnabled(allFeaturesEnabledRequest)).isTrue();
     assertThat(featureFlags.isProgramEligibilityConditionsEnabled(allFeaturesEnabledRequest))
         .isTrue();
   }

--- a/server/test/services/export/CsvExporterTest.java
+++ b/server/test/services/export/CsvExporterTest.java
@@ -2,9 +2,6 @@ package services.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.typesafe.config.Config;
-import featureflags.FeatureFlags;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import models.Question;
@@ -12,26 +9,18 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Test;
-import org.mockito.Mockito;
 import repository.TimeFilter;
-import services.DateConverter;
 import services.applicant.ApplicantData;
-import services.applicant.ApplicantService;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
 import services.applicant.question.MultiSelectQuestion;
 import services.applicant.question.NameQuestion;
-import services.program.ProgramService;
-import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 
 public class CsvExporterTest extends AbstractExporterTest {
 
   private static final CSVFormat DEFAULT_FORMAT = CSVFormat.DEFAULT.builder().setHeader().build();
-  private static final FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
-
-  private final DateConverter dateConverter = new DateConverter(ZoneId.of("UTC"));
 
   private ApplicantQuestion getApplicantQuestion(QuestionDefinition questionDefinition) {
     return new ApplicantQuestion(questionDefinition, new ApplicantData(), Optional.empty());
@@ -143,32 +132,6 @@ public class CsvExporterTest extends AbstractExporterTest {
             "Submit time",
             "Submitted by",
             "Status");
-  }
-
-  @Test
-  public void programCsv_statusTrackingDisabled() throws Exception {
-    createFakeQuestions();
-    createFakeProgram();
-
-    CsvExporterService exporterService =
-        new CsvExporterService(
-            instanceOf(ProgramService.class),
-            instanceOf(QuestionService.class),
-            instanceOf(ApplicantService.class),
-            featureFlags,
-            instanceOf(Config.class),
-            dateConverter);
-
-    CSVParser parser =
-        CSVParser.parse(exporterService.getProgramCsv(fakeProgram.id), DEFAULT_FORMAT);
-    List<CSVRecord> records = parser.getRecords();
-
-    assertThat(records).hasSize(0);
-
-    // Status is not present in the headers.
-    assertThat(parser.getHeaderNames())
-        .containsExactly(
-            "Applicant ID", "Application ID", "Applicant language", "Submit time", "Submitted by");
   }
 
   @Test

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -2,24 +2,16 @@ package services.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import featureflags.FeatureFlags;
 import java.util.Optional;
 import models.Application;
 import models.Program;
 import org.junit.Test;
-import org.mockito.Mockito;
 import repository.SubmittedApplicationFilter;
 import services.CfJsonDocumentContext;
-import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
 import services.Path;
-import services.applicant.ApplicantService;
-import services.program.ProgramService;
 
 public class JsonExporterTest extends AbstractExporterTest {
-  private static final FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
-
-  private final DateConverter dateConverter = instanceOf(DateConverter.class);
 
   @Test
   public void testAllQuestionTypesWithoutEnumerators() throws Exception {
@@ -159,33 +151,6 @@ public class JsonExporterTest extends AbstractExporterTest {
         0,
         ".applicant_household_members[0].household_members_jobs[2].household_members_days_worked.number",
         333);
-  }
-
-  @Test
-  public void testStatusTrackingDisabled() throws Exception {
-    createFakeQuestions();
-    createFakeProgram();
-    createFakeApplications();
-
-    JsonExporter exporter =
-        new JsonExporter(
-            instanceOf(ApplicantService.class),
-            instanceOf(ProgramService.class),
-            featureFlags,
-            dateConverter);
-
-    String resultJsonString =
-        exporter
-            .export(
-                fakeProgram.getProgramDefinition(),
-                IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
-                SubmittedApplicationFilter.EMPTY)
-            .getLeft();
-    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
-
-    resultAsserter.assertLengthOf(3);
-    testApplicationTopLevelAnswers(fakeProgram, resultAsserter, applicationOne, 2);
-    resultAsserter.assertDoesNotHavePath("$[0].status");
   }
 
   private void testApplicationTopLevelAnswers(

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -176,10 +176,6 @@ public class JsonExporterTest extends AbstractExporterTest {
       assertThat((int) resultJson.getDocumentContext().read("$.length()")).isEqualTo(num);
     }
 
-    void assertDoesNotHavePath(String path) {
-      assertThat(resultJson.hasPath(Path.create(path))).isFalse();
-    }
-
     void assertValueAtPath(String path, String value) {
       assertThat(resultJson.readString(Path.create(path)).get()).isEqualTo(value);
     }

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -3,7 +3,6 @@ package services.export;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
-import com.google.inject.util.Providers;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.pdf.PdfArray;
 import com.itextpdf.text.pdf.PdfDictionary;
@@ -12,19 +11,12 @@ import com.itextpdf.text.pdf.PdfObject;
 import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.PdfString;
 import com.itextpdf.text.pdf.parser.PdfTextExtractor;
-import com.typesafe.config.Config;
-import featureflags.FeatureFlags;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import services.applicant.ApplicantService;
 
 public class PdfExporterTest extends AbstractExporterTest {
-  private static final FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
 
   @Before
   public void createTestData() throws Exception {
@@ -150,33 +142,6 @@ public class PdfExporterTest extends AbstractExporterTest {
     for (int i = 3; i < linesFromPDF.size(); i++) {
       assertThat(linesFromPDF.get(i)).isEqualTo(linesFromStaticString.get(i));
     }
-  }
-
-  @Test
-  public void statusTrackingDisabled() throws IOException, DocumentException {
-    PdfExporter exporter =
-        new PdfExporter(
-            instanceOf(ApplicantService.class),
-            Providers.of(LocalDateTime.now(ZoneId.systemDefault())),
-            instanceOf(Config.class),
-            featureFlags);
-
-    String applicantNameWithApplicationId =
-        String.format(
-            "%s (%d)", applicationOne.getApplicantData().getApplicantName(), applicationOne.id);
-    PdfExporter.InMemoryPdf result = exporter.export(applicationOne);
-    PdfReader pdfReader = new PdfReader(result.getByteArray());
-    StringBuilder textFromPDF = new StringBuilder();
-
-    textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
-
-    assertThat(textFromPDF).isNotNull();
-    List<String> linesFromPDF = Splitter.on('\n').splitToList(textFromPDF.toString());
-    assertThat(textFromPDF).isNotNull();
-    String programName = applicationOne.getProgram().getProgramDefinition().adminName();
-    assertThat(linesFromPDF.get(0)).isEqualTo(applicantNameWithApplicationId);
-    assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
-    assertThat(linesFromPDF.get(2)).doesNotContain("Status");
   }
 
   public static final String APPLICATION_SIX_STRING =


### PR DESCRIPTION
### Description

Makes status tracking an always on feature and removes the control to enable/disable it.

The application.conf values are maintained though have no effect, as removal will cause errors in deployments that have them configured.

## Release notes

Promotes the Status Tracking feature to be always available.  Exported data will now include "Status" fields if the feature had not been enabled already.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #3942
