### PR TITLE
Fix multiple service area values bug

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -321,16 +321,25 @@ describe('create and edit predicates', () => {
         programName,
         'Screen 1',
       )
-      await adminPredicates.addPredicate(
-        'eligibility-predicate-q',
-        /* action= */ null,
-        'service_area',
-        'in service area',
-        'Seattle',
-      )
+
+      // Add two to ensure the JS correctly handles multiple value rows
+      await adminPredicates.addPredicates([
+        {
+          questionName: 'eligibility-predicate-q',
+          scalar: 'service_area',
+          operator: 'in service area',
+          values: ['Seattle', 'Seattle'],
+        },
+      ])
 
       await adminPredicates.expectPredicateDisplayTextContains(
-        'Screen 1 is eligible if "eligibility-predicate-q" is in service area "Seattle"',
+        '"eligibility-predicate-q" is in service area "Seattle"',
+      )
+
+      // ensure the edit page renders without errors
+      await adminPredicates.clickEditPredicateButton('eligibility')
+      expect(await page.innerText('h2')).toContain(
+        'Configure eligibility conditions',
       )
     })
   }

--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -250,6 +250,20 @@ class AdminPredicateConfiguration {
       el.closest('label')?.setAttribute('for', newId)
     })
 
+    newRow.querySelectorAll('select').forEach((el: HTMLSelectElement) => {
+      const groupNumString = assertNotNull(el.name.match(/group-(\d+)/))[1]
+
+      let groupNum = parseInt(groupNumString, 10)
+      el.name = el.name.replace(/group-\d+/, `group-${++groupNum}`)
+
+      // The server-rendered inputs have UUID-generated IDs to ensure uniqueness on the page.
+      // We reuse those IDs and add a suffix to likewise ensure uniqueness for the new inputs.
+      const newId = `${el.id}-${groupNum}`
+      el.id = newId
+
+      el.closest('label')?.setAttribute('for', newId)
+    })
+
     const deleteButtonDiv = assertNotNull(
       newRow.querySelector('.predicate-config-delete-value-row'),
     ) as HTMLElement

--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -221,6 +221,20 @@ class AdminPredicateConfiguration {
     }
   }
 
+  updateNameAndIdForFormControl(el: HTMLInputElement | HTMLSelectElement) {
+    const groupNumString = assertNotNull(el.name.match(/group-(\d+)/))[1]
+
+    let groupNum = parseInt(groupNumString, 10)
+    el.name = el.name.replace(/group-\d+/, `group-${++groupNum}`)
+
+    // The server-rendered inputs have UUID-generated IDs to ensure uniqueness on the page.
+    // We reuse those IDs and add a suffix to likewise ensure uniqueness for the new inputs.
+    const newId = `${el.id}-${groupNum}`
+    el.id = newId
+
+    el.closest('label')?.setAttribute('for', newId)
+  }
+
   /** Add a value row by duplicating the last row in the list and updating its group IDs. */
   predicateAddValueRow(event: Event) {
     event.preventDefault()
@@ -237,32 +251,14 @@ class AdminPredicateConfiguration {
         el.value = ''
       }
 
-      const groupNumString = assertNotNull(el.name.match(/group-(\d+)/))[1]
-
-      let groupNum = parseInt(groupNumString, 10)
-      el.name = el.name.replace(/group-\d+/, `group-${++groupNum}`)
-
-      // The server-rendered inputs have UUID-generated IDs to ensure uniqueness on the page.
-      // We reuse those IDs and add a suffix to likewise ensure uniqueness for the new inputs.
-      const newId = `${el.id}-${groupNum}`
-      el.id = newId
-
-      el.closest('label')?.setAttribute('for', newId)
+      this.updateNameAndIdForFormControl(el)
     })
 
-    newRow.querySelectorAll('select').forEach((el: HTMLSelectElement) => {
-      const groupNumString = assertNotNull(el.name.match(/group-(\d+)/))[1]
-
-      let groupNum = parseInt(groupNumString, 10)
-      el.name = el.name.replace(/group-\d+/, `group-${++groupNum}`)
-
-      // The server-rendered inputs have UUID-generated IDs to ensure uniqueness on the page.
-      // We reuse those IDs and add a suffix to likewise ensure uniqueness for the new inputs.
-      const newId = `${el.id}-${groupNum}`
-      el.id = newId
-
-      el.closest('label')?.setAttribute('for', newId)
-    })
+    newRow
+      .querySelectorAll('select')
+      .forEach((el: HTMLSelectElement) =>
+        this.updateNameAndIdForFormControl(el),
+      )
 
     const deleteButtonDiv = assertNotNull(
       newRow.querySelector('.predicate-config-delete-value-row'),


### PR DESCRIPTION
### Description

Fixes a bug in the multi-value predicate configure view (enabled by `PREDICATES_MULTIPLE_QUESTIONS_ENABLED` feature flag). Address service area values are specified using a `select` element, whereas all other scalar values use an `input`. Since the JS code that creates new value rows only looks for `input` elements, it didn't update the `name` attribute of the `select` for address service areas.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)