### PR TITLE
Fix image building scripts for Docker CLI on linux

### DIFF
--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -8,11 +8,11 @@ IMAGE="civiform-browser-test"
 LOCATION="browser-test/"
 DOCKERFILE="browser-test/playwright.Dockerfile"
 
-BUILD_ARGS=("-f" "${DOCKERFILE}" \
-  -t "civiform/${IMAGE}:latest" \
-  --cache-from "civiform/${IMAGE}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  "${LOCATION}")
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}:latest
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  ${LOCATION}"
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,7 +21,8 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+$cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -26,12 +26,14 @@ $cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-docker buildx build --load "${BUILD_ARGS[@]}"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
   echo "push ${IMAGE} build"
 fi
 

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -8,10 +8,10 @@ IMAGE="civiform-browser-test"
 LOCATION="browser-test/"
 DOCKERFILE="browser-test/playwright.Dockerfile"
 
-BUILD_ARGS=("-f" "${DOCKERFILE}"
-  -t "civiform/${IMAGE}:latest"
-  --cache-from "civiform/${IMAGE}"
-  --build-arg BUILDKIT_INLINE_CACHE=1
+BUILD_ARGS=("-f" "${DOCKERFILE}" \
+  -t "civiform/${IMAGE}:latest" \
+  --cache-from "civiform/${IMAGE}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   "${LOCATION}")
 
 PLATFORM_ARG=()

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -8,11 +8,11 @@ IMAGE="civiform-dev"
 LOCATION="."
 DOCKERFILE="Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}" \
-  -t "civiform/${IMAGE}:latest" \
-  --cache-from "civiform/${IMAGE}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  "${LOCATION}")
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}:latest
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  ${LOCATION}"
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,7 +21,8 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+$cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -26,13 +26,15 @@ $cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-docker buildx build --load "${BUILD_ARGS[@]}"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -8,10 +8,10 @@ IMAGE="civiform-dev"
 LOCATION="."
 DOCKERFILE="Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}:latest"
-  --cache-from "civiform/${IMAGE}"
-  --build-arg BUILDKIT_INLINE_CACHE=1
+BUILD_ARGS=(-f "${DOCKERFILE}" \
+  -t "civiform/${IMAGE}:latest" \
+  --cache-from "civiform/${IMAGE}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   "${LOCATION}")
 
 PLATFORM_ARG=()

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -8,10 +8,10 @@ IMAGE="oidc-provider"
 LOCATION="test-support/"
 DOCKERFILE="test-support/oidc.Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}:latest"
-  --cache-from "civiform/${IMAGE}"
-  --build-arg BUILDKIT_INLINE_CACHE=1
+BUILD_ARGS=(-f "${DOCKERFILE}" \
+  -t "civiform/${IMAGE}:latest" \
+  --cache-from "civiform/${IMAGE}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   "${LOCATION}")
 
 PLATFORM_ARG=()

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -8,11 +8,11 @@ IMAGE="oidc-provider"
 LOCATION="test-support/"
 DOCKERFILE="test-support/oidc.Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}" \
-  -t "civiform/${IMAGE}:latest" \
-  --cache-from "civiform/${IMAGE}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  "${LOCATION}")
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}:latest
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  ${LOCATION}"
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,7 +21,8 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+$cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -21,18 +21,20 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
 $cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-docker buildx build --load "${BUILD_ARGS[@]}"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
 fi
 
 docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -8,10 +8,10 @@ IMAGE="civiform-localstack"
 LOCATION="localstack/"
 DOCKERFILE="localstack/localstack.Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}:latest"
-  --cache-from "civiform/${IMAGE}"
-  --build-arg BUILDKIT_INLINE_CACHE=1
+BUILD_ARGS=(-f "${DOCKERFILE}" \
+  -t "civiform/${IMAGE}:latest" \
+  --cache-from "civiform/${IMAGE}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   "${LOCATION}")
 
 PLATFORM_ARG=()

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -26,13 +26,15 @@ $cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-docker buildx build --load "${BUILD_ARGS[@]}"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -8,11 +8,11 @@ IMAGE="civiform-localstack"
 LOCATION="localstack/"
 DOCKERFILE="localstack/localstack.Dockerfile"
 
-BUILD_ARGS=(-f "${DOCKERFILE}" \
-  -t "civiform/${IMAGE}:latest" \
-  --cache-from "civiform/${IMAGE}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  "${LOCATION}")
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}:latest
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  ${LOCATION}"
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,7 +21,8 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+$cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -16,13 +16,13 @@ readonly DOCKERFILE="prod.Dockerfile"
 echo "Building ${SNAPSHOT_TAG}..."
 
 BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}"
-  -t "civiform/${IMAGE}:latest"
-  -t "civiform/${IMAGE}:${SNAPSHOT_TAG}"
-  --cache-from "civiform/${IMAGE}"
-  --build-arg BUILDKIT_INLINE_CACHE=1
-  --build-arg "git_commit_sha=${GIT_SHA}"
-  --build-arg "image_tag=${SNAPSHOT_TAG}"
+  -t "civiform/${IMAGE}" \
+  -t "civiform/${IMAGE}:latest" \
+  -t "civiform/${IMAGE}:${SNAPSHOT_TAG}" \
+  --cache-from "civiform/${IMAGE}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg "git_commit_sha=${GIT_SHA}" \
+  --build-arg "image_tag=${SNAPSHOT_TAG}" \
   "${LOCATION}")
 
 readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -15,22 +15,23 @@ readonly DOCKERFILE="prod.Dockerfile"
 
 echo "Building ${SNAPSHOT_TAG}..."
 
-BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}" \
-  -t "civiform/${IMAGE}:latest" \
-  -t "civiform/${IMAGE}:${SNAPSHOT_TAG}" \
-  --cache-from "civiform/${IMAGE}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg "git_commit_sha=${GIT_SHA}" \
-  --build-arg "image_tag=${SNAPSHOT_TAG}" \
-  "${LOCATION}")
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}
+  -t civiform/${IMAGE}:latest
+  -t civiform/${IMAGE}:${SNAPSHOT_TAG}
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  --build-arg git_commit_sha=${GIT_SHA}
+  --build-arg image_tag=${SNAPSHOT_TAG}
+  ${LOCATION}"
 
 readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
 readonly PLATFORM_ARG=(--platform "${PLATFORM}")
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+$cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -30,18 +30,20 @@ readonly PLATFORM_ARG=(--platform "${PLATFORM}")
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
 $cmd
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-docker buildx build --load "${BUILD_ARGS[@]}"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"


### PR DESCRIPTION
### Description

Somehow, formatting lists of arguments that included unescaped newlines did not previously cause the docker CLI problems but now it does. At least on linux. Unfortunately for us our shell autoformatter, [shfmt](https://github.com/mvdan/sh), removes backslashes inside array declarations, which would have been the simpler fix for this.

Instead, to appease *both* docker and shfmt, the fix here uses a format string instead of an array to hold the args, formats the docker buildx command into a format string as well, and then invokes it. I don't know why the second step was necessary instead of being able to invoke `docker buildx` directly, but attempting the latter resulted in an argument error from the docker CLI tool.

The end.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4106