### PR TITLE
Fix missing bold fonts in screenshot tests (1/2)

### DIFF
--- a/browser-test/fonts.conf
+++ b/browser-test/fonts.conf
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<!--
+  This is a partial solution to https://github.com/civiform/civiform/issues/3225.
+  It forces fc-match to pick a font that contains a range of bold styles
+-->
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer><family>Ubuntu</family></prefer>
+  </alias>
+</fontconfig>

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -31,3 +31,10 @@ CMD ["/usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh
 # Save build results to anonymous volumes for reuse
 VOLUME ["/usr/src/civiform-browser-tests/node_modules"]
 VOLUME ["/usr/src/civiform-browser-tests"]
+
+# Symlink the fonts config
+# This is to solve https://github.com/civiform/civiform/issues/3225. It forces
+# `fc-match` to pick a font that contains bold styles for the `system-ui`
+# generic font family.
+RUN mkdir -p /root/.config/fontconfig/ && \
+    ln -s /usr/src/civiform-browser-tests/fonts.conf /root/.config/fontconfig/fonts.conf


### PR DESCRIPTION
### Description

Add a fonts.conf to the browser-tests docker container. Part 1/2. 

Details:
- Part 2 is #4239 and updates the goldens.
- This is split into two parts so that the presubmits don't break, since there's an issue where they're using the old docker container for the presubmit run.
- The font used by Chromium in the browser-tests docker image did not have a full range of bolds, so bold fonts were rendered as normal weights.
- To fix this, we override the font picked by the OS for the `system-ui` font-family to be `Ubuntu`, which has a full range of bold weights.
- Additional debugging and context for why this was the best choice for the fix are in #3225.

## Release notes

n/a

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [n/a] Created tests which fail without the change (if possible)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/application.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes
