### PR TITLE
Adding english default strings for address correction ui

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -2,6 +2,11 @@ package services;
 
 /** Contains keys into the {@code messages} files used for translation. */
 public enum MessageKey {
+  ADDRESS_CORRECTION_HEADING("title.addressCorrectionHeading"),
+  ADDRESS_CORRECTION_SUB_HEADING("content.addressCorrectionSubHeading"),
+  ADDRESS_CORRECTION_PAGE_INSTRUCTIONS("content.addressCorrectionPageInstructions"),
+  ADDRESS_CORRECTION_AS_ENTERED_HEADING("content.addressCorrectionAsEnteredHeading"),
+  ADDRESS_CORRECTION_SUGGESTIONS_HEADING("content.addressCorrectionSuggestionsHeading"),
   ADDRESS_LABEL_CITY("label.city"),
   ADDRESS_LABEL_LINE_2("label.addressLine2"),
   ADDRESS_LABEL_STATE("label.state"),

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -290,6 +290,25 @@ title.createAnAccount=Create an account or sign in
 # A message urging users to create an account to save their data.
 content.pleaseCreateAccount=If you sign into a city account now, your information will be saved and you''ll be able to return at any time to complete future applications.  If you do not already have an account, the login page will allow you to register.  You won''t lose any data you''ve already entered.
 
+#----------------------------------------------------------------------#
+# ADDRESS CORRECTION - text when viewing the address correction screen #
+#----------------------------------------------------------------------#
+
+# Title on the page
+title.addressCorrectionHeading=Address Correction
+
+# Page subheading
+content.addressCorrectionSubHeading=Verify address
+
+# Page instructions
+content.addressCorrectionPageInstructions=Is this a valid address? Please select the one that best corresponds to your mailing address. You can also click "Edit" to make any changes to the address you entered.
+
+# Section heading for selecting the address as the user entered it
+content.addressCorrectionAsEnteredHeading=Address entered:
+
+# Section heading for the list of suggested addresses
+content.addressCorrectionSuggestionsHeading=Suggested address(es):
+
 #----------------------------------------------------------#
 # ADDRESS QUESTION - text when viewing an address question #
 #----------------------------------------------------------#


### PR DESCRIPTION
### Description

Adding new strings that will be used in the address correction ui. Submitting separately to get the ball rolling on translations. Related to #4044

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

