### PR TITLE
i18n for 'Error saving application' banner

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -167,7 +167,11 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 if (cause instanceof ApplicationSubmissionException) {
                   Call reviewPage =
                       routes.ApplicantProgramReviewController.review(applicantId, programId);
-                  return found(reviewPage).flashing("banner", "Error saving application.");
+                  String errorMsg =
+                      messagesApi
+                          .preferred(request)
+                          .at(MessageKey.BANNER_ERROR_SAVING_APPLICATION.getKeyName());
+                  return found(reviewPage).flashing("banner", errorMsg);
                 }
                 if (cause instanceof ApplicationOutOfDateException) {
                   String errorMsg =

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -20,6 +20,7 @@ public enum MessageKey {
   ADDRESS_VALIDATION_STREET_REQUIRED("validation.streetRequired"),
   ARIA_LABEL_EDIT("ariaLabel.edit"),
   ARIA_LABEL_ANSWER("ariaLabel.answer"),
+  BANNER_ERROR_SAVING_APPLICATION("banner.errorSavingApplication"),
   BUTTON_APPLY("button.apply"),
   BUTTON_APPLY_SR("button.applySr"),
   BUTTON_CHOOSE_FILE("button.chooseFile"),

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -277,6 +277,9 @@ toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If
 # Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client's information has changed you can edit your answers and then proceed with the application.
 
+# Error when there was an exception while submitting the application
+banner.errorSavingApplication=Error saving application
+
 #---------------------------------------------------------------------------------------------#
 # APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
 #---------------------------------------------------------------------------------------------#

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -274,6 +274,9 @@ toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If
 # Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client's information has changed you can edit your answers and then proceed with the application.
 
+# Error when there was an exception while submitting the application
+banner.errorSavingApplication=Error saving application
+
 #---------------------------------------------------------------------------------------------#
 # APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
 #---------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Description

This adds i18n support for the 'Error saving application' banner, which shows when an exception occurs while saving the application.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/4071
