### PR TITLE
Call asText and not toString to get value from json

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -180,15 +180,15 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
                         .build();
                 Address candidateAddress =
                     Address.builder()
-                        .setStreet(attributes.get("Address").toString())
-                        .setLine2(attributes.get("SubAddr").toString())
-                        .setCity(attributes.get("City").toString())
-                        .setState(attributes.get("RegionAbbr").toString())
-                        .setZip(attributes.get("Postal").toString())
+                        .setStreet(attributes.get("Address").asText())
+                        .setLine2(attributes.get("SubAddr").asText())
+                        .setCity(attributes.get("City").asText())
+                        .setState(attributes.get("RegionAbbr").asText())
+                        .setZip(attributes.get("Postal").asText())
                         .build();
                 AddressSuggestion addressCandidate =
                     AddressSuggestion.builder()
-                        .setSingleLineAddress(candidateJson.get("address").toString())
+                        .setSingleLineAddress(candidateJson.get("address").asText())
                         .setLocation(addressLocation)
                         .setScore(candidateJson.get("score").asInt())
                         .setAddress(candidateAddress)

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -149,7 +149,7 @@ public class EsriClientTest {
     Optional<AddressSuggestion> addressSuggestion = suggestions.stream().findFirst();
     assertThat(addressSuggestion.isPresent()).isTrue();
     String street = addressSuggestion.get().getAddress().getStreet();
-    assertEquals("\"380 New York St\"", street);
+    assertEquals("380 New York St", street);
   }
 
   @Test


### PR DESCRIPTION
### Description

Calling toString gets the value surrounded by double quotes. Switching to call asText which returns the value from the json object without being surrounded by quotes.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)


