### PR TITLE
Add a more robust UI for feature flags

### DIFF
--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -1,6 +1,5 @@
 package controllers.dev;
 
-import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import featureflags.FeatureFlags;
 import javax.inject.Inject;
@@ -8,6 +7,7 @@ import play.Environment;
 import play.mvc.Http.HeaderNames;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import views.dev.FeatureFlagView;
 
 /**
  * Allows for overriding of feature flags by an Admin via HTTP request.
@@ -17,30 +17,17 @@ import play.mvc.Result;
  */
 public final class FeatureFlagOverrideController extends DevController {
 
-  private final FeatureFlags featureFlags;
+  private final FeatureFlagView featureFlagView;
 
   @Inject
   public FeatureFlagOverrideController(
-      Environment environment, Config configuration, FeatureFlags featureFlags) {
+      Environment environment, Config configuration, FeatureFlagView featureFlagView) {
     super(environment, configuration);
-    this.featureFlags = featureFlags;
+    this.featureFlagView = featureFlagView;
   }
 
   public Result index(Request request) {
-    ImmutableMap<String, Boolean> flags = featureFlags.getAllFlags(request);
-
-    var flagSettingsString = new StringBuilder();
-    for (String key : flags.keySet()) {
-      flagSettingsString.append(String.format("    %s: %s\n", key, flags.get(key)));
-    }
-
-    return ok(
-        String.format(
-            "Overrides are allowed if all are true:\n"
-                + "Server environment: %s\n"
-                + "Configuration: %s\n\n"
-                + "Current flags:\n%s",
-            isDevOrStagingEnvironment(), featureFlags.areOverridesEnabled(), flagSettingsString));
+    return ok(featureFlagView.render(request, isDevOrStagingEnvironment()));
   }
 
   public Result enable(Request request, String flagName) {

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -130,10 +130,11 @@ public final class FeatureFlags {
    * <p>Returns false if the value is not present.
    */
   private boolean getFlagEnabled(Request request, String flag) {
-    Boolean configValue = getFlagEnabledFromConfig(flag);
-    if (!configValue) {
+    Optional<Boolean> maybeConfigValue = getFlagEnabledFromConfig(flag);
+    if (maybeConfigValue.isEmpty()) {
       return false;
     }
+    Boolean configValue = maybeConfigValue.get();
 
     if (!areOverridesEnabled()) {
       return configValue;
@@ -147,16 +148,12 @@ public final class FeatureFlags {
     return configValue;
   }
 
-  /**
-   * Returns the current setting for {@code flag} from {@link Config} if present.
-   *
-   * <p>Returns false if the value is not present.
-   */
-  public boolean getFlagEnabledFromConfig(String flag) {
+  /** Returns the current setting for {@code flag} from {@link Config} if present. */
+  public Optional<Boolean> getFlagEnabledFromConfig(String flag) {
     if (!config.hasPath(flag)) {
       logger.warn("Feature flag requested for unconfigured flag: {}", flag);
-      return false;
+      return Optional.empty();
     }
-    return config.getBoolean(flag);
+    return Optional.of(config.getBoolean(flag));
   }
 }

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -131,6 +131,9 @@ public final class FeatureFlags {
    */
   private boolean getFlagEnabled(Request request, String flag) {
     Boolean configValue = getFlagEnabledFromConfig(flag);
+    if (!configValue) {
+      return false;
+    }
 
     if (!areOverridesEnabled()) {
       return configValue;

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -126,13 +126,11 @@ public final class FeatureFlags {
   /**
    * Returns the current setting for {@code flag} from {@link Config} if present, allowing for an
    * overriden value from the session cookie.
+   *
+   * <p>Returns false if the value is not present.
    */
   private boolean getFlagEnabled(Request request, String flag) {
-    if (!config.hasPath(flag)) {
-      logger.warn("Feature flag requested for unconfigured flag: {}", flag);
-      return false;
-    }
-    Boolean configValue = config.getBoolean(flag);
+    Boolean configValue = getFlagEnabledFromConfig(flag);
 
     if (!areOverridesEnabled()) {
       return configValue;
@@ -144,5 +142,18 @@ public final class FeatureFlags {
       return sessionValue.get();
     }
     return configValue;
+  }
+
+  /**
+   * Returns the current setting for {@code flag} from {@link Config} if present.
+   *
+   * <p>Returns false if the value is not present.
+   */
+  public boolean getFlagEnabledFromConfig(String flag) {
+    if (!config.hasPath(flag)) {
+      logger.warn("Feature flag requested for unconfigured flag: {}", flag);
+      return false;
+    }
+    return config.getBoolean(flag);
   }
 }

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -16,6 +16,7 @@ import featureflags.FeatureFlags;
 import j2html.tags.Tag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.TableTag;
+import j2html.tags.specialized.TdTag;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import play.mvc.Http.Request;
@@ -55,7 +56,7 @@ public class FeatureFlagView extends BaseHtmlView {
     var sortedKeys = flags.keySet().stream().sorted().collect(Collectors.toUnmodifiableList());
     TableTag flagTable =
         table()
-            .withClass("mt-10")
+            .withClasses("mt-10", "text-left")
             .with(
                 caption("Current flag values"),
                 tr().with(
@@ -79,14 +80,23 @@ public class FeatureFlagView extends BaseHtmlView {
               : a().withHref(routes.FeatureFlagOverrideController.enable(flagName).url())
                   .withText("enable");
       flagFlipLink.withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT);
+
+      // If the session value is different highlight that.
+      // There's no easy way to add the bold conditionally since withX() overwrites values.
+      TdTag sessionValueTD = td(sessionValue.toString());
+      if (sessionOverrides) {
+        sessionValueTD.withClasses(BaseStyles.TABLE_CELL_STYLES, "font-bold");
+      } else {
+        sessionValueTD.withClasses(BaseStyles.TABLE_CELL_STYLES);
+      }
+
       flagTable.with(
           tr().with(
                   configureCell(td(flagName)),
                   configureCell(td(configValue.toString())),
                   // If the session value is different highlight that.
                   td(sessionDisplay).withClasses(BaseStyles.TABLE_CELL_STYLES, "font-bold"),
-                  // There's no withCondClasses, so leave off TABLE_CELL_STYLE.
-                  td(sessionValue.toString()).withCondClass(sessionOverrides, "font-bold"),
+                  sessionValueTD,
                   configureCell(td(flagFlipLink))));
     }
 

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -1,0 +1,112 @@
+package views.dev;
+
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.caption;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.h1;
+import static j2html.TagCreator.h2;
+import static j2html.TagCreator.table;
+import static j2html.TagCreator.td;
+import static j2html.TagCreator.th;
+import static j2html.TagCreator.tr;
+
+import com.google.common.collect.ImmutableMap;
+import controllers.dev.routes;
+import featureflags.FeatureFlags;
+import j2html.tags.Tag;
+import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.TableTag;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import play.mvc.Http.Request;
+import play.twirl.api.Content;
+import views.BaseHtmlLayout;
+import views.BaseHtmlView;
+import views.HtmlBundle;
+import views.JsBundle;
+import views.style.BaseStyles;
+
+public class FeatureFlagView extends BaseHtmlView {
+
+  private final BaseHtmlLayout layout;
+  private final FeatureFlags featureFlags;
+
+  @Inject
+  public FeatureFlagView(BaseHtmlLayout layout, FeatureFlags featureFlags) {
+
+    this.layout = layout;
+    this.featureFlags = featureFlags;
+  }
+
+  public Content render(Request request, boolean isDevOrStagingEnvironment) {
+    // Create system level control view.
+    TableTag serverSettingTable =
+        table()
+            .with(
+                tr().with(
+                        td("Server environment: ").withClass("pr-4"),
+                        td(Boolean.toString(isDevOrStagingEnvironment))),
+                tr().with(
+                        td("Configuration: "),
+                        td(Boolean.toString(featureFlags.areOverridesEnabled()))));
+
+    // Create per flag view.
+    ImmutableMap<String, Boolean> flags = featureFlags.getAllFlags(request);
+    var sortedKeys = flags.keySet().stream().sorted().collect(Collectors.toUnmodifiableList());
+    TableTag flagTable =
+        table()
+            .withClass("mt-10")
+            .with(
+                caption("Current flag values"),
+                tr().with(
+                        configureCell(th("Flag name")),
+                        configureCell(th("Server value")),
+                        configureCell(th("Session value")),
+                        configureCell(th("Effective value")),
+                        configureCell(th("Flip flag"))));
+
+    // For each flag show its config value, session value (if different), the effective value for
+    // the user and a control to toggle the value.
+    for (String flagName : sortedKeys) {
+      Boolean configValue = featureFlags.getFlagEnabledFromConfig(flagName);
+      Boolean sessionValue = flags.get(flagName);
+      Boolean sessionOverrides = !configValue.equals(sessionValue);
+      String sessionDisplay = sessionOverrides ? sessionValue.toString() : "";
+      Tag flagFlipLink =
+          sessionValue
+              ? a().withHref(routes.FeatureFlagOverrideController.disable(flagName).url())
+                  .withText("disable")
+              : a().withHref(routes.FeatureFlagOverrideController.enable(flagName).url())
+                  .withText("enable");
+      flagFlipLink.withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT);
+      flagTable.with(
+          tr().with(
+                  configureCell(td(flagName)),
+                  configureCell(td(configValue.toString())),
+                  // If the session value is different highlight that.
+                  td(sessionDisplay).withClasses(BaseStyles.TABLE_CELL_STYLES, "font-bold"),
+                  // There's no withCondClasses, so leave off TABLE_CELL_STYLE.
+                  td(sessionValue.toString()).withCondClass(sessionOverrides, "font-bold"),
+                  configureCell(td(flagFlipLink))));
+    }
+
+    // Build the page.
+    DivTag content =
+        div()
+            .with(
+                h1("Feature Flags").withClasses("py-6"),
+                h2("Overrides are allowed if all are true:").withClasses("py-2"))
+            .with(serverSettingTable);
+    HtmlBundle bundle =
+        layout
+            .getBundle()
+            .setTitle("Feature Flags")
+            .addMainContent(content, flagTable)
+            .setJsBundle(JsBundle.ADMIN);
+    return layout.render(bundle);
+  }
+
+  Tag configureCell(Tag tag) {
+    return tag.withClasses(BaseStyles.TABLE_CELL_STYLES);
+  }
+}

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -45,18 +45,18 @@ public class FeatureFlagView extends BaseHtmlView {
         table()
             .with(
                 tr().with(
-                        td("Server environment: ").withClass("pr-4"),
-                        td(Boolean.toString(isDevOrStagingEnvironment))),
+                        configureCell(td("Server environment: ")),
+                        configureCell(td(Boolean.toString(isDevOrStagingEnvironment)))),
                 tr().with(
-                        td("Configuration: "),
-                        td(Boolean.toString(featureFlags.areOverridesEnabled()))));
+                        configureCell(td("Configuration: ")),
+                        configureCell(td(Boolean.toString(featureFlags.areOverridesEnabled())))));
 
     // Create per flag view.
     ImmutableMap<String, Boolean> flags = featureFlags.getAllFlags(request);
     var sortedKeys = flags.keySet().stream().sorted().collect(Collectors.toUnmodifiableList());
     TableTag flagTable =
         table()
-            .withClasses("mt-10", "text-left")
+            .withClasses("p-6", "mt-10", "text-left")
             .with(
                 caption("Current flag values"),
                 tr().with(
@@ -101,17 +101,18 @@ public class FeatureFlagView extends BaseHtmlView {
     }
 
     // Build the page.
-    DivTag content =
+    DivTag serverSettingSection =
         div()
             .with(
                 h1("Feature Flags").withClasses("py-6"),
-                h2("Overrides are allowed if all are true:").withClasses("py-2"))
-            .with(serverSettingTable);
+                h2("Overrides are allowed if all are true:"))
+            .with(serverSettingTable)
+            .withClass("p-6");
     HtmlBundle bundle =
         layout
             .getBundle()
             .setTitle("Feature Flags")
-            .addMainContent(content, flagTable)
+            .addMainContent(serverSettingSection, div().withClass("px-4").with(flagTable))
             .setJsBundle(JsBundle.ADMIN);
     return layout.render(bundle);
   }

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -34,11 +34,21 @@ public class FeatureFlagView extends BaseHtmlView {
 
   @Inject
   public FeatureFlagView(BaseHtmlLayout layout, FeatureFlags featureFlags) {
-
     this.layout = layout;
     this.featureFlags = featureFlags;
   }
 
+  /**
+   * Renders a view of the current feature flag state.
+   *
+   * <p>Includes:
+   *
+   * <ul>
+   *   <li>Server controls for allowing overrides
+   *   <li>Individual flags and their constituent values, including a link to toggle the session
+   *       value.
+   * </ul>
+   */
   public Content render(Request request, boolean isDevOrStagingEnvironment) {
     // Create system level control view.
     TableTag serverSettingTable =
@@ -72,6 +82,7 @@ public class FeatureFlagView extends BaseHtmlView {
       Boolean configValue = featureFlags.getFlagEnabledFromConfig(flagName).orElse(false);
       Boolean sessionValue = flags.get(flagName);
       Boolean sessionOverrides = !configValue.equals(sessionValue);
+      // Only show values that override the system default.
       String sessionDisplay = sessionOverrides ? sessionValue.toString() : "";
       Tag flagFlipLink =
           sessionValue

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -82,7 +82,7 @@ public class FeatureFlagView extends BaseHtmlView {
       Boolean configValue = featureFlags.getFlagEnabledFromConfig(flagName).orElse(false);
       Boolean sessionValue = flags.get(flagName);
       Boolean sessionOverrides = !configValue.equals(sessionValue);
-      // Only show values that override the system default.
+      // Only show values that override the system default for clarity.
       String sessionDisplay = sessionOverrides ? sessionValue.toString() : "";
       Tag flagFlipLink =
           sessionValue

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -69,7 +69,7 @@ public class FeatureFlagView extends BaseHtmlView {
     // For each flag show its config value, session value (if different), the effective value for
     // the user and a control to toggle the value.
     for (String flagName : sortedKeys) {
-      Boolean configValue = featureFlags.getFlagEnabledFromConfig(flagName);
+      Boolean configValue = featureFlags.getFlagEnabledFromConfig(flagName).orElse(false);
       Boolean sessionValue = flags.get(flagName);
       Boolean sessionOverrides = !configValue.equals(sessionValue);
       String sessionDisplay = sessionOverrides ? sessionValue.toString() : "";

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -89,7 +89,7 @@ public class FeatureFlagOverrideControllerTest {
 
     // Verify
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).startsWith("Overrides are allowed");
+    assertThat(contentAsString(result)).contains("Overrides are allowed");
   }
 
   private void setupControllerInMode(Mode mode) {


### PR DESCRIPTION
### Description

Add a proper View class for Feature Flags which includes a more exhaustive view of their values and an easy ability to toggle the value.

Default state:

![image](https://user-images.githubusercontent.com/90928876/217895313-1c442239-812a-4ca2-9260-a3b549665320.png)


With Session values:

![image](https://user-images.githubusercontent.com/90928876/217895290-687c27da-31c2-4ca8-838e-fd8c29a6c29e.png)


## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
