### PR TITLE
Add env-var-docs.json and PR automation scripts

### DIFF
--- a/.github/workflows/pr_env_var_docs.yaml
+++ b/.github/workflows/pr_env_var_docs.yaml
@@ -12,8 +12,9 @@ on:
       - 'main'
     paths:
       - 'env-var-docs/**'
-      - 'server/conf/application.conf'
       - 'server/conf/env-var-docs.json'
+      - 'server/conf/application.conf'
+      - 'server/conf/helper/*.conf'
       - '.github/workflows/pr_env_var_docs.yaml'
 
 jobs:

--- a/.github/workflows/pr_env_var_docs.yaml
+++ b/.github/workflows/pr_env_var_docs.yaml
@@ -40,3 +40,6 @@ jobs:
           # We're getting intermittent issues with codecov trying to upload lately
           # disabling it from failing the entire pipeline for now.
           fail_ci_if_error: false
+
+      - name: Check environment variables
+        run: bin/env-var-docs-check-vars

--- a/bin/env-var-docs-check-vars
+++ b/bin/env-var-docs-check-vars
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+# DOC: Runs env-var-docs/{check_vars_documented,run_regex_tests}.py.
+
+source bin/lib.sh
+
+if [[ ! -d env-var-docs/venv ]]; then
+  echo "ERROR: venv directory does not exist. First run 'bin/env-var-docs-create-venv' then run this script."
+  exit 1
+fi
+
+source env-var-docs/venv/bin/activate
+
+export APPLICATION_CONF_PATH=server/conf/application.conf
+export ENV_VAR_DOCS_PATH=server/conf/env-var-docs.json
+
+echo "Running env-var-docs/check_vars_documented.py..."
+python env-var-docs/check_vars_documented.py
+
+echo "Running env-var-docs/run_regex_tests.py..."
+python env-var-docs/run_regex_tests.py

--- a/bin/env-var-docs-run-tests
+++ b/bin/env-var-docs-run-tests
@@ -16,5 +16,4 @@ mypy env-var-docs --exclude build
 
 echo "Running pytest..."
 pytest --cov=env-var-docs --cov-report=term --cov-report=html --cov-report=xml
-
 echo "To see coverage report, open 'htmlcov/index.html' in a web browser."

--- a/env-var-docs/README.md
+++ b/env-var-docs/README.md
@@ -38,6 +38,14 @@ server is deployed.
   repository](https://github.com/civiform/docs/tree/main/docs/it-manual/sre-playbook/server-environment-variables).
   Runs as a part of our release automation.
 
+### Running locally
+
+To run check_vars_documented.py and run_regex_tests.py locally:
+
+1. First ensure a python virtual environment (venv) is created to run the
+   scripts in: `bin/env-var-docs-create-venv`.
+1. Run `bin/env-var-docs-check-vars`.
+
 ## Developer setup
 
 ### TL;DR

--- a/env-var-docs/check_vars_documented.py
+++ b/env-var-docs/check_vars_documented.py
@@ -1,0 +1,155 @@
+"""Checks that every environment variable referenced in application.conf has documentation.
+
+Requires the following variables to be present in the environment:
+    APPLICATION_CONF_PATH: the path to application.conf.
+    ENV_VAR_DOCS_PATH: the path to env-var-docs.json.
+
+See ./README.md for instuctions on how to run this script locally.
+"""
+
+import dataclasses
+import env_var_docs.parser
+import env_var_docs.errors_formatter
+import os
+import pprint
+import re
+import sys
+import typing
+
+
+def errorexit(msg):
+    """Logs a message and exits"""
+    sys.stderr.write(msg + "\n")
+    exit(1)
+
+
+@dataclasses.dataclass
+class Config:
+    """Holds file paths read at runtime."""
+    app_conf_path: str
+    docs_path: str
+
+
+def make_config() -> Config:
+    """Returns a Config by reading the paths set in APPLICATION_CONF_PATH and
+    ENV_VAR_DOCS_PATH environment variables.
+
+    Exits if there are any validation errors.
+    """
+
+    def validate_path(env_var) -> str:
+        path = os.environ[env_var]
+        if not os.path.isfile(path):
+            errorexit(f"'{path}' does not point to a file")
+        return path
+
+    try:
+        app_conf = validate_path("APPLICATION_CONF_PATH")
+        var_docs = validate_path("ENV_VAR_DOCS_PATH")
+    except KeyError as e:
+        errorexit(f"{e.args[0]} must be present in the environment variables")
+
+    return Config(app_conf, var_docs)
+
+
+def main():
+    config = make_config()
+    vars = vars_from_application_conf(config.app_conf_path)
+    with open(config.docs_path) as f:
+        documented_vars, parse_errors = vars_from_docs(f)
+        if len(parse_errors) != 0:
+            msg = f"{config.docs_path} is invalid:\n"
+            msg += env_var_docs.errors_formatter.format(parse_errors)
+            errorexit(msg)
+
+    undocumented = vars - documented_vars
+    overdocumented = documented_vars - vars
+
+    errors = False
+    msg = "CiviForm environment variables are not correctly documented. See https://github.com/civiform/civiform/blob/main/env-var-docs/README.md for information. Issues:\n"
+    if len(undocumented) != 0:
+        errors = True
+        msg += f"\nThe following vars are not documented in {config.docs_path}:\n{pprint.pformat(undocumented)}\n"
+    if len(overdocumented) != 0:
+        errors = True
+        msg += f"\nThe following vars are documented in {config.docs_path} but not referenced in {config.app_conf_path}:\n{pprint.pformat(overdocumented)}"
+    if errors:
+        errorexit(msg)
+
+
+def vars_from_application_conf(app_conf_path: str) -> set[str]:
+    """Parses an application.conf file and returns the set of referenced environment variables.
+
+    If the application.conf file includes other conf files, those files will
+    also be parsed for referenced environment variables.
+    """
+
+    # Matches any comment lines.
+    comment_regex = re.compile(r"^\s*(#|//)")
+
+    # Matches any include statements. Captures the file name in group 1.
+    include_regex = re.compile(r"^\s*include\s+\"(.+)\"$")
+
+    # Matches any UPPER_SNAKE_CASE variables in substitutions like
+    # ${?WHITELABEL_SMALL_LOGO_URL}. Captures the variable name in group 1.
+    env_var_regex = re.compile(r"^.*\${\?\s*([A-Z0-9_]+)\s*}")
+
+    dir_base = os.path.dirname(app_conf_path)
+    files_to_parse = [app_conf_path]
+    vars = set()
+
+    while len(files_to_parse) != 0:
+        path = files_to_parse.pop()
+        with open(path) as f:
+            f.seek(0)  # Ensure we are reading from the start of the file.
+            for line in f:
+                if comment_regex.match(line) != None:
+                    continue
+
+                include_match = include_regex.match(line)
+                if include_match != None:
+                    assert include_match is not None  # Appease mypy.
+                    include_path = include_match.group(1)
+                    if include_path == None:
+                        errorexit(
+                            f"ERROR: include_regex matched on {line} but found no file path"
+                        )
+
+                    files_to_parse.append(os.path.join(dir_base, include_path))
+                    continue
+
+                match = env_var_regex.match(line)
+                if match == None:
+                    continue
+                assert match is not None  # Appease mypy.
+                var = match.group(1)
+                if var == None:
+                    continue
+
+                vars.add(var)
+
+    return vars
+
+
+def vars_from_docs(
+    docs_file: typing.TextIO
+) -> tuple[set[str] | None, list[env_var_docs.parser.NodeParseError]]:
+    """If docs_file has no parsing errors, returns the set of defined
+    environment variables in an environment variable documentation file.
+    Otherwise returns the parsing errors.
+    """
+    vars = set()
+
+    def add(node: env_var_docs.parser.Node):
+        if isinstance(node.details, env_var_docs.parser.Variable):
+            vars.add(node.name)
+
+    errors = env_var_docs.parser.visit(docs_file, add)
+    if len(errors) != 0:
+        return None, errors
+
+    return vars, []
+
+
+if __name__ == "__main__":
+    main()

--- a/env-var-docs/check_vars_documented_test.py
+++ b/env-var-docs/check_vars_documented_test.py
@@ -1,0 +1,286 @@
+from check_vars_documented import make_config, vars_from_application_conf, vars_from_docs, main
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+
+
+class TestValidateEnvVariables(unittest.TestCase):
+
+    def setUp(self):
+        os.environ = {}
+
+    def test_no_app_conf(self):
+        stderr = io.StringIO()
+        with tempfile.NamedTemporaryFile() as tf, contextlib.redirect_stderr(
+                stderr):
+            os.environ["ENV_VAR_DOCS_PATH"] = tf.name
+            with self.assertRaises(SystemExit):
+                make_config()
+            self.assertTrue(
+                "APPLICATION_CONF_PATH must be present in the environment variables"
+                in stderr.getvalue())
+
+    def test_app_conf_is_dir(self):
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory(
+        ) as dir_name, contextlib.redirect_stderr(stderr):
+            os.environ["APPLICATION_CONF_PATH"] = dir_name
+            with self.assertRaises(SystemExit):
+                make_config()
+            self.assertTrue("does not point to a file" in stderr.getvalue())
+
+    def test_no_env_var(self):
+        stderr = io.StringIO()
+        with tempfile.NamedTemporaryFile() as tf, contextlib.redirect_stderr(
+                stderr):
+            os.environ["APPLICATION_CONF_PATH"] = tf.name
+            with self.assertRaises(SystemExit):
+                make_config()
+            self.assertTrue(
+                "ENV_VAR_DOCS_PATH must be present in the environment variables"
+                in stderr.getvalue())
+
+    def test_config_returned(self):
+        with tempfile.NamedTemporaryFile(
+        ) as appconf, tempfile.NamedTemporaryFile() as envvar:
+            os.environ["APPLICATION_CONF_PATH"] = appconf.name
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            got = make_config()
+            self.assertEqual(got.app_conf_path, appconf.name)
+            self.assertEqual(got.docs_path, envvar.name)
+
+
+class TestVarsFromAppConf(unittest.TestCase):
+
+    def setUp(self):
+        self.no_vars = """
+#mykey = ${some.value}
+# mykey = ${?JAVA_HOME}
+// mykey = ${?JAVA_HOME}
+akka {
+  #log-config-on-start = ${?LOG_CONFIG_ON_START}
+  #log-config-on-start = true
+  logger-startup-timeout = 30s
+}"""
+
+        self.vars_1 = """
+mykey = ${?MY_VAR} # Some var
+myotherkey = ${? MY_OTHER_VAR   }"""
+
+        self.vars_2 = """
+somekey = ${?SOME_VAR}
+someotherkey = ${?SOME_OTHER_VAR}"""
+
+        self.blank_imports_no_vars = 'include "no_vars"'
+        self.blank_imports_vars_1 = 'include "vars_1"'
+
+        self.vars_1_imports_no_vars = 'include "no_vars"' + self.vars_1
+        self.vars_1_imports_vars_2 = 'include "vars_2"' + self.vars_1
+        self.vars_2_imports_vars_1 = 'include "vars_1"' + self.vars_2
+
+        self.blank_imports_vars_1_and_vars_2 = 'include "vars_1"\ninclude "vars_2"'
+
+        self.vars_3_imports_vars_1_and_vars_2 = """
+include "vars_1"
+include "vars_2"
+
+extrakey = ${?EXTRA_VAR}
+extrakey2 = ${?EXTRA_VAR2}"""
+
+        self.vars_1_set = set(["MY_VAR", "MY_OTHER_VAR"])
+        self.vars_2_set = set(["SOME_VAR", "SOME_OTHER_VAR"])
+        self.vars_3_set = set(["EXTRA_VAR", "EXTRA_VAR2"])
+
+        self.conf_dir = tempfile.TemporaryDirectory()
+        for n in ["no_vars", "vars_1", "vars_2", "blank_imports_no_vars",
+                  "blank_imports_vars_1", "vars_1_imports_no_vars",
+                  "vars_1_imports_vars_2", "vars_2_imports_vars_1",
+                  "blank_imports_vars_1_and_vars_2",
+                  "vars_3_imports_vars_1_and_vars_2"]:
+            with open(self.temp_path(n), mode="w") as f:
+                f.write(getattr(self, n))
+
+    def temp_path(self, name):
+        """Returns a path in self.conf_dir. Should only be called after
+        self.conf_dir has been initialized."""
+
+        return f"{self.conf_dir.name}/{name}"
+
+    def test_no_vars(self):
+        got = vars_from_application_conf(self.temp_path("no_vars"))
+        self.assertSetEqual(got, set())
+
+    def test_vars_1(self):
+        got = vars_from_application_conf(self.temp_path("vars_1"))
+        self.assertSetEqual(got, self.vars_1_set)
+
+    def test_vars_2(self):
+        got = vars_from_application_conf(self.temp_path("vars_2"))
+        self.assertSetEqual(got, self.vars_2_set)
+
+    def test_blank_imports_no_vars(self):
+        got = vars_from_application_conf(
+            self.temp_path("blank_imports_no_vars"))
+        self.assertSetEqual(got, set())
+
+    def test_blank_imports_vars_1(self):
+        got = vars_from_application_conf(self.temp_path("blank_imports_vars_1"))
+        self.assertSetEqual(got, self.vars_1_set)
+
+    def test_vars_1_imports_no_vars(self):
+        got = vars_from_application_conf(
+            self.temp_path("vars_1_imports_no_vars"))
+        self.assertSetEqual(got, self.vars_1_set)
+
+    def test_vars_1_imports_vars_2(self):
+        got = vars_from_application_conf(
+            self.temp_path("vars_1_imports_vars_2"))
+        self.assertSetEqual(got, self.vars_1_set | self.vars_2_set)
+
+    def test_vars_2_imports_vars_1(self):
+        got = vars_from_application_conf(
+            self.temp_path("vars_2_imports_vars_1"))
+        self.assertSetEqual(got, self.vars_1_set | self.vars_2_set)
+
+    def test_blank_imports_vars_1_and_vars_2(self):
+        got = vars_from_application_conf(
+            self.temp_path("blank_imports_vars_1_and_vars_2"))
+        self.assertSetEqual(got, self.vars_1_set | self.vars_2_set)
+
+    def test_vars_3_imports_vars_1_and_vars_2(self):
+        got = vars_from_application_conf(
+            self.temp_path("vars_3_imports_vars_1_and_vars_2"))
+        self.assertSetEqual(
+            got, self.vars_1_set | self.vars_2_set | self.vars_3_set)
+
+
+class TestVarsFromDocs(unittest.TestCase):
+    env_var_docs = """
+    {
+        "MY_VAR": {
+            "description": "A var",
+            "type": "string"
+        },
+        "A group": {
+            "group_description": "Some group",
+            "members": {
+                "MY_OTHER_VAR": {
+                    "description": "Another var",
+                    "type": "string"
+                }
+            }
+        }
+    }
+    """
+
+    def test_no_vars(self):
+        with io.StringIO("{}") as f:
+            got, gotErrors = vars_from_docs(f)
+            self.assertEqual(gotErrors, [])
+            self.assertSetEqual(got, set())
+
+    def test_some_vars(self):
+        with io.StringIO(self.env_var_docs) as f:
+            got, gotErrors = vars_from_docs(f)
+            self.assertEqual(gotErrors, [])
+            self.assertSetEqual(got, set(["MY_VAR", "MY_OTHER_VAR"]))
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        os.environ = {}
+
+    app_conf = """
+    mykey = ${?MY_VAR}
+    """
+    env_var_docs = """
+    {
+        "MY_VAR": {
+            "description": "A var",
+            "type": "string"
+        }
+    }
+    """
+    invalid_env_var_docs = """
+    {
+        "MY_VAR": {
+          "description": "A var",
+          "type": "not my type"
+        }
+    }
+    """
+
+    def test_invalid_env_var_docs_file(self):
+        with tempfile.NamedTemporaryFile(
+                mode='w') as appconf, tempfile.NamedTemporaryFile(
+                    mode='w') as envvar:
+            appconf.write(self.app_conf)
+            appconf.flush()
+            envvar.write(self.invalid_env_var_docs)
+            envvar.flush()
+            os.environ["APPLICATION_CONF_PATH"] = appconf.name
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                main()
+            self.assertTrue("is invalid:" in stderr.getvalue())
+
+    def test_under_documented(self):
+        with tempfile.NamedTemporaryFile(
+                mode='w') as appconf, tempfile.NamedTemporaryFile(
+                    mode='w') as envvar:
+            appconf.write(self.app_conf)
+            appconf.flush()
+            envvar.write("{}")
+            envvar.flush()
+            os.environ["APPLICATION_CONF_PATH"] = appconf.name
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                main()
+            self.assertTrue(
+                "The following vars are not documented" in stderr.getvalue())
+
+    def test_over_documented(self):
+        with tempfile.NamedTemporaryFile(
+                mode='w') as appconf, tempfile.NamedTemporaryFile(
+                    mode='w') as envvar:
+            appconf.write("")
+            appconf.flush()
+            envvar.write(self.env_var_docs)
+            envvar.flush()
+            os.environ["APPLICATION_CONF_PATH"] = appconf.name
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                main()
+            self.assertRegex(
+                stderr.getvalue(),
+                r"The following vars are documented in .* but not referenced")
+
+    def test_documented(self):
+        with tempfile.NamedTemporaryFile(
+                mode='w') as appconf, tempfile.NamedTemporaryFile(
+                    mode='w') as envvar:
+            appconf.write(self.app_conf)
+            appconf.flush()
+            envvar.write(self.env_var_docs)
+            envvar.flush()
+            os.environ["APPLICATION_CONF_PATH"] = appconf.name
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+
+            # Tests that main runs without exiting.
+            main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/env-var-docs/check_vars_documented_test.py
+++ b/env-var-docs/check_vars_documented_test.py
@@ -66,12 +66,12 @@ akka {
 }"""
 
         self.vars_1 = """
-mykey = ${?MY_VAR} # Some var
-myotherkey = ${? MY_OTHER_VAR   }"""
+my_var_1 = ${?MY_VAR_1} # Some var
+my_var_2 = ${? MY_VAR_2   }"""
 
         self.vars_2 = """
-somekey = ${?SOME_VAR}
-someotherkey = ${?SOME_OTHER_VAR}"""
+my_var_3 = ${?MY_VAR_3}
+my_var_4 = ${?MY_VAR_4}"""
 
         self.blank_imports_no_vars = 'include "no_vars"'
         self.blank_imports_vars_1 = 'include "vars_1"'
@@ -86,12 +86,12 @@ someotherkey = ${?SOME_OTHER_VAR}"""
 include "vars_1"
 include "vars_2"
 
-extrakey = ${?EXTRA_VAR}
-extrakey2 = ${?EXTRA_VAR2}"""
+my_var_5 = ${?MY_VAR_5}
+my_var_6 = ${?MY_VAR_6}"""
 
-        self.vars_1_set = set(["MY_VAR", "MY_OTHER_VAR"])
-        self.vars_2_set = set(["SOME_VAR", "SOME_OTHER_VAR"])
-        self.vars_3_set = set(["EXTRA_VAR", "EXTRA_VAR2"])
+        self.vars_1_set = set(["MY_VAR_1", "MY_VAR_2"])
+        self.vars_2_set = set(["MY_VAR_3", "MY_VAR_4"])
+        self.vars_3_set = set(["MY_VAR_5", "MY_VAR_6"])
 
         self.conf_dir = tempfile.TemporaryDirectory()
         for n in ["no_vars", "vars_1", "vars_2", "blank_imports_no_vars",

--- a/env-var-docs/parser-package/src/env_var_docs/errors_formatter.py
+++ b/env-var-docs/parser-package/src/env_var_docs/errors_formatter.py
@@ -1,0 +1,27 @@
+import env_var_docs.parser
+
+
+def format(errors: list[env_var_docs.parser.NodeParseError]) -> str:
+    """Formats a list of NodeParseErrors returned from
+    env_var_docs.parser.visit as a human-readable string.
+
+    Example:
+
+    errors = env_var_docs.parser.visit(file, fn)
+    if len(errors) != 0:
+        print(f"file is invalid:\n{env_var_docs.errors_formatter(errors)}")
+    """
+    msg = ""
+
+    for error in errors:
+        msg += f"{error.path}:\n"
+
+        msg += "\tErrors from parsing as a Variable:\n"
+        for e in error.variable_errors:
+            msg += f"\t\t{e.path}: {e.msg}\n"
+
+        msg += f"\tErrors from parsing as a Group:\n"
+        for e in error.group_errors:
+            msg += f"\t\t{e.path}: {e.msg}\n"
+
+    return msg

--- a/env-var-docs/parser-package/tests/errors_formatter_test.py
+++ b/env-var-docs/parser-package/tests/errors_formatter_test.py
@@ -1,0 +1,53 @@
+from env_var_docs.parser import ParseError, NodeParseError
+from env_var_docs.errors_formatter import format
+import unittest
+
+
+class TestFormat(unittest.TestCase):
+
+    def test_no_errors(self):
+        got = format([])
+        self.assertEqual(got, "")
+
+    def test_errors(self):
+        got = format(
+            [
+                NodeParseError(
+                    path="file.a",
+                    group_errors=[
+                        ParseError(
+                            path="file.a", msg="group field is required")
+                    ],
+                    variable_errors=[
+                        ParseError(
+                            path="file.a", msg="variable field is required")
+                    ]),
+                NodeParseError(
+                    path="file.b",
+                    group_errors=[
+                        ParseError(
+                            path="file.b.c", msg="field has unsupported value")
+                    ],
+                    variable_errors=[
+                        ParseError(path="file.b.d", msg="surprise!"),
+                        ParseError(
+                            path="file.b.d", msg="Are errors so surprising?")
+                    ]),
+            ])
+        self.assertEqual(
+            got, """file.a:
+\tErrors from parsing as a Variable:
+\t\tfile.a: variable field is required
+\tErrors from parsing as a Group:
+\t\tfile.a: group field is required
+file.b:
+\tErrors from parsing as a Variable:
+\t\tfile.b.d: surprise!
+\t\tfile.b.d: Are errors so surprising?
+\tErrors from parsing as a Group:
+\t\tfile.b.c: field has unsupported value
+""")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/env-var-docs/run_regex_tests.py
+++ b/env-var-docs/run_regex_tests.py
@@ -1,0 +1,159 @@
+"""Checks that every regex test in env-var-docs.json passes.
+
+Requires the following variables to be present in the environment:
+    ENV_VAR_DOCS_PATH: the path to env-var-docs.json.
+
+See ./README.md for instuctions on how to run this script locally.
+"""
+
+import dataclasses
+import env_var_docs.parser
+import env_var_docs.errors_formatter
+import os
+import re
+import sys
+import typing
+
+
+def errorexit(msg):
+    """Logs a message and exits"""
+    sys.stderr.write(msg + "\n")
+    exit(1)
+
+
+def env_var_docs_path() -> str:
+    """Returns the path to the env-var-docs.json file set by the
+    ENV_VAR_DOCS_PATH environment variable.
+
+    Exits if there are any validation errors.
+    """
+    try:
+        path = os.environ["ENV_VAR_DOCS_PATH"]
+        if not os.path.isfile(path):
+            errorexit(f"'{path}' does not point to a file")
+    except KeyError as e:
+        errorexit(f"{e.args[0]} must be present in the environment variables")
+
+    return path
+
+
+def main():
+    docs_path = env_var_docs_path()
+    with open(docs_path) as f:
+        failed_tests, parse_errors = run_tests(f)
+        if len(parse_errors) != 0:
+            msg = f"{docs_path} is invalid:\n"
+            msg += env_var_docs.errors_formatter.format(parse_errors)
+            errorexit(msg)
+
+    if len(failed_tests) != 0:
+        errorexit(f"Test failures: {failed_tests}")
+
+
+def run_tests(
+    docs_file: typing.TextIO
+) -> tuple[list[str] | None, list[env_var_docs.parser.NodeParseError]]:
+    """Runs any provided regex tests in an environment variable documentation file.
+
+    Returns a list of environment variable names that failed their tests. Test
+    failure or pass messages are printed as the tests are run.
+    """
+
+    failures = []
+
+    def run_test(node: env_var_docs.parser.Node):
+        if not isinstance(node.details, env_var_docs.parser.Variable):
+            return
+
+        var = node.details
+        if var.regex is None:
+            return
+
+        # appease mypy.
+        assert var.regex is not None
+        assert var.regex_tests is not None
+        result = _run_test(node.name, var.regex, var.regex_tests)
+        print(result)
+        if result.regex_error != "" or result.failing_matches:
+            failures.append(node.name)
+
+    parse_errors = env_var_docs.parser.visit(docs_file, run_test)
+    if len(parse_errors) != 0:
+        return None, parse_errors
+
+    return failures, []
+
+
+@dataclasses.dataclass
+class Match:
+    input: str
+    shouldMatch: bool
+    didMatch: bool
+
+
+@dataclasses.dataclass
+class Test:
+    variable: str
+    regex: str
+    regex_error: str
+    matches: list[Match]
+    failing_matches: bool
+
+    def __str__(self) -> str:
+        """Formats a Test for printing."""
+        status = "PASSED"
+        if self.regex_error != "":
+            status = "FAILED: invalid regex"
+        if self.failing_matches:
+            status = "FAILED: not all matches passed"
+
+        out = f"RUN '{self.variable}' {status}\n"
+        if status == "PASSED":
+            return out
+
+        out += f"\tRegex: '{self.regex}'\n"
+        if self.regex_error != "":
+            out += f"\tRegex compile error: {self.regex_error}\n"
+            return out  # If regex did not compile, there will be no failed matches.
+
+        for match in self.matches:
+            out += (
+                f"\tRUN '{match.input}' {'PASSED:' if match.shouldMatch == match.didMatch else 'FAILED:'}\n"
+                f"\t\tShould match: {match.shouldMatch}\n"
+                f"\t\tDid  match: {match.didMatch}\n")
+
+        return out
+
+
+def _run_test(
+        node_name: str, regex_text: str,
+        tests: list[env_var_docs.parser.RegexTest]) -> Test:
+    try:
+        regex = re.compile(regex_text)
+    except re.error as e:
+        # Test failed because the regex could not compile.
+        return Test(
+            variable=node_name,
+            regex=regex_text,
+            regex_error=e.msg,
+            matches=[],
+            failing_matches=False)
+
+    matches = []
+    failing_matches = False
+    for test in tests:
+        did_match = (regex.match(test.val) != None)
+        if test.should_match != did_match:
+            failing_matches = True
+        matches.append(Match(test.val, test.should_match, did_match))
+
+    return Test(
+        variable=node_name,
+        regex=regex_text,
+        regex_error="",
+        matches=matches,
+        failing_matches=failing_matches)
+
+
+if __name__ == "__main__":
+    main()

--- a/env-var-docs/run_regex_tests_test.py
+++ b/env-var-docs/run_regex_tests_test.py
@@ -1,0 +1,127 @@
+from env_var_docs.parser import Node, Variable, RegexTest
+from run_regex_tests import _run_test, env_var_docs_path, main
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+
+
+class TestValidateEnvVariables(unittest.TestCase):
+
+    def setUp(self):
+        os.environ = {}
+
+    def test_no_env_vars(self):
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+            env_var_docs_path()
+        self.assertTrue(
+            "ENV_VAR_DOCS_PATH must be present in the environment variables" in
+            stderr.getvalue())
+
+    def test_points_to_dir(self):
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as dir_name:
+            os.environ["ENV_VAR_DOCS_PATH"] = dir_name
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                env_var_docs_path()
+            self.assertTrue("does not point to a file" in stderr.getvalue())
+
+    def test_path_returned(self):
+        with tempfile.NamedTemporaryFile() as envvar:
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            got = env_var_docs_path()
+            self.assertEqual(got, envvar.name)
+
+
+class TestRunTest(unittest.TestCase):
+
+    def test_invalid_regex(self):
+        got = _run_test(
+            "TEST_VAR", "(", [RegexTest(val="test", should_match=True)])
+        self.assertNotEqual(got.regex_error, "")
+        self.assertFalse(got.failing_matches)
+
+    def test_failing_match(self):
+        got = _run_test(
+            "TEST_VAR", ".*", [RegexTest(val="test", should_match=False)])
+        self.assertEqual(got.regex_error, "")
+        self.assertTrue(got.failing_matches)
+
+    def test_passing_match(self):
+        got = _run_test(
+            "TEST_VAR", ".*", [RegexTest(val="test", should_match=True)])
+        self.assertEqual(got.regex_error, "")
+        self.assertFalse(got.failing_matches)
+
+    def test_some_passing_some_failing_match(self):
+        got = _run_test(
+            "TEST_VAR",
+            ".*",
+            [
+                # Passing RegexTest because 'test' matches '.*'.
+                RegexTest(val="test", should_match=True),
+                # Failing RegexTest because 'test' matches '.*'.
+                RegexTest(val="test", should_match=False)
+            ])
+        self.assertEqual(got.regex_error, "")
+        self.assertTrue(got.failing_matches)
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        os.environ = {}
+
+    def test_failing_tests(self):
+        docs = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string",
+                "regex": ".*",
+                "regex_tests": [
+                    { "val": "will you be my match?", "should_match": false }
+                ]
+            }
+        }
+        """
+        with tempfile.NamedTemporaryFile(mode='w') as envvar:
+            envvar.write(docs)
+            envvar.flush()
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["LOCAL_OUTPUT"] = True
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                main()
+            self.assertIn("Test failures: ['MY_VAR']", stderr.getvalue())
+
+    def test_no_failing_tests(self):
+        docs = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string",
+                "regex": ".*",
+                "regex_tests": [
+                    { "val": "will you be my match?", "should_match": true }
+                ]
+            }
+        }
+        """
+        with tempfile.NamedTemporaryFile(mode='w') as envvar:
+            envvar.write(docs)
+            envvar.flush()
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["LOCAL_OUTPUT"] = True
+
+            # Test that main does not exit.
+            main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -29,11 +29,11 @@ function get_modified_java_files() {
   ) | grep -E ".+\.java$"
 }
 
-function get_modified_ts_files() {
+function get_modified_ts_and_json_files() {
   (
     get_tracked_modified_files
     get_untracked_files
-  ) | grep -E ".+\.ts$"
+  ) | grep -E ".+\.(ts|json)$"
 }
 
 function get_modified_python_files() {
@@ -51,8 +51,8 @@ else
   echo 'Done formatting java'
 fi
 
-if [[ -z $(get_modified_ts_files) ]]; then
-  echo 'No modified TypeScript files found'
+if [[ -z $(get_modified_ts_and_json_files) ]]; then
+  echo 'No modified TypeScript or JSON files found'
 else
   echo 'Start formatting with prettier'
   # prettier is installed as node module in `formatter` directory

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -14,6 +14,8 @@
 # And if an environment variable exists when there is no other subsitution, then
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
+#
+# Environment variable substitutions should all be SCREAMING_SNAKE_CASE.
 
 include "helper/auth.conf"
 include "helper/cloud.conf"

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -373,7 +373,11 @@
     "type": "string"
   },
   "CIVIFORM_IMAGE_TAG": {
-    "description": "The tag of the docker image this server is running inside.  Is added as a HTML meta tag with name 'civiform-build-tag'.  If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page.",
+    "description": "The tag of the docker image this server is running inside. Is added as a HTML meta tag with name 'civiform-build-tag'. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if CIVIFORM_VERSION is the empty string or set to 'latest'.",
+    "type": "string"
+  },
+  "CIVIFORM_VERSION": {
+    "description": "The release version of CiviForm. For example: v1.18.0. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if it a value other than the empty string or 'latest'.",
     "type": "string"
   },
   "Observability": {
@@ -473,6 +477,14 @@
       },
       "STAGING_DISABLE_APPLICANT_GUEST_LOGIN": {
         "description": "If this is a staging deployment and this variable is set to true, the 'CONTINUE AS GUEST' button is not shown on the login page.",
+        "type": "bool"
+      },
+      "PHONE_QUESTION_TYPE_ENABLED": {
+        "description": "Enables the phone number question type.",
+        "type": "bool"
+      },
+      "NEW_LOGIN_FORM_ENABLED": {
+        "description": "Enables the new login form page.",
         "type": "bool"
       }
     }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -1,0 +1,480 @@
+{
+  "Branding": {
+    "group_description": "Configuration options for CiviForm branding.",
+    "members": {
+      "WHITELABEL_SMALL_LOGO_URL": {
+        "description": "Small logo for the civic entity used on the login page.",
+        "type": "string"
+      },
+      "WHITELABEL_LOGO_WITH_NAME_URL": {
+        "description": "Logo with civic entity name used on the applicant-facing program index page.",
+        "type": "string"
+      },
+      "WHITELABEL_CIVIC_ENTITY_SHORT_NAME": {
+        "description": "The short display name of the civic entity, will use 'TestCity' if not set.",
+        "type": "string"
+      },
+      "WHITELABEL_CIVIC_ENTITY_FULL_NAME": {
+        "description": "The full display name of the civic entity, will use 'City of TestCity' if not set.",
+        "type": "string"
+      },
+      "FAVICON_URL": {
+        "description": "The URL of a 32x32 or 16x16 pixel [favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon) image, in GIF, PNG, or ICO format.",
+        "type": "string"
+      }
+    }
+  },
+  "External service dependencies": {
+    "group_description": "Configures connections to external services the CiviForm server relies on.",
+    "members": {
+      "Applicant Identity Provider": {
+        "group_description": "Configuration options for the [applicant identity provider](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#applicant-authentication).",
+        "members": {
+          "CIVIFORM_APPLICANT_IDP": {
+            "description": "What identity provider to use for applicants.",
+            "type": "string",
+            "values": [
+              "idcs",
+              "login-radius",
+              "generic-oidc",
+              "login-gov",
+              "auth0",
+              "disabled"
+            ]
+          },
+          "APPLICANT_REGISTER_URI": {
+            "description": "URI to create a new account in the applicant identity provider.",
+            "type": "string"
+          },
+          "Oracle Identity Cloud Service": {
+            "group_description": "Configuration options for the [idcs](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#oracle-idcs) provider.",
+            "members": {
+              "IDCS_CLIENT_ID": {
+                "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with IDCS. A Civiform instance is always the client.",
+                "type": "string"
+              },
+              "IDCS_SECRET": {
+                "description": "A secret known only to the client (Civiform) and authorization server, specifically for IDCS OIDC systems. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
+                "type": "string"
+              },
+              "IDCS_DISCOVERY_URI": {
+                "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with the IDCS auth provider.",
+                "type": "string"
+              }
+            }
+          },
+          "Login Radius": {
+            "group_description": "Configuration optiosn for the [login-radius](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#loginradius-saml) provider",
+            "members": {
+              "LOGIN_RADIUS_API_KEY": {
+                "description": "The API key used to interact with LoginRadius.",
+                "type": "string"
+              },
+              "LOGIN_RADIUS_METADATA_URI": {
+                "description": "The base URL to construct SAML endpoints, based on the SAML2 spec.",
+                "type": "string"
+              },
+              "LOGIN_RADIUS_SAML_APP_NAME": {
+                "description": "The name for the app, based on the SAML2 spec.",
+                "type": "string"
+              },
+              "LOGIN_RADIUS_KEYSTORE_NAME": {
+                "description": "Name of the SAML2 keystore, used to store digital certificates and private keys for SAML auth.",
+                "type": "string"
+              },
+              "LOGIN_RADIUS_KEYSTORE_PASS": {
+                "description": "The password used the protect the integrity of the SAML keystore file.",
+                "type": "string"
+              },
+              "LOGIN_RADIUS_PRIVATE_KEY_PASS": {
+                "description": "The password used to protect the private key of the SAML digital certificate.",
+                "type": "string"
+              }
+            }
+          },
+          "OpenID Connect": {
+            "group_description": "Configuration options for the [generic-oidc](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#generic-oidc-oidc) provider.",
+            "members": {
+              "APPLICANT_OIDC_PROVIDER_LOGOUT": {
+                "description": "Enables [central logout](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#logout).",
+                "type": "bool"
+              },
+              "APPLICANT_OIDC_OVERRIDE_LOGOUT_URL": {
+                "description": "By default the 'end_session_endpoint' from the auth provider discovery metadata file is used as the logout endpoint. However for some integrations that standard flow might not work and we need to override logout URL.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM": {
+                "description": "URL param used to pass the post logout redirect url in the logout request to the auth provider. It defaults to 'post_logout_redirect_uri' if this variable is unset. If this variable is set to the empty string, the post logout redirect url is not passed at all and instead it needs to be hardcoded on the the auth provider (otherwise the user won't be redirected back to civiform after logout).",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_PROVIDER_NAME": {
+                "description": "The name of the OIDC (OpenID Connect) auth provider (server), such as “Auth0” or “LoginRadius”.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_CLIENT_ID": {
+                "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers. A Civiform instance is always the client.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_CLIENT_SECRET": {
+                "description": "A secret known only to the client (Civiform) and authorization server. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_DISCOVERY_URI": {
+                "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with a given auth provider.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_RESPONSE_MODE": {
+                "description": "Informs the auth server of the desired auth processing flow, based on the OpenID Connect spec.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_RESPONSE_TYPE": {
+                "description": "Informs the auth server of the mechanism to be used for returning response params from the auth endpoint, based on the OpenID Connect spec.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_ADDITIONAL_SCOPES": {
+                "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_LOCALE_ATTRIBUTE": {
+                "description": "The locale of the user, such as “en-US”.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_EMAIL_ATTRIBUTE": {
+                "description": "The OIDC attribute name for the user’s email address.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_FIRST_NAME_ATTRIBUTE": {
+                "description": "The OIDC attribute name for the user’s first name.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE": {
+                "description": "The OIDC attribute name for the user’s middle name.",
+                "type": "string"
+              },
+              "APPLICANT_OIDC_LAST_NAME_ATTRIBUTE": {
+                "description": "The OIDC attribute name for the user’s last name.",
+                "type": "string"
+              }
+            }
+          },
+          "Login.gov": {
+            "group_description": "Configuration options for the [login-gov](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#login.gov-oidc) provider",
+            "members": {
+              "LOGIN_GOV_CLIENT_ID": {
+                "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with Login.gov. A Civiform instance is always the client.",
+                "type": "string"
+              },
+              "LOGIN_GOV_DISCOVERY_URI": {
+                "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with a given auth provider, specifically for Login.gov.",
+                "type": "string"
+              },
+              "LOGIN_GOV_ADDITIONAL_SCOPES": {
+                "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides. Scopes should be separated by a space.",
+                "type": "string"
+              },
+              "LOGIN_GOV_ACR_VALUE": {
+                "description": "[Authentication Context Class Reference requests](https://developers.login.gov/oidc/#request-parameters). ial/1 is for open registration, email only. ial/2 is for requiring identity verification.",
+                "type": "string",
+                "values": [
+                  "http://idmanagement.gov/ns/assurance/ial/1",
+                  "http://idmanagement.gov/ns/assurance/ial/2"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "Administrator Identity Provider": {
+        "group_description": "Configuration options for the [administrator identity provider](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#admin-authentication).",
+        "members": {
+          "ADFS_CLIENT_ID": {
+            "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with ADFS. A Civiform instance is always the client.",
+            "type": "string"
+          },
+          "ADFS_SECRET": {
+            "description": "A secret known only to the client (Civiform) and authorization server. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
+            "type": "string"
+          },
+          "ADFS_DISCOVERY_URI": {
+            "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with the IDCS auth provider.",
+            "type": "string"
+          },
+          "ADFS_GLOBAL_ADMIN_GROUP": {
+            "description": "The name of the admin group in Active Directory, typically used to tell if a user is a global admin.",
+            "type": "string"
+          },
+          "ADFS_ADDITIONAL_SCOPES": {
+            "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides. Scopes should be separated by a space.",
+            "type": "string"
+          },
+          "AD_GROUPS_ATTRIBUTE_NAME": {
+            "description": "The attribute name for looking up the groups associated with a particular user.",
+            "type": "string"
+          }
+        }
+      },
+      "Database": {
+        "group_description": "Configures the connection to the PostgreSQL database.",
+        "members": {
+          "DATABASE_APPLY_DESTRUCTIVE_CHANGES": {
+            "description": "If enabled, [playframework down evolutions](https://www.playframework.com/documentation/2.8.x/Evolutions#Evolutions-scripts) are automatically applied on server start if needed.",
+            "type": "bool"
+          },
+          "DATABASE_CONNECTION_POOL_SIZE": {
+            "description": "Sets how many connections to the database are maintained.",
+            "type": "int"
+          },
+          "DB_JDBC_STRING": {
+            "description": "The database URL.",
+            "type": "string"
+          },
+          "DB_USERNAME": {
+            "description": "The username used to connect to the database.",
+            "type": "string"
+          },
+          "DB_PASSWORD": {
+            "description": "The password used to connect to the database.",
+            "type": "string"
+          }
+        }
+      },
+      "AWS_REGION": {
+        "description": "Region where the AWS SES service exists. If STORAGE_SERVICE_NAME is set to 'aws', it is also the region where the AWS s3 service exists.",
+        "type": "string"
+      },
+      "AWS_SES_SENDER": {
+        "description": "The email address used for the 'from' email header for emails sent by CiviForm.",
+        "type": "string"
+      },
+      "Application File Upload Storage": {
+        "group_description": "Configuration options for the application file upload storage provider",
+        "members": {
+          "STORAGE_SERVICE_NAME": {
+            "description": "What static file storage provider to use.",
+            "type": "string",
+            "values": ["s3", "azure-blob"]
+          },
+          "AWS_S3_BUCKET_NAME": {
+            "description": "s3 bucket to store files in.",
+            "type": "string"
+          },
+          "AWS_S3_FILE_LIMIT_MB": {
+            "description": "The max size (in Mb) of files uploaded to s3.",
+            "type": "string"
+          },
+          "AZURE_STORAGE_ACCOUNT_NAME": {
+            "description": "The azure account name where the blob storage service exists.",
+            "type": "string"
+          },
+          "AZURE_STORAGE_ACCOUNT_CONTAINER": {
+            "description": "Azure blob storage container name to store files in.",
+            "type": "string"
+          },
+          "AZURE_LOCAL_CONNECTION_STRING": {
+            "description": "Allows local [Azurite emulator](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) to be used for developer deployments.",
+            "type": "string"
+          }
+        }
+      },
+      "ESRI Address Validation": {
+        "group_description": "Configuration options for the ESRI GIS client and address validation/correction feature.",
+        "members": {
+          "ESRI_ADDRESS_CORRECTION_ENABLED": {
+            "description": "Enables the feature that allows address correction for address questions.",
+            "type": "bool"
+          },
+          "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
+            "description": "The URL CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
+            "type": "string"
+          },
+          "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED": {
+            "description": "Enables the feature that allows for service area validation of a corrected address. ESRI_ADDRESS_CORRECTION_ENABLED needs to be enabled.",
+            "type": "bool"
+          },
+          "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {
+            "description": "Human readable labels used to present the service area validation options in CiviForm’s admin UI.",
+            "type": "index-list"
+          },
+          "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS": {
+            "description": "The value CiviForm uses to validate if an address is in a service area.",
+            "type": "index-list"
+          },
+          "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS": {
+            "description": "The URL CiviForm will use to call Esri’s [map query service](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm) for service area validation.",
+            "type": "index-list"
+          },
+          "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES": {
+            "description": "The attribute CiviForm checks from the service area validation response to get the service area validation ID.",
+            "type": "index-list"
+          },
+          "ESRI_EXTERNAL_CALL_TRIES": {
+            "description": "The number of tries CiviForm will attempt requests to external Esri services.",
+            "type": "int"
+          }
+        }
+      }
+    }
+  },
+  "Email addresses": {
+    "group_description": "Configuration options for [CiviForm email usage](https://docs.civiform.us/it-manual/sre-playbook/email-configuration).",
+    "members": {
+      "SUPPORT_EMAIL_ADDRESS": {
+        "description": "This email address is listed in the footer for applicants to contact support.",
+        "type": "string"
+      },
+      "IT_EMAIL_ADDRESS": {
+        "description": "This email address receives error notifications from CiviForm when things break.",
+        "type": "string"
+      },
+      "STAGING_ADMIN_LIST": {
+        "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the program administrator's email address.",
+        "type": "string"
+      },
+      "STAGING_TI_LIST": {
+        "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the trusted intermediary's email address.",
+        "type": "string"
+      },
+      "STAGING_APPLICANT_LIST": {
+        "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the applicant's email address.",
+        "type": "string"
+      }
+    }
+  },
+  "SECRET_KEY": {
+    "description": "The [secret key](http://www.playframework.com/documentation/latest/ApplicationSecret) is used to sign Play's session cookie. This must be changed for production.",
+    "type": "string"
+  },
+  "BASE_URL": {
+    "description": "The URL of the CiviForm deployment.  Must start with 'https://' or 'http://'.",
+    "type": "string",
+    "regex": "^(http://|https://)",
+    "regex_tests": [
+      {"val": "http://my-civiform.org", "should_match": true},
+      {"val": "https://my-civiform.org", "should_match": true},
+      {"val": "my-civiform.org", "should_match": false}
+    ]
+  },
+  "STAGING_HOSTNAME": {
+    "description": "DNS name of the staging deployment.  Must not start with 'https://' or 'http://'.",
+    "type": "string",
+    "regex": "^(?!http://|https://)",
+    "regex_tests": [
+      {"val": "my-civiform.org", "should_match": true},
+      {"val": "http://my-civiform.org", "should_match": false},
+      {"val": "https://my-civiform.org", "should_match": false}
+    ]
+  },
+  "CIVIFORM_SUPPORTED_LANGUAGES": {
+    "description": "The languages that applicants can choose from when specifying their language preference and that admins can choose from when adding translations for programs and applications.",
+    "type": "index-list"
+  },
+  "CIVIFORM_TIME_ZONE_ID": {
+    "description": "A Java [time zone ID](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html) indicating the time zone for this CiviForm deployment. All times in the system will be calculated in this zone. Default value is 'America/Los_Angeles'",
+    "type": "string"
+  },
+  "CIVIFORM_IMAGE_TAG": {
+    "description": "The tag of the docker image this server is running inside.  Is added as a HTML meta tag with name 'civiform-build-tag'.  If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page.",
+    "type": "string"
+  },
+  "Observability": {
+    "group_description": "Configuration options for CiviForm observability features.",
+    "members": {
+      "CIVIFORM_SERVER_METRICS_ENABLED": {
+        "description": "If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If disabled, '/metrics' returns a 404.",
+        "type": "bool"
+      },
+      "MEASUREMENT_ID": {
+        "description": "The Google Analytics tracking ID.  If set, Google Analytics JavaScript scripts are added to the CiviForm pages.",
+        "type": "string"
+      }
+    }
+  },
+  "Data Export API": {
+    "group_description": "Configuration options for the [CiviForm API](https://docs.civiform.us/it-manual/api).",
+    "members": {
+      "CIVIFORM_API_SECRET_SALT": {
+        "description": "A cryptographic [secret salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) used for salting API keys before storing their hash values in the database. This value should be kept strictly secret. If one suspects the secret has been leaked or otherwise comprised it should be changed and all active API keys should be retired and reissued. Default value is 'changeme'.",
+        "type": "string"
+      },
+      "CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET": {
+        "description": "When true prevents the CiviForm admin from issuing API keys that allow callers from all IP addresses (i.e. a CIDR mask of /0).",
+        "type": "bool"
+      },
+      "CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE_SIZE": {
+        "description": "An integer specifying the maximum number of entries returned in a page of results for the applications export API.",
+        "type": "int"
+      }
+    }
+  },
+  "Durable Jobs": {
+    "group_description": "Configuration options for the CiviForm Job Runner.",
+    "members": {
+      "DURABLE_JOBS_POLL_INTERVAL_SECONDS": {
+        "description": "An integer specifying the polling interval in seconds for the durable job system. A smaller number here increases the polling frequency, which results in jobs running sooner when they are scheduled to be run immediately, at the cost of more pressure on the database. Default value is 5.",
+        "type": "int"
+      },
+      "DURABLE_JOBS_JOB_TIMEOUT_MINUTES": {
+        "description": "An integer specifying the timeout in minutes for durable jobs i.e. how long a single job is allowed to run before the system attempts to interrupt it. Default value is 30.",
+        "type": "int"
+      },
+      "DURABLE_JOBS_THREAD_POOL_SIZE": {
+        "description": "The number of server threads available for the durable job runner. More than a single thread will the server execute multiple jobs in parallel. Default value is 1.",
+        "type": "int"
+      }
+    }
+  },
+  "Feature Flags": {
+    "group_description": "Configuration options to enable or disable optional or in-development features.",
+    "members": {
+      "CF_OPTIONAL_QUESTIONS": {
+        "description": "If enabled, allows questions to be optional in programs. Is enabled by default.",
+        "type": "bool"
+      },
+      "ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS": {
+        "description": "If enabled, CiviForm Admins are able to see all applications for all programs. Is disabled by default.",
+        "type": "bool"
+      },
+      "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE": {
+        "description": "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login screen. Is disabled by default.",
+        "type": "bool"
+      },
+      "PROGRAM_READ_ONLY_VIEW_ENABLED": {
+        "description": "If enabled, the admin UI can show a read only view of a program. If disabled, the only way to view a program is to start editing it. Is disabled by default.",
+        "type": "bool"
+      },
+      "PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED": {
+        "description": "Enables the [program eligibility](https://github.com/civiform/civiform/issues/3744) feature.",
+        "type": "bool"
+      },
+      "CIVIFORM_ADMIN_REPORTING_UI_ENABLED": {
+        "description": "Enables the [in-app reporting feature](https://docs.google.com/document/d/1iXb58tt6j7CczPKyW18p0fUqv6SCVpoZqhqM84BKoYM/edit#heading=h.3c4zscx27v6u).",
+        "type": "bool"
+      },
+      "FEATURE_FLAG_OVERRIDES_ENABLED": {
+        "description": "Allows feature flags to be overridden via request cookies. Is used by browswer tests. Should only be enabled in test and staging deployments.",
+        "type": "bool"
+      },
+      "INTAKE_FORM_ENABLED": {
+        "description": "Enables the Common Intake Form feature.",
+        "type": "bool"
+      },
+      "NONGATED_ELIGIBILITY_ENABLED": {
+        "description": "Enables the feature that allows setting eligibility criteria to non-gating.",
+        "type": "bool"
+      },
+
+      "STAGING_ADD_NOINDEX_META_TAG": {
+        "description": "If this is a staging deployment and this variable is set to true, a [robots noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) metadata tag is added to the CiviForm pages. This causes the staging site to not be listed on search engines.",
+        "type": "bool"
+      },
+      "STAGING_DISABLE_DEMO_MODE_LOGINS": {
+        "description": "If this is a staging deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page.",
+        "type": "bool"
+      },
+      "STAGING_DISABLE_APPLICANT_GUEST_LOGIN": {
+        "description": "If this is a staging deployment and this variable is set to true, the 'CONTINUE AS GUEST' button is not shown on the login page.",
+        "type": "bool"
+      }
+    }
+  }
+}

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -24,9 +24,6 @@ staging_disable_applicant_guest_login = ${?STAGING_DISABLE_APPLICANT_GUEST_LOGIN
 # Preview features.
 
 # In development features.
-# Status Tracking is a default feature as of Jan 2023, this control is deprecated.
-application_status_tracking_enabled = true
-application_status_tracking_enabled = ${?CIVIFORM_APPLICATION_STATUS_TRACKING_ENABLED}
 program_read_only_view_enabled = false
 program_read_only_view_enabled = ${?PROGRAM_READ_ONLY_VIEW_ENABLED}
 


### PR DESCRIPTION
### Description

Followup to https://github.com/civiform/civiform/pull/4225.  Adds the env-var-docs.json documentation file and the scripts that ensure it has all the proper variables and that any provided regex_tests pass.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Add test in check_vars_documented_test.py for imported conf files
- [x] Add bin scripts
- [x] Add new scripts to pr_env_var_docs action
