### PR TITLE
Simplify toParameters override

### DIFF
--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -63,6 +63,8 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
 
     Map<String, List<String>> params = super.toParameters();
 
+    // Remove post_logout_redirect_uri and replace with custom logic.
+    params.remove("post_logout_redirect_uri");
     if (postLogoutRedirectURI != null && !postLogoutRedirectParam.isEmpty()) {
       params.put(
           postLogoutRedirectParam, Collections.singletonList(postLogoutRedirectURI.toString()));

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -6,7 +6,6 @@ import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.pac4j.core.exception.TechnicalException;
@@ -62,14 +61,11 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
   @Override
   public Map<String, List<String>> toParameters() {
 
-    Map<String, List<String>> params = new LinkedHashMap<>();
+    Map<String, List<String>> params = super.toParameters();
 
     if (postLogoutRedirectURI != null && !postLogoutRedirectParam.isEmpty()) {
       params.put(
           postLogoutRedirectParam, Collections.singletonList(postLogoutRedirectURI.toString()));
-    }
-    if (getState() != null) {
-      params.put("state", Collections.singletonList(getState().getValue()));
     }
 
     extraParams.forEach((key, value) -> params.put(key, Collections.singletonList(value)));


### PR DESCRIPTION
### Description

`CustomOidcLogoutRequest` overrides `toParameters()`. The way it is done adds duplicate code for some built-in `toParameters` logic, and removes other logic that we could use, like `id_token_hint`.

This does not fix #3863, but will help when we use the param later on since pac4j adds `id_token_hint` for us [here](https://github.com/hidglobal/oauth-2.0-sdk-with-openid-connect-extensions/blob/0a7fa5785ce8ac17ac95ce5294a24c8743794a6f/src/main/java/com/nimbusds/openid/connect/sdk/LogoutRequest.java#L172).