### PR TITLE
Remove use of `APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM`.

### DIFF
--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -46,14 +46,6 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     this.clientId = clientId;
   }
 
-  /** Helper function for retriving values from the application.conf, */
-  private static Optional<String> getConfigurationValue(Config civiformConfiguration, String name) {
-    if (civiformConfiguration.hasPath(name)) {
-      return Optional.ofNullable(civiformConfiguration.getString(name));
-    }
-    return Optional.empty();
-  }
-
   /**
    * Sets param that contains uri that user will be redirected to after they are logged out from the
    * auth provider. In OIDC spec it should be `post_logout_redirect_uri` but some providers override

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -35,17 +35,13 @@ import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
  */
 public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuilder {
 
-  private String postLogoutRedirectParam;
+  private Optional<String> postLogoutRedirectParamOverride = Optional.empty();
   private final String clientId;
 
   public CiviformOidcLogoutActionBuilder(
       Config civiformConfiguration, OidcConfiguration oidcConfiguration, String clientId) {
     super(oidcConfiguration);
     checkNotNull(civiformConfiguration);
-    // Use `post_logout_redirect_uri` by default according OIDC spec.
-    this.postLogoutRedirectParam =
-        getConfigurationValue(civiformConfiguration, "auth.oidc_post_logout_param")
-            .orElse("post_logout_redirect_uri");
 
     this.clientId = clientId;
   }
@@ -60,11 +56,11 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
 
   /**
    * Sets param that contains uri that user will be redirected to after they are logged out from the
-   * auth provider. In OIDC spec it should be `post_logout_redirect_uri` but some providers use
-   * different value.
+   * auth provider. In OIDC spec it should be `post_logout_redirect_uri` but some providers override
+   * it to a different value.
    */
-  public CiviformOidcLogoutActionBuilder setPostLogoutRedirectParam(String param) {
-    this.postLogoutRedirectParam = param;
+  public CiviformOidcLogoutActionBuilder setPostLogoutRedirectParamOverride(String param) {
+    this.postLogoutRedirectParamOverride = Optional.of(param);
     return this;
   }
 
@@ -91,7 +87,7 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
         LogoutRequest logoutRequest =
             new CustomOidcLogoutRequest(
                 endSessionEndpoint,
-                postLogoutRedirectParam,
+                postLogoutRedirectParamOverride.orElse("post_logout_redirect_uri"),
                 new URI(targetUrl),
                 Optional.of(clientId),
                 state);

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -64,8 +64,6 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
 
     Map<String, List<String>> params = super.toParameters();
 
-    // Remove post_logout_redirect_uri and replace with custom logic.
-    params.remove("post_logout_redirect_uri");
     if (postLogoutRedirectURI != null && !postLogoutRedirectParam.isEmpty()) {
       params.put(
           postLogoutRedirectParam, Collections.singletonList(postLogoutRedirectURI.toString()));

--- a/server/app/auth/oidc/applicant/Auth0ClientProvider.java
+++ b/server/app/auth/oidc/applicant/Auth0ClientProvider.java
@@ -53,7 +53,7 @@ public class Auth0ClientProvider extends GenericOidcClientProvider {
 
     // See https://auth0.com/docs/api/authentication#logout
     ((CiviformOidcLogoutActionBuilder) client.getLogoutActionBuilder())
-        .setPostLogoutRedirectParam("returnTo");
+        .setPostLogoutRedirectParamOverride("returnTo");
 
     return client;
   }

--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -15,13 +15,6 @@ auth {
   # might not be working and we need to override logout URL.
   oidc_override_logout_url = ${?APPLICANT_OIDC_OVERRIDE_LOGOUT_URL}
 
-  # URL param used to pass post logout redirect url in the logout request to the
-  # auth provider. It defaults to 'post_logout_redirect_uri' if this value is
-  # unset. If this value set to empty string - post logout redirect url is not
-  # passed at all and instead it needs to be hardcoded on the auth provider
-  # (otherwise user won't be redirected back to civiform after logout).
-  oidc_post_logout_param = ${?APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM}
-
   # Direct URI to create new account.
   register_uri = ${?APPLICANT_REGISTER_URI}
 }


### PR DESCRIPTION
### Description

Neither Seattle nor Bloomington use `APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM` - we can remove it and have the default configuration be for `post_logout_redirect_uri`.

In general, the need for this URI to be overriden is a consequence of the identity provider, not of the civic entity's preferences, so we should do it in the auth provider code.

The only auth provider that needs to override it right now is Auth0, which overrides it to `returnTo`.

Relates to #4280.
