### PR TITLE
Evaluate address service area predicates

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -324,7 +324,7 @@ describe('create and edit predicates', () => {
       await adminPredicates.addPredicate(
         'eligibility-predicate-q',
         /* action= */ null,
-        'service area',
+        'service_area',
         'in service area',
         'Seattle',
       )

--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -103,7 +103,7 @@ export class AdminPredicates {
     let groupNum = 1
     for (const valueToSet of values) {
       // Service areas are the only value input that use a select
-      if (scalar === 'service area') {
+      if (scalar === 'service_area') {
         const valueSelect = await this.page.$(
           `select[name="group-${groupNum++}-question-${questionId}-predicateValue"]`,
         )

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -68,7 +68,9 @@ public final class JsonPathPredicateGenerator {
             getPath(node).predicateFormat(),
             Scalar.SERVICE_AREA.name().toLowerCase(),
             Operator.IN_SERVICE_AREA.toJsonPathOperator(),
-            String.format("/%s_InArea_\\d+/", node.serviceAreaId())));
+            String.format(
+                "/([a-zA-Z\\-]+_[a-zA-Z]+_\\d+,)*%s_InArea_\\d+(,[a-zA-Z\\-]+_[a-zA-Z]+_\\d+)*/",
+                node.serviceAreaId())));
   }
 
   private Path getPath(LeafExpressionNode node) throws InvalidPredicateException {

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -10,7 +10,11 @@ import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
 import services.applicant.exception.InvalidPredicateException;
 import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.Scalar;
+import services.program.predicate.LeafAddressServiceAreaExpressionNode;
+import services.program.predicate.LeafExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
 import services.question.types.QuestionDefinition;
 
 /** Generates {@link JsonPathPredicate}s based on the current applicant filling out the program. */
@@ -37,10 +41,37 @@ public final class JsonPathPredicateGenerator {
   /**
    * Formats a {@link LeafOperationExpressionNode} in JsonPath format: {@code path[?(expression)]}
    *
-   * <p>Example: \$.applicant.address[?(@.zip in ["12345", "56789"])]
+   * <p>Example: \$.applicant.name[?(@.last in ["Smith", "Lee"])]
    */
   public JsonPathPredicate fromLeafNode(LeafOperationExpressionNode node)
       throws InvalidPredicateException {
+    return JsonPathPredicate.create(
+        String.format(
+            "%s[?(@.%s %s %s)]",
+            getPath(node).predicateFormat(),
+            node.scalar().name().toLowerCase(),
+            node.operator().toJsonPathOperator(),
+            node.comparedValue().value()));
+  }
+
+  /**
+   * Formats a {@link services.program.predicate.LeafAddressServiceAreaExpressionNode} in JsonPath
+   * format: {@code path[?(expression)]}
+   *
+   * <p>Example: \$.applicant.address[?(@.service_area =~ /seattle_InArea_\d+/i)]
+   */
+  public JsonPathPredicate fromLeafAddressServiceAreaNode(LeafAddressServiceAreaExpressionNode node)
+      throws InvalidPredicateException {
+    return JsonPathPredicate.create(
+        String.format(
+            "%s[?(@.%s %s %s)]",
+            getPath(node).predicateFormat(),
+            Scalar.SERVICE_AREA.name().toLowerCase(),
+            Operator.IN_SERVICE_AREA.toJsonPathOperator(),
+            String.format("/%s_InArea_\\d+/", node.serviceAreaId())));
+  }
+
+  private Path getPath(LeafExpressionNode node) throws InvalidPredicateException {
     if (!questionsById.containsKey(node.questionId())) {
       // This means a predicate was incorrectly configured - we are depending upon a question that
       // does not appear anywhere in this program.
@@ -69,13 +100,7 @@ public final class JsonPathPredicateGenerator {
       path = path.withoutArrayReference();
     }
 
-    return JsonPathPredicate.create(
-        String.format(
-            "%s[?(@.%s %s %s)]",
-            path.predicateFormat(),
-            node.scalar().name().toLowerCase(),
-            node.operator().toJsonPathOperator(),
-            node.comparedValue().value()));
+    return path;
   }
 
   private Optional<RepeatedEntity> getTargetContext(QuestionDefinition targetQuestion)

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -3,6 +3,7 @@ package services.applicant.predicate;
 import services.applicant.ApplicantData;
 import services.applicant.exception.InvalidPredicateException;
 import services.program.predicate.AndNode;
+import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.OrNode;
 import services.program.predicate.PredicateExpressionNode;
@@ -29,8 +30,7 @@ public final class PredicateEvaluator {
       case LEAF_OPERATION:
         return evaluateLeafNode(node.getLeafOperationNode());
       case LEAF_ADDRESS_SERVICE_AREA:
-        // TODO(https://github.com/civiform/civiform/issues/4048): check if address in service area
-        return true;
+        return evaluateLeafAddressServiceAreaNode(node.getLeafAddressNode());
       case AND:
         return evaluateAndNode(node.getAndNode());
       case OR:
@@ -48,6 +48,19 @@ public final class PredicateEvaluator {
   private boolean evaluateLeafNode(LeafOperationExpressionNode node) {
     try {
       JsonPathPredicate predicate = predicateGenerator.fromLeafNode(node);
+      return applicantData.evalPredicate(predicate);
+    } catch (InvalidPredicateException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if and only if the answer for the address question referenced by the {@link
+   * LeafAddressServiceAreaExpressionNode} has an in-area service area in {@link ApplicantData}.
+   */
+  private boolean evaluateLeafAddressServiceAreaNode(LeafAddressServiceAreaExpressionNode node) {
+    try {
+      JsonPathPredicate predicate = predicateGenerator.fromLeafAddressServiceAreaNode(node);
       return applicantData.evalPredicate(predicate);
     } catch (InvalidPredicateException e) {
       return false;

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -64,7 +64,7 @@ public final class PredicateEvaluator {
 
   /**
    * Returns true if and only if the answer for the address question referenced by the {@link
-   * LeafAddressServiceAreaExpressionNode} has an in-area service area in {@link ApplicantData}.
+   * LeafAddressServiceAreaExpressionNode} has an in-area or failed service area in {@link ApplicantData}.
    */
   private boolean evaluateLeafAddressServiceAreaNode(LeafAddressServiceAreaExpressionNode node) {
     try {

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -1,5 +1,7 @@
 package services.applicant.predicate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import services.applicant.ApplicantData;
 import services.applicant.exception.InvalidPredicateException;
 import services.program.predicate.AndNode;
@@ -10,6 +12,8 @@ import services.program.predicate.PredicateExpressionNode;
 
 /** Evaluates complex predicates based on the given {@link ApplicantData}. */
 public final class PredicateEvaluator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PredicateEvaluator.class);
 
   private final ApplicantData applicantData;
   private final JsonPathPredicateGenerator predicateGenerator;
@@ -50,6 +54,10 @@ public final class PredicateEvaluator {
       JsonPathPredicate predicate = predicateGenerator.fromLeafNode(node);
       return applicantData.evalPredicate(predicate);
     } catch (InvalidPredicateException e) {
+      LOGGER.error(
+          "InvalidPredicateException when evaluating LeafOperationExpressionNode {}: {}",
+          node,
+          e.getMessage());
       return false;
     }
   }
@@ -63,6 +71,10 @@ public final class PredicateEvaluator {
       JsonPathPredicate predicate = predicateGenerator.fromLeafAddressServiceAreaNode(node);
       return applicantData.evalPredicate(predicate);
     } catch (InvalidPredicateException e) {
+      LOGGER.error(
+          "InvalidPredicateException when evaluating LeafAddressServiceAreaExpressionNode {}: {}",
+          node,
+          e.getMessage());
       return false;
     }
   }

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -64,7 +64,8 @@ public final class PredicateEvaluator {
 
   /**
    * Returns true if and only if the answer for the address question referenced by the {@link
-   * LeafAddressServiceAreaExpressionNode} has an in-area or failed service area in {@link ApplicantData}.
+   * LeafAddressServiceAreaExpressionNode} has an in-area or failed service area in {@link
+   * ApplicantData}.
    */
   private boolean evaluateLeafAddressServiceAreaNode(LeafAddressServiceAreaExpressionNode node) {
     try {

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -46,7 +46,7 @@ public enum Scalar {
       "entity name", ScalarType.STRING), // This is used for adding/updating enumerator entries
 
   // Special scalars for Address questions
-  SERVICE_AREA("service area", ScalarType.SERVICE_AREA),
+  SERVICE_AREA("service_area", ScalarType.SERVICE_AREA),
 
   // Metadata scalars
   UPDATED_AT("updated at", ScalarType.LONG),

--- a/server/app/services/geo/ServiceAreaState.java
+++ b/server/app/services/geo/ServiceAreaState.java
@@ -1,0 +1,24 @@
+package services.geo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/** The result of checking an address for membership in a service area. */
+public enum ServiceAreaState {
+  // The address is in the service area.
+  IN_AREA("InArea"),
+  // The address is not in the service area.
+  NOT_IN_AREA("NotInArea"),
+  // The check failed for technical reasons.
+  FAILED("Failed");
+
+  private final String serializationFormat;
+
+  ServiceAreaState(String serializationFormat) {
+    this.serializationFormat = checkNotNull(serializationFormat);
+  }
+
+  /** The string representation of this state for storage in the database. */
+  public String getSerializationFormat() {
+    return this.serializationFormat;
+  }
+}

--- a/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
+++ b/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
@@ -7,12 +7,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import services.question.types.QuestionDefinition;
 
 /** Represents an assertion that an address question is within a given service area. */
 @JsonTypeName("leafAddressServiceArea")
 @AutoValue
 public abstract class LeafAddressServiceAreaExpressionNode implements LeafExpressionNode {
+  public static final Pattern SERVICE_AREA_ID_PATTERN = Pattern.compile("[a-zA-Z\\d\\-]+");
 
   @JsonCreator
   public static LeafAddressServiceAreaExpressionNode create(

--- a/server/app/services/program/predicate/Operator.java
+++ b/server/app/services/program/predicate/Operator.java
@@ -85,7 +85,7 @@ public enum Operator {
       ImmutableSet.of(ScalarType.LIST_OF_STRINGS),
       ImmutableSet.of(OperatorRightHandType.LIST_OF_LONGS, OperatorRightHandType.LIST_OF_STRINGS)),
   IN_SERVICE_AREA(
-      "n/a",
+      "=~",
       "in service area",
       ImmutableSet.of(ScalarType.SERVICE_AREA),
       ImmutableSet.of(OperatorRightHandType.SERVICE_AREA));

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -301,6 +301,12 @@ public final class PredicateGenerator {
         return PredicateValue.of(localDate);
 
       case SERVICE_AREA:
+        if (!LeafAddressServiceAreaExpressionNode.SERVICE_AREA_ID_PATTERN
+            .matcher(value)
+            .matches()) {
+          throw new BadRequestException(String.format("Invalid service area ID: %s", value));
+        }
+
         return PredicateValue.serviceArea(value);
 
       case LONG:

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -287,12 +287,13 @@ public class JsonPathPredicateGeneratorTest {
     assertThat(predicate)
         .isEqualTo(
             JsonPathPredicate.create(
-                "$.applicant.applicant_address[?(@.service_area =~ /seattle_InArea_\\d+/i)]"));
+                "$.applicant.applicant_address[?(@.service_area =~"
+                    + " /([a-zA-Z\\-]+_[a-zA-Z]+_\\d+,)*seattle_InArea_\\d+(,[a-zA-Z\\-]+_[a-zA-Z]+_\\d+)*/)]"));
 
     ApplicantData data = new ApplicantData();
     data.putString(
         Path.create("applicant.applicant_address.service_area"),
-        "bloomington_NotInArea_1234,seattle_InArea_5678");
+        "bloomington_NotInArea_1234,king-county_InArea_2222,seattle_InArea_5678,Arkansas_NotInArea_8765");
 
     assertThat(data.evalPredicate(predicate)).isTrue();
   }

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -117,6 +117,29 @@ public class PredicateGeneratorTest extends ResetPostgres {
   }
 
   @Test
+  public void generatePredicateDefinition_singleQuestion_serviceArea_invalidId_throws()
+      throws Exception {
+    DynamicForm form =
+        buildForm(
+            ImmutableMap.of(
+                "predicateAction",
+                "HIDE_BLOCK",
+                String.format("question-%d-scalar", testQuestionBank.applicantAddress().id),
+                "SERVICE_AREA",
+                String.format("question-%d-operator", testQuestionBank.applicantAddress().id),
+                "IN_SERVICE_AREA",
+                String.format(
+                    "group-1-question-%d-predicateValue", testQuestionBank.applicantAddress().id),
+                "seattle invalid"));
+
+    assertThatThrownBy(
+            () ->
+                predicateGenerator.generatePredicateDefinition(
+                    programDefinition, form, readOnlyQuestionService))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
   public void generatePredicateDefinition_multiQuestion_multiValue() throws Exception {
     DynamicForm form =
         buildForm(


### PR DESCRIPTION
### Description

Evaluates `LeafAddressServiceAreaExpressionNode`s using the JsonPath library.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4028