### PR TITLE
Wrap english text on translations page

### DIFF
--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.each;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.p;
-import static j2html.TagCreator.pre;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.DomContent;
@@ -114,7 +113,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
                 .withClasses("px-2", "py-1", "text-sm", "bg-gray-100")
                 .with(
                     p("English text:").withClass("font-medium"),
-                    pre(localizedStrings.getDefault()).withClasses("font-sans")));
+                    p(localizedStrings.getDefault()).withClasses("font-sans")));
   }
 
   /** Creates a fieldset wrapping several form fields to be rendered. */


### PR DESCRIPTION
### Description

Change `pre` tag to `p` tag to allow text to wrap within div.


before
![Screenshot 2023-02-23 at 3 01 15 PM](https://user-images.githubusercontent.com/24319951/221063524-c25b5287-60e3-45f4-a53d-2988372483f6.png)

after
![Screenshot 2023-02-23 at 3 00 33 PM](https://user-images.githubusercontent.com/24319951/221063568-8a00cfcb-55a8-4541-a061-a80cfd1c56dd.png)

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4233
