### PR TITLE
ProgramDetails link in Applicant's Ineligible page should point to the program's external link

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -268,6 +268,13 @@ describe('create and edit predicates', () => {
     await applicantQuestions.expectIneligiblePage()
     await validateScreenshot(page, 'ineligible')
 
+    await page.click('text=program details')
+    const popupPromise = page.waitForEvent('popup')
+    const popup = await popupPromise
+    const popupURL = await popup.evaluate('location.href')
+
+    // Verify if the program details page Url ends in "/programs/{program ID}"
+    expect(popupURL).toMatch('https://usa.gov')
     // Return to the screen and fill it out to be eligible.
     await page.goBack()
     await applicantQuestions.answerTextQuestion('eligible')

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -274,7 +274,7 @@ describe('create and edit predicates', () => {
     const popupURL = await popup.evaluate('location.href')
 
     // Verify if the program details page Url to be the external link"
-    expect(popupURL).toMatch('https://usa.gov')
+    expect(popupURL).toMatch('https://www.usa.gov/')
     // Return to the screen and fill it out to be eligible.
     await page.goBack()
     await applicantQuestions.answerTextQuestion('eligible')

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -273,7 +273,7 @@ describe('create and edit predicates', () => {
     const popup = await popupPromise
     const popupURL = await popup.evaluate('location.href')
 
-    // Verify if the program details page Url ends in "/programs/{program ID}"
+    // Verify if the program details page Url to be the external link"
     expect(popupURL).toMatch('https://usa.gov')
     // Return to the screen and fill it out to be eligible.
     await page.goBack()

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -38,6 +38,7 @@ import services.applicant.exception.ProgramBlockNotFoundException;
 import services.applicant.question.FileUploadQuestion;
 import services.cloud.StorageClient;
 import services.program.PathNotInBlockException;
+import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.exceptions.UnsupportedScalarTypeException;
@@ -408,7 +409,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         && !roApplicantProgramService.isBlockEligible(blockId)) {
       CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
       try {
-        String externalLink = programService.getProgramDefinition(programId).externalLink();
+        ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
 
         return supplyAsync(
             () ->
@@ -420,7 +421,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                         applicantName,
                         messagesApi.preferred(request),
                         applicantId,
-                        externalLink)));
+                        programDefinition)));
       } catch (ProgramNotFoundException e) {
         notFound(e.toString());
       }

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -39,6 +39,7 @@ import services.applicant.question.FileUploadQuestion;
 import services.cloud.StorageClient;
 import services.program.PathNotInBlockException;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import services.question.exceptions.UnsupportedScalarTypeException;
 import services.question.types.QuestionType;
 import views.ApplicationBaseView;
@@ -67,6 +68,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   private final FeatureFlags featureFlags;
   private final String baseUrl;
   private final IneligibleBlockView ineligibleBlockView;
+  private final ProgramService programService;
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -83,7 +85,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       Config configuration,
       FeatureFlags featureFlags,
       FileUploadViewStrategy fileUploadViewStrategy,
-      IneligibleBlockView ineligibleBlockView) {
+      IneligibleBlockView ineligibleBlockView,
+      ProgramService programService) {
     this.applicantService = checkNotNull(applicantService);
     this.messagesApi = checkNotNull(messagesApi);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
@@ -96,6 +99,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     this.ineligibleBlockView = checkNotNull(ineligibleBlockView);
     this.editView =
         editViewFactory.create(new ApplicantQuestionRendererFactory(fileUploadViewStrategy));
+    this.programService = checkNotNull(programService);
   }
 
   /**
@@ -403,16 +407,23 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     if (featureFlags.isProgramEligibilityConditionsEnabled(request)
         && !roApplicantProgramService.isBlockEligible(blockId)) {
       CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
-      return supplyAsync(
-          () ->
-              ok(
-                  ineligibleBlockView.render(
-                      request,
-                      submittingProfile,
-                      roApplicantProgramService,
-                      applicantName,
-                      messagesApi.preferred(request),
-                      applicantId)));
+      try {
+        String externalLink = programService.getProgramDefinition(programId).externalLink();
+
+        return supplyAsync(
+            () ->
+                ok(
+                    ineligibleBlockView.render(
+                        request,
+                        submittingProfile,
+                        roApplicantProgramService,
+                        applicantName,
+                        messagesApi.preferred(request),
+                        applicantId,
+                        externalLink)));
+      } catch (ProgramNotFoundException e) {
+        notFound(e.toString());
+      }
     }
 
     Optional<String> nextBlockIdMaybe =

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -27,6 +27,7 @@ import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.exception.ApplicationNotEligibleException;
 import services.applicant.exception.ApplicationOutOfDateException;
 import services.applicant.exception.ApplicationSubmissionException;
+import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import views.applicant.ApplicantProgramSummaryView;
@@ -214,8 +215,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                   Optional<String> applicantName =
                       applicantService.getName(applicantId).toCompletableFuture().join();
                   try {
-                    String externalLink =
-                        programService.getProgramDefinition(programId).externalLink();
+                    ProgramDefinition programDefinition =
+                        programService.getProgramDefinition(programId);
                     return ok(
                         ineligibleBlockView.render(
                             request,
@@ -224,7 +225,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                             applicantName,
                             messagesApi.preferred(request),
                             applicantId,
-                            externalLink));
+                            programDefinition));
                   } catch (ProgramNotFoundException e) {
                     notFound(e.toString());
                   }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -27,7 +27,9 @@ import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.exception.ApplicationNotEligibleException;
 import services.applicant.exception.ApplicationOutOfDateException;
 import services.applicant.exception.ApplicationSubmissionException;
+import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import views.applicant.ApplicantProgramSummaryView;
 import views.applicant.IneligibleBlockView;
 import views.components.ToastMessage;
@@ -47,6 +49,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   private final IneligibleBlockView ineligibleBlockView;
   private final ProfileUtils profileUtils;
   private final FeatureFlags featureFlags;
+  private final ProgramService programService;
 
   @Inject
   public ApplicantProgramReviewController(
@@ -56,7 +59,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
       ApplicantProgramSummaryView summaryView,
       IneligibleBlockView ineligibleBlockView,
       ProfileUtils profileUtils,
-      FeatureFlags featureFlags) {
+      FeatureFlags featureFlags,
+      ProgramService programService) {
     this.applicantService = checkNotNull(applicantService);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
     this.messagesApi = checkNotNull(messagesApi);
@@ -64,6 +68,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
     this.ineligibleBlockView = checkNotNull(ineligibleBlockView);
     this.profileUtils = checkNotNull(profileUtils);
     this.featureFlags = checkNotNull(featureFlags);
+    this.programService = checkNotNull(programService);
   }
 
   public CompletionStage<Result> review(Request request, long applicantId, long programId) {
@@ -209,6 +214,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
                   Optional<String> applicantName =
                       applicantService.getName(applicantId).toCompletableFuture().join();
+                  try{
+                    String externalLink = programService.getProgramDefinition(programId).externalLink();
                   return ok(
                       ineligibleBlockView.render(
                           request,
@@ -216,7 +223,13 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           roApplicantProgramService,
                           applicantName,
                           messagesApi.preferred(request),
-                          applicantId));
+                          applicantId,
+                        externalLink));
+                }
+                catch(ProgramNotFoundException e)
+                {
+                  notFound(e.toString());
+                }
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -27,7 +27,6 @@ import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.exception.ApplicationNotEligibleException;
 import services.applicant.exception.ApplicationOutOfDateException;
 import services.applicant.exception.ApplicationSubmissionException;
-import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import views.applicant.ApplicantProgramSummaryView;
@@ -214,22 +213,21 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
                   Optional<String> applicantName =
                       applicantService.getName(applicantId).toCompletableFuture().join();
-                  try{
-                    String externalLink = programService.getProgramDefinition(programId).externalLink();
-                  return ok(
-                      ineligibleBlockView.render(
-                          request,
-                          submittingProfile,
-                          roApplicantProgramService,
-                          applicantName,
-                          messagesApi.preferred(request),
-                          applicantId,
-                        externalLink));
-                }
-                catch(ProgramNotFoundException e)
-                {
-                  notFound(e.toString());
-                }
+                  try {
+                    String externalLink =
+                        programService.getProgramDefinition(programId).externalLink();
+                    return ok(
+                        ineligibleBlockView.render(
+                            request,
+                            submittingProfile,
+                            roApplicantProgramService,
+                            applicantName,
+                            messagesApi.preferred(request),
+                            applicantId,
+                            externalLink));
+                  } catch (ProgramNotFoundException e) {
+                    notFound(e.toString());
+                  }
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -38,14 +38,20 @@ public final class IneligibleBlockView extends ApplicationBaseView {
       ReadOnlyApplicantProgramService roApplicantProgramService,
       Optional<String> applicantName,
       Messages messages,
-      long applicantId) {
+      long applicantId,
+      String externalLink) {
     long programId = roApplicantProgramService.getProgramId();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
+    // Use external link if it is present else use the default Program details page
+    String programDetailsLink =
+      externalLink.isEmpty()
+        ? routes.ApplicantProgramsController.view(applicantId, programId).url()
+        : externalLink;
     ATag infoLink =
         new LinkElement()
             .setStyles("mb-4", "underline")
             .setText(messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase())
-            .setHref(routes.ApplicantProgramsController.view(applicantId, programId).url())
+            .setHref(programDetailsLink)
             .opensInNewTab()
             .setIcon(Icons.OPEN_IN_NEW, LinkElement.IconPosition.END)
             .asAnchorText()

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -15,6 +15,7 @@ import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import services.MessageKey;
 import services.applicant.ReadOnlyApplicantProgramService;
+import services.program.ProgramDefinition;
 import views.ApplicationBaseView;
 import views.HtmlBundle;
 import views.components.Icons;
@@ -39,14 +40,14 @@ public final class IneligibleBlockView extends ApplicationBaseView {
       Optional<String> applicantName,
       Messages messages,
       long applicantId,
-      String externalLink) {
+      ProgramDefinition programDefinition) {
     long programId = roApplicantProgramService.getProgramId();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
-        externalLink.isEmpty()
+        programDefinition.externalLink().isEmpty()
             ? routes.ApplicantProgramsController.view(applicantId, programId).url()
-            : externalLink;
+            : programDefinition.externalLink();
     ATag infoLink =
         new LinkElement()
             .setStyles("mb-4", "underline")

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -44,9 +44,9 @@ public final class IneligibleBlockView extends ApplicationBaseView {
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
-      externalLink.isEmpty()
-        ? routes.ApplicantProgramsController.view(applicantId, programId).url()
-        : externalLink;
+        externalLink.isEmpty()
+            ? routes.ApplicantProgramsController.view(applicantId, programId).url()
+            : externalLink;
     ATag infoLink =
         new LinkElement()
             .setStyles("mb-4", "underline")


### PR DESCRIPTION
### Description

ProgramDetails link in Applicant's Ineligible page should point to the program's external link.

## Release notes

ProgramDetails link in Applicant's Ineligible page should point to the program's external link.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #4240 
