### PR TITLE
Enable new background job processing system

### DIFF
--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -19,9 +19,6 @@ import scala.concurrent.ExecutionContext;
 /**
  * Configures {@link durablejobs.DurableJob}s with their {@link DurableJobName} and, if they are
  * recurring, their {@link durablejobs.RecurringJobExecutionTimeResolver}.
- *
- * <p>NOTE: THIS SYSTEM IS STILL UNDER DEVELOPMENT AND THIS MODULE IS NOT CURRENTLY ENABLED IN
- * application.conf TODO(https://github.com/civiform/civiform/issues/4191): Enable DurableJobModule
  */
 public final class DurableJobModule extends AbstractModule {
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -225,6 +225,7 @@ play.modules {
   enabled += modules.MainModule
   enabled += modules.DatabaseSeedModule
   enabled += modules.ProgramCreationModule
+  enabled += modules.DurableJobModule
 
   # If there are any built-in modules that you want to disable, you can list them here.
   #disabled += ""


### PR DESCRIPTION
### Description

Add DurableJobModule to the list of enabled modules, which will cause the server to poll for scheduled jobs and run them.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4191