### PR TITLE
Error notification emails for durable jobs

### DIFF
--- a/server/app/models/PersistedDurableJob.java
+++ b/server/app/models/PersistedDurableJob.java
@@ -46,6 +46,10 @@ public final class PersistedDurableJob extends BaseModel {
     return executionTime;
   }
 
+  public boolean hasFailedWithNoRemainingAttempts() {
+    return successTime == null && remainingAttempts == 0;
+  }
+
   public Optional<Instant> getSuccessTime() {
     return Optional.ofNullable(successTime);
   }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -197,6 +197,12 @@ measurement_id = ${?MEASUREMENT_ID}
 support_email_address = "CiviForm@seattle.gov"
 support_email_address = ${?SUPPORT_EMAIL_ADDRESS}
 
+## IT Email Address
+# This email address receives error notifications from CiviForm when things break
+it_email_address = "CiviForm@seattle.gov"
+it_email_address = ${?SUPPORT_EMAIL_ADDRESS}
+it_email_address = ${?IT_EMAIL_ADDRESS}
+
 staging_program_admin_notification_mailing_list = "seattle-civiform-program-admins-notify@google.com"
 staging_program_admin_notification_mailing_list = ${?STAGING_ADMIN_LIST}
 staging_ti_notification_mailing_list = "seattle-civiform-trusted-intermediaries-notify@google.com"

--- a/server/test/models/PersistedDurableJobTest.java
+++ b/server/test/models/PersistedDurableJobTest.java
@@ -35,4 +35,15 @@ public class PersistedDurableJobTest extends ResetPostgres {
     job.decrementRemainingAttempts();
     assertThat(job.getRemainingAttempts()).isEqualTo(2);
   }
+
+  @Test
+  public void hasFailedWithNoRemainingAttempts() {
+    var job = new PersistedDurableJob("fake-job-name", Instant.ofEpochMilli(1000));
+
+    assertThat(job.hasFailedWithNoRemainingAttempts()).isFalse();
+    job.decrementRemainingAttempts().decrementRemainingAttempts().decrementRemainingAttempts();
+    assertThat(job.hasFailedWithNoRemainingAttempts()).isTrue();
+    job.setSuccessTime(Instant.now());
+    assertThat(job.hasFailedWithNoRemainingAttempts()).isFalse();
+  }
 }


### PR DESCRIPTION
### Description

Sends an email to the support staff email address or IT staff email address when durable jobs fail with no attempts remaining.

Introduces a new config var `IT_EMAIL_ADDRESS`. If set, error notifications will go there. If unset, error notifications will go to `SUPPORT_EMAIL_ADDRESS`.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes [#3899](https://github.com/civiform/civiform/issues/3899)