### PR TITLE
Bugfix: Update eligibility definition question versions

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -26,6 +26,7 @@ import models.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import services.program.BlockDefinition;
+import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.predicate.AndNode;
@@ -312,6 +313,16 @@ public final class VersionRepository {
       updatedBlock.setVisibilityPredicate(
           PredicateDefinition.create(
               updatePredicateNodeVersions(oldPredicate.rootNode()), oldPredicate.action()));
+    }
+    if (block.eligibilityDefinition().isPresent()) {
+      EligibilityDefinition eligibilityDefinition = block.eligibilityDefinition().get();
+      PredicateDefinition oldPredicate = eligibilityDefinition.predicate();
+      PredicateDefinition newPredicate =
+          PredicateDefinition.create(
+              updatePredicateNodeVersions(oldPredicate.rootNode()), oldPredicate.action());
+
+      updatedBlock.setEligibilityDefinition(
+          eligibilityDefinition.toBuilder().setPredicate(newPredicate).build());
     }
     if (block.optionalPredicate().isPresent()) {
       PredicateDefinition oldPredicate = block.optionalPredicate().get();

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -15,6 +15,7 @@ import models.Version;
 import org.junit.Before;
 import org.junit.Test;
 import services.applicant.question.Scalar;
+import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.predicate.AndNode;
 import services.program.predicate.LeafAddressServiceAreaExpressionNode;
@@ -377,6 +378,8 @@ public class VersionRepositoryTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(oldTwo)
             .withVisibilityPredicate(predicate)
+            .withEligibilityDefinition(
+                EligibilityDefinition.builder().setPredicate(predicate).build())
             .build();
     program.save();
 
@@ -401,6 +404,17 @@ public class VersionRepositoryTest extends ResetPostgres {
                 .get(1)
                 .visibilityPredicate()
                 .get()
+                .rootNode()
+                .getLeafOperationNode()
+                .questionId())
+        .isEqualTo(newOne.id);
+    assertThat(
+            updated
+                .blockDefinitions()
+                .get(1)
+                .eligibilityDefinition()
+                .get()
+                .predicate()
                 .rootNode()
                 .getLeafOperationNode()
                 .questionId())


### PR DESCRIPTION
### Description

Eligibility definitions need to be updated with latest question IDs for the questions they reference when new question versions are published.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4290