### PR TITLE
Add version ref to autoassign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign
+      - uses: toshimaru/auto-author-assign@1.6.2


### PR DESCRIPTION
### Description

Github doesn't recognize `uses` directive as an action without the `@[version number]` portion

