### PR TITLE
Switching from using full state name to state abbreviation

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -44,7 +44,7 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
   public static final String ESRI_CONTENT_TYPE = "application/json";
   // Specify output fields to return in the geocoding response with the outFields parameter
   public static final String ESRI_FIND_ADDRESS_CANDIDATES_OUT_FIELDS =
-      "Address, SubAddr, City, Region, Postal";
+      "Address, SubAddr, City, RegionAbbr, Postal";
   // The service supports responses in JSON or PJSON format. You can specify the response format
   // using the f parameter. This is a required parameter
   public static final String ESRI_FIND_ADDRESS_CANDIDATES_FORMAT = "json";

--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -183,7 +183,7 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
                         .setStreet(attributes.get("Address").toString())
                         .setLine2(attributes.get("SubAddr").toString())
                         .setCity(attributes.get("City").toString())
-                        .setState(attributes.get("Region").toString())
+                        .setState(attributes.get("RegionAbbr").toString())
                         .setZip(attributes.get("Postal").toString())
                         .build();
                 AddressSuggestion addressCandidate =

--- a/server/test/resources/esri/findAddressCandidates.json
+++ b/server/test/resources/esri/findAddressCandidates.json
@@ -15,7 +15,7 @@
         "SubAddr": "",
         "Address": "380 New York St",
         "City": "Redlands",
-        "Region": "California",
+        "RegionAbbr": "CA",
         "Postal": "92373"
       },
       "extent": {

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -138,7 +138,7 @@ public class EsriClientTest {
             .setStreet("380 New York St")
             .setLine2("")
             .setCity("Redlands")
-            .setState("California")
+            .setState("CA")
             .setZip("92373")
             .build();
 
@@ -159,7 +159,7 @@ public class EsriClientTest {
             .setStreet("380 New York St")
             .setLine2("")
             .setCity("Redlands")
-            .setState("California")
+            .setState("CA")
             .setZip("92373")
             .build();
 
@@ -177,7 +177,7 @@ public class EsriClientTest {
             .setStreet("380 New York St")
             .setLine2("")
             .setCity("Redlands")
-            .setState("California")
+            .setState("CA")
             .setZip("92373")
             .build();
 


### PR DESCRIPTION
### Description
Our address control uses a dropdown for state. The dropdown is configured solely as two character state abbreviations. Currently the ESRI client is returning the full name of the state. This switches it from using the field `Region` to `RegionAbbr` in the ESRI reponse. 

So going from using `Washington` to just `WA`.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
