### PR TITLE
Add discard draft confirmation

### DIFF
--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -315,6 +315,7 @@ export class AdminQuestions {
     await this.page.click(
       this.selectWithinQuestionTableRow(questionName, ':text("Discard Draft")'),
     )
+    await this.page.click(':text("Discard")')
     await waitForPageJsLoad(this.page)
     await this.expectAdminQuestionsPage()
   }


### PR DESCRIPTION
### Description

Add a confirmation modal when admins discard a question draft.


### Checklist

#### General

- [x] Add confirmation modal for Discard Draft button

### Issue(s) this completes

Fixes #2105
