### PR TITLE
Rename auth classes

### DIFF
--- a/server/app/auth/AuthIdentityProviderName.java
+++ b/server/app/auth/AuthIdentityProviderName.java
@@ -14,7 +14,7 @@ public enum AuthIdentityProviderName {
   AUTH0_APPLICANT("auth0"),
   DISABLED_APPLICANT("disabled");
 
-  public static String AUTH_APPLICANT_CONFIG_PATH = "auth.applicant_idp";
+  public static final String AUTH_APPLICANT_CONFIG_PATH = "auth.applicant_idp";
 
   private final String authIdentityProviderNameString;
 

--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -49,8 +49,7 @@ public class CiviFormProfile {
         .thenApplyAsync(
             (a) ->
                 a.getApplicants().stream()
-                    .sorted(Comparator.comparing(Applicant::getWhenCreated))
-                    .findFirst()
+                    .min(Comparator.comparing(Applicant::getWhenCreated))
                     .orElseThrow(),
             httpContext.current());
   }

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -32,14 +32,14 @@ import repository.UserRepository;
  * - pac4j doesn't come with it. It's abstract because AD and IDCS need slightly different
  * implementations of the two abstract methods.
  */
-public abstract class OidcProfileAdapter extends OidcProfileCreator {
+public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
-  private static final Logger logger = LoggerFactory.getLogger(OidcProfileAdapter.class);
+  private static final Logger logger = LoggerFactory.getLogger(CiviformOidcProfileCreator.class);
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
   protected final CiviFormProfileMerger civiFormProfileMerger;
 
-  public OidcProfileAdapter(
+  public CiviformOidcProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
@@ -69,7 +69,7 @@ public abstract class OidcProfileAdapter extends OidcProfileCreator {
     return Optional.empty();
   }
 
-  protected final Optional<String> getAuthorityId(OidcProfile oidcProfile) {
+  private Optional<String> getAuthorityId(OidcProfile oidcProfile) {
     // In OIDC the user is uniquely identified by the iss(user) and sub(ject)
     // claims.
     // https://openid.net/specs/openid-connect-core-1_0.html#IDToken

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -23,18 +23,18 @@ import repository.UserRepository;
 
 /**
  * This class provides the base applicant OIDC implementation. It's abstract because AD and other
- * providers need slightly different implementations and profile adaptors, and use different config
+ * providers need slightly different implementations and profile creators, and use different config
  * values.
  */
-public abstract class OidcProvider implements Provider<OidcClient> {
+public abstract class OidcClientProvider implements Provider<OidcClient> {
 
-  private static final Logger logger = LoggerFactory.getLogger(OidcProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(OidcClientProvider.class);
   protected final Config civiformConfig;
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
   protected final String baseUrl;
 
-  public OidcProvider(
+  public OidcClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -58,9 +58,9 @@ public abstract class OidcProvider implements Provider<OidcClient> {
   protected abstract Optional<String> getProviderName();
 
   /*
-   * Provide the profile adaptor that should be used.
+   * Provide the profile creator that should be used.
    */
-  public abstract ProfileCreator getProfileAdapter(OidcConfiguration config, OidcClient client);
+  public abstract ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client);
 
   /*
    * The OIDC Client ID.
@@ -215,7 +215,7 @@ public abstract class OidcProvider implements Provider<OidcClient> {
       client.setName(providerName.get());
     }
     client.setCallbackUrl(callbackURL);
-    client.setProfileCreator(getProfileAdapter(config, client));
+    client.setProfileCreator(getProfileCreator(config, client));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setLogoutActionBuilder(
         new CiviformOidcLogoutActionBuilder(civiformConfig, config, config.getClientId()));

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -14,7 +14,7 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import repository.UserRepository;
 
 /** Provider class for the AD OIDC Client. */
-public class AdfsProvider implements Provider<OidcClient> {
+public class AdfsClientProvider implements Provider<OidcClient> {
 
   private final Config configuration;
   private final String baseUrl;
@@ -22,7 +22,7 @@ public class AdfsProvider implements Provider<OidcClient> {
   private final Provider<UserRepository> applicantRepositoryProvider;
 
   @Inject
-  public AdfsProvider(
+  public AdfsClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -82,7 +82,7 @@ public class AdfsProvider implements Provider<OidcClient> {
     // of a profile for different identity profiles we have different creators.
     // This is what links the user to the stuff they have access to.
     client.setProfileCreator(
-        new AdfsProfileAdapter(
+        new AdfsProfileCreator(
             config, client, profileFactory, configuration, applicantRepositoryProvider));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.init();

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -3,7 +3,7 @@ package auth.oidc.admin;
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
 import auth.Role;
-import auth.oidc.OidcProfileAdapter;
+import auth.oidc.CiviformOidcProfileCreator;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import java.util.List;
@@ -21,13 +21,13 @@ import repository.UserRepository;
  * profile. Right now this is only extracting the email address, since that is all that AD provides
  * right now.
  */
-public class AdfsProfileAdapter extends OidcProfileAdapter {
-  private static final Logger logger = LoggerFactory.getLogger(AdfsProfileAdapter.class);
+public class AdfsProfileCreator extends CiviformOidcProfileCreator {
+  private static final Logger logger = LoggerFactory.getLogger(AdfsProfileCreator.class);
 
   private final String adminGroupName;
   private final String ad_groups_attribute_name;
 
-  public AdfsProfileAdapter(
+  public AdfsProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -4,7 +4,7 @@ import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.Role;
-import auth.oidc.OidcProfileAdapter;
+import auth.oidc.CiviformOidcProfileCreator;
 import com.beust.jcommander.internal.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -28,7 +28,7 @@ import repository.UserRepository;
  * - pac4j doesn't come with it. It's abstract because AD and IDCS need slightly different
  * implementations of the two abstract methods.
  */
-public abstract class OidcApplicantProfileAdapter extends OidcProfileAdapter {
+public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator {
 
   @VisibleForTesting public final String emailAttributeName;
 
@@ -36,7 +36,7 @@ public abstract class OidcApplicantProfileAdapter extends OidcProfileAdapter {
 
   @VisibleForTesting public final ImmutableList<String> nameAttributeNames;
 
-  public OidcApplicantProfileAdapter(
+  public ApplicantProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
@@ -50,7 +50,7 @@ public abstract class OidcApplicantProfileAdapter extends OidcProfileAdapter {
     this.nameAttributeNames = Preconditions.checkNotNull(nameAttributeNames);
   }
 
-  private final Optional<String> getName(OidcProfile oidcProfile) {
+  private Optional<String> getName(OidcProfile oidcProfile) {
     String name =
         nameAttributeNames.stream()
             .filter(s -> !s.isBlank())
@@ -61,7 +61,7 @@ public abstract class OidcApplicantProfileAdapter extends OidcProfileAdapter {
     return Optional.ofNullable(Strings.emptyToNull(name));
   }
 
-  private final Optional<String> getLocale(OidcProfile oidcProfile) {
+  private Optional<String> getLocale(OidcProfile oidcProfile) {
     return localeAttributeName
         .filter(s -> !s.isBlank())
         .map(name -> oidcProfile.getAttribute(name, String.class))

--- a/server/app/auth/oidc/applicant/Auth0ClientProvider.java
+++ b/server/app/auth/oidc/applicant/Auth0ClientProvider.java
@@ -19,10 +19,10 @@ import repository.UserRepository;
  *
  * <p>https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
  */
-public class Auth0Provider extends GenericOidcProvider {
+public class Auth0ClientProvider extends GenericOidcClientProvider {
 
   @Inject
-  public Auth0Provider(
+  public Auth0ClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {

--- a/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
@@ -12,8 +12,8 @@ import repository.UserRepository;
  * profile. Right now this is only extracting the email address, since that is all that AD provides
  * right now.
  */
-public class GenericOidcProfileAdapter extends OidcApplicantProfileAdapter {
-  public GenericOidcProfileAdapter(
+public class GenericApplicantProfileCreator extends ApplicantProfileCreator {
+  public GenericApplicantProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import auth.ProfileFactory;
-import auth.oidc.OidcProvider;
+import auth.oidc.OidcClientProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -13,7 +13,7 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import repository.UserRepository;
 
-public class GenericOidcProvider extends OidcProvider {
+public class GenericOidcClientProvider extends OidcClientProvider {
 
   private static final String ATTRIBUTE_PREFIX = "applicant_generic_oidc";
   private static final ImmutableList<String> DEFAULT_SCOPES =
@@ -34,7 +34,7 @@ public class GenericOidcProvider extends OidcProvider {
   private static final String LOCALE_ATTRIBUTE_CONFIG_NAME = "locale_attribute";
 
   @Inject
-  public GenericOidcProvider(
+  public GenericOidcClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -53,7 +53,7 @@ public class GenericOidcProvider extends OidcProvider {
   }
 
   @Override
-  public ProfileCreator getProfileAdapter(OidcConfiguration config, OidcClient client) {
+  public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
     String emailAttr = getConfigurationValueOrThrow(EMAIL_ATTRIBUTE_CONFIG_NAME);
     Optional<String> localeAttr = getConfigurationValue(LOCALE_ATTRIBUTE_CONFIG_NAME);
 
@@ -61,7 +61,7 @@ public class GenericOidcProvider extends OidcProvider {
     getConfigurationValue(FIRST_NAME_ATTRIBUTE_CONFIG_NAME).ifPresent(nameAttrsBuilder::add);
     getConfigurationValue(MIDDLE_NAME_ATTRIBUTE_CONFIG_NAME).ifPresent(nameAttrsBuilder::add);
     getConfigurationValue(LAST_NAME_ATTRIBUTE_CONFIG_NAME).ifPresent(nameAttrsBuilder::add);
-    return new GenericOidcProfileAdapter(
+    return new GenericApplicantProfileCreator(
         config,
         client,
         profileFactory,

--- a/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
@@ -25,14 +25,14 @@ import repository.UserRepository;
  * This class takes an existing CiviForm profile and augments it with the information from an IDCS
  * profile.
  */
-public final class IdcsProfileAdapter extends OidcApplicantProfileAdapter {
-  public static final Logger logger = LoggerFactory.getLogger(IdcsProfileAdapter.class);
+public final class IdcsApplicantProfileCreator extends ApplicantProfileCreator {
+  public static final Logger logger = LoggerFactory.getLogger(IdcsApplicantProfileCreator.class);
 
   private static final String EMAIL_ATTRIBUTE_NAME = "user_emailid";
   private static final String LOCALE_ATTRIBUTE_NAME = "user_locale";
   private static final String NAME_ATTRIBUTE_NAME = "user_displayname";
 
-  public IdcsProfileAdapter(
+  public IdcsApplicantProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import auth.ProfileFactory;
-import auth.oidc.OidcProvider;
+import auth.oidc.OidcClientProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
@@ -13,7 +13,7 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import repository.UserRepository;
 
 /** This class customized the OIDC provider to a specific provider, allowing overrides to be set. */
-public final class IdcsProvider extends OidcProvider {
+public final class IdcsClientProvider extends OidcClientProvider {
 
   private static final String ATTRIBUTE_PREFIX = "idcs";
   private static final String CLIENT_ID_CONFIG_NAME = "client_id";
@@ -24,7 +24,7 @@ public final class IdcsProvider extends OidcProvider {
       ImmutableList.of("openid", "profile", "email");
 
   @Inject
-  public IdcsProvider(
+  public IdcsClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -42,8 +42,9 @@ public final class IdcsProvider extends OidcProvider {
   }
 
   @Override
-  public ProfileCreator getProfileAdapter(OidcConfiguration config, OidcClient client) {
-    return new IdcsProfileAdapter(config, client, profileFactory, applicantRepositoryProvider);
+  public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
+    return new IdcsApplicantProfileCreator(
+        config, client, profileFactory, applicantRepositoryProvider);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -20,12 +20,12 @@ import repository.UserRepository;
 /*
  * Login.gov (https://developers.login.gov/oidc/) OIDC provider using the PKCE method.
  */
-public final class LoginGovProvider extends GenericOidcProvider {
+public final class LoginGovClientProvider extends GenericOidcClientProvider {
   // Login.gov requires a state longer than 22 characters
-  static RandomValueGenerator stateGenerator = new RandomValueGenerator(30);
+  static final RandomValueGenerator stateGenerator = new RandomValueGenerator(30);
 
   @Inject
-  public LoginGovProvider(
+  public LoginGovClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -39,10 +39,10 @@ public final class LoginGovProvider extends GenericOidcProvider {
   }
 
   @Override
-  public ProfileCreator getProfileAdapter(OidcConfiguration config, OidcClient client) {
+  public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
 
     var nameAttrs = ImmutableList.of("given_name", "family_name");
-    return new GenericOidcProfileAdapter(
+    return new GenericApplicantProfileCreator(
         config,
         client,
         profileFactory,

--- a/server/app/auth/saml/LoginRadiusClientProvider.java
+++ b/server/app/auth/saml/LoginRadiusClientProvider.java
@@ -18,9 +18,9 @@ import repository.UserRepository;
 
 // TODO(#3856): Update with a non deprecated saml impl.
 @SuppressWarnings("deprecation")
-public class LoginRadiusProvider implements Provider<SAML2Client> {
+public class LoginRadiusClientProvider implements Provider<SAML2Client> {
 
-  private static final Logger logger = LoggerFactory.getLogger(LoginRadiusProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(LoginRadiusClientProvider.class);
 
   private final Config configuration;
   private final ProfileFactory profileFactory;
@@ -28,7 +28,7 @@ public class LoginRadiusProvider implements Provider<SAML2Client> {
   private final String baseUrl;
 
   @Inject
-  public LoginRadiusProvider(
+  public LoginRadiusClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
       Provider<UserRepository> applicantRepositoryProvider) {
@@ -62,7 +62,7 @@ public class LoginRadiusProvider implements Provider<SAML2Client> {
     SAML2Client client = new SAML2Client(config);
 
     client.setProfileCreator(
-        new SamlProfileAdapter(config, client, profileFactory, applicantRepositoryProvider));
+        new SamlProfileCreator(config, client, profileFactory, applicantRepositoryProvider));
 
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setCallbackUrl(baseUrl + "/callback");

--- a/server/app/auth/saml/SamlProfileCreator.java
+++ b/server/app/auth/saml/SamlProfileCreator.java
@@ -29,20 +29,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
-public class SamlProfileAdapter extends AuthenticatorProfileCreator {
+public class SamlProfileCreator extends AuthenticatorProfileCreator {
 
-  private static final Logger logger = LoggerFactory.getLogger(SamlProfileAdapter.class);
+  private static final Logger logger = LoggerFactory.getLogger(SamlProfileCreator.class);
   protected final CiviFormProfileMerger civiFormProfileMerger;
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
   protected final SAML2Configuration saml2Configuration;
   // TODO(#3856): Update with a non deprecated saml impl.
   @SuppressWarnings("deprecation")
-  protected SAML2Client saml2Client;
+  protected final SAML2Client saml2Client;
 
   // TODO(#3856): Update with a non deprecated saml impl.
   @SuppressWarnings("deprecation")
-  public SamlProfileAdapter(
+  public SamlProfileCreator(
       SAML2Configuration configuration,
       SAML2Client client,
       ProfileFactory profileFactory,

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -15,12 +15,12 @@ import auth.FakeAdminClient;
 import auth.GuestClient;
 import auth.ProfileFactory;
 import auth.Role;
-import auth.oidc.admin.AdfsProvider;
-import auth.oidc.applicant.Auth0Provider;
-import auth.oidc.applicant.GenericOidcProvider;
-import auth.oidc.applicant.IdcsProvider;
-import auth.oidc.applicant.LoginGovProvider;
-import auth.saml.LoginRadiusProvider;
+import auth.oidc.admin.AdfsClientProvider;
+import auth.oidc.applicant.Auth0ClientProvider;
+import auth.oidc.applicant.GenericOidcClientProvider;
+import auth.oidc.applicant.IdcsClientProvider;
+import auth.oidc.applicant.LoginGovClientProvider;
+import auth.saml.LoginRadiusClientProvider;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -127,7 +127,9 @@ public class SecurityModule extends AbstractModule {
   private void bindAdminIdpProvider() {
     // Currently the only supported admin auth provider. As we add other admin auth providers,
     // this can be converted into a switch statement.
-    bind(IndirectClient.class).annotatedWith(AdminAuthClient.class).toProvider(AdfsProvider.class);
+    bind(IndirectClient.class)
+        .annotatedWith(AdminAuthClient.class)
+        .toProvider(AdfsClientProvider.class);
   }
 
   private void bindApplicantIdpProvider(com.typesafe.config.Config config) {
@@ -144,31 +146,31 @@ public class SecurityModule extends AbstractModule {
         case LOGIN_RADIUS_APPLICANT:
           bind(IndirectClient.class)
               .annotatedWith(ApplicantAuthClient.class)
-              .toProvider(LoginRadiusProvider.class);
+              .toProvider(LoginRadiusClientProvider.class);
           logger.info("Using Login Radius for applicant auth provider");
           break;
         case IDCS_APPLICANT:
           bind(IndirectClient.class)
               .annotatedWith(ApplicantAuthClient.class)
-              .toProvider(IdcsProvider.class);
+              .toProvider(IdcsClientProvider.class);
           logger.info("Using IDCS for applicant auth provider");
           break;
         case GENERIC_OIDC_APPLICANT:
           bind(IndirectClient.class)
               .annotatedWith(ApplicantAuthClient.class)
-              .toProvider(GenericOidcProvider.class);
+              .toProvider(GenericOidcClientProvider.class);
           logger.info("Using generic OIDC for applicant auth provider");
           break;
         case LOGIN_GOV_APPLICANT:
           bind(IndirectClient.class)
               .annotatedWith(ApplicantAuthClient.class)
-              .toProvider(LoginGovProvider.class);
+              .toProvider(LoginGovClientProvider.class);
           logger.info("Using login.gov PKCE OIDC for applicant auth provider");
           break;
         case AUTH0_APPLICANT:
           bind(IndirectClient.class)
               .annotatedWith(ApplicantAuthClient.class)
-              .toProvider(Auth0Provider.class);
+              .toProvider(Auth0ClientProvider.class);
           logger.info("Using Auth0 for applicant auth provider");
           break;
         default:

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
-import auth.oidc.applicant.IdcsProfileAdapter;
+import auth.oidc.applicant.IdcsApplicantProfileCreator;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
@@ -20,14 +20,14 @@ import repository.UserRepository;
 import services.applicant.ApplicantData;
 import support.CfTestHelpers;
 
-public class OidcProfileAdapterTest extends ResetPostgres {
+public class CiviformOidcProfileCreatorTest extends ResetPostgres {
   private static final String EMAIL = "foo@bar.com";
   private static final String NAME = "Philip J. Fry";
   private static final String ISSUER = "issuer";
   private static final String SUBJECT = "subject";
   private static final String AUTHORITY_ID = "iss: issuer sub: subject";
 
-  private OidcProfileAdapter oidcProfileAdapter;
+  private CiviformOidcProfileCreator oidcProfileAdapter;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
 
@@ -39,7 +39,7 @@ public class OidcProfileAdapterTest extends ResetPostgres {
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
     oidcProfileAdapter =
-        new IdcsProfileAdapter(
+        new IdcsApplicantProfileCreator(
             client_config,
             client,
             profileFactory,

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -25,7 +25,7 @@ import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
 public class Auth0ProviderTest extends ResetPostgres {
-  private Auth0Provider auth0Provider;
+  private Auth0ClientProvider auth0Provider;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
   private static final String BASE_URL =
@@ -54,7 +54,7 @@ public class Auth0ProviderTest extends ResetPostgres {
 
     // Just need some complete adaptor to access methods.
     auth0Provider =
-        new Auth0Provider(
+        new Auth0ClientProvider(
             config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
   }
 

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -18,7 +18,7 @@ import repository.UserRepository;
 import services.applicant.ApplicantData;
 import support.CfTestHelpers;
 
-public class GenericOidcProfileAdapterTest extends ResetPostgres {
+public class GenericApplicantProfileCreatorTest extends ResetPostgres {
   private static final String ISSUER = "issuer";
   private static final String SUBJECT = "subject";
 
@@ -28,7 +28,7 @@ public class GenericOidcProfileAdapterTest extends ResetPostgres {
   private static final String MIDDLE_NAME_ATTRIBUTE_NAME = "middle_name";
   private static final String LAST_NAME_ATTRIBUTE_NAME = "last_name";
 
-  private GenericOidcProfileAdapter oidcProfileAdapter;
+  private GenericApplicantProfileCreator oidcProfileAdapter;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
 
@@ -40,7 +40,7 @@ public class GenericOidcProfileAdapterTest extends ResetPostgres {
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
     oidcProfileAdapter =
-        new GenericOidcProfileAdapter(
+        new GenericApplicantProfileCreator(
             client_config,
             client,
             profileFactory,

--- a/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
@@ -21,8 +21,8 @@ import repository.UserRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
-public class GenericOidcProviderTest extends ResetPostgres {
-  private GenericOidcProvider genericOidcProvider;
+public class GenericOidcClientProviderTest extends ResetPostgres {
+  private GenericOidcClientProvider genericOidcProvider;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
   private static final String DISCOVERY_URI =
@@ -54,7 +54,7 @@ public class GenericOidcProviderTest extends ResetPostgres {
 
     // Just need some complete adaptor to access methods.
     genericOidcProvider =
-        new GenericOidcProvider(
+        new GenericOidcClientProvider(
             config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
   }
 
@@ -62,10 +62,10 @@ public class GenericOidcProviderTest extends ResetPostgres {
   public void Test_getConfigurationValues() {
     OidcClient client = genericOidcProvider.get();
     OidcConfiguration client_config = client.getConfiguration();
-    ProfileCreator adaptor = genericOidcProvider.getProfileAdapter(client_config, client);
+    ProfileCreator adaptor = genericOidcProvider.getProfileCreator(client_config, client);
 
-    assertThat(adaptor.getClass()).isEqualTo(GenericOidcProfileAdapter.class);
-    GenericOidcProfileAdapter profileAdapter = (GenericOidcProfileAdapter) adaptor;
+    assertThat(adaptor.getClass()).isEqualTo(GenericApplicantProfileCreator.class);
+    GenericApplicantProfileCreator profileAdapter = (GenericApplicantProfileCreator) adaptor;
 
     String provider = genericOidcProvider.getProviderName().orElse("");
     assertThat(provider).isEqualTo("Auth0");

--- a/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
@@ -19,8 +19,8 @@ import repository.UserRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
-public class IdcsProviderTest extends ResetPostgres {
-  private IdcsProvider idcsProvider;
+public class IdcsClientProviderTest extends ResetPostgres {
+  private IdcsClientProvider idcsProvider;
   private ProfileFactory profileFactory;
   private static UserRepository userRepository;
   private static final String DISCOVERY_URI =
@@ -46,7 +46,7 @@ public class IdcsProviderTest extends ResetPostgres {
 
     // Just need some complete adaptor to access methods.
     idcsProvider =
-        new IdcsProvider(
+        new IdcsClientProvider(
             config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
   }
 
@@ -54,7 +54,7 @@ public class IdcsProviderTest extends ResetPostgres {
   public void Test_getConfigurationValues() {
     OidcClient client = idcsProvider.get();
     OidcConfiguration client_config = client.getConfiguration();
-    ProfileCreator adaptor = idcsProvider.getProfileAdapter(client_config, client);
+    ProfileCreator adaptor = idcsProvider.getProfileCreator(client_config, client);
 
     String clientId = idcsProvider.getClientID();
     assertThat(clientId).isEqualTo("idcs-fake-oidc-client");
@@ -71,6 +71,6 @@ public class IdcsProviderTest extends ResetPostgres {
     String callbackUrl = client.getCallbackUrl();
     assertThat(callbackUrl).isEqualTo(BASE_URL + "/callback");
 
-    assertThat(adaptor.getClass()).isEqualTo(IdcsProfileAdapter.class);
+    assertThat(adaptor.getClass()).isEqualTo(IdcsApplicantProfileCreator.class);
   }
 }

--- a/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
@@ -27,8 +27,8 @@ import repository.UserRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
-public class LoginGovProviderTest extends ResetPostgres {
-  private LoginGovProvider loginGovProvider;
+public class LoginGovClientProviderTest extends ResetPostgres {
+  private LoginGovClientProvider loginGovProvider;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
   private static final String BASE_URL =
@@ -54,7 +54,7 @@ public class LoginGovProviderTest extends ResetPostgres {
 
     // Just need some complete adaptor to access methods.
     loginGovProvider =
-        new LoginGovProvider(
+        new LoginGovClientProvider(
             config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
   }
 
@@ -62,7 +62,7 @@ public class LoginGovProviderTest extends ResetPostgres {
   public void testGetConfigurationValues() {
     OidcClient client = loginGovProvider.get();
     OidcConfiguration client_config = client.getConfiguration();
-    ProfileCreator adaptor = loginGovProvider.getProfileAdapter(client_config, client);
+    ProfileCreator adaptor = loginGovProvider.getProfileCreator(client_config, client);
 
     String clientId = loginGovProvider.getClientID();
     assertThat(clientId).isEqualTo(CLIENT_ID);
@@ -79,7 +79,7 @@ public class LoginGovProviderTest extends ResetPostgres {
     String callbackUrl = client.getCallbackUrl();
     assertThat(callbackUrl).isEqualTo(BASE_URL + "/callback");
 
-    assertThat(adaptor.getClass()).isEqualTo(GenericOidcProfileAdapter.class);
+    assertThat(adaptor.getClass()).isEqualTo(GenericApplicantProfileCreator.class);
 
     String provider = loginGovProvider.getProviderName().orElse("");
     assertThat(provider).isEqualTo("LoginGov");


### PR DESCRIPTION
### Description

Many classes in the `auth` package are confusingly named. This PR renames many of them to make it easier to read and understand code in the future.

For example, our `OidcProfileAdapter` extends pac4j's `OidcProfileCreator`, which mainly has a `Optional<UserProfile> create()` method. We should be calling our class `CiviformOidcProfileCreator` to (1) differentiate it from pac4j's and (2) more importantly, continue suggesting that it does in fact create, not adapt, profiles.

Also, implement some trivial fixes in the auth package that IntelliJ suggests

### Issue(s)

Steps towards #4280
