### PR TITLE
Always allow submitting an application if eligibility is non-gating.

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -507,6 +507,40 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.expectIneligiblePage()
     })
 
+    it('shows not eligible upon submit with ineligible answer with gating eligibility', async () => {
+      const {page, applicantQuestions} = ctx
+      await loginAsGuest(page)
+      await selectApplicantLanguage(page, 'English')
+      await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await enableFeatureFlag(page, 'nongated_eligibility_enabled')
+      await applicantQuestions.applyProgram(fullProgramName)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerNumberQuestion('1')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.expectIneligiblePage()
+
+      // Verify the question is marked ineligible.
+      await applicantQuestions.gotoApplicantHomePage()
+      await applicantQuestions.seeEligibilityTag(
+        fullProgramName,
+        /* isEligible= */ false,
+      )
+      await applicantQuestions.clickApplyProgramButton(fullProgramName)
+      await applicantQuestions.expectQuestionIsNotEligible(
+        AdminQuestions.NUMBER_QUESTION_TEXT,
+      )
+
+      // Answer the other question.
+      await applicantQuestions.clickContinue()
+      await applicantQuestions.answerEmailQuestion('email@email.com')
+
+      // Submit and expect to be told it's ineligible.
+      await applicantQuestions.clickNext()
+      await applicantQuestions.clickSubmit()
+      await applicantQuestions.expectIneligiblePage()
+    })
+
     it('shows may be eligible with nongating eligibility', async () => {
       const {page, adminPrograms, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -370,6 +370,7 @@ describe('Applicant navigation flow', () => {
       await loginAsGuest(page)
       await selectApplicantLanguage(page, 'English')
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await disableFeatureFlag(page, 'nongated_eligibility_enabled')
       await applicantQuestions.applyProgram(fullProgramName)
 
       // Fill out application and submit.
@@ -398,6 +399,7 @@ describe('Applicant navigation flow', () => {
       await loginAsGuest(page)
       await selectApplicantLanguage(page, 'English')
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await disableFeatureFlag(page, 'nongated_eligibility_enabled')
       await applicantQuestions.applyProgram(fullProgramName)
 
       // Fill out application and without submitting.
@@ -434,6 +436,7 @@ describe('Applicant navigation flow', () => {
       // Add the partial program.
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await disableFeatureFlag(page, 'nongated_eligibility_enabled')
       await adminPrograms.addProgram(overlappingOneQProgramName)
       await adminPrograms.editProgramBlock(
         overlappingOneQProgramName,
@@ -475,6 +478,7 @@ describe('Applicant navigation flow', () => {
       await loginAsGuest(page)
       await selectApplicantLanguage(page, 'English')
       await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await disableFeatureFlag(page, 'nongated_eligibility_enabled')
       await applicantQuestions.applyProgram(fullProgramName)
 
       // Fill out application and submit.
@@ -501,6 +505,36 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.clickNext()
       await applicantQuestions.clickSubmit()
       await applicantQuestions.expectIneligiblePage()
+    })
+
+    it('does not show not eligible upon submit with nongating eligibility', async () => {
+      const {page, adminPrograms, applicantQuestions} = ctx
+      await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+      await enableFeatureFlag(page, 'nongated_eligibility_enabled')
+
+      await loginAsAdmin(page)
+      await adminPrograms.createNewVersion(fullProgramName)
+      await adminPrograms.setProgramEligibilityToNongating(fullProgramName)
+      await adminPrograms.publishProgram(fullProgramName)
+      await logout(page)
+
+      await loginAsGuest(page)
+      await selectApplicantLanguage(page, 'English')
+
+      await applicantQuestions.applyProgram(fullProgramName)
+
+      // Fill out application and without submitting.
+      await applicantQuestions.answerNumberQuestion('1')
+      await applicantQuestions.clickNext()
+
+      // Go back to in progress application and submit.
+      await applicantQuestions.gotoApplicantHomePage()
+      await applicantQuestions.applyProgram(fullProgramName)
+      await applicantQuestions.answerEmailQuestion('test@test.com')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.submitFromReviewPage()
+      await applicantQuestions.gotoApplicantHomePage()
+      await applicantQuestions.seeNoEligibilityTags(fullProgramName)
     })
   })
 

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -522,7 +522,7 @@ describe('Applicant navigation flow', () => {
       await selectApplicantLanguage(page, 'English')
       await applicantQuestions.applyProgram(fullProgramName)
 
-      // Fill out application and without submitting.
+      // Fill out application without submitting.
       await applicantQuestions.answerNumberQuestion('5')
       await applicantQuestions.clickNext()
 
@@ -532,6 +532,7 @@ describe('Applicant navigation flow', () => {
         fullProgramName,
         /* isEligible= */ true,
       )
+
       // Go back to in progress application and submit.
       await applicantQuestions.applyProgram(fullProgramName)
       await applicantQuestions.answerEmailQuestion('test@test.com')
@@ -557,13 +558,15 @@ describe('Applicant navigation flow', () => {
 
       await applicantQuestions.applyProgram(fullProgramName)
 
-      // Fill out application and without submitting.
+      // Fill out application without submitting.
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickNext()
 
-      // Go back to in progress application and submit.
+      // Verify that there's no indication of eligibility.
       await applicantQuestions.gotoApplicantHomePage()
       await applicantQuestions.seeNoEligibilityTags(fullProgramName)
+
+      // Go back to in progress application and submit.
       await applicantQuestions.applyProgram(fullProgramName)
       await applicantQuestions.answerEmailQuestion('test@test.com')
       await applicantQuestions.clickNext()

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -231,6 +231,11 @@ export class AdminPrograms {
     await this.expectProgramSettingsPage()
   }
 
+  async setProgramEligibilityToNongating(programName: string) {
+    await this.gotoProgramSettingsPage(programName)
+    await this.page.click('#eligibility-toggle')
+  }
+
   async gotoEditDraftProgramPage(programName: string) {
     await this.gotoAdminProgramsPage()
     await this.expectDraftProgram(programName)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -233,7 +233,12 @@ export class AdminPrograms {
 
   async setProgramEligibilityToNongating(programName: string) {
     await this.gotoProgramSettingsPage(programName)
-    await this.page.click('#eligibility-toggle')
+    const nonGatingEligibilityValue = await this.page
+      .locator('input[name=eligibilityIsGating]')
+      .inputValue()
+    if (nonGatingEligibilityValue == 'false') {
+      await this.page.locator('#eligibility-toggle').click()
+    }
   }
 
   async gotoEditDraftProgramPage(programName: string) {

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -568,6 +568,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                     applicantId, programId, nextBlockIdMaybe.get())));
   }
 
+  /** Returns true if eligibility is gating and the application is ineligible, false otherwise. */
   private boolean shouldRenderIneligibleBlockView(
       Request request,
       ReadOnlyApplicantProgramService roApplicantProgramService,

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -568,7 +568,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                     applicantId, programId, nextBlockIdMaybe.get())));
   }
 
-  /** Returns true if eligibility is gating and the application is ineligible, false otherwise. */
+  /** Returns true if eligibility is gating and the block is ineligible, false otherwise. */
   private boolean shouldRenderIneligibleBlockView(
       Request request,
       ReadOnlyApplicantProgramService roApplicantProgramService,

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -523,12 +523,11 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       }
     }
 
-    if (featureFlags.isProgramEligibilityConditionsEnabled(request)
-        && !roApplicantProgramService.isBlockEligible(blockId)) {
-      CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
-      try {
-        ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
-
+    try {
+      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      if (shouldRenderIneligibleBlockView(
+          request, roApplicantProgramService, programDefinition, blockId)) {
+        CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
         return supplyAsync(
             () ->
                 ok(
@@ -539,9 +538,9 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                         messagesApi.preferred(request),
                         applicantId,
                         programDefinition)));
-      } catch (ProgramNotFoundException e) {
-        notFound(e.toString());
       }
+    } catch (ProgramNotFoundException e) {
+      notFound(e.toString());
     }
 
     Optional<String> nextBlockIdMaybe =
@@ -567,6 +566,21 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             redirect(
                 routes.ApplicantProgramBlocksController.edit(
                     applicantId, programId, nextBlockIdMaybe.get())));
+  }
+
+  private boolean shouldRenderIneligibleBlockView(
+      Request request,
+      ReadOnlyApplicantProgramService roApplicantProgramService,
+      ProgramDefinition programDefinition,
+      String blockId) {
+    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+      return false;
+    }
+    if (featureFlags.isNongatedEligibilityEnabled(request)
+        && !programDefinition.eligibilityIsGating()) {
+      return false;
+    }
+    return !roApplicantProgramService.isBlockEligible(blockId);
   }
 
   private ImmutableMap<String, String> cleanForm(Map<String, String> formData) {

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -155,11 +155,11 @@ public class ApplicantProgramReviewController extends CiviFormController {
     if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
       return false;
     }
-    ProgramDefinition program = programService.getProgramDefinition(programId);
-    if (featureFlags.isNongatedEligibilityEnabled(request) && !program.eligibilityIsGating()) {
+    if (featureFlags.isNongatedEligibilityEnabled(request)
+        && !programService.getProgramDefinition(programId).eligibilityIsGating()) {
       return false;
     }
-    return roApplicantProgramService.isApplicationEligible();
+    return !roApplicantProgramService.isApplicationEligible();
   }
 
   private ApplicantProgramSummaryView.Params.Builder generateParamsBuilder(

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -149,6 +149,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
             });
   }
 
+  /** Returns true if eligibility is gating and the application is ineligible, false otherwise. */
   private boolean shouldShowNotEligibleBanner(
       Request request, ReadOnlyApplicantProgramService roApplicantProgramService, long programId)
       throws ProgramNotFoundException {

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -89,7 +89,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               Messages messages = messagesApi.preferred(request);
               Optional<ToastMessage> notEligibleBanner = Optional.empty();
               try {
-                if (shouldShowEligibilityToast(request, roApplicantProgramService, programId)) {
+                if (shouldShowNotEligibleBanner(request, roApplicantProgramService, programId)) {
                   notEligibleBanner =
                       Optional.of(
                           new ToastMessage(
@@ -149,7 +149,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
             });
   }
 
-  private boolean shouldShowEligibilityToast(
+  private boolean shouldShowNotEligibleBanner(
       Request request, ReadOnlyApplicantProgramService roApplicantProgramService, long programId)
       throws ProgramNotFoundException {
     if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {

--- a/server/app/models/Program.java
+++ b/server/app/models/Program.java
@@ -97,6 +97,11 @@ public class Program extends BaseModel {
 
   @Constraints.Required private ProgramType programType;
 
+  /**
+   * If true, eligibility conditions should gate application submission for this program. If false,
+   * ineligible applications should still be allowed to be submitted and tags that note that the
+   * applicant may not qualify should be hidden.
+   */
   @Constraints.Required private Boolean eligibilityIsGating;
 
   @ManyToMany(mappedBy = "programs")

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -59,6 +59,7 @@ public abstract class AnswerData {
    */
   public abstract boolean isEligible();
 
+  /** True if the program's eligibility is set to gate application submission. */
   public abstract boolean eligibilityIsGating();
 
   /** The applicant's response to the question. */

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -59,6 +59,8 @@ public abstract class AnswerData {
    */
   public abstract boolean isEligible();
 
+  public abstract boolean eligibilityIsGating();
+
   /** The applicant's response to the question. */
   public abstract String answerText();
 
@@ -106,6 +108,8 @@ public abstract class AnswerData {
     public abstract Builder setIsAnswered(boolean isAnswered);
 
     public abstract Builder setIsEligible(boolean isEligible);
+
+    public abstract Builder setEligibilityIsGating(boolean eligibilityIsGating);
 
     public abstract Builder setAnswerText(String answerText);
 

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -59,7 +59,10 @@ public abstract class AnswerData {
    */
   public abstract boolean isEligible();
 
-  /** True if the program's eligibility is set to gate application submission. */
+  /**
+   * True if the program's eligibility is set to gating. If false, tags that note that the applicant
+   * may not qualify should also be hidden.
+   */
   public abstract boolean eligibilityIsGating();
 
   /** The applicant's response to the question. */

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -60,8 +60,8 @@ public abstract class AnswerData {
   public abstract boolean isEligible();
 
   /**
-   * True if the program's eligibility is set to gating. If false, tags that note that the applicant
-   * may not qualify should also be hidden.
+   * True if the program's eligibility is set to gating. If false, eligibility is NOT gating tags
+   * that note that the applicant may not qualify should also be hidden.
    */
   public abstract boolean eligibilityIsGating();
 

--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -274,6 +274,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setQuestionTextForScreenReader(questionTextForScreenReader)
                 .setIsAnswered(isAnswered)
                 .setIsEligible(isEligible)
+                .setEligibilityIsGating(programDefinition.eligibilityIsGating())
                 .setAnswerText(answerText)
                 .setEncodedFileKey(encodedFileKey)
                 .setOriginalFileName(originalFileName)

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -184,7 +184,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
     // Show that the question makes the application ineligible if it is answered and is a reason the
     // application is ineligible.
-    if (!data.isEligible() && data.isAnswered()) {
+    if (data.eligibilityIsGating() && !data.isEligible() && data.isAnswered()) {
       actionAndTimestampDiv.with(
           div(messages.at(MessageKey.CONTENT_DOES_NOT_QUALIFY.getKeyName()))
               .withClasses(

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -306,8 +306,7 @@ public final class ProgramIndexView extends BaseHtmlView {
           programCardApplicationStatus(
               preferredLocale, cardData.latestSubmittedApplicationStatus().get()));
     }
-    if (featureFlags.isProgramEligibilityConditionsEnabled(request)
-        && cardData.isProgramMaybeEligible().isPresent()) {
+    if (shouldShowEligibilityTag(request, cardData)) {
       programData.with(eligibilityTag(request, messages, cardData.isProgramMaybeEligible().get()));
     }
     programData.with(title, description);
@@ -365,6 +364,21 @@ public final class ProgramIndexView extends BaseHtmlView {
                     "block", "shrink-0", BaseStyles.BG_SEATTLE_BLUE, "rounded-t-xl", "h-3"))
         .with(programData)
         .with(actionDiv);
+  }
+
+  private boolean shouldShowEligibilityTag(
+      Http.Request request, ApplicantService.ApplicantProgramData cardData) {
+    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+      return false;
+    }
+    if (!cardData.isProgramMaybeEligible().isPresent()) {
+      return false;
+    }
+    if (cardData.isProgramMaybeEligible().get()) {
+      return true;
+    }
+    return !featureFlags.isNongatedEligibilityEnabled(request)
+        || cardData.program().eligibilityIsGating();
   }
 
   private PTag programCardApplicationStatus(

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -372,10 +372,14 @@ public final class ProgramIndexView extends BaseHtmlView {
    */
   private boolean shouldShowEligibilityTag(
       Http.Request request, ApplicantService.ApplicantProgramData cardData) {
-    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)
-        || !cardData.isProgramMaybeEligible().isPresent()) {
+    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
       return false;
     }
+
+    if (!cardData.isProgramMaybeEligible().isPresent()) {
+      return false;
+    }
+
     return !featureFlags.isNongatedEligibilityEnabled(request)
         || cardData.program().eligibilityIsGating()
         || cardData.isProgramMaybeEligible().get();

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -366,19 +366,19 @@ public final class ProgramIndexView extends BaseHtmlView {
         .with(actionDiv);
   }
 
+  /**
+   * If eligibility is gating, the eligibility tag should always show when present. If eligibility
+   * is non-gating, the eligibility tag should only show if the user may be eligible.
+   */
   private boolean shouldShowEligibilityTag(
       Http.Request request, ApplicantService.ApplicantProgramData cardData) {
-    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)
+        || !cardData.isProgramMaybeEligible().isPresent()) {
       return false;
-    }
-    if (!cardData.isProgramMaybeEligible().isPresent()) {
-      return false;
-    }
-    if (cardData.isProgramMaybeEligible().get()) {
-      return true;
     }
     return !featureFlags.isNongatedEligibilityEnabled(request)
-        || cardData.program().eligibilityIsGating();
+        || cardData.program().eligibilityIsGating()
+        || cardData.isProgramMaybeEligible().get();
   }
 
   private PTag programCardApplicationStatus(

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -15,6 +15,7 @@ program_eligibility_conditions_enabled = false
 program_read_only_view_enabled = false
 esri_address_correction_enabled = false
 intake_form_enabled = false
+nongated_eligibility_enabled = false
 
 # The default value is true, we set it to false here because we do not know
 # the IP address that will be used to call the API in the browser tests.

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -67,6 +67,7 @@ import services.program.ProgramQuestionDefinitionInvalidException;
 import services.program.ProgramQuestionDefinitionNotFoundException;
 import services.program.ProgramService;
 import services.program.ProgramServiceImpl;
+import services.program.ProgramType;
 import services.program.StatusDefinitions;
 import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
@@ -765,7 +766,8 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 programDefinition.id(),
                 trustedIntermediaryProfile,
-                /* eligibilityFeatureEnabled= */ false)
+                /* eligibilityFeatureEnabled= */ false,
+                /* nonGatedEligibilityFeatureEnabled= */ false)
             .toCompletableFuture()
             .join();
 
@@ -827,7 +829,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             applicant.id,
             firstProgram.id,
             trustedIntermediaryProfile,
-            /* eligibilityFeatureEnabled= */ false)
+            /* eligibilityFeatureEnabled= */ false,
+            /* nonGatedEligibilityFeatureEnabled= */ false)
         .toCompletableFuture()
         .join();
 
@@ -840,7 +843,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             applicant.id,
             secondProgram.id,
             trustedIntermediaryProfile,
-            /* eligibilityFeatureEnabled= */ false)
+            /* eligibilityFeatureEnabled= */ false,
+            /* nonGatedEligibilityFeatureEnabled= */ false)
         .toCompletableFuture()
         .join();
 
@@ -872,7 +876,8 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 programDefinition.id(),
                 trustedIntermediaryProfile,
-                /* eligibilityFeatureEnabled= */ false)
+                /* eligibilityFeatureEnabled= */ false,
+                /* nonGatedEligibilityFeatureEnabled= */ false)
             .toCompletableFuture()
             .join();
 
@@ -892,7 +897,8 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 programDefinition.id(),
                 trustedIntermediaryProfile,
-                /* eligibilityFeatureEnabled= */ false)
+                /* eligibilityFeatureEnabled= */ false,
+                /* nonGatedEligibilityFeatureEnabled= */ false)
             .toCompletableFuture()
             .join();
 
@@ -951,11 +957,50 @@ public class ApplicantServiceTest extends ResetPostgres {
                         applicant.id,
                         programDefinition.id(),
                         trustedIntermediaryProfile,
-                        /* eligibilityFeatureEnabled= */ true)
+                        /* eligibilityFeatureEnabled= */ true,
+                        /* nonGatedEligibilityFeatureEnabled= */ true)
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationNotEligibleException.class)
         .withMessageContaining("Application", "failed to save");
+  }
+
+  @Test
+  public void
+      submitApplication_allowsIneligibleApplicationToBeSubmittedwhenEligibilityIsNongating() {
+    createProgramWithNongatingEligibility(questionDefinition);
+    Applicant applicant = subject.createApplicant().toCompletableFuture().join();
+    applicant.setAccount(resourceCreator.insertAccount());
+    applicant.save();
+
+    // First name is matched for eligibility.
+    Path questionPath =
+        ApplicantData.APPLICANT_PATH.join(questionDefinition.getQuestionPathSegment());
+    ImmutableMap<String, String> updates =
+        ImmutableMap.<String, String>builder()
+            .put(questionPath.join(Scalar.FIRST_NAME).toString(), "Ineligible answer")
+            .put(questionPath.join(Scalar.LAST_NAME).toString(), "irrelevant answer")
+            .build();
+    subject
+        .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
+        .toCompletableFuture()
+        .join();
+
+    Application application =
+        subject
+            .submitApplication(
+                applicant.id,
+                programDefinition.id(),
+                trustedIntermediaryProfile,
+                /* eligibilityFeatureEnabled= */ true,
+                /* nonGatedEligibilityFeatureEnabled= */ true)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(application.getApplicant()).isEqualTo(applicant);
+    assertThat(application.getProgram().getProgramDefinition().id())
+        .isEqualTo(programDefinition.id());
+    assertThat(application.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
   }
 
   @Test
@@ -1088,7 +1133,8 @@ public class ApplicantServiceTest extends ResetPostgres {
                         applicant.id,
                         programDefinition.id(),
                         trustedIntermediaryProfile,
-                        /* eligibilityFeatureEnabled= */ false)
+                        /* eligibilityFeatureEnabled= */ false,
+                        /* nonGatedEligibilityFeatureEnabled= */ false)
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationOutOfDateException.class)
@@ -1819,6 +1865,37 @@ public class ApplicantServiceTest extends ResetPostgres {
             .build();
     programDefinition =
         ProgramBuilder.newDraftProgram("test program", "desc")
+            .withBlock()
+            .withRequiredQuestionDefinitions(ImmutableList.of(question))
+            .withEligibilityDefinition(eligibilityDef)
+            .buildDefinition();
+  }
+
+  private void createProgramWithNongatingEligibility(NameQuestionDefinition question) {
+    EligibilityDefinition eligibilityDef =
+        EligibilityDefinition.builder()
+            .setPredicate(
+                PredicateDefinition.create(
+                    PredicateExpressionNode.create(
+                        LeafOperationExpressionNode.create(
+                            question.getId(),
+                            Scalar.FIRST_NAME,
+                            Operator.EQUAL_TO,
+                            PredicateValue.of("eligible name"))),
+                    PredicateAction.ELIGIBLE_BLOCK))
+            .build();
+    programDefinition =
+        ProgramBuilder.newDraftProgram(
+                ProgramDefinition.builder()
+                    .setId(123)
+                    .setAdminName("name")
+                    .setAdminDescription("desc")
+                    .setExternalLink("https://usa.gov")
+                    .setDisplayMode(DisplayMode.PUBLIC)
+                    .setProgramType(ProgramType.DEFAULT)
+                    .setEligibilityIsGating(false)
+                    .setStatusDefinitions(new StatusDefinitions())
+                    .build())
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(question))
             .withEligibilityDefinition(eligibilityDef)

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -967,7 +967,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void
-      submitApplication_allowsIneligibleApplicationToBeSubmittedwhenEligibilityIsNongating() {
+      submitApplication_allowsIneligibleApplicationToBeSubmittedWhenEligibilityIsNongating() {
     createProgramWithNongatingEligibility(questionDefinition);
     Applicant applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -90,6 +90,16 @@ public class ProgramBuilder {
     return new ProgramBuilder(program.id, builder);
   }
 
+  /** Creates a {@link ProgramBuilder} with a new {@link Program} in draft state. */
+  public static ProgramBuilder newDraftProgram(ProgramDefinition programDefinition) {
+    VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
+    Program program = new Program(programDefinition, versionRepository.getDraftVersion());
+    program.save();
+    ProgramDefinition.Builder builder =
+        program.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of());
+    return new ProgramBuilder(program.id, builder);
+  }
+
   /**
    * Creates a {@link ProgramBuilder} with a new {@link Program} in active state, with blank
    * description and name.


### PR DESCRIPTION
### Description

Updates the application logic for non-gating eligibility so that application submission is never blocked and text about the applicant not qualifying is removed.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)

