### PR TITLE
Fix intake form uniqueness logic to look at active and draft programs.

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -83,10 +83,6 @@ public final class ProgramRepository {
     return names.build();
   }
 
-  public Boolean commonIntakeFormExists() {
-    return database.find(Program.class).where().eq("program_type", "common_intake_form").exists();
-  }
-
   /**
    * Makes {@code existingProgram} the DRAFT revision configuration of the question, creating a new
    * DRAFT if necessary.

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -85,6 +85,11 @@ public final class ActiveAndDraftPrograms {
     return versionedByName.get(name).second();
   }
 
+  public ProgramDefinition getMostRecentProgramDefinition(String name) {
+    Optional<ProgramDefinition> draft = getDraftProgramDefinition(name);
+    return draft.isPresent() ? draft.get() : getActiveProgramDefinition(name).get();
+  }
+
   public boolean anyDraft() {
     return draftPrograms.size() > 0;
   }

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -86,8 +86,7 @@ public final class ActiveAndDraftPrograms {
   }
 
   public ProgramDefinition getMostRecentProgramDefinition(String name) {
-    Optional<ProgramDefinition> draft = getDraftProgramDefinition(name);
-    return draft.isPresent() ? draft.get() : getActiveProgramDefinition(name).get();
+    return getDraftProgramDefinition(name).orElseGet(getActiveProgramDefinition(name)::get);
   }
 
   public boolean anyDraft() {

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -85,10 +85,14 @@ public final class ActiveAndDraftPrograms {
     return versionedByName.get(name).second();
   }
 
+  /** Returns the most recent version of the specified program, which may be active or a draft. */
   public ProgramDefinition getMostRecentProgramDefinition(String name) {
     return getDraftProgramDefinition(name).orElseGet(getActiveProgramDefinition(name)::get);
   }
 
+  /**
+   * Returns the most recent versions of all the programs, which may be a mix of active and draft.
+   */
   public ImmutableList<ProgramDefinition> getMostRecentProgramDefinitions() {
     return getProgramNames().stream()
         .map(this::getMostRecentProgramDefinition)

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -89,6 +89,12 @@ public final class ActiveAndDraftPrograms {
     return getDraftProgramDefinition(name).orElseGet(getActiveProgramDefinition(name)::get);
   }
 
+  public ImmutableList<ProgramDefinition> getMostRecentProgramDefinitions() {
+    return getProgramNames().stream()
+        .map(this::getMostRecentProgramDefinition)
+        .collect(ImmutableList.toImmutableList());
+  }
+
   public boolean anyDraft() {
     return draftPrograms.size() > 0;
   }

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -1173,14 +1173,8 @@ public final class ProgramServiceImpl implements ProgramService {
    * common intake form if it exists. The most recent version may be in the draft or active stage.
    */
   private Optional<ProgramDefinition> getCommonIntakeForm() {
-    ActiveAndDraftPrograms activeAndDraftPrograms = getActiveAndDraftPrograms();
-    for (String name : activeAndDraftPrograms.getProgramNames()) {
-      ProgramDefinition mostRecentVersion =
-          activeAndDraftPrograms.getMostRecentProgramDefinition(name);
-      if (mostRecentVersion.isCommonIntakeForm()) {
-        return Optional.of(mostRecentVersion);
-      }
-    }
-    return Optional.empty();
+    return getActiveAndDraftPrograms().getMostRecentProgramDefinitions().stream()
+        .filter(p -> p.isCommonIntakeForm())
+        .findFirst();
   }
 }

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -195,15 +195,6 @@ public class ProgramRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void commonIntakeFormExists() {
-    resourceCreator.insertActiveProgram("regular program");
-    assertThat(repo.commonIntakeFormExists()).isFalse();
-
-    resourceCreator.insertActiveCommonIntakeForm("common intake form");
-    assertThat(repo.commonIntakeFormExists()).isTrue();
-  }
-
-  @Test
   public void returnsAllAdmins() throws ProgramNotFoundException {
     Program withAdmins = resourceCreator.insertActiveProgram("with admins");
     Account admin = new Account();

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -301,6 +301,14 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
   @Test
   public void createProgram_allowsSettingCommonIntakeFormWhenNoneExists() {
+    // No common intake form in the most recent version of any program, although some programs
+    // were previously marked as common intake.
+    ProgramBuilder.newObsoleteProgram("one")
+        .withProgramType(ProgramType.COMMON_INTAKE_FORM)
+        .build();
+    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
+    ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.DEFAULT).build();
+
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
             "name-one",
@@ -569,8 +577,15 @@ public class ProgramServiceImplTest extends ResetPostgres {
   @Test
   public void updateProgram_allowsSettingProgramAsCommonIntakeFormWhenNoneExists()
       throws Exception {
-    ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
+    // No common intake form in the most recent version of any program, although some programs
+    // were previously marked as common intake.
+    ProgramBuilder.newObsoleteProgram("one")
+        .withProgramType(ProgramType.COMMON_INTAKE_FORM)
+        .build();
+    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
+    ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.DEFAULT).build();
 
+    ProgramDefinition program = ProgramBuilder.newDraftProgram("three").buildDefinition();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateProgramDefinition(
             program.id(),

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -215,6 +215,11 @@ public class ProgramBuilder {
     return this;
   }
 
+  public ProgramBuilder withProgramType(ProgramType programType) {
+    builder.setProgramType(programType);
+    return this;
+  }
+
   /**
    * Creates a {@link BlockBuilder} with this {@link ProgramBuilder} with empty name and
    * description.


### PR DESCRIPTION
### Description

Previously, the uniqueness validation logic for the common intake form looked at all programs. This included obsolete programs and active programs for which there was a draft, however, which meant that you couldn't actually change which program was the common intake form. This change fixes it by only checking for the common intake form among draft programs and active programs that don't have a draft. 

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
