### PR TITLE
Remove `possiblyModifyConfigBasedOnCred` base method

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -134,10 +134,9 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
   }
 
   @Override
-  public final Optional<UserProfile> create(
+  public Optional<UserProfile> create(
       Credentials cred, WebContext context, SessionStore sessionStore) {
     ProfileUtils profileUtils = new ProfileUtils(sessionStore, profileFactory);
-    possiblyModifyConfigBasedOnCred(cred);
     Optional<UserProfile> oidcProfile = super.create(cred, context, sessionStore);
 
     if (oidcProfile.isEmpty()) {
@@ -192,6 +191,4 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
         .toCompletableFuture()
         .join();
   }
-
-  protected abstract void possiblyModifyConfigBasedOnCred(Credentials cred);
 }

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import java.util.List;
 import javax.inject.Provider;
-import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -86,10 +85,5 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
       return profileFactory.wrapProfileData(profileFactory.createNewAdmin());
     }
     return profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin());
-  }
-
-  @Override
-  protected void possiblyModifyConfigBasedOnCred(Credentials cred) {
-    // No need!
   }
 }

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -15,7 +15,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -94,11 +93,6 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
   @Override
   protected final void adaptForRole(CiviFormProfile profile, ImmutableSet<Role> roles) {
     // Not used for applicants.
-  }
-
-  @Override
-  protected void possiblyModifyConfigBasedOnCred(Credentials cred) {
-    // Only used for Idcs.
   }
 
   /** Merge the two provided profiles into a new CiviFormProfileData. */

--- a/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
@@ -12,8 +12,12 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Provider;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
@@ -48,7 +52,13 @@ public final class IdcsApplicantProfileCreator extends ApplicantProfileCreator {
   }
 
   @Override
-  protected void possiblyModifyConfigBasedOnCred(Credentials cred) {
+  public Optional<UserProfile> create(
+      Credentials cred, WebContext context, SessionStore sessionStore) {
+    possiblyModifyConfigBasedOnCred(cred);
+    return super.create(cred, context, sessionStore);
+  }
+
+  private void possiblyModifyConfigBasedOnCred(Credentials cred) {
     // The flow here is not immediately intuitive. IDCS is to blame. :) The normal
     // flow for authenticating a user is "get user's data via POST. Decode it, check
     // that it is signed, and use it." IDCS throws in an extra step here - in order


### PR DESCRIPTION
### Description

Remove `possiblyModifyConfigBasedOnCred` base method on `CiviformOidcProfileCreator`. This only applies to one concrete class, so it should be a helper method of that class.

Relates to #4280.
