### PR TITLE
Use stubbed clock for reporting tests

### DIFF
--- a/server/test/repository/ReportingRepositoryTest.java
+++ b/server/test/repository/ReportingRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
-import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -28,7 +27,7 @@ public class ReportingRepositoryTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    repo = instanceOf(ReportingRepository.class);
+    repo = new ReportingRepository(testClock);
     applicant = resourceCreator.insertApplicantWithAccount();
     programA = ProgramBuilder.newActiveProgram().withName("Fake Program A").build();
     programB = ProgramBuilder.newActiveProgram().withName("Fake Program B").build();
@@ -36,8 +35,8 @@ public class ReportingRepositoryTest extends ResetPostgres {
 
   @Test
   public void monthlyReportingView() {
-    Instant lastMonth = Instant.now().minus(40, ChronoUnit.DAYS);
-    Instant twoMonthsAgo = Instant.now().minus(70, ChronoUnit.DAYS);
+    Instant lastMonth = testClock.instant().minus(40, ChronoUnit.DAYS);
+    Instant twoMonthsAgo = testClock.instant().minus(70, ChronoUnit.DAYS);
 
     ImmutableList.of(
             Triple.of(LifecycleStage.ACTIVE, lastMonth, lastMonth.plusSeconds(100)),
@@ -81,7 +80,7 @@ public class ReportingRepositoryTest extends ResetPostgres {
 
   @Test
   public void loadThisMonthReportingData() {
-    Instant today = Instant.now(instanceOf(Clock.class));
+    Instant today = testClock.instant();
 
     ImmutableList.of(
             Triple.of(LifecycleStage.ACTIVE, today, today.plusSeconds(100)),

--- a/server/test/repository/ResetPostgres.java
+++ b/server/test/repository/ResetPostgres.java
@@ -5,6 +5,9 @@ import static play.test.Helpers.fakeApplication;
 import akka.stream.Materializer;
 import io.ebean.DB;
 import io.ebean.Database;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import models.LifecycleStage;
 import models.Models;
 import models.Version;
@@ -19,6 +22,9 @@ import support.ResourceCreator;
 import support.TestQuestionBank;
 
 public class ResetPostgres {
+
+  protected Clock testClock =
+      Clock.fixed(Instant.parse("2021-01-15T00:00:00.00Z"), ZoneId.systemDefault());
 
   protected static Application app;
 


### PR DESCRIPTION
### Description

The reporting tests used `Instant.now()` as the basis for creating test dates. This caused tests to fail when it got far enough away from the month when the tests were written.