### PR TITLE
Fixes landing_page test when run on prod CiviForm image

### DIFF
--- a/browser-test/src/landing_page.test.ts
+++ b/browser-test/src/landing_page.test.ts
@@ -57,9 +57,7 @@ describe('the landing page', () => {
     sharedTests(ctx, 'landing-page-with-version')
 
     it('has civiform version', async () => {
-      expect(await ctx.page.textContent('html')).toContain(
-        'CiviForm version:',
-      )
+      expect(await ctx.page.textContent('html')).toContain('CiviForm version:')
     })
   })
 })

--- a/browser-test/src/landing_page.test.ts
+++ b/browser-test/src/landing_page.test.ts
@@ -41,7 +41,7 @@ describe('the landing page', () => {
 
     it('does not have civiform version', async () => {
       expect(await ctx.page.textContent('html')).not.toContain(
-        'CiviForm version: dev',
+        'CiviForm version:',
       )
     })
   })
@@ -58,7 +58,7 @@ describe('the landing page', () => {
 
     it('has civiform version', async () => {
       expect(await ctx.page.textContent('html')).toContain(
-        'CiviForm version: dev',
+        'CiviForm version:',
       )
     })
   })


### PR DESCRIPTION
### Description

Test added in https://github.com/civiform/civiform/pull/4205.  Was discovered that the test does not pass on Seattle staging, which uses an image build with bin/build-prod.