### PR TITLE
Ensure applicant uses existing application

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -3,6 +3,7 @@ package repository;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
@@ -32,7 +33,7 @@ public final class ApplicationRepository {
   private final UserRepository userRepository;
   private final Database database;
   private final DatabaseExecutionContext executionContext;
-  private static final Logger logger = LoggerFactory.getLogger(ApplicationRepository.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationRepository.class);
 
   @Inject
   public ApplicationRepository(
@@ -58,11 +59,7 @@ public final class ApplicationRepository {
         .findEach(fn);
   }
 
-  /**
-   * Submit an application, which will delete any in-progress drafts, obsolete any submitted
-   * applications to a program with the same name (to include past versions of the same program),
-   * and create a new application in the active state.
-   */
+  @VisibleForTesting
   public CompletionStage<Application> submitApplication(
       Applicant applicant, Program program, Optional<String> tiSubmitterEmail) {
     return supplyAsync(
@@ -70,6 +67,11 @@ public final class ApplicationRepository {
         executionContext.current());
   }
 
+  /**
+   * Submit an application, which will delete any in-progress drafts, obsolete any submitted
+   * applications to a program with the same name (to include past versions of the same program),
+   * and create a new application in the active state.
+   */
   public CompletionStage<Optional<Application>> submitApplication(
       long applicantId, long programId, Optional<String> tiSubmitterEmail) {
     return this.perform(
@@ -90,21 +92,28 @@ public final class ApplicationRepository {
               .eq("applicant.id", applicant.id)
               .eq("program.name", program.getProgramDefinition().adminName())
               .findList();
+
       ImmutableList<Application> drafts =
           oldApplications.stream()
               .filter(app -> app.getLifecycleStage().equals(LifecycleStage.DRAFT))
               .collect(ImmutableList.toImmutableList());
-      if (drafts.size() > 1) {
+
+      final Application application;
+      if (drafts.size() == 1) {
+        application = drafts.get(0);
+      } else if (drafts.isEmpty()) {
+        LOGGER.error(
+            "No DRAFT applications found when submitting for applicant {} program {}",
+            applicant.id,
+            program.id);
+        application = new Application(applicant, program, LifecycleStage.ACTIVE);
+      } else {
         throw new RuntimeException(
             String.format(
                 "Found more than one DRAFT application for applicant %d, program %d.",
                 applicant.id, program.id));
       }
 
-      Application application =
-          drafts.isEmpty()
-              ? new Application(applicant, program, LifecycleStage.ACTIVE)
-              : drafts.get(0);
       application.setApplicantData(applicant.getApplicantData());
       application.setLifecycleStage(LifecycleStage.ACTIVE);
       application.setSubmitTimeToNow();
@@ -118,6 +127,15 @@ public final class ApplicationRepository {
             || app.getLifecycleStage().equals(LifecycleStage.OBSOLETE)) {
           continue;
         }
+        LOGGER.error(
+            "Multiple applications found at submit time for applicant {} to program {} {}:"
+                + " application {}",
+            applicant.id,
+            program.id,
+            program.getProgramDefinition().adminName(),
+            app.id);
+
+        app.setSubmitTimeToNow();
         app.setLifecycleStage(LifecycleStage.OBSOLETE);
         app.save();
       }
@@ -128,6 +146,10 @@ public final class ApplicationRepository {
     }
   }
 
+  /**
+   * Retrieves an applicant and program record and executes the provided function with them with
+   * some error handling.
+   */
   private CompletionStage<Optional<Application>> perform(
       long applicantId, long programId, Function<ApplicationArguments, Application> fn) {
     CompletionStage<Optional<Applicant>> applicantDb = userRepository.lookupApplicant(applicantId);
@@ -148,7 +170,7 @@ public final class ApplicationRepository {
         .thenApplyAsync(Optional::of)
         .exceptionally(
             exception -> {
-              logger.error(exception.toString());
+              LOGGER.error(exception.toString());
               exception.printStackTrace();
               return Optional.empty();
             });
@@ -195,7 +217,7 @@ public final class ApplicationRepository {
               .createQuery(Application.class)
               .where()
               .eq("applicant.id", applicant.id)
-              .eq("program.id", program.id)
+              .eq("program.name", program.getProgramDefinition().adminName())
               .eq("lifecycle_stage", LifecycleStage.DRAFT)
               .findOneOrEmpty();
       Application application =
@@ -208,18 +230,17 @@ public final class ApplicationRepository {
     }
   }
 
+  @VisibleForTesting
+  CompletionStage<Application> createOrUpdateDraft(Applicant applicant, Program program) {
+    return supplyAsync(
+        () -> createOrUpdateDraftApplicationInternal(applicant, program),
+        executionContext.current());
+  }
+
   /**
    * Create a draft application for the specified program. Update the draft application if one
    * already exists.
    */
-  public CompletionStage<Application> createOrUpdateDraft(Applicant applicant, Program program) {
-    return supplyAsync(
-        () -> {
-          return createOrUpdateDraftApplicationInternal(applicant, program);
-        },
-        executionContext.current());
-  }
-
   public CompletionStage<Optional<Application>> createOrUpdateDraft(
       long applicantId, long programId) {
     return this.perform(

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -102,7 +102,7 @@ public final class ApplicationRepository {
       if (drafts.size() == 1) {
         application = drafts.get(0);
       } else if (drafts.isEmpty()) {
-        LOGGER.error(
+        LOGGER.warning(
             "No DRAFT applications found when submitting for applicant {} program {}",
             applicant.id,
             program.id);
@@ -127,7 +127,7 @@ public final class ApplicationRepository {
             || app.getLifecycleStage().equals(LifecycleStage.OBSOLETE)) {
           continue;
         }
-        LOGGER.error(
+        LOGGER.warning(
             "Multiple applications found at submit time for applicant {} to program {} {}:"
                 + " application {}",
             applicant.id,

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -102,7 +102,7 @@ public final class ApplicationRepository {
       if (drafts.size() == 1) {
         application = drafts.get(0);
       } else if (drafts.isEmpty()) {
-        LOGGER.warning(
+        LOGGER.warn(
             "No DRAFT applications found when submitting for applicant {} program {}",
             applicant.id,
             program.id);
@@ -127,7 +127,7 @@ public final class ApplicationRepository {
             || app.getLifecycleStage().equals(LifecycleStage.OBSOLETE)) {
           continue;
         }
-        LOGGER.warning(
+        LOGGER.warn(
             "Multiple applications found at submit time for applicant {} to program {} {}:"
                 + " application {}",
             applicant.id,
@@ -257,7 +257,7 @@ public final class ApplicationRepository {
   }
 
   /**
-   * Get all applications with the specified {@link LifecyleStage}s for an applicant.
+   * Get all applications with the specified {@link LifecycleStage}s for an applicant.
    *
    * <p>The {@link Program} associated with the application is eagerly loaded.
    */

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -91,10 +91,16 @@ public class ApplicationRepositoryTest extends ResetPostgres {
   public void createOrUpdateDraftApplication_updatesExistingDraft() {
     Applicant applicant = saveApplicant("Alice");
     Program program = createProgram("Program");
+    // If the applicant already has an application to a different version of
+    // the same program, that version should be used.
+    Program programV2 = createProgram("Program");
+
+    assertThat(program.id).isNotEqualTo(programV2.id);
+
     Application appDraft1 =
         repo.createOrUpdateDraft(applicant, program).toCompletableFuture().join();
     Application appDraft2 =
-        repo.createOrUpdateDraft(applicant, program).toCompletableFuture().join();
+        repo.createOrUpdateDraft(applicant, programV2).toCompletableFuture().join();
 
     assertThat(appDraft1.id).isEqualTo(appDraft2.id);
     // Since this is a draft application, it shouldn't have a submit time set.


### PR DESCRIPTION
### Description

This PR addresses this bug: https://github.com/civiform/civiform/issues/3227

The program admin UI shows all non-draft, non-deleted applications for a given program ([query](https://github.com/civiform/civiform/blob/bionj-missing-submission-time-bug/server/app/repository/ProgramRepository.java#L224-L233)), meaning all `ACTIVE` and `OBSOLETE` applications are considered submitted. This is a reasonable assumption given submitting an application updates it from `DRAFT` to `ACTIVE` and marks all other applications to the same program as `OBSOLETE`, throwing an exception if more than one `DRAFT` is found for the program ([that happens here](https://github.com/civiform/civiform/blob/main/server/app/repository/ApplicationRepository.java#L86-L123)).

However, the logic to throw an exception if multiple drafts are found is more recent than the rest of the code, so it's possible multiple drafts were found in the past and marked `OBSOLETE` without setting a submission time. This PR sets the submission time on those and logs an error so we know it's happening if it continues to.

Also, when the applicant successfully (no validation errors) submits their first block update to a program, CiviForm creates a DRAFT application for them for that particular program version. It does this by checking if there is an existing draft yet ([that happens here](https://github.com/civiform/civiform/blob/main/server/app/repository/ApplicationRepository.java#L190-L209)). However the previous version of the code only checked for drafts to that particular version of the program, instead of all versions of the program. This PR fixes that.

This PR also adds more logging in general to the area around submitting applications in hopes we can better understand this bug if it is in fact an ongoing an issue and not an artifact of the older server code's behavior.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes [#3227](https://github.com/civiform/civiform/issues/3227)