### PR TITLE
Show message and exit if trying to build prod image on Mac

### DIFF
--- a/bin/build-prod
+++ b/bin/build-prod
@@ -15,14 +15,14 @@ readonly DOCKERFILE="prod.Dockerfile"
 readonly HOST_CPU_ARCH="$(docker info --format='{{.Architecture}}')"
 
 if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
-    echo "----------------------------------------------------------------"
-    echo " WARNING"
-    echo "----------------------------------------------------------------"
-    echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
-    echo " Currently only x86_64 is supported by our prod.Dockerfile."
-    echo "----------------------------------------------------------------"
-    echo ""
-    exit 1
+  echo "----------------------------------------------------------------"
+  echo " WARNING"
+  echo "----------------------------------------------------------------"
+  echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
+  echo " Currently only x86_64 is supported by our prod.Dockerfile."
+  echo "----------------------------------------------------------------"
+  echo ""
+  exit 1
 fi
 
 echo "Building ${SNAPSHOT_TAG}..."
@@ -59,5 +59,3 @@ if [[ "${PUSH_IMAGE}" ]]; then
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
-
-

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -22,7 +22,7 @@ if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
     echo " Currently only x86_64 is supported by our prod.Dockerfile."
     echo "----------------------------------------------------------------"
     echo ""
-    exit
+    exit 1
 fi
 
 echo "Building ${SNAPSHOT_TAG}..."

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -12,6 +12,18 @@ readonly SNAPSHOT_TAG="SNAPSHOT-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}"
 readonly IMAGE="civiform"
 readonly LOCATION="."
 readonly DOCKERFILE="prod.Dockerfile"
+readonly HOST_CPU_ARCH="$(docker info --format='{{.Architecture}}')"
+
+if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
+    echo "----------------------------------------------------------------"
+    echo " WARNING"
+    echo "----------------------------------------------------------------"
+    echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
+    echo " Currently only x86_64 is supported by our prod.Dockerfile."
+    echo "----------------------------------------------------------------"
+    echo ""
+    exit
+fi
 
 echo "Building ${SNAPSHOT_TAG}..."
 
@@ -47,3 +59,5 @@ if [[ "${PUSH_IMAGE}" ]]; then
 fi
 
 docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
+
+


### PR DESCRIPTION
### Description

Our prod image currently doesn't support arm. This causes confusion if you don't know that is the case. Adding a check and message to alert if trying to build an unsupported platform. We can remove this later when we get arm support added.

