### PR TITLE
Fix logout by passing `id_token_hint` to identity provider.

### DIFF
--- a/server/app/auth/CiviFormProfileData.java
+++ b/server/app/auth/CiviFormProfileData.java
@@ -3,9 +3,13 @@ package auth;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
+import com.nimbusds.jwt.JWT;
+import java.util.Optional;
 import models.Account;
 import models.Applicant;
 import org.pac4j.core.profile.CommonProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import repository.DatabaseExecutionContext;
 
 /**
@@ -16,6 +20,9 @@ import repository.DatabaseExecutionContext;
  * <p>It is wrapped by CiviFormProfile, which is what we should use server-side.
  */
 public class CiviFormProfileData extends CommonProfile {
+  private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileData.class);
+
+  private Optional<JWT> idToken;
 
   public CiviFormProfileData() {
     super();
@@ -24,6 +31,23 @@ public class CiviFormProfileData extends CommonProfile {
   public CiviFormProfileData(Long accountId) {
     this();
     this.setId(accountId.toString());
+    this.idToken = Optional.empty();
+    logger.warn("DEBUG LOGOUT: CiviFormProfileData 1 param constructor");
+  }
+
+  public CiviFormProfileData(Long accountId, JWT idToken) {
+    this();
+    this.setId(accountId.toString());
+    this.idToken = Optional.of(idToken);
+    logger.warn("DEBUG LOGOUT: CiviFormProfileData 2 param constructor. idToken = {}", idToken);
+  }
+
+  public Optional<JWT> getIdToken() {
+    return idToken;
+  }
+
+  public void setIdToken(JWT idToken) {
+    this.idToken = Optional.of(idToken);
   }
 
   /**

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -1,15 +1,21 @@
 package auth;
 
+import com.nimbusds.jwt.JWT;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import javax.inject.Provider;
 import models.Account;
 import models.Applicant;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.UserProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
 /** Helper class for common {@code UserProfile} merging logic. */
 public final class CiviFormProfileMerger {
+
+  private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileMerger.class);
 
   private final ProfileFactory profileFactory;
   private final Provider<UserRepository> applicantRepositoryProvider;
@@ -30,20 +36,33 @@ public final class CiviFormProfileMerger {
    * @param mergeFunction a function that merges an external profile into a Civiform profile, or
    *     provides one if it doesn't exist
    */
-  public <T> Optional<UserProfile> mergeProfiles(
+  public <T extends CommonProfile> Optional<UserProfile> mergeProfiles(
       Optional<Applicant> applicantInDatabase,
       Optional<CiviFormProfile> guestProfile,
+      Optional<JWT> idToken,
       T authProviderProfile,
       BiFunction<Optional<CiviFormProfile>, T, UserProfile> mergeFunction) {
 
+    logger.warn("DEBUG LOGOUT: mergeProfiles 1");
+
     if (applicantInDatabase.isPresent()) {
+      logger.warn("DEBUG LOGOUT: mergeProfiles 2");
       if (guestProfile.isEmpty()) {
+        logger.warn("DEBUG LOGOUT: mergeProfiles 3");
         // Easy merge case - we have an existing applicant, but no guest profile.
         // This will be the most common.
         guestProfile = Optional.of(profileFactory.wrap(applicantInDatabase.get()));
       } else {
+        logger.warn("DEBUG LOGOUT: mergeProfiles 4");
         // Merge the two applicants and prefer the newer one.
         guestProfile = Optional.of(mergeProfiles(applicantInDatabase.get(), guestProfile.get()));
+      }
+
+      logger.warn("DEBUG LOGOUT: mergeProfiles 5");
+
+      if (idToken.isPresent()) {
+        logger.warn("DEBUG LOGOUT: mergeProfiles 6");
+        guestProfile.get().getProfileData().setIdToken(idToken.get());
       }
     }
 

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -2,33 +2,40 @@ package auth.oidc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
+import com.nimbusds.jwt.JWT;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import com.typesafe.config.Config;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.util.generator.ValueGenerator;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
+import org.pac4j.oidc.profile.OidcProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Custom OidcLogoutActionBuilder for CiviFormProfileData (since it extends CommonProfile, not
  * OidcProfile). Also allows for divergence from the [oidc
  * spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) if your provider requires it
  * (e.g. Auth0).
- *
- * <p>Does not provide the recommended id_token_hint, since these are not stored by the civiform
- * profile.
  *
  * <p>Uses the post_logout_redirect_uri parameter by default, but allows overriding to a different
  * value using the auth.oidc_post_logout_param config variable
@@ -38,12 +45,19 @@ import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
  */
 public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuilder {
 
+  private static final Logger logger =
+      LoggerFactory.getLogger(CiviformOidcLogoutActionBuilder.class);
+
   private String postLogoutRedirectParam;
-  private ImmutableMap<String, String> extraParams;
+  private Map<String, String> extraParams;
+  private final ProfileFactory profileFactory;
   private Optional<ValueGenerator> stateGenerator = Optional.empty();
 
   public CiviformOidcLogoutActionBuilder(
-      Config civiformConfiguration, OidcConfiguration oidcConfiguration, String clientID) {
+      Config civiformConfiguration,
+      OidcConfiguration oidcConfiguration,
+      ProfileFactory profileFactory,
+      String clientID) {
     super(oidcConfiguration);
     checkNotNull(civiformConfiguration);
     // Use `post_logout_redirect_uri` by default according OIDC spec.
@@ -53,10 +67,11 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     Optional<String> clientIdParam =
         getConfigurationValue(civiformConfiguration, "auth.oidc_logout_client_id_param");
 
+    this.profileFactory = checkNotNull(profileFactory);
+    this.extraParams = new HashMap<>();
+
     if (clientIdParam.isPresent()) {
-      this.extraParams = ImmutableMap.of(clientIdParam.get(), clientID);
-    } else {
-      this.extraParams = ImmutableMap.of();
+      this.extraParams.put(clientIdParam.get(), clientID);
     }
   }
 
@@ -111,27 +126,58 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
   @Override
   public Optional<RedirectionAction> getLogoutAction(
       WebContext context, SessionStore sessionStore, UserProfile currentProfile, String targetUrl) {
+    ProfileUtils profileUtils = new ProfileUtils(sessionStore, profileFactory);
+
+    // This is returning Optional.empty
+    Optional<CiviFormProfile> civiFormProfile = profileUtils.currentUserProfile(context);
+    ProfileManager profileManager = new ProfileManager(context, sessionStore);
+    Optional<OidcProfile> oidcProfile = profileManager.getProfile(OidcProfile.class);
+    logger.warn("DEBUG LOGOUT: getLogoutAction 1, oidcProfile = {}", oidcProfile);
+
+    // CiviFormProfileData civiFormProfileData = (CiviFormProfileData) currentProfile;
+    // final Optional<JWT> idTokenNew = civiFormProfileData.getIdToken();
+
+    // logger.warn("DEBUG LOGOUT: getLogoutAction 1.1, idTokenNew= {}", idTokenNew);
+    //
+    // idTokenNew.ifPresent(idToken -> extraParams.put("id_token_hint", idToken.serialize()));
+
+    if (civiFormProfile.isPresent()
+        && civiFormProfile.get().getProfileData().getIdToken().isPresent()) {
+      logger.warn("DEBUG LOGOUT: getLogoutAction 2");
+      JWT idToken = civiFormProfile.get().getProfileData().getIdToken().get();
+      logger.warn("DEBUG LOGOUT: getLogoutAction 3, idToken={}", idToken.serialize());
+      extraParams.put("id_token_hint", idToken.serialize());
+    } else {
+      logger.warn(
+          "DEBUG LOGOUT: getLogoutAction 3.1, profile present={}", civiFormProfile.isPresent());
+    }
+
     String logoutUrl = configuration.findLogoutUrl();
     if (CommonHelper.isNotBlank(logoutUrl) && currentProfile instanceof CiviFormProfileData) {
+      logger.warn("DEBUG LOGOUT: getLogoutAction 4");
       try {
         URI endSessionEndpoint = new URI(logoutUrl);
         // Optional state param for logout is only needed by certain OIDC providers.
         State state = null;
         if (getStateGenerator().isPresent()) {
+          logger.warn("DEBUG LOGOUT: getLogoutAction 5");
           state = new State(getStateGenerator().get().generateValue(context, sessionStore));
         }
 
+        logger.warn("DEBUG LOGOUT: getLogoutAction 6, extraParams={}", extraParams);
         LogoutRequest logoutRequest =
             new CustomOidcLogoutRequest(
                 endSessionEndpoint,
                 postLogoutRedirectParam,
                 new URI(targetUrl),
-                extraParams,
+                ImmutableMap.copyOf(extraParams),
                 state);
 
+        logger.warn("DEBUG LOGOUT: getLogoutAction 7");
         return Optional.of(
             HttpActionHelper.buildRedirectUrlAction(context, logoutRequest.toURI().toString()));
       } catch (URISyntaxException e) {
+        logger.warn("DEBUG LOGOUT: getLogoutAction 8");
         throw new TechnicalException(e);
       }
     }

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -218,7 +218,8 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
     client.setProfileCreator(getProfileCreator(config, client));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setLogoutActionBuilder(
-        new CiviformOidcLogoutActionBuilder(civiformConfig, config, config.getClientId()));
+        new CiviformOidcLogoutActionBuilder(
+            civiformConfig, config, profileFactory, config.getClientId()));
 
     try {
       client.init();

--- a/server/app/auth/saml/SamlProfileCreator.java
+++ b/server/app/auth/saml/SamlProfileCreator.java
@@ -79,7 +79,11 @@ public class SamlProfileCreator extends AuthenticatorProfileCreator {
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> guestProfile = profileUtils.currentUserProfile(context);
     return civiFormProfileMerger.mergeProfiles(
-        existingApplicant, guestProfile, profile, this::mergeCiviFormProfile);
+        existingApplicant,
+        guestProfile,
+        /* idToken = */ Optional.empty(),
+        profile,
+        this::mergeCiviFormProfile);
   }
 
   @VisibleForTesting

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -74,6 +74,7 @@ public class CiviFormProfileMergerTest {
         civiFormProfileMerger.mergeProfiles(
             /* applicantInDatabase = */ Optional.empty(),
             /* guestProfile = */ Optional.empty(),
+            /* idToken = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
@@ -89,6 +90,7 @@ public class CiviFormProfileMergerTest {
         civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
             /* guestProfile = */ Optional.empty(),
+            /* idToken = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -105,6 +107,7 @@ public class CiviFormProfileMergerTest {
         civiFormProfileMerger.mergeProfiles(
             /* applicantInDatabase = */ Optional.empty(),
             Optional.of(civiFormProfile),
+            /* idToken = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -121,6 +124,7 @@ public class CiviFormProfileMergerTest {
         civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
             Optional.of(civiFormProfile),
+            /* idToken = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();

--- a/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
+++ b/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
@@ -31,11 +31,11 @@ public class CustomOidcLogoutRequestTest {
             new URI("https://auth.com/logout"),
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
-            /* extraParams= */ ImmutableMap.of("clientId", "12345"),
+            /* extraParams= */ ImmutableMap.of("clientId", "12345", "id_token_hint", "MyIdToken"),
             /* state= */ null);
     assertThat(request.toURI().toString())
         .isEqualTo(
-            "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&clientId=12345");
+            "https://auth.com/logout?clientId=12345&post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&id_token_hint=MyIdToken");
   }
 
   @Test


### PR DESCRIPTION
### Description

As per #3863, logout is not working for some identity providers since we do not pass [`id_token_hint`](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) as per the OpenID connect spec.

This PR fixes that by adding the ID Token (as a JWT) into the `CiviFormProfileData` class, and putting it in the `extraParams` in the `CiviformOidcLogoutActionBuilder`.

### Issue(s) this completes

#3863
