### PR TITLE
Avoid parsing emails as URLs in TextFormatter.

### DIFF
--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -69,7 +69,6 @@ public final class TextFormatter {
     ImmutableList.Builder<DomContent> contentBuilder = ImmutableList.builder();
     for (int i = 0; i < urls.size(); i++) {
       Url url = urls.get(i);
-      System.out.println(url.getOriginalUrl());
       try {
         // While technically they could be part of the URL, trailing punctuation
         // is more likely to be part of the surrounding text, so we strip.

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -96,7 +96,9 @@ public final class TextFormatter {
       }
       // If immediately following this URL there's an '@' and another URL, they could
       // be two parts of an email address, so skip them both in case.
-      if (i < (urls.size() - 2)) {
+      // [0] [1] [2]
+      // len: 3
+      if (i < (urls.size() - 1)) {
         int nextUrlStartIndex = content.indexOf(urls.get(i + 1).getOriginalUrl());
         if (content.charAt(nextUrlStartIndex - 1) == '@') {
           i = i + 1;

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -87,6 +87,7 @@ lazy val root = (project in file("."))
 
       // Apache libraries for export
       "org.apache.commons" % "commons-csv" % "1.9.0",
+      "commons-validator" % "commons-validator" % "1.7",
 
       // pdf library for export
       "com.itextpdf" % "itextpdf" % "5.5.13.3",

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -51,6 +51,16 @@ public class TextFormatterTest {
   }
 
   @Test
+  public void emailsDoNotGetDetectedAsUrls() {
+    String text = "hello first.last@example.com other@example.com. Tag @example!";
+    ImmutableList<DomContent> content =
+        TextFormatter.createLinksAndEscapeText(
+            text, TextFormatter.UrlOpenAction.SameTab, /*addRequiredIndicator=*/ false);
+    assertThat(content).hasSize(1);
+    assertThat(content.get(0).render()).isEqualTo(new Text(text).render());
+  }
+
+  @Test
   public void rendersRequiredIndicator() {
     ImmutableList<DomContent> content =
         TextFormatter.createLinksAndEscapeText(

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -52,7 +52,7 @@ public class TextFormatterTest {
 
   @Test
   public void emailsDoNotGetDetectedAsUrls() {
-    String text = "hello first.last@example.com other@example.com. Tag @example!";
+    String text = "hello @example@, other@example.com. first.last@example.com!";
     ImmutableList<DomContent> content =
         TextFormatter.createLinksAndEscapeText(
             text, TextFormatter.UrlOpenAction.SameTab, /*addRequiredIndicator=*/ false);


### PR DESCRIPTION
### Description

Avoid parsing emails as URLs in TextFormatter.

## Release notes

The UrlDetector library has a known issue where it does not detect emails correctly. As a result, something like "first.last@example.com" gets converted to `<a href="http://first.last">first.last</a><a href="http://example.com">example.com</a>` and "first@example.com" gets converted to `<a href="http://first@example.com">first@example.com</a>`. The library appears to be unmaintained, however, and I was unable to find a good alternative. As a workaround, this adds a check before converting a substring that was detected as a URL into a link to see if it's likely actually an email, in which case it gets parsed as plain text instead. This won't handle all cases but should fix the most common cases.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #2930.
