### PR TITLE
Pass github token to googlejavaformat action

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           version: 1.9
           skip-commit: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: show diff
         run: git add .; git diff --exit-code HEAD


### PR DESCRIPTION
Attempt at fixing occasional format action failures. The googlejavaformat-action tries to get release info differently based on if it has a github-token or not. WIthout it uses curl. Adding the token to the action here because we might be hitting the failure due to api rate limit being exceeded.

See https://github.com/axel-op/googlejavaformat-action#github-token. While their comments are specific about macOS it could still be a rate limit issue.

Example of failure
```
Run axel-op/googlejavaformat-action@v3
  with:
    version: 1.9
    skip-commit: true
    args: --replace
    files: **/*.java
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/11.0.10-9/x64
    JAVA_HOME_11_X64: /opt/hostedtoolcache/Java_Zulu_jdk/11.0.10-9/x64
Error: TypeError: releases.find is not a function
```

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
