### PR TITLE
Add translations for login title

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -115,6 +115,7 @@ public enum MessageKey {
   TITLE_APPLICATION_NOT_ELIGIBLE("title.applicantNotEligible"),
   TITLE_APPLICATION_NOT_ELIGIBLE_TI("title.applicantNotEligibleTi"),
   TITLE_CREATE_AN_ACCOUNT("title.createAnAccount"),
+  TITLE_LOGIN("title.login"),
   TITLE_PROGRAMS("title.programs"),
   TITLE_PROGRAMS_ACTIVE_UPDATED("title.activeProgramsUpdated"),
   TITLE_PROGRAMS_IN_PROGRESS_UPDATED("title.inProgressProgramsUpdated"),

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -70,7 +70,7 @@ public class LoginForm extends BaseHtmlView {
   }
 
   public Content render(Http.Request request, Messages messages, Optional<String> message) {
-    String title = "Login";
+    String title = messages.at(MessageKey.TITLE_LOGIN.getKeyName());
 
     HtmlBundle htmlBundle = this.layout.getBundle().setTitle(title);
     htmlBundle.addMainContent(mainContent(request, messages));

--- a/server/conf/messages
+++ b/server/conf/messages
@@ -55,6 +55,9 @@ content.mobileFileUploadHelp=On your phone? “Choose File” also allows you to
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Login
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Please log in with your {0} account
 

--- a/server/conf/messages.am
+++ b/server/conf/messages.am
@@ -47,6 +47,9 @@ content.mobileFileUploadHelp=በእርስዎ ስልክ ላይ? እንዲሁም �
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=ግባ
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=እባክዎ በ{0} መለያዎ ይግቡ
 

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -52,6 +52,9 @@ content.mobileFileUploadHelp=On your phone? “Choose File” also allows you to
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Login
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Please log in with your {0} account
 

--- a/server/conf/messages.es-US
+++ b/server/conf/messages.es-US
@@ -50,6 +50,9 @@ content.mobileFileUploadHelp=¿Estás usando el teléfono? "Elegir archivo" tamb
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Acceso
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Accede con tu cuenta {0}
 

--- a/server/conf/messages.ko
+++ b/server/conf/messages.ko
@@ -48,6 +48,9 @@ content.mobileFileUploadHelp=휴대전화를 사용 중이신가요? '파일 선
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=로그인
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt={0} 계정으로 로그인하세요.
 

--- a/server/conf/messages.so
+++ b/server/conf/messages.so
@@ -41,6 +41,9 @@ content.mobileFileUploadHelp=Telefoonkaaga? “Choose File” sidoo kale waxuu k
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Soo gal
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Fadlan ku gal akoonkaaga Magaalada {0}
 

--- a/server/conf/messages.tl
+++ b/server/conf/messages.tl
@@ -47,6 +47,9 @@ content.mobileFileUploadHelp=Ginagamit ang iyong telepono? Binibigyang-daan ka r
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Mag log in
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Maari lamang maglog-in gamit ang inyong account sa Lungsod ng {0}
 

--- a/server/conf/messages.vi
+++ b/server/conf/messages.vi
@@ -47,6 +47,9 @@ content.mobileFileUploadHelp=Trên điện thoại của bạn? Tính năng "Ch�
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=Đăng nhập
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Vui lòng đăng nhập bằng tài khoản {0} của bạn
 

--- a/server/conf/messages.zh-TW
+++ b/server/conf/messages.zh-TW
@@ -47,6 +47,9 @@ content.mobileFileUploadHelp=如果您是使用手機操作，還可以透過「
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
+# Title of the login page.
+title.login=登錄
+
 # Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=請使用「{0}」帳戶登入
 


### PR DESCRIPTION
### Description

Adds translations for the "Login" page title. References them with a new `MessageKey` `TITLE_LOGIN`.

I used a free language translation service since the translation is trivial.

### Issue(s) this completes

First step towards #3548 - based on [Mikita's comment](https://github.com/civiform/civiform/issues/3548#issuecomment-1264087589) we should also detect users' preferred language so that we can actually localize the login page *before* they log in and select a language.