### PR TITLE
Fixes public Esri findAddressCandidates compatability with civic entity service area validation endpoints

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -256,6 +256,7 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
     request.addQueryParameter("geometryType", "esriGeometryPoint");
     request.addQueryParameter("returnGeometry", "false");
     request.addQueryParameter("outFields", "*");
+    request.addQueryParameter("inSR", location.getWellKnownId().toString());
     String geo = "{'x':";
     geo += location.getLongitude();
     geo += ",'y':";

--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -256,6 +256,7 @@ public class EsriClient implements WSBodyReadables, WSBodyWritables {
     request.addQueryParameter("geometryType", "esriGeometryPoint");
     request.addQueryParameter("returnGeometry", "false");
     request.addQueryParameter("outFields", "*");
+    // "inSR" specifies the spatial reference for the service to use
     request.addQueryParameter("inSR", location.getWellKnownId().toString());
     String geo = "{'x':";
     geo += location.getLongitude();


### PR DESCRIPTION
### Description

This adds the inSR parameter to the call to Esri in `fetchServiceAreaFeatures`, which allows the endpoint to use the coordinates from address suggestions if the well known ID/spatial reference is different than the service's default. In this case the public findAddressCandidates returns 4326 by default and Seattle's service area validation endpoint is 2926 by default.
