### PR TITLE
Bugfix: editing multi-question predicates

### DIFF
--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -102,8 +102,7 @@ public final class PredicateGenerator {
                           .map(AndNode::create)
                           .map(PredicateExpressionNode::create)
                           .collect(toImmutableList()))),
-              predicateAction,
-              PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS);
+              predicateAction);
         }
 
       case SINGLE_QUESTION:
@@ -112,9 +111,7 @@ public final class PredicateGenerator {
               leafNodes.entries().stream().map(Map.Entry::getValue).findFirst().get();
 
           return PredicateDefinition.create(
-              PredicateExpressionNode.create(singleQuestionNode),
-              predicateAction,
-              PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
+              PredicateExpressionNode.create(singleQuestionNode), predicateAction);
         }
 
       default:

--- a/server/app/views/admin/programs/ProgramBlockBaseView.java
+++ b/server/app/views/admin/programs/ProgramBlockBaseView.java
@@ -47,16 +47,16 @@ abstract class ProgramBlockBaseView extends BaseHtmlView {
     DivTag container = div();
 
     if (predicateDefinition
-        .computePredicateFormat()
+        .predicateFormat()
         .equals(PredicateDefinition.PredicateFormat.SINGLE_QUESTION)) {
       return container.with(
           text(predicateDefinition.toDisplayString(blockName, questionDefinitions)));
     } else if (!predicateDefinition
-        .computePredicateFormat()
+        .predicateFormat()
         .equals(PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS)) {
       throw new IllegalArgumentException(
           String.format(
-              "Predicate type %s is unsupported.", predicateDefinition.computePredicateFormat()));
+              "Predicate type %s is unsupported.", predicateDefinition.predicateFormat()));
     }
 
     ImmutableList<PredicateExpressionNode> andNodes =

--- a/server/app/views/admin/programs/ProgramBlockPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicateConfigureView.java
@@ -342,7 +342,7 @@ public final class ProgramBlockPredicateConfigureView extends ProgramBlockBaseVi
    */
   private static ImmutableList<PredicateExpressionNode> getExistingAndNodes(
       PredicateDefinition existingPredicate) {
-    PredicateDefinition.PredicateFormat format = existingPredicate.computePredicateFormat();
+    PredicateDefinition.PredicateFormat format = existingPredicate.predicateFormat();
     switch (format) {
       case SINGLE_QUESTION:
         {

--- a/server/test/models/ProgramTest.java
+++ b/server/test/models/ProgramTest.java
@@ -218,7 +218,8 @@ public class ProgramTest extends ResetPostgres {
     BlockDefinition block = found.getProgramDefinition().getBlockDefinition(1L);
     assertThat(block.visibilityPredicate()).hasValue(predicate);
     assertThat(block.eligibilityDefinition()).hasValue(eligibilityDefinition);
-    assertThat(block.eligibilityDefinition().get().predicate().predicateFormat()).isEmpty();
+    assertThat(block.eligibilityDefinition().get().predicate().predicateFormat())
+        .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(block.optionalPredicate()).isEmpty();
   }
 

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -366,8 +366,23 @@ public class VersionRepositoryTest extends ResetPostgres {
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
-                LeafOperationExpressionNode.create(
-                    oldOne.id, Scalar.NUMBER, Operator.EQUAL_TO, PredicateValue.of(100))),
+                OrNode.create(
+                    ImmutableList.of(
+                        PredicateExpressionNode.create(
+                            AndNode.create(
+                                ImmutableList.of(
+                                    PredicateExpressionNode.create(
+                                        LeafOperationExpressionNode.create(
+                                            oldOne.id,
+                                            Scalar.NUMBER,
+                                            Operator.EQUAL_TO,
+                                            PredicateValue.of(100))),
+                                    PredicateExpressionNode.create(
+                                        LeafOperationExpressionNode.create(
+                                            oldTwo.id,
+                                            Scalar.NUMBER,
+                                            Operator.GREATER_THAN,
+                                            PredicateValue.of(10))))))))),
             PredicateAction.SHOW_BLOCK);
 
     // Create a program that uses the old questions in blocks and block predicates.
@@ -405,6 +420,16 @@ public class VersionRepositoryTest extends ResetPostgres {
                 .visibilityPredicate()
                 .get()
                 .rootNode()
+                .getOrNode()
+                .children()
+                .stream()
+                .findFirst()
+                .get()
+                .getAndNode()
+                .children()
+                .stream()
+                .findFirst()
+                .get()
                 .getLeafOperationNode()
                 .questionId())
         .isEqualTo(newOne.id);
@@ -416,9 +441,28 @@ public class VersionRepositoryTest extends ResetPostgres {
                 .get()
                 .predicate()
                 .rootNode()
+                .getOrNode()
+                .children()
+                .stream()
+                .findFirst()
+                .get()
+                .getAndNode()
+                .children()
+                .stream()
+                .findFirst()
+                .get()
                 .getLeafOperationNode()
                 .questionId())
         .isEqualTo(newOne.id);
+    assertThat(
+            updated
+                .blockDefinitions()
+                .get(1)
+                .eligibilityDefinition()
+                .get()
+                .predicate()
+                .predicateFormat())
+        .isEqualTo(PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS);
   }
 
   @Test

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -67,7 +67,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
         predicateGenerator.generatePredicateDefinition(
             programDefinition, form, readOnlyQuestionService);
 
-    assertThat(predicateDefinition.predicateFormat().get())
+    assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
@@ -102,7 +102,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
         predicateGenerator.generatePredicateDefinition(
             programDefinition, form, readOnlyQuestionService);
 
-    assertThat(predicateDefinition.predicateFormat().get())
+    assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
@@ -174,7 +174,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
         predicateGenerator.generatePredicateDefinition(
             programDefinition, form, readOnlyQuestionService);
 
-    assertThat(predicateDefinition.predicateFormat().get())
+    assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.SHOW_BLOCK);
     assertThat(predicateDefinition.getQuestions())
@@ -244,7 +244,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
         predicateGenerator.generatePredicateDefinition(
             programDefinition, form, readOnlyQuestionService);
 
-    assertThat(predicateDefinition.predicateFormat().get())
+    assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())

--- a/server/test/views/admin/programs/ProgramBlockBaseViewTest.java
+++ b/server/test/views/admin/programs/ProgramBlockBaseViewTest.java
@@ -80,8 +80,7 @@ public class ProgramBlockBaseViewTest {
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(PredicateValue.of("test@example.com"))
                                             .build()))))))),
-            PredicateAction.HIDE_BLOCK,
-            PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS);
+            PredicateAction.HIDE_BLOCK);
 
     DivTag result =
         new ProgramBlockBaseViewTestChild()
@@ -138,8 +137,7 @@ public class ProgramBlockBaseViewTest {
                                             .setComparedValue(
                                                 PredicateValue.of("other@example.com"))
                                             .build()))))))),
-            PredicateAction.HIDE_BLOCK,
-            PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS);
+            PredicateAction.HIDE_BLOCK);
 
     DivTag result =
         new ProgramBlockBaseViewTestChild()


### PR DESCRIPTION
### Description

Format detection for predicates previously relied on detecting and then persisting in the database a value representing the format. This was involved in the attached bug when the value wasn't copied over to new versions of the predicate when the predicate's question version references are updated.

This bugfix removes the behavior of persisting the format in favor of programmatically detecting the format whenever needed.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4294