### PR TITLE
Removing Seattle Staging Hostname

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -184,7 +184,7 @@ adfs.ad_groups_attribute_name = ${?AD_GROUPS_ATTRIBUTE_NAME}
 base_url = "http://localhost:9000"
 base_url = ${?BASE_URL}
 # Staging hostname should not start with https(s)://.
-staging_hostname = "staging.seattle.civiform.com"
+staging_hostname = ""
 staging_hostname = ${?STAGING_HOSTNAME}
 
 measurement_id = ${?MEASUREMENT_ID}


### PR DESCRIPTION
### Description

This is now configured in Seattle's repository. Removing the hard-coded valued of Seattle's staging site in order to clean up the config file.

Without default staging_hostname to "" the application breaks on localhost.
