### PR TITLE
Pin playwright image to specific version

### DIFF
--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/playwright:focal
+FROM mcr.microsoft.com/playwright:v1.31.2-focal
 
 ENV PROJECT_DIR /usr/src/civiform-browser-tests
 # Store playwright browsers within node_modules directory. This way playwright


### PR DESCRIPTION
### Description

Pin the playwright image to a specific version matching the version in the package.json file per recommendations from Microsoft.

https://mcr.microsoft.com/en-us/product/playwright/about

> It is recommended to use Docker image version that matches Playwright version. If the Playwright version in your Docker image does not match the version in your project/tests, Playwright will be unable to locate browser executables.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
