### PR TITLE
Reduce Question Bank opening wait

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -352,9 +352,10 @@ export class AdminPrograms {
   }
 
   private async waitForQuestionBankAnimationToFinish() {
-    // Animation is 150ms. Give whole second to avoid flakiness on slow CPU
+    // Animation is 150ms. Give some extra overhead to avoid flakiness on slow CPU.
+    // This is currently called over 300 times which adds up.
     // https://tailwindcss.com/docs/transition-property
-    await this.page.waitForTimeout(1000)
+    await this.page.waitForTimeout(250)
   }
 
   async openQuestionBank() {


### PR DESCRIPTION
### Description

`waitForQuestionBankAnimationToFinish()` currently always waits 1s to allow an ideally 150ms animation to complete.  It is called about 340 times which adds up.

This reduces that time to 250ms saving over 4m in the serial browser test run.

Addresses #4111 


## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
