### PR TITLE
Rename `Roles` enum to `Role`.

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -91,17 +91,17 @@ public class CiviFormProfile {
 
   /** Returns true if the profile has TI role. */
   public boolean isTrustedIntermediary() {
-    return getRoles().contains(Roles.ROLE_TI.toString());
+    return getRoles().contains(Role.ROLE_TI.toString());
   }
 
   /** Returns true if the profile has CiviForm Admin role. */
   public boolean isCiviFormAdmin() {
-    return profileData.getRoles().contains(Roles.ROLE_CIVIFORM_ADMIN.toString());
+    return profileData.getRoles().contains(Role.ROLE_CIVIFORM_ADMIN.toString());
   }
 
   /** Returns true if the profile has Program Admin role. */
   public boolean isProgramAdmin() {
-    return this.getRoles().contains(Roles.ROLE_PROGRAM_ADMIN.toString());
+    return this.getRoles().contains(Role.ROLE_PROGRAM_ADMIN.toString());
   }
 
   /** Returns the account ID associated with the profile. */

--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -48,7 +48,7 @@ public final class ProfileFactory {
   }
 
   public CiviFormProfileData createNewApplicant() {
-    return create(new Roles[] {Roles.ROLE_APPLICANT});
+    return create(new Role[] {Role.ROLE_APPLICANT});
   }
 
   public CiviFormProfileData createNewAdmin() {
@@ -60,7 +60,7 @@ public final class ProfileFactory {
   }
 
   public CiviFormProfileData createNewAdmin(Optional<String> maybeAuthorityId) {
-    CiviFormProfileData profileData = create(new Roles[] {Roles.ROLE_CIVIFORM_ADMIN});
+    CiviFormProfileData profileData = create(new Role[] {Role.ROLE_CIVIFORM_ADMIN});
 
     wrapProfileData(profileData)
         .getAccount()
@@ -90,10 +90,10 @@ public final class ProfileFactory {
   }
 
   /* One admin can have multiple roles; they can be both a program admin and a civiform admin. */
-  private CiviFormProfileData create(Roles[] roleList) {
+  private CiviFormProfileData create(Role[] roleList) {
     CiviFormProfileData p = new CiviFormProfileData();
     p.init(dbContext);
-    for (Roles role : roleList) {
+    for (Role role : roleList) {
       p.addRole(role.toString());
     }
     return p;
@@ -108,7 +108,7 @@ public final class ProfileFactory {
   }
 
   public CiviFormProfileData createNewProgramAdmin() {
-    return create(new Roles[] {Roles.ROLE_PROGRAM_ADMIN});
+    return create(new Role[] {Role.ROLE_PROGRAM_ADMIN});
   }
 
   /**
@@ -116,7 +116,7 @@ public final class ProfileFactory {
    * with a fake email address.
    */
   public CiviFormProfileData createFakeProgramAdmin() {
-    CiviFormProfileData p = create(new Roles[] {Roles.ROLE_PROGRAM_ADMIN});
+    CiviFormProfileData p = create(new Role[] {Role.ROLE_PROGRAM_ADMIN});
     wrapProfileData(p)
         .getAccount()
         .thenAccept(
@@ -140,8 +140,7 @@ public final class ProfileFactory {
    * programs with a fake email address.
    */
   public CiviFormProfileData createFakeDualAdmin() {
-    CiviFormProfileData p =
-        create(new Roles[] {Roles.ROLE_PROGRAM_ADMIN, Roles.ROLE_CIVIFORM_ADMIN});
+    CiviFormProfileData p = create(new Role[] {Role.ROLE_PROGRAM_ADMIN, Role.ROLE_CIVIFORM_ADMIN});
     wrapProfileData(p)
         .getAccount()
         .thenAccept(
@@ -173,7 +172,7 @@ public final class ProfileFactory {
       group = existingGroups.get(0);
     }
 
-    CiviFormProfileData tiProfileData = create(new Roles[] {Roles.ROLE_TI});
+    CiviFormProfileData tiProfileData = create(new Role[] {Role.ROLE_TI});
     wrapProfileData(tiProfileData)
         .getAccount()
         .thenAccept(

--- a/server/app/auth/Role.java
+++ b/server/app/auth/Role.java
@@ -1,7 +1,7 @@
 package auth;
 
 /** Enum class of all roles a civiform profile can have. */
-public enum Roles {
+public enum Role {
   ROLE_APPLICANT("ROLE_APPLICANT"),
   ROLE_TI("ROLE_TI"),
   ROLE_CIVIFORM_ADMIN("ROLE_CIVIFORM_ADMIN"),
@@ -9,7 +9,7 @@ public enum Roles {
 
   private final String roleName;
 
-  Roles(String roleName) {
+  Role(String roleName) {
     this.roleName = roleName;
   }
 

--- a/server/app/auth/oidc/OidcProfileAdapter.java
+++ b/server/app/auth/oidc/OidcProfileAdapter.java
@@ -5,7 +5,7 @@ import auth.CiviFormProfileData;
 import auth.CiviFormProfileMerger;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
-import auth.Roles;
+import auth.Role;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -53,9 +53,9 @@ public abstract class OidcProfileAdapter extends OidcProfileCreator {
 
   protected abstract String emailAttributeName();
 
-  protected abstract ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile);
+  protected abstract ImmutableSet<Role> roles(CiviFormProfile profile, OidcProfile oidcProfile);
 
-  protected abstract void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles);
+  protected abstract void adaptForRole(CiviFormProfile profile, ImmutableSet<Role> roles);
 
   /** Create a totally new CiviForm profile informed by the provided OidcProfile. */
   public abstract CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile);
@@ -125,9 +125,9 @@ public abstract class OidcProfileAdapter extends OidcProfileCreator {
     civiformProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
 
     // Meaning: whatever you signed in with most recently is the role you have.
-    ImmutableSet<Roles> roles = roles(civiformProfile, oidcProfile);
+    ImmutableSet<Role> roles = roles(civiformProfile, oidcProfile);
     roles.stream()
-        .map(Roles::toString)
+        .map(Role::toString)
         .forEach(role -> civiformProfile.getProfileData().addRole(role));
     adaptForRole(civiformProfile, roles);
     return civiformProfile.getProfileData();

--- a/server/app/auth/oidc/admin/AdfsProfileAdapter.java
+++ b/server/app/auth/oidc/admin/AdfsProfileAdapter.java
@@ -2,7 +2,7 @@ package auth.oidc.admin;
 
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
-import auth.Roles;
+import auth.Role;
 import auth.oidc.OidcProfileAdapter;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
@@ -44,16 +44,16 @@ public class AdfsProfileAdapter extends OidcProfileAdapter {
   }
 
   @Override
-  protected ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
+  protected ImmutableSet<Role> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
     if (this.isGlobalAdmin(oidcProfile)) {
-      return ImmutableSet.of(Roles.ROLE_CIVIFORM_ADMIN);
+      return ImmutableSet.of(Role.ROLE_CIVIFORM_ADMIN);
     }
-    return ImmutableSet.of(Roles.ROLE_PROGRAM_ADMIN);
+    return ImmutableSet.of(Role.ROLE_PROGRAM_ADMIN);
   }
 
   @Override
-  protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles) {
-    if (roles.contains(Roles.ROLE_CIVIFORM_ADMIN)) {
+  protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Role> roles) {
+    if (roles.contains(Role.ROLE_CIVIFORM_ADMIN)) {
       profile
           .getAccount()
           .thenAccept(

--- a/server/app/auth/oidc/applicant/OidcApplicantProfileAdapter.java
+++ b/server/app/auth/oidc/applicant/OidcApplicantProfileAdapter.java
@@ -3,7 +3,7 @@ package auth.oidc.applicant;
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
-import auth.Roles;
+import auth.Role;
 import auth.oidc.OidcProfileAdapter;
 import com.beust.jcommander.internal.Nullable;
 import com.google.common.annotations.VisibleForTesting;
@@ -84,15 +84,15 @@ public abstract class OidcApplicantProfileAdapter extends OidcProfileAdapter {
   }
 
   @Override
-  protected final ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
+  protected final ImmutableSet<Role> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
     if (isTrustedIntermediary(profile)) {
-      return ImmutableSet.of(Roles.ROLE_APPLICANT, Roles.ROLE_TI);
+      return ImmutableSet.of(Role.ROLE_APPLICANT, Role.ROLE_TI);
     }
-    return ImmutableSet.of(Roles.ROLE_APPLICANT);
+    return ImmutableSet.of(Role.ROLE_APPLICANT);
   }
 
   @Override
-  protected final void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles) {
+  protected final void adaptForRole(CiviFormProfile profile, ImmutableSet<Role> roles) {
     // Not used for applicants.
   }
 

--- a/server/app/auth/saml/SamlProfileAdapter.java
+++ b/server/app/auth/saml/SamlProfileAdapter.java
@@ -5,7 +5,7 @@ import auth.CiviFormProfileData;
 import auth.CiviFormProfileMerger;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
-import auth.Roles;
+import auth.Role;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -175,8 +175,8 @@ public class SamlProfileAdapter extends AuthenticatorProfileCreator {
 
     civiFormProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     // Meaning: whatever you signed in with most recently is the role you have.
-    ImmutableSet<Roles> roles = roles(civiFormProfile);
-    for (Roles role : roles) {
+    ImmutableSet<Role> roles = roles(civiFormProfile);
+    for (Role role : roles) {
       civiFormProfile.getProfileData().addRole(role.toString());
     }
     return civiFormProfile.getProfileData();
@@ -195,10 +195,10 @@ public class SamlProfileAdapter extends AuthenticatorProfileCreator {
     return sj.toString();
   }
 
-  protected ImmutableSet<Roles> roles(CiviFormProfile profile) {
+  protected ImmutableSet<Role> roles(CiviFormProfile profile) {
     if (profile.getAccount().join().getMemberOfGroup().isPresent()) {
-      return ImmutableSet.of(Roles.ROLE_APPLICANT, Roles.ROLE_TI);
+      return ImmutableSet.of(Role.ROLE_APPLICANT, Role.ROLE_TI);
     }
-    return ImmutableSet.of(Roles.ROLE_APPLICANT);
+    return ImmutableSet.of(Role.ROLE_APPLICANT);
   }
 }

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -14,7 +14,7 @@ import auth.CiviFormProfileData;
 import auth.FakeAdminClient;
 import auth.GuestClient;
 import auth.ProfileFactory;
-import auth.Roles;
+import auth.Role;
 import auth.oidc.admin.AdfsProvider;
 import auth.oidc.applicant.Auth0Provider;
 import auth.oidc.applicant.GenericOidcProvider;
@@ -288,23 +288,23 @@ public class SecurityModule extends AbstractModule {
         // ANY_ADMIN.
         Authorizers.ANY_ADMIN.toString(),
         new RequireAnyRoleAuthorizer(
-            Roles.ROLE_CIVIFORM_ADMIN.toString(), Roles.ROLE_PROGRAM_ADMIN.toString()),
+            Role.ROLE_CIVIFORM_ADMIN.toString(), Role.ROLE_PROGRAM_ADMIN.toString()),
 
         // Having ROLE_PROGRAM_ADMIN authorizes a profile as PROGRAM_ADMIN.
         Authorizers.PROGRAM_ADMIN.toString(),
-        new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()),
+        new RequireAllRolesAuthorizer(Role.ROLE_PROGRAM_ADMIN.toString()),
 
         // Having ROLE_CIVIFORM_ADMIN authorizes a profile as CIVIFORM_ADMIN.
         Authorizers.CIVIFORM_ADMIN.toString(),
-        new RequireAllRolesAuthorizer(Roles.ROLE_CIVIFORM_ADMIN.toString()),
+        new RequireAllRolesAuthorizer(Role.ROLE_CIVIFORM_ADMIN.toString()),
 
         // Having ROLE_APPLICANT authorizes a profile as APPLICANT.
         Authorizers.APPLICANT.toString(),
-        new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()),
+        new RequireAllRolesAuthorizer(Role.ROLE_APPLICANT.toString()),
 
         // Having ROLE_TI authorizes a profile as TI.
         Authorizers.TI.toString(),
-        new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
+        new RequireAllRolesAuthorizer(Role.ROLE_TI.toString()));
   }
 
   // This provider is consumed by play-pac4j to get the app's security configuration.

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -2,6 +2,7 @@ package services.role;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+import auth.Role;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -27,7 +28,7 @@ public final class RoleService {
   }
 
   /**
-   * Get a set of {@link Account}s that have the role {@link auth.Roles#ROLE_CIVIFORM_ADMIN}.
+   * Get a set of {@link Account}s that have the role {@link Role#ROLE_CIVIFORM_ADMIN}.
    *
    * @return an {@link ImmutableSet} of {@link Account}s that are CiviForm admins.
    */
@@ -37,10 +38,10 @@ public final class RoleService {
 
   /**
    * Promotes the set of accounts (identified by email) to the role of {@link
-   * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
-   * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be
-   * program admins. Instead, we return a {@link CiviFormError} listing the admin accounts that
-   * could not be promoted to program admins.
+   * Role#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
+   * Role#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be program
+   * admins. Instead, we return a {@link CiviFormError} listing the admin accounts that could not be
+   * promoted to program admins.
    *
    * @param programId the ID of the {@link models.Program} these accounts administer
    * @param accountEmails a {@link ImmutableSet} of account emails to make program admins

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -12,7 +12,7 @@ import static j2html.TagCreator.text;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.Roles;
+import auth.Role;
 import com.typesafe.config.Config;
 import controllers.routes;
 import featureflags.FeatureFlags;
@@ -177,7 +177,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
   }
 
   private DivTag maybeRenderTiButton(Optional<CiviFormProfile> profile, String userName) {
-    if (profile.isPresent() && profile.get().getRoles().contains(Roles.ROLE_TI.toString())) {
+    if (profile.isPresent() && profile.get().getRoles().contains(Role.ROLE_TI.toString())) {
       String tiDashboardText = "View and Add Clients";
       String tiDashboardLink =
           controllers.ti.routes.TrustedIntermediaryController.dashboard(


### PR DESCRIPTION
### Description

`Roles` represents a single role, so it should be renamed to `Role`.

In some uses like `ImmutableSet<Roles> roles`, this is especially confusing.

