### PR TITLE
Allow URLs to be blank as part of program creation validation.

### DIFF
--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -314,8 +314,11 @@ public final class ProgramServiceImpl implements ProgramService {
   // Checks whether a URL would work correctly if an href attribute was set to it.
   // That is, it must start with http:// or https:// so that the href link doesn't
   // treat it as relative to the current URL.
+  //
+  // We treat blank links as an exception, so that we can default to the program
+  // details page if a link isn't provided.
   private boolean isValidAbsoluteLink(String url) {
-    return url.startsWith("http://") || url.startsWith("https://");
+    return url.isBlank() || url.startsWith("http://") || url.startsWith("https://");
   }
 
   /**

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -455,7 +455,6 @@ public class ProgramServiceImplTest extends ResetPostgres {
         .containsOnly(
             CiviFormError.of("A public display name for the program is required"),
             CiviFormError.of("A public description for the program is required"),
-            CiviFormError.of("A program link must begin with 'http://' or 'https://'"),
             CiviFormError.of("A program note is required"));
   }
 

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -159,8 +159,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
             CiviFormError.of("A public display name for the program is required"),
             CiviFormError.of("A public description for the program is required"),
             CiviFormError.of("A program URL is required"),
-            CiviFormError.of("A program note is required"),
-            CiviFormError.of("A program link must begin with 'http://' or 'https://'"));
+            CiviFormError.of("A program note is required"));
   }
 
   @Test


### PR DESCRIPTION
### Description

Allows links to be blank, which should automatically send users to the `/programs` page when clicked.


Fixes #4188
