### PR TITLE
Adding new container for mock web services

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -58,7 +58,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['formatter', 'localstack', 'browser_test', 'oidc']
+        version:
+          [
+            'formatter',
+            'localstack',
+            'browser_test',
+            'oidc',
+            'mock-web-services',
+          ]
         include:
           - version: formatter
             image: 'civiform/formatter:latest'
@@ -79,6 +86,11 @@ jobs:
             image: 'civiform/oidc-provider:latest'
             script: 'bin/build-dev-oidc'
             file_pattern: 'test-support/'
+            platform: 'linux/amd64,linux/arm64' # build for m1 mac, too
+          - version: mock-web-services
+            image: 'civiform/mock-web-services:latest'
+            script: 'bin/build-mock-web-services'
+            file_pattern: 'esri-mock-service/'
             platform: 'linux/amd64,linux/arm64' # build for m1 mac, too
     concurrency:
       group: build_dependancies-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr_server.yaml
+++ b/.github/workflows/pr_server.yaml
@@ -15,6 +15,7 @@ on:
       - 'bin/**'
       - 'browser-test/**'
       - 'test-support/**'
+      - 'mock-web-services/**'
       - 'Dockerfile'
       - 'prod.Dockerfile'
       - '.github/workflows/**'

--- a/.github/workflows/pr_server_skip.yaml
+++ b/.github/workflows/pr_server_skip.yaml
@@ -14,6 +14,7 @@ on:
       - 'bin/**'
       - 'browser-test/**'
       - 'test-support/**'
+      - 'mock-web-services/**'
       - 'Dockerfile'
       - 'prod.Dockerfile'
       - '.github/workflows/**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,12 @@ jobs:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
         run: bin/build-localstack-env
+      - name: Build mock-web-services
+        env:
+          DOCKER_BUILDKIT: 1
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: civiform
+        run: bin/build-mock-web-services
       - name: Bring up test env with Localstack
         run: bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
@@ -146,6 +152,12 @@ jobs:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
         run: bin/build-localstack-env
+      - name: Build mock-web-services
+        env:
+          DOCKER_BUILDKIT: 1
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: civiform
+        run: bin/build-mock-web-services
       - name: Bring up test env with Azurite
         run: bin/run-browser-test-env --azure --ci
       - name: Run browser tests with Azurite

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ env-var-docs/**/*build
 env-var-docs/**/*.egg*
 .coverage
 coverage.xml
+
+# Python
+.venv/
+__pycache__/

--- a/bin/build-mock-web-services
+++ b/bin/build-mock-web-services
@@ -1,0 +1,41 @@
+#! /usr/bin/env bash
+
+# DOC: Build a new docker image for running the mock web services container and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+
+source bin/lib.sh
+
+IMAGE="mock-web-services"
+LOCATION="mock-web-services/"
+DOCKERFILE="mock-web-services/mock-web-services.Dockerfile"
+
+BUILD_ARGS="-f ${DOCKERFILE}
+  -t civiform/${IMAGE}:latest
+  --cache-from civiform/${IMAGE}
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  --build-context server=server/
+  ${LOCATION}"
+
+PLATFORM_ARG=()
+if [[ "${PLATFORM}" ]]; then
+  PLATFORM_ARG=(--platform "${PLATFORM}")
+fi
+
+# Build the multi-platform image
+echo "start ${IMAGE} build"
+cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
+$cmd
+
+# Load the image from the cache
+echo "load ${IMAGE} build"
+cmd="docker buildx build --load ${BUILD_ARGS}"
+$cmd
+
+if [[ "${PUSH_IMAGE}" ]]; then
+  docker::do_dockerhub_login
+  # Push the image from the cache to dockerhub
+  echo "push ${IMAGE} build"
+  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
+  $cmd
+fi
+
+docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -33,6 +33,7 @@ function pull_all() {
   docker pull docker.io/civiform/civiform-localstack:latest &
   docker pull docker.io/civiform/formatter:latest &
   docker pull docker.io/civiform/civiform-browser-test:latest &
+  docker pull docker.io/civiform/mock-web-services:latest &
 
   wait
 
@@ -82,6 +83,11 @@ while [ "${1:-}" != "" ]; do
     "--browser-tests")
       echo "Pull browser-tests docker image"
       docker pull docker.io/civiform/civiform-browser-test:latest
+      ;;
+
+    "--mock-web-services")
+      echo "Pull mock-web-services docker image"
+      docker pull docker.io/civiform/mock-web-services:latest
       ;;
 
     *)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,9 @@ services:
     ports:
       - 10000:10000
 
+  mock-web-services:
+    image: civiform-mock-web-services
+
   db:
     image: postgres:12.14
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       # Use an explicit port to not conflict with other test instances.
       - OIDC_PORT=3390
 
+  mock-web-services:
+    image: civiform/mock-web-services
+
   db:
     image: postgres:12.14
     restart: always
@@ -53,6 +56,7 @@ services:
     links:
       - 'db:database'
       - 'dev-oidc'
+      - 'mock-web-services'
     expose:
       - '9000'
       - '8457'
@@ -109,4 +113,8 @@ services:
       - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
+      - ESRI_ADDRESS_CORRECTION_ENABLED=true
+      - ESRI_FIND_ADDRESS_CANDIDATES_URL=http://mock-web-services:8000/esri/findAddressCandidates
+      - ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED=true
+      - ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS.0=http://mock-web-services:8000/esri/serviceAreaFeatures
     entrypoint: /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,4 @@ services:
       - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
-      - ESRI_ADDRESS_CORRECTION_ENABLED=true
-      - ESRI_FIND_ADDRESS_CANDIDATES_URL=http://mock-web-services:8000/esri/findAddressCandidates
-      - ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED=true
-      - ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS.0=http://mock-web-services:8000/esri/serviceAreaFeatures
     entrypoint: /bin/bash

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -102,5 +102,6 @@ else
     --in-place \
     --recursive \
     --exclude env-var-docs/venv \
+    --exclude mock-web-services/.venv \
     .
 fi

--- a/mock-web-services/README.md
+++ b/mock-web-services/README.md
@@ -13,6 +13,11 @@ container `docker run --name mockweb -p 8000:8000 civiform/mock-web-services:lat
 ## Esri Endpoints
 
 There are currently two endpoints to handle Esri ArcGIS endpoints we leverage.
+One for finding address candidates and one for determining service area
+features.
+
+These endpoints return JSON from files shared with the FakeEsriClient.java and
+unit tests.
 
 ### Find Address Candidates
 

--- a/mock-web-services/README.md
+++ b/mock-web-services/README.md
@@ -19,6 +19,13 @@ features.
 These endpoints return JSON from files shared with the FakeEsriClient.java and
 unit tests.
 
+## Determining
+
+The EsriModule is used to determine if we load the RealEsriClient or the FakeEsriClient.
+When using the mock service we want to use the RealEsriClient. This is what is
+used when a value is provided for "esri_find_address_candidates_url". If no
+value is configured we fall back to the FakeEsriClient.
+
 ### Find Address Candidates
 
 Endpoint to mock Esri [findAddressCandidates](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). We use the address as a key in determining which type of response this will return.

--- a/mock-web-services/README.md
+++ b/mock-web-services/README.md
@@ -1,0 +1,47 @@
+# Mock Web Services
+
+The Mock Web Services is a lightweight Python Flask app that is used to create
+mock REST endpoints to mimic external vendor APIs. This allows for full testing,
+including the network, of integrations to these APIs without being bound to the
+real implementations.
+
+## Running
+
+To start this server run `python app.py` from this directory or start the docker
+container `docker run --name mockweb -p 8000:8000 civiform/mock-web-services:latest`
+
+## Esri Endpoints
+
+There are currently two endpoints to handle Esri ArcGIS endpoints we leverage.
+
+### Find Address Candidates
+
+Endpoint to mock Esri [findAddressCandidates](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). We use the address as a key in determining which type of response this will return.
+
+Valid options are:
+
+- Address In Area
+- Legit Address
+- Bogus Address
+
+#### Examples in curl
+
+- `curl http://localhost:8000/esri/findAddressCandidates?address=Address%20In%20Area`
+- `curl http://localhost:8000/esri/findAddressCandidates?address=Legit%20Address`
+- `curl http://localhost:8000/esri/findAddressCandidates?address=Bogus%20Address`
+
+### Service Area Features with Map Service/Layer
+
+Endpoint to mock Esri [Map Service/Layer](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm) and used for service area validations. We use the _y_ value in the geometry json parameter as a key in determining which type of response this will return.
+
+Valid options are:
+
+- 100.0
+- 101.0
+- 102.0
+
+#### Examples in curl
+
+- `curl http://localhost:8000/esri/serviceAreaFeatures?geometry=%7B'x'%3A-100.0,'y'%3A100.0,'spatialReference'%3A4326%7D`
+- `curl http://localhost:8000/esri/serviceAreaFeatures?geometry=%7B'x'%3A-100.0,'y'%3A101.0,'spatialReference'%3A4326%7D`
+- `curl http://localhost:8000/esri/serviceAreaFeatures?geometry=%7B'x'%3A-100.0,'y'%3A102.0,'spatialReference'%3A4326%7D`

--- a/mock-web-services/app.py
+++ b/mock-web-services/app.py
@@ -2,28 +2,46 @@ from flask import Flask, Response, request, json
 from esri import EsriMockWebService
 
 app = Flask(__name__)
-esriWS = EsriMockWebService(app)
+esri_ws = EsriMockWebService(app)
 
 
 @app.route("/esri/findAddressCandidates")
-def findAddressCandidates():
+def find_address_candidates():
+    """
+    Endpoint to mock Esri findAddressCandidates. We use the address as a key in
+    determining which type of response this will return.
+
+    Valid options are:
+        * Address In Area
+        * Legit Address
+        * Bogus Address
+    """
     try:
         address = request.args.get("address")
-        return esriWS.findAddressCandidates(address)
+        return esri_ws.find_address_candidates(address)
     except Exception as e:
         print(e)
-        return Response("Bad request", status=400)
+        return Response("Bad request. " + e, status=400)
 
 
 @app.route("/esri/serviceAreaFeatures")
-def serviceAreaFeatures():
+def service_area_features():
+    """
+    Endpoint to mock Esri service area validation. We use the latitude as a
+    key in determining which type of response this will return.
+
+    Valid options are:
+        * 100.0
+        * 101.0
+        * 102.0
+    """
     try:
         geometry = json.loads(request.args.get("geometry").replace("'", '"'))
         latitude = geometry.get("y")
-        return esriWS.serviceAreaFeatures(latitude)
+        return esri_ws.service_area_features(latitude)
     except Exception as e:
         print(e)
-        return Response("Bad request", status=400)
+        return Response("Bad request. " + e, status=400)
 
 
 if __name__ == "__main__":

--- a/mock-web-services/app.py
+++ b/mock-web-services/app.py
@@ -1,0 +1,31 @@
+from flask import Flask, Response, request, json
+from esri import EsriMockWebService
+
+app = Flask(__name__)
+esriWS = EsriMockWebService(app)
+
+
+@app.route("/esri/findAddressCandidates")
+def findAddressCandidates():
+    try:
+        address = request.args.get("address")
+        return esriWS.findAddressCandidates(address)
+    except Exception as e:
+        print(e)
+        return Response("Bad request", status=400)
+
+
+@app.route("/esri/serviceAreaFeatures")
+def serviceAreaFeatures():
+    try:
+        geometry = json.loads(request.args.get("geometry").replace("'", '"'))
+        latitude = geometry.get("y")
+        return esriWS.serviceAreaFeatures(latitude)
+    except Exception as e:
+        print(e)
+        return Response("Bad request", status=400)
+
+
+if __name__ == "__main__":
+    app.debug = True
+    app.run(host="0.0.0.0", port=8000)

--- a/mock-web-services/esri/__init__.py
+++ b/mock-web-services/esri/__init__.py
@@ -21,9 +21,11 @@ class EsriMockWebService(WebService):
         based on key in put address value.
         """
         if address == "Address In Area" or address == "Legit Address":
-            return self.return_json_response_from_file(self.file_root + "findAddressCandidates.json")
+            return self.return_json_response_from_file(
+                self.file_root + "findAddressCandidates.json")
         elif address == "Bogus Address":
-            return self.return_json_response_from_file(self.file_root + "findAddressCandidatesNoCandidates.json")
+            return self.return_json_response_from_file(
+                self.file_root + "findAddressCandidatesNoCandidates.json")
         else:
             raise Exception("Invalid mock request")
 
@@ -33,10 +35,13 @@ class EsriMockWebService(WebService):
         input value of the latitude
         """
         if latitude == 100.0:
-            return self.return_json_response_from_file(self.file_root + "serviceAreaFeatures.json")
+            return self.return_json_response_from_file(
+                self.file_root + "serviceAreaFeatures.json")
         elif latitude == 101.0:
-            return self.return_json_response_from_file(self.file_root + "serviceAreaFeaturesNoFeatures.json")
+            return self.return_json_response_from_file(
+                self.file_root + "serviceAreaFeaturesNoFeatures.json")
         elif latitude == 102.0:
-            return self.return_json_response_from_file(self.file_root + "serviceAreaFeaturesNotInArea.json")
+            return self.return_json_response_from_file(
+                self.file_root + "serviceAreaFeaturesNotInArea.json")
         else:
             raise Exception("Invalid mock request")

--- a/mock-web-services/esri/__init__.py
+++ b/mock-web-services/esri/__init__.py
@@ -2,31 +2,41 @@ from webservice import WebService
 
 
 class EsriMockWebService(WebService):
+    """
+    Mock service for Esri endpoints that can map specific key input values to
+    pre-created json stored in files.
+
+    The files used by this service are shared with the FakeEsriClient.java class
+    and used in the unit tests.
+    """
 
     def __init__(self, app):
         WebService.__init__(self, app)
         self.app = app
         self.file_root = "../server/test/resources/esri/"
 
-    def findAddressCandidates(self, address):
+    def find_address_candidates(self, address):
+        """
+        Returns json response for Esri's findAddressCandidates endpoint
+        based on key in put address value.
+        """
         if address == "Address In Area" or address == "Legit Address":
-            return self.returnJsonResponseFromFile(
-                self.file_root + "findAddressCandidates.json")
+            return self.return_json_response_from_file(self.file_root + "findAddressCandidates.json")
         elif address == "Bogus Address":
-            return self.returnJsonResponseFromFile(
-                self.file_root + "findAddressCandidatesNoCandidates.json")
+            return self.return_json_response_from_file(self.file_root + "findAddressCandidatesNoCandidates.json")
         else:
             raise Exception("Invalid mock request")
 
-    def serviceAreaFeatures(self, latitude):
+    def service_area_features(self, latitude):
+        """
+        Returns json response for Esri's service area endpoint based on key
+        input value of the latitude
+        """
         if latitude == 100.0:
-            return self.returnJsonResponseFromFile(
-                self.file_root + "serviceAreaFeatures.json")
+            return self.return_json_response_from_file(self.file_root + "serviceAreaFeatures.json")
         elif latitude == 101.0:
-            return self.returnJsonResponseFromFile(
-                self.file_root + "serviceAreaFeaturesNoFeatures.json")
+            return self.return_json_response_from_file(self.file_root + "serviceAreaFeaturesNoFeatures.json")
         elif latitude == 102.0:
-            return self.returnJsonResponseFromFile(
-                self.file_root + "serviceAreaFeaturesNotInArea.json")
+            return self.return_json_response_from_file(self.file_root + "serviceAreaFeaturesNotInArea.json")
         else:
             raise Exception("Invalid mock request")

--- a/mock-web-services/esri/__init__.py
+++ b/mock-web-services/esri/__init__.py
@@ -1,0 +1,32 @@
+from webservice import WebService
+
+
+class EsriMockWebService(WebService):
+
+    def __init__(self, app):
+        WebService.__init__(self, app)
+        self.app = app
+        self.file_root = "../server/test/resources/esri/"
+
+    def findAddressCandidates(self, address):
+        if address == "Address In Area" or address == "Legit Address":
+            return self.returnJsonResponseFromFile(
+                self.file_root + "findAddressCandidates.json")
+        elif address == "Bogus Address":
+            return self.returnJsonResponseFromFile(
+                self.file_root + "findAddressCandidatesNoCandidates.json")
+        else:
+            raise Exception("Invalid mock request")
+
+    def serviceAreaFeatures(self, latitude):
+        if latitude == 100.0:
+            return self.returnJsonResponseFromFile(
+                self.file_root + "serviceAreaFeatures.json")
+        elif latitude == 101.0:
+            return self.returnJsonResponseFromFile(
+                self.file_root + "serviceAreaFeaturesNoFeatures.json")
+        elif latitude == 102.0:
+            return self.returnJsonResponseFromFile(
+                self.file_root + "serviceAreaFeaturesNotInArea.json")
+        else:
+            raise Exception("Invalid mock request")

--- a/mock-web-services/mock-web-services.Dockerfile
+++ b/mock-web-services/mock-web-services.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11.3-slim
+
+RUN useradd --create-home appuser --no-log-init
+
+USER appuser
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt --no-warn-script-location
+COPY . .
+COPY --from=server /test/resources/esri /server/test/resources/esri
+
+EXPOSE 8000
+
+CMD ["python", "app.py"]
+

--- a/mock-web-services/requirements.txt
+++ b/mock-web-services/requirements.txt
@@ -1,0 +1,6 @@
+click==8.1.3
+Flask==2.2.3
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.2
+Werkzeug==2.2.3

--- a/mock-web-services/webservice/__init__.py
+++ b/mock-web-services/webservice/__init__.py
@@ -1,18 +1,21 @@
 class WebService:
+    """Base class contain helper methods for returning responses."""
 
     def __init__(self, app):
         self.app = app
 
-    def readFile(self, filename):
-        with open(filename, "r") as file:
+    def read_file(self, file_path):
+        """Reads a file from path and returns it as a string."""
+        with open(file_path, "r") as file:
             jsonstr = file.read()
 
         return jsonstr
 
-    def returnJsonResponse(self, jsonstr):
-        return self.app.response_class(
-            response=jsonstr, mimetype="application/json")
+    def return_json_response(self, jsonstr):
+        """Return a string of json as the response as the correct mimetype."""
+        return self.app.response_class(response=jsonstr, mimetype="application/json")
 
-    def returnJsonResponseFromFile(self, filename):
-        jsonstr = self.readFile(filename)
-        return self.returnJsonResponse(jsonstr)
+    def return_json_response_from_file(self, file_path):
+        """Reads a file from path and returns a response formatted as json"""
+        jsonstr = self.read_file(file_path)
+        return self.return_json_response(jsonstr)

--- a/mock-web-services/webservice/__init__.py
+++ b/mock-web-services/webservice/__init__.py
@@ -1,0 +1,18 @@
+class WebService:
+
+    def __init__(self, app):
+        self.app = app
+
+    def readFile(self, filename):
+        with open(filename, "r") as file:
+            jsonstr = file.read()
+
+        return jsonstr
+
+    def returnJsonResponse(self, jsonstr):
+        return self.app.response_class(
+            response=jsonstr, mimetype="application/json")
+
+    def returnJsonResponseFromFile(self, filename):
+        jsonstr = self.readFile(filename)
+        return self.returnJsonResponse(jsonstr)

--- a/mock-web-services/webservice/__init__.py
+++ b/mock-web-services/webservice/__init__.py
@@ -13,7 +13,8 @@ class WebService:
 
     def return_json_response(self, jsonstr):
         """Return a string of json as the response as the correct mimetype."""
-        return self.app.response_class(response=jsonstr, mimetype="application/json")
+        return self.app.response_class(
+            response=jsonstr, mimetype="application/json")
 
     def return_json_response_from_file(self, file_path):
         """Reads a file from path and returns a response formatted as json"""

--- a/server/app/modules/EsriModule.java
+++ b/server/app/modules/EsriModule.java
@@ -11,9 +11,9 @@ import services.geo.esri.EsriClient;
 
 /**
  * Configures the class used for the Esri client. When the config value is set for
- * "esri_find_address_candidates_url" we use the RealEsriClient. If the value is not
- * set we'll use the FakeEsriClient. This allows the real client to be used whether
- * we are using an actual Esri endpoint or if using the Mock Web Services.
+ * "esri_find_address_candidates_url" we use the RealEsriClient. If the value is not set we'll use
+ * the FakeEsriClient. This allows the real client to be used whether we are using an actual Esri
+ * endpoint or if using the Mock Web Services.
  */
 public final class EsriModule extends AbstractModule {
   private static final String FAKE_ESRI_CLIENT_CLASS_NAME = "services.geo.esri.FakeEsriClient";

--- a/server/app/modules/EsriModule.java
+++ b/server/app/modules/EsriModule.java
@@ -10,8 +10,10 @@ import play.Environment;
 import services.geo.esri.EsriClient;
 
 /**
- * Configures the class used for the Esri client. When running in a dev or CI environment, the fake
- * client is used to simulate responses from an Esri service.
+ * Configures the class used for the Esri client. When the config value is set for
+ * "esri_find_address_candidates_url" we use the RealEsriClient. If the value is not
+ * set we'll use the FakeEsriClient. This allows the real client to be used whether
+ * we are using an actual Esri endpoint or if using the Mock Web Services.
  */
 public final class EsriModule extends AbstractModule {
   private static final String FAKE_ESRI_CLIENT_CLASS_NAME = "services.geo.esri.FakeEsriClient";

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -33,15 +33,11 @@ play.filters {
 program_eligibility_conditions_enabled = true
 feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
-esri_address_correction_enabled = false
 # Terms of service https://www.esri.com/content/dam/esrisites/en-us/media/legal/ma-translations/english.pdf
 # See sections 2.3.a.6, 2.5.b and 3.2.d
-esri_find_address_candidates_url = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
 esri_external_call_tries = 3
-esri_address_service_area_validation_enabled = false
 esri_address_service_area_validation_labels = ["Seattle"]
 esri_address_service_area_validation_ids = ["Seattle"]
-esri_address_service_area_validation_urls = ["https://gisdata.seattle.gov/server/rest/services/COS/Seattle_City_Limits/MapServer/1/query"]
 esri_address_service_area_validation_attributes = ["CITYNAME"]
 
 intake_form_enabled = false

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -35,7 +35,12 @@ feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
 # Terms of service https://www.esri.com/content/dam/esrisites/en-us/media/legal/ma-translations/english.pdf
 # See sections 2.3.a.6, 2.5.b and 3.2.d
+# Esri Mock Service
+esri_address_correction_enabled=true
+esri_find_address_candidates_url = "http://mock-web-services:8000/esri/findAddressCandidates"
 esri_external_call_tries = 3
+esri_address_service_area_validation_enabled=true
+esri_address_service_area_validation_urls = ["http://mock-web-services:8000/esri/serviceAreaFeatures"]
 esri_address_service_area_validation_labels = ["Seattle"]
 esri_address_service_area_validation_ids = ["Seattle"]
 esri_address_service_area_validation_attributes = ["CITYNAME"]

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -23,4 +23,5 @@ feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
 
 # address service area validation relative path for testing
+esri_find_address_candidates_url = ""
 esri_address_service_area_validation_urls = ["/query"]

--- a/server/conf/helper/esri.conf
+++ b/server/conf/helper/esri.conf
@@ -2,6 +2,8 @@
 # address correction
 esri_address_correction_enabled = false
 esri_address_correction_enabled = ${?ESRI_ADDRESS_CORRECTION_ENABLED}
+
+esri_find_address_candidates_url = ""
 esri_find_address_candidates_url = ${?ESRI_FIND_ADDRESS_CANDIDATES_URL}
 # address service area validation
 esri_address_service_area_validation_enabled = false

--- a/test-support/prod-simulator-compose.yml
+++ b/test-support/prod-simulator-compose.yml
@@ -9,12 +9,16 @@ services:
     environment:
       POSTGRES_PASSWORD: example
 
+  mock-web-services:
+    image: civiform/mock-web-services
+
   civiform:
     image: civiform:prod
     restart: always
     container_name: play
     links:
       - 'db:database'
+      - 'mock-web-services'
     ports:
       - 9000:9000
     environment:

--- a/test-support/prod-simulator-compose.yml
+++ b/test-support/prod-simulator-compose.yml
@@ -9,16 +9,12 @@ services:
     environment:
       POSTGRES_PASSWORD: example
 
-  mock-web-services:
-    image: civiform/mock-web-services
-
   civiform:
     image: civiform:prod
     restart: always
     container_name: play
     links:
       - 'db:database'
-      - 'mock-web-services'
     ports:
       - 9000:9000
     environment:


### PR DESCRIPTION
### Description

Adding new container for development time use to provide mock web service endpoints, such as for ESRI. It's able to deal with other possible endpoints in the future so we don't have to make multiple different containers.

It's a very light Flask app that just serves up specific json responses based on a handful of known inputs. I built it to mimic that FakeEsriService.java file so they can be used interchangeably. Everything is plumbed into the build with a container already.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary


