### PR TITLE
Remove state generator param from CiviformOidcLogoutActionBuilder

### DIFF
--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -17,7 +17,6 @@ import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
-import org.pac4j.core.util.generator.ValueGenerator;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
 
@@ -40,7 +39,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
 
   private String postLogoutRedirectParam;
   private ImmutableMap<String, String> extraParams;
-  private Optional<ValueGenerator> stateGenerator = Optional.empty();
+  private boolean enableStateGenerator = false;
 
   public CiviformOidcLogoutActionBuilder(
       Config civiformConfiguration, OidcConfiguration oidcConfiguration, String clientID) {
@@ -68,18 +67,14 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     return Optional.empty();
   }
 
-  public Optional<ValueGenerator> getStateGenerator() {
-    return stateGenerator;
-  }
-
   /**
    * If the OIDC provider requires the optional state param for logout (see
    * https://openid.net/specs/openid-connect-rpinitiated-1_0.html), set a state generator here. Note
    * that the state is not saved and validated by the client, so it does not achive the goal of
    * "maintain state between the logout request and the callback" as specified by the spec.
    */
-  public CiviformOidcLogoutActionBuilder setStateGenerator(final ValueGenerator stateGenerator) {
-    this.stateGenerator = Optional.of(stateGenerator);
+  public CiviformOidcLogoutActionBuilder enableStateGenerator() {
+    enableStateGenerator = true;
     return this;
   }
 
@@ -115,10 +110,11 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     if (CommonHelper.isNotBlank(logoutUrl) && currentProfile instanceof CiviFormProfileData) {
       try {
         URI endSessionEndpoint = new URI(logoutUrl);
+
         // Optional state param for logout is only needed by certain OIDC providers.
         State state = null;
-        if (getStateGenerator().isPresent()) {
-          state = new State(getStateGenerator().get().generateValue(context, sessionStore));
+        if (enableStateGenerator) {
+          state = new State(configuration.getStateGenerator().generateValue(context, sessionStore));
         }
 
         LogoutRequest logoutRequest =

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -39,7 +39,6 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
 
   private String postLogoutRedirectParam;
   private ImmutableMap<String, String> extraParams;
-  private boolean enableStateGenerator = false;
 
   public CiviformOidcLogoutActionBuilder(
       Config civiformConfiguration, OidcConfiguration oidcConfiguration, String clientID) {
@@ -65,17 +64,6 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
       return Optional.ofNullable(civiformConfiguration.getString(name));
     }
     return Optional.empty();
-  }
-
-  /**
-   * If the OIDC provider requires the optional state param for logout (see
-   * https://openid.net/specs/openid-connect-rpinitiated-1_0.html), set a state generator here. Note
-   * that the state is not saved and validated by the client, so it does not achive the goal of
-   * "maintain state between the logout request and the callback" as specified by the spec.
-   */
-  public CiviformOidcLogoutActionBuilder enableStateGenerator() {
-    enableStateGenerator = true;
-    return this;
   }
 
   /**
@@ -111,11 +99,11 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
       try {
         URI endSessionEndpoint = new URI(logoutUrl);
 
-        // Optional state param for logout is only needed by certain OIDC providers.
-        State state = null;
-        if (enableStateGenerator) {
-          state = new State(configuration.getStateGenerator().generateValue(context, sessionStore));
-        }
+        // Optional state param for logout is only needed by certain OIDC providers, but we
+        // always include it since it can help with cross-site forgery attacks.
+        // OidcConfiguration comes with a default state generator.
+        State state =
+            new State(configuration.getStateGenerator().generateValue(context, sessionStore));
 
         LogoutRequest logoutRequest =
             new CustomOidcLogoutRequest(

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -99,7 +99,6 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
 
     // Apply logout settings specific to login.gov
     ((CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder())
-        .enableStateGenerator()
         // See https://developers.login.gov/oidc/#logout-request
         .setExtraParams(ImmutableMap.of("client_id", getClientID()));
 

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -99,7 +99,7 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
 
     // Apply logout settings specific to login.gov
     ((CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder())
-        .setStateGenerator(stateGenerator)
+        .enableStateGenerator()
         // See https://developers.login.gov/oidc/#logout-request
         .setExtraParams(ImmutableMap.of("client_id", getClientID()));
 


### PR DESCRIPTION
### Description

Remove state generator param from `CiviformOidcLogoutActionBuilder`. We already have it in the `OidcConfiguration`.

### Issue(s) this completes

Progress towards #4280
