### PR TITLE
Remove unused `extraParams` from `CiviformOidcLogoutActionBuilder`.

### DIFF
--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -3,7 +3,6 @@ package auth.oidc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfileData;
-import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import com.typesafe.config.Config;
@@ -94,7 +93,6 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
                 endSessionEndpoint,
                 postLogoutRedirectParam,
                 new URI(targetUrl),
-                /* extraParams =*/ ImmutableMap.of(),
                 Optional.of(clientId),
                 state);
 

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -1,6 +1,5 @@
 package auth.oidc;
 
-import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
@@ -32,9 +31,6 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
   /** The optional post-logout redirection URI. */
   private final URI postLogoutRedirectURI;
 
-  /** Optional extra query params to add to the URL. */
-  private final ImmutableMap<String, String> extraParams;
-
   /**
    * Create new OIDC logout request with a optional redirect url, optional client id, and other
    * params. If the OIDC provider requires the optional state param for logout (see
@@ -46,7 +42,6 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
       final URI uri,
       final String postLogoutRedirectParam,
       final URI postLogoutRedirectURI,
-      final ImmutableMap<String, String> extraParams,
       final Optional<String> clientId,
       final State state) {
 
@@ -61,11 +56,6 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
 
     this.postLogoutRedirectParam = postLogoutRedirectParam;
     this.postLogoutRedirectURI = postLogoutRedirectURI;
-    if (extraParams == null) {
-      this.extraParams = ImmutableMap.of();
-    } else {
-      this.extraParams = extraParams;
-    }
   }
 
   /** Returns the URI query parameters for this logout request. */
@@ -80,8 +70,6 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
       params.put(
           postLogoutRedirectParam, Collections.singletonList(postLogoutRedirectURI.toString()));
     }
-
-    extraParams.forEach((key, value) -> params.put(key, Collections.singletonList(value)));
 
     return params;
   }

--- a/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
+++ b/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
@@ -2,7 +2,6 @@ package auth.oidc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import java.net.URI;
@@ -18,7 +17,6 @@ public class CustomOidcLogoutRequestTest {
             new URI("https://auth.com/logout"),
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
-            /* extraParams= */ ImmutableMap.of(),
             /* clientId = */ Optional.empty(),
             /* state= */ null);
     assertThat(request.toURI().toString())
@@ -27,13 +25,12 @@ public class CustomOidcLogoutRequestTest {
   }
 
   @Test
-  public void toUri_extraParams() throws Exception {
+  public void toUri_withClientId() throws Exception {
     LogoutRequest request =
         new CustomOidcLogoutRequest(
             new URI("https://auth.com/logout"),
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
-            /* extraParams= */ ImmutableMap.of(),
             /* clientId = */ Optional.of("12345"),
             /* state= */ null);
     assertThat(request.toURI().toString())
@@ -48,7 +45,6 @@ public class CustomOidcLogoutRequestTest {
             new URI("https://auth.com/logout"),
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
-            /* extraParams= */ ImmutableMap.of(),
             /* clientId = */ Optional.empty(),
             new State("stateValue"));
     assertThat(request.toURI().toString())
@@ -66,7 +62,6 @@ public class CustomOidcLogoutRequestTest {
             new URI("https://auth.com/logout#fragmentHere"),
             "",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
-            /* extraParams= */ ImmutableMap.of(),
             /* clientId = */ Optional.empty(),
             /* state= */ null);
     assertThat(request.toURI().toString()).isEqualTo("https://auth.com/logout#fragmentHere");


### PR DESCRIPTION
### Description

Remove unused `extraParams` from `CiviformOidcLogoutActionBuilder`.

### Issue(s) this completes

Relates to #4280.
