### PR TITLE
Make applicant code async when showing the IneligiblePage from a submit exception

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -418,7 +418,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                         request,
                         submittingProfile,
                         roApplicantProgramService,
-                        applicantName,
                         messagesApi.preferred(request),
                         applicantId,
                         programDefinition)));

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -209,7 +209,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                     ProgramDefinition programDefinition =
                         programService.getProgramDefinition(programId);
 
-                    applicantService
+                    var unusedFuture = applicantService
                         .getReadOnlyApplicantProgramService(applicantId, programId)
                         .toCompletableFuture()
                         .thenCombineAsync(

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -218,15 +218,11 @@ public class ApplicantProgramReviewController extends CiviFormController {
                     ProgramDefinition programDefinition =
                         programService.getProgramDefinition(programId);
 
-                    Optional<String> applicantName =
-                        roApplicantProgramService.getApplicantData().getApplicantName();
-
                     return ok(
                         ineligibleBlockView.render(
                             request,
                             submittingProfile,
                             roApplicantProgramService,
-                            applicantName,
                             messagesApi.preferred(request),
                             applicantId,
                             programDefinition));

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -175,7 +175,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
             .getReadOnlyApplicantProgramService(applicantId, programId)
             .toCompletableFuture();
     return readOnlyApplicantProgramServiceFuture
-        .thenComposeAsync(readOnlyApplicantProgramService -> submitApp.toCompletableFuture())
+        .thenComposeAsync(v -> submitApp.toCompletableFuture())
         .thenApplyAsync(
             application -> {
               Long applicationId = application.id;

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -209,23 +209,24 @@ public class ApplicantProgramReviewController extends CiviFormController {
                     ProgramDefinition programDefinition =
                         programService.getProgramDefinition(programId);
 
-                    var unusedFuture = applicantService
-                        .getReadOnlyApplicantProgramService(applicantId, programId)
-                        .toCompletableFuture()
-                        .thenCombineAsync(
-                            applicantService.getName(applicantId).toCompletableFuture(),
-                            (roApplicantProgramService, applicantName) -> {
-                              return ok(
-                                  ineligibleBlockView.render(
-                                      request,
-                                      submittingProfile,
-                                      roApplicantProgramService,
-                                      applicantName,
-                                      messagesApi.preferred(request),
-                                      applicantId,
-                                      programDefinition));
-                            },
-                            httpExecutionContext.current());
+                    var unusedFuture =
+                        applicantService
+                            .getReadOnlyApplicantProgramService(applicantId, programId)
+                            .toCompletableFuture()
+                            .thenCombineAsync(
+                                applicantService.getName(applicantId).toCompletableFuture(),
+                                (roApplicantProgramService, applicantName) -> {
+                                  return ok(
+                                      ineligibleBlockView.render(
+                                          request,
+                                          submittingProfile,
+                                          roApplicantProgramService,
+                                          applicantName,
+                                          messagesApi.preferred(request),
+                                          applicantId,
+                                          programDefinition));
+                                },
+                                httpExecutionContext.current());
                   } catch (ProgramNotFoundException e) {
                     notFound(e.toString());
                   }

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -37,10 +37,11 @@ public final class IneligibleBlockView extends ApplicationBaseView {
       Request request,
       CiviFormProfile submittingProfile,
       ReadOnlyApplicantProgramService roApplicantProgramService,
-      Optional<String> applicantName,
       Messages messages,
       long applicantId,
       ProgramDefinition programDefinition) {
+    Optional<String> applicantName =
+      roApplicantProgramService.getApplicantData().getApplicantName();
     long programId = roApplicantProgramService.getProgramId();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     // Use external link if it is present else use the default Program details page

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -41,7 +41,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
       long applicantId,
       ProgramDefinition programDefinition) {
     Optional<String> applicantName =
-      roApplicantProgramService.getApplicantData().getApplicantName();
+        roApplicantProgramService.getApplicantData().getApplicantName();
     long programId = roApplicantProgramService.getProgramId();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     // Use external link if it is present else use the default Program details page


### PR DESCRIPTION
### Description

Moved the call to get the ReadOnlyApplicantProgramService towards the beginning, so its available to us later on. 

I also realized I could make the call to get applicantName in the inEligibleBlockView instead of passing it, so I did that as well.

By doing this, we're better following the development standards to implement applicant code asynchronously - https://docs.civiform.us/contributor-guide/developer-guide/development-standards#async-request-handling

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

#3744
