### PR TITLE
Enforce absolute links in LinkElement hrefs

### DIFF
--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -114,7 +114,10 @@ public abstract class BaseHtmlView {
       div.with(new LinkElement().setText("∅").asButtonNoHref());
     } else {
       div.with(
-          new LinkElement().setText("←").setHref(linkForPage.apply(page - 1).url()).asButton());
+          new LinkElement()
+              .setText("←")
+              .setRelativeHref(linkForPage.apply(page - 1).url())
+              .asButton());
     }
     String paginationText =
         pageCount > 0 ? String.format("Page %d of %d", page, pageCount) : "No results";
@@ -122,7 +125,10 @@ public abstract class BaseHtmlView {
         div(paginationText).withClasses("leading-3", "float-left", "inline-block", "p-2", "m-4"));
     if (pageCount > page) {
       div.with(
-          new LinkElement().setText("→").setHref(linkForPage.apply(page + 1).url()).asButton());
+          new LinkElement()
+              .setText("→")
+              .setAbsoluteHref(linkForPage.apply(page + 1).url())
+              .asButton());
     } else {
       div.with(new LinkElement().setText("∅").asButtonNoHref());
     }

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -63,7 +63,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
       String linkDestination, Locale locale, boolean isCurrentlySelected) {
     LinkElement link =
         new LinkElement()
-            .setHref(linkDestination)
+            .setAbsoluteHref(linkDestination)
             .setText(locale.getDisplayLanguage(LocalizedStrings.DEFAULT_LOCALE));
 
     if (isCurrentlySelected) {

--- a/server/app/views/admin/apikeys/ApiKeyNewOneView.java
+++ b/server/app/views/admin/apikeys/ApiKeyNewOneView.java
@@ -48,7 +48,7 @@ public final class ApiKeyNewOneView extends BaseHtmlView {
     text("Specify a subnet using "),
     new LinkElement()
         .setText("CIDR notation")
-        .setHref("https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing")
+        .setAbsoluteHref("https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing")
         .opensInNewTab()
         .asAnchorText(),
     text(

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -379,7 +379,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
 
     return new LinkElement()
         .setId("application-view-link-" + application.id)
-        .setHref(viewLink)
+        .setAbsoluteHref(viewLink)
         .setText(text)
         .setStyles("mr-2", ReferenceClasses.VIEW_BUTTON)
         .asAnchorText();

--- a/server/app/views/admin/programs/ProgramBlockPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicateConfigureView.java
@@ -243,7 +243,7 @@ public final class ProgramBlockPredicateConfigureView extends ProgramBlockBaseVi
   private ATag renderBackLink(
       String editPredicateUrl, String typeDisplayName, BlockDefinition blockDefinition) {
     return new LinkElement()
-        .setHref(editPredicateUrl)
+        .setAbsoluteHref(editPredicateUrl)
         .setIcon(Icons.ARROW_LEFT, LinkElement.IconPosition.START)
         .setText(
             String.format(

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -195,7 +195,7 @@ public final class ProgramBlockPredicatesEditView extends ProgramBlockBaseView {
                     .with(div().withClasses("flex-grow"))
                     .with(
                         new LinkElement()
-                            .setHref(editBlockUrl)
+                            .setAbsoluteHref(editBlockUrl)
                             .setText(String.format("Return to edit %s", blockName))
                             .asAnchorText()))
             // Show the current predicate.

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditViewV2.java
@@ -191,7 +191,7 @@ public final class ProgramBlockPredicatesEditViewV2 extends ProgramBlockBaseView
                     .with(div().withClasses("flex-grow"))
                     .with(
                         new LinkElement()
-                            .setHref(editBlockUrl)
+                            .setAbsoluteHref(editBlockUrl)
                             .setText(String.format("Return to edit %s", blockDefinition.name()))
                             .asAnchorText()))
             // Show the current predicate.

--- a/server/app/views/admin/programs/ProgramEditView.java
+++ b/server/app/views/admin/programs/ProgramEditView.java
@@ -70,7 +70,7 @@ public final class ProgramEditView extends ProgramFormBuilder {
         controllers.admin.routes.AdminProgramBlocksController.index(programId).url();
     return new LinkElement()
         .setId("manage-questions-link")
-        .setHref(manageQuestionLink)
+        .setAbsoluteHref(manageQuestionLink)
         .setText("Manage Questions →")
         .setStyles("mx-4", "float-right")
         .asAnchorText();

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -270,7 +270,8 @@ public final class ProgramIndexView extends BaseHtmlView {
             span(" - " + visibilityText + " "),
             new LinkElement()
                 .setText("Edit")
-                .setHref(controllers.admin.routes.AdminProgramController.edit(program.id()).url())
+                .setAbsoluteHref(
+                    controllers.admin.routes.AdminProgramController.edit(program.id()).url())
                 .asAnchorText());
   }
 
@@ -280,7 +281,7 @@ public final class ProgramIndexView extends BaseHtmlView {
             span(" - "),
             new LinkElement()
                 .setText("Edit")
-                .setHref(
+                .setAbsoluteHref(
                     controllers.admin.routes.AdminQuestionController.edit(question.getId()).url())
                 .asAnchorText());
   }

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -87,7 +87,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                             span("Applicant-visible program details"),
                             new LinkElement()
                                 .setText("(edit default)")
-                                .setHref(programDetailsLink)
+                                .setAbsoluteHref(programDetailsLink)
                                 .setStyles("ml-2")
                                 .asAnchorText()),
                     ImmutableList.of(
@@ -154,7 +154,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                       span(String.format("Application status: %s", configuredStatus.statusText())),
                       new LinkElement()
                           .setText("(edit default)")
-                          .setHref(programStatusesLink)
+                          .setAbsoluteHref(programStatusesLink)
                           .setStyles("ml-2")
                           .asAnchorText()),
               fieldsBuilder.build()));

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -387,7 +387,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .with(
                     span("Learn more about each of the data export settings in the "),
                     new LinkElement()
-                        .setHref(
+                        .setAbsoluteHref(
                             "https://docs.civiform.us/user-manual/civiform-admin-guide/manage-questions#question-export-settings")
                         .setText("documentation")
                         .opensInNewTab()

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -150,7 +150,7 @@ public final class QuestionTranslationView extends TranslationFormView {
                 span("Applicant-visible question details"),
                 new LinkElement()
                     .setText("(edit default)")
-                    .setHref(
+                    .setAbsoluteHref(
                         controllers.admin.routes.AdminQuestionController.edit(
                                 questionDefinition.getId())
                             .url())

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -71,7 +71,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
     ATag emailAction =
         new LinkElement()
             .setText(supportEmail)
-            .setHref("mailto:" + supportEmail)
+            .setRelativeHref("mailto:" + supportEmail)
             .opensInNewTab()
             .asAnchorText();
 

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -200,7 +200,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
             .setStyles("bottom-0", "right-0", "text-blue-600", StyleUtils.hover("text-blue-700"));
     if (data.isAnswered()) {
       editElement
-          .setHref(
+          .setAbsoluteHref(
               routes.ApplicantProgramBlocksController.review(
                       applicantId, data.programId(), data.blockId())
                   .url())
@@ -208,7 +208,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
           .setIcon(Icons.EDIT, LinkElement.IconPosition.START);
     } else {
       editElement
-          .setHref(
+          .setAbsoluteHref(
               routes.ApplicantProgramBlocksController.edit(
                       applicantId, data.programId(), data.blockId())
                   .url())

--- a/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
@@ -64,20 +64,20 @@ public final class ApplicantUpsellCreateAccountView extends BaseHtmlView {
                     .with(div().withClasses("flex-grow"))
                     .with(
                         new LinkElement()
-                            .setHref(redirectTo)
+                            .setAbsoluteHref(redirectTo)
                             .setText(
                                 messages.at(MessageKey.LINK_APPLY_TO_ANOTHER_PROGRAM.getKeyName()))
                             .asButton()
                             .withClasses(ApplicantStyles.BUTTON_NOT_RIGHT_NOW))
                     .with(
                         new LinkElement()
-                            .setHref(org.pac4j.play.routes.LogoutController.logout().url())
+                            .setAbsoluteHref(org.pac4j.play.routes.LogoutController.logout().url())
                             .setText(messages.at(MessageKey.LINK_ALL_DONE.getKeyName()))
                             .asButton()
                             .withClasses(ApplicantStyles.BUTTON_NOT_RIGHT_NOW))
                     .with(
                         new LinkElement()
-                            .setHref(
+                            .setAbsoluteHref(
                                 routes.LoginController.applicantLogin(Optional.of(redirectTo))
                                     .url())
                             .setText(
@@ -98,7 +98,7 @@ public final class ApplicantUpsellCreateAccountView extends BaseHtmlView {
     } else {
       content.with(
           new LinkElement()
-              .setHref(redirectTo)
+              .setAbsoluteHref(redirectTo)
               .setText(messages.at(MessageKey.LINK_APPLY_TO_ANOTHER_PROGRAM.getKeyName()))
               .asAnchorText());
     }

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -42,7 +42,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
         new LinkElement()
             .setStyles("mb-4", "underline")
             .setText(messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase())
-            .setHref(routes.ApplicantProgramsController.view(applicantId, programId).url())
+            .setAbsoluteHref(routes.ApplicantProgramsController.view(applicantId, programId).url())
             .opensInNewTab()
             .setIcon(Icons.OPEN_IN_NEW, LinkElement.IconPosition.END)
             .asAnchorText()
@@ -82,14 +82,15 @@ public final class IneligibleBlockView extends ApplicationBaseView {
                     .with(div().withClasses("flex-grow"))
                     .with(
                         new LinkElement()
-                            .setHref(routes.ApplicantProgramsController.index(applicantId).url())
+                            .setAbsoluteHref(
+                                routes.ApplicantProgramsController.index(applicantId).url())
                             .setText(
                                 messages.at(MessageKey.LINK_APPLY_TO_ANOTHER_PROGRAM.getKeyName()))
                             .asButton()
                             .withClasses(ApplicantStyles.BUTTON_NOT_RIGHT_NOW))
                     .with(
                         new LinkElement()
-                            .setHref(
+                            .setAbsoluteHref(
                                 routes.ApplicantProgramReviewController.review(
                                         applicantId, programId)
                                     .url())

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -298,7 +298,7 @@ public final class ProgramIndexView extends BaseHtmlView {
             .setId(baseId + "-info-link")
             .setStyles("mb-2", "text-sm", "underline")
             .setText(messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()))
-            .setHref(programDetailsLink)
+            .setAbsoluteHref(programDetailsLink)
             .opensInNewTab()
             .setIcon(Icons.OPEN_IN_NEW, LinkElement.IconPosition.END)
             .asAnchorText()

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -292,7 +292,7 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
             new LinkElement()
                 .setId(String.format("act-as-%d-button", newestApplicant.get().id))
                 .setText("Applicant Dashboard ➔")
-                .setHref(
+                .setAbsoluteHref(
                     controllers.applicant.routes.ApplicantProgramsController.index(
                             newestApplicant.get().id)
                         .url())

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -58,8 +58,24 @@ public final class LinkElement {
     return this;
   }
 
-  public LinkElement setHref(String href) {
+  public LinkElement setRelativeHref(String href) {
+    if (href.startsWith("http://") || href.startsWith("https://")) {
+      throw new RuntimeException("Relative href links cannot start with a protocol specifier.");
+    }
+
     this.href = href;
+    return this;
+  }
+
+  public LinkElement setAbsoluteHref(String href) {
+    // We must have a protocol specified on the LinkElement so that it is not interpreted as a
+    // relative link.
+    // If the href doesn't have a protocol specified, use https.
+    if (!href.startsWith("http://") && !href.startsWith("https://")) {
+      this.href = "https://" + href;
+    } else {
+      this.href = href;
+    }
     return this;
   }
 


### PR DESCRIPTION
### Description

This avoids the problem in #4188 where program description links were being appended to the current view's URL, since they were being interpreted as relative.

### Checklist

#### General

- [x] Renames `LinkElement`'s `setHref()` to `setAbsoluteHref()`
- [x] Enforces that links it start with `http://` or `https://`.

### Issue(s) this completes

Fixes #4188
