### PR TITLE
Fixes EsriClient to work better with Seattle's find address candidates endpoint

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -206,10 +206,23 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
                 Address candidateAddress =
                     Address.builder()
                         .setStreet(candidateJson.get("address").asText())
-                        .setLine2(attributes.get("SubAddr") == null || attributes.get("SubAddr").isEmpty() ? address.getLine2() : attributes.get("SubAddr").asText())
-                        .setCity(attributes.get("City") == null || attributes.get("City").isEmpty() ? address.getCity() : attributes.get("City").asText())
-                        .setState(attributes.get("RegionAbbr") == null || attributes.get("RegionAbbr").isEmpty() ? address.getState() : attributes.get("RegionAbbr").asText())
-                        .setZip(attributes.get("Postal") == null || attributes.get("Postal").isEmpty() ? address.getZip() : attributes.get("Postal").asText())
+                        .setLine2(
+                            attributes.get("SubAddr") == null || attributes.get("SubAddr").isEmpty()
+                                ? address.getLine2()
+                                : attributes.get("SubAddr").asText())
+                        .setCity(
+                            attributes.get("City") == null || attributes.get("City").isEmpty()
+                                ? address.getCity()
+                                : attributes.get("City").asText())
+                        .setState(
+                            attributes.get("RegionAbbr") == null
+                                    || attributes.get("RegionAbbr").isEmpty()
+                                ? address.getState()
+                                : attributes.get("RegionAbbr").asText())
+                        .setZip(
+                            attributes.get("Postal") == null || attributes.get("Postal").isEmpty()
+                                ? address.getZip()
+                                : attributes.get("Postal").asText())
                         .build();
                 AddressSuggestion addressCandidate =
                     AddressSuggestion.builder()

--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -144,28 +144,14 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
         Optional.ofNullable(addressJson.findPath(AddressField.STATE.getValue()).textValue());
     Optional<String> postal =
         Optional.ofNullable(addressJson.findPath(AddressField.ZIP.getValue()).textValue());
-    String singleLineAddress = "";
-    if (address.isPresent()) {
-      singleLineAddress += address.get();
-    }
 
-    if (address2.isPresent()) {
-      singleLineAddress += " " + address2.get();
-    }
-
-    if (city.isPresent()) {
-      singleLineAddress += " " + city.get();
-    }
-
-    if (region.isPresent()) {
-      singleLineAddress += " " + region.get();
-    }
-
-    if (postal.isPresent()) {
-      singleLineAddress += " " + postal.get();
-    }
-
-    request.addQueryParameter("SingleLine", singleLineAddress);
+    StringBuilder singleLineAddress = new StringBuilder();
+    address.ifPresent(val -> singleLineAddress.append(val));
+    address2.ifPresent(val -> singleLineAddress.append(" " + val));
+    city.ifPresent(val -> singleLineAddress.append(" " + val + " ,"));
+    region.ifPresent(val -> singleLineAddress.append(" " + val));
+    postal.ifPresent(val -> singleLineAddress.append(" " + val));
+    request.addQueryParameter("SingleLine", singleLineAddress.toString());
 
     return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)
         .thenApply(
@@ -220,10 +206,10 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
                 Address candidateAddress =
                     Address.builder()
                         .setStreet(candidateJson.get("address").asText())
-                        .setLine2(attributes.get("SubAddr") == null ? address.getLine2() : attributes.get("SubAddr").asText())
+                        .setLine2(attributes.get("SubAddr") == null || attributes.get("SubAddr").isEmpty() ? address.getLine2() : attributes.get("SubAddr").asText())
                         .setCity(attributes.get("City") == null || attributes.get("City").isEmpty() ? address.getCity() : attributes.get("City").asText())
-                        .setState(attributes.get("RegionAbbr") == null ? address.getState() : attributes.get("RegionAbbr").asText())
-                        .setZip(attributes.get("Postal") == null ? address.getZip() : attributes.get("Postal").asText())
+                        .setState(attributes.get("RegionAbbr") == null || attributes.get("RegionAbbr").isEmpty() ? address.getState() : attributes.get("RegionAbbr").asText())
+                        .setZip(attributes.get("Postal") == null || attributes.get("Postal").isEmpty() ? address.getZip() : attributes.get("Postal").asText())
                         .build();
                 AddressSuggestion addressCandidate =
                     AddressSuggestion.builder()

--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -349,7 +349,7 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
               List<String> features =
                   ctx.read(
                       "features[*].attributes." + esriServiceAreaValidationOption.getAttribute());
-              System.out.println("features = " + features);
+
               for (EsriServiceAreaValidationOption option : optionList) {
                 if (features.contains(option.getId())) {
                   inclusionListBuilder.add(

--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -220,10 +220,10 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
                 Address candidateAddress =
                     Address.builder()
                         .setStreet(candidateJson.get("address").asText())
-                        .setLine2(attributes.get("SubAddr") == null ? "" : attributes.get("SubAddr").asText())
-                        .setCity(attributes.get("City") == null ? "" : attributes.get("City").asText())
-                        .setState(attributes.get("RegionAbbr") == null ? "" : attributes.get("RegionAbbr").asText())
-                        .setZip(attributes.get("Postal") == null ? "" : attributes.get("Postal").asText())
+                        .setLine2(attributes.get("SubAddr") == null ? address.getLine2() : attributes.get("SubAddr").asText())
+                        .setCity(attributes.get("City") == null || attributes.get("City").isEmpty() ? address.getCity() : attributes.get("City").asText())
+                        .setState(attributes.get("RegionAbbr") == null ? address.getState() : attributes.get("RegionAbbr").asText())
+                        .setZip(attributes.get("Postal") == null ? address.getZip() : attributes.get("Postal").asText())
                         .build();
                 AddressSuggestion addressCandidate =
                     AddressSuggestion.builder()
@@ -324,7 +324,6 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
     return fetchServiceAreaFeatures(location, esriServiceAreaValidationOption.getUrl())
         .thenApply(
             (maybeJson) -> {
-              System.out.println("maybeJson = " + maybeJson);
               if (maybeJson.isEmpty()) {
                 logger.error(
                     "EsriClient.fetchServiceAreaFeatures JSON response is empty. Called by"

--- a/server/test/resources/esri/findAddressCandidates.json
+++ b/server/test/resources/esri/findAddressCandidates.json
@@ -5,7 +5,7 @@
   },
   "candidates": [
     {
-      "address": "380 New York St, Redlands, California, 92373",
+      "address": "380 New York St",
       "location": {
         "x": -117.19479001927878,
         "y": 34.057264995787875
@@ -14,7 +14,6 @@
       "attributes": {
         "SubAddr": "",
         "Address": "380 New York St",
-        "City": "Redlands",
         "RegionAbbr": "CA",
         "Postal": "92373"
       },


### PR DESCRIPTION
### Description

Thre's an issue with Seattle's endpoint https://gisrevprxy.seattle.gov/arcgis/rest/services/locators/COS/GeocodeServer/findAddressCandidates does not work with the address parameters like the public endpoint does, despite the documentation saying it does https://gisdata.seattle.gov/server/sdk/rest/index.html#/Find_Address_Candidates/02ss00000015000000/.

So https://gisrevprxy.seattle.gov/arcgis/rest/services/locators/COS/GeocodeServer/findAddressCandidates?outFields=Address, SubAddr, City, RegionAbbr, Postal&f=json&address=609 Westlake Ave N&city=Seattle&region=WA&postal=85716 does not return what https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?outFields=Address, SubAddr, City, RegionAbbr, Postal&f=json&address=609 Westlake Ave N&city=Seattle&region=WA&postal=85716 does.

This updates EsriClient to work with what the endpoint does return (which the standard public endpoint also does).

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
