### PR TITLE
Fix crash when ADFS sends a single group

### DIFF
--- a/server/app/auth/oidc/admin/AdfsGroupAccessor.java
+++ b/server/app/auth/oidc/admin/AdfsGroupAccessor.java
@@ -1,0 +1,37 @@
+package auth.oidc.admin;
+
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.pac4j.oidc.profile.OidcProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AdfsGroupAccessor {
+  private static final Logger logger = LoggerFactory.getLogger(AdfsGroupAccessor.class);
+
+  public static List<String> getGroups(OidcProfile oidcProfile, String adGroupsAttributeName) {
+    if (!oidcProfile.containsAttribute(adGroupsAttributeName)) {
+      return List.of();
+    }
+
+    try {
+      // This line is unchecked so that setting the `clazz` argument to a raw type (List) that is
+      // later converted to a generic type (List<String>) is allowed by the compiler.
+      @SuppressWarnings("unchecked")
+      List<String> groups = oidcProfile.getAttribute(adGroupsAttributeName, List.class);
+      return groups;
+    } catch (ClassCastException e) {
+      // The attribute value may not be a List in some cases (such as the single group case, when
+      // it is a String).
+      logger.info("AD group for attribute {} was not a list.", adGroupsAttributeName);
+    }
+
+    try {
+      String group = oidcProfile.getAttribute(adGroupsAttributeName, String.class);
+      return StringUtils.isEmpty(group) ? List.of() : List.of(group);
+    } catch (ClassCastException e) {
+      logger.info("AD group for attribute {} was not a String nor List.", adGroupsAttributeName);
+      throw e;
+    }
+  }
+}

--- a/server/app/auth/oidc/admin/AdfsGroupAccessor.java
+++ b/server/app/auth/oidc/admin/AdfsGroupAccessor.java
@@ -6,9 +6,18 @@ import org.pac4j.oidc.profile.OidcProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Encapsulates the logic for retrieving the list of groups a given user is a part of from Active
+ * Directory Federation Services (ADFS).
+ */
 public final class AdfsGroupAccessor {
   private static final Logger logger = LoggerFactory.getLogger(AdfsGroupAccessor.class);
 
+  /**
+   * Gets the list of groups a user (represented by an {@link OidcProfile}), is in. Due to an
+   * inconsistency from ADFS, the attribute returned by {@link OidcProfile#getAttribute} may be a
+   * List or a String. We must account for both or risk a {@link ClassCastException}.
+   */
   public static List<String> getGroups(OidcProfile oidcProfile, String adGroupsAttributeName) {
     if (!oidcProfile.containsAttribute(adGroupsAttributeName)) {
       return List.of();
@@ -23,7 +32,7 @@ public final class AdfsGroupAccessor {
     } catch (ClassCastException e) {
       // The attribute value may not be a List in some cases (such as the single group case, when
       // it is a String).
-      logger.info("AD group for attribute {} was not a list.", adGroupsAttributeName);
+      logger.info("AD group for attribute {} was not a List.", adGroupsAttributeName);
     }
 
     try {

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -11,8 +11,6 @@ import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
 /**
@@ -21,8 +19,6 @@ import repository.UserRepository;
  * right now.
  */
 public class AdfsProfileCreator extends CiviformOidcProfileCreator {
-  private static final Logger logger = LoggerFactory.getLogger(AdfsProfileCreator.class);
-
   private final String adminGroupName;
   private final String ad_groups_attribute_name;
 
@@ -64,18 +60,8 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private boolean isGlobalAdmin(OidcProfile profile) {
-    List<Object> groups =
-        profile.containsAttribute(this.ad_groups_attribute_name)
-            ? profile.getAttribute(this.ad_groups_attribute_name, List.class)
-            : null;
-
-    if (groups == null) {
-      logger.error("Missing group claim in ADFS OIDC profile.");
-      return false;
-    }
-
+    List<String> groups = AdfsGroupAccessor.getGroups(profile, this.ad_groups_attribute_name);
     return groups.contains(this.adminGroupName);
   }
 

--- a/server/test/auth/oidc/admin/AdfsGroupAccessorTest.java
+++ b/server/test/auth/oidc/admin/AdfsGroupAccessorTest.java
@@ -1,0 +1,63 @@
+package auth.oidc.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.Test;
+import org.pac4j.oidc.profile.OidcProfile;
+
+public class AdfsGroupAccessorTest {
+
+  private static final String AD_GROUPS_ATTRIBUTE_NAME = "ad-groups-attribute";
+
+  @Test
+  public void getGroups_getsGroups_asList() {
+    OidcProfile oidcProfile = new OidcProfile();
+    List<String> groups = List.of("aaa", "bbb", "ccc");
+    oidcProfile.addAttribute(AD_GROUPS_ATTRIBUTE_NAME, groups);
+
+    List<String> groupsResult = AdfsGroupAccessor.getGroups(oidcProfile, AD_GROUPS_ATTRIBUTE_NAME);
+    assertThat(groupsResult).isEqualTo(groups);
+  }
+
+  @Test
+  public void getGroups_getsGroups_asString() {
+    OidcProfile oidcProfile = new OidcProfile();
+    String groups = "aaa";
+    oidcProfile.addAttribute(AD_GROUPS_ATTRIBUTE_NAME, groups);
+
+    List<String> groupsResult = AdfsGroupAccessor.getGroups(oidcProfile, AD_GROUPS_ATTRIBUTE_NAME);
+    assertThat(groupsResult).containsExactly(groups);
+  }
+
+  @Test
+  public void getGroups_returnsEmptyList_whenAttributeIsEmptyString() {
+    OidcProfile oidcProfile = new OidcProfile();
+    String groups = "";
+    oidcProfile.addAttribute(AD_GROUPS_ATTRIBUTE_NAME, groups);
+
+    List<String> groupsResult = AdfsGroupAccessor.getGroups(oidcProfile, AD_GROUPS_ATTRIBUTE_NAME);
+    assertThat(groupsResult).isEmpty();
+  }
+
+  @Test
+  public void getGroups_returnsEmptyList_whenAttributeNotPresent() {
+    // No attributes added to OidcProfile.
+    OidcProfile oidcProfile = new OidcProfile();
+
+    List<String> groupsResult = AdfsGroupAccessor.getGroups(oidcProfile, AD_GROUPS_ATTRIBUTE_NAME);
+    assertThat(groupsResult).isEmpty();
+  }
+
+  @Test
+  public void getGroups_throwsException_whenAdGroupsValueIsNotAStringOrList() {
+    int groups = 12345;
+    OidcProfile oidcProfile = new OidcProfile();
+
+    oidcProfile.addAttribute(AD_GROUPS_ATTRIBUTE_NAME, groups);
+
+    assertThatThrownBy(() -> AdfsGroupAccessor.getGroups(oidcProfile, AD_GROUPS_ATTRIBUTE_NAME), "")
+        .isInstanceOf(ClassCastException.class);
+  }
+}


### PR DESCRIPTION
### Description

Fixes an issue where if AD sends in a string instead of a list of groups (in the case of a single or 0 groups), we can handle it.

Previously, we could only handle:
* A list of groups returned by ADFS

Now we can handle:
* A list of groups
* A string that represents one group
* An empty string

### Testing

I've sent a Docker image of commit 0ca3a7 to Cliff at Bloomington and he verified it is working correctly.

### Issue(s) this completes

Fixes #4295
