### PR TITLE
Fix vscode-setup

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -8,5 +8,5 @@ docker::set_project_name_dev
 bin/pull-image
 
 docker::compose_dev up --wait -d
-docker::dev_and_test_server_sbt_command 8457
+docker::dev_and_test_server_sbt_command 8457 $1
 docker::compose_dev stop civiform

--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -17,7 +17,7 @@ bin/sbt makePom
 
 # Copy the generated target directory from the docker container to a local dir
 # so that we can use globs to copy the correct file out.
-docker::compose_dev --profile shell cp civiform-shell:/usr/src/server/target server/temp
+docker::compose_dev --profile shell cp civiform:/usr/src/server/target server/temp
 
 cp server/temp/scala-*/*.pom \
   server/pom.xml


### PR DESCRIPTION
### Description

Previously, bin/sbt was not taking any additional arguments and passing them along to docker::dev_and_test_server_sbt_command. This meant that when vscode-setup tried running 'bin/sbt makePom', it wouldn't actually do that and it would just sit in the shell. Also, for some reason, docker compose can't seem to figure out what the 'civiform-shell' service is, even though it's defined in docker-compose.dev.yml.  However, we're just using the civiform service anyway, so this fixes the cp command to use the civiform service to copy the target directory to the local server directory so we can munge the pom file appropriately.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
