### PR TITLE
Adds route to get the status of a feature flag

### DIFF
--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -17,12 +17,14 @@ import views.dev.FeatureFlagView;
  */
 public final class FeatureFlagOverrideController extends Controller {
 
+  private final FeatureFlags featureFlags;
   private final FeatureFlagView featureFlagView;
   private final boolean isDevOrStaging;
 
   @Inject
   public FeatureFlagOverrideController(
-      FeatureFlagView featureFlagView, DeploymentType deploymentType) {
+      FeatureFlags featureFlags, FeatureFlagView featureFlagView, DeploymentType deploymentType) {
+    this.featureFlags = featureFlags;
     this.featureFlagView = featureFlagView;
     this.isDevOrStaging = deploymentType.isDevOrStaging();
   }
@@ -46,5 +48,10 @@ public final class FeatureFlagOverrideController extends Controller {
     }
     String redirectTo = request.getHeaders().get(HeaderNames.REFERER).orElse("/");
     return redirect(redirectTo).addingToSession(request, flagName, "false");
+  }
+
+  /** Returns the status of a feature flag. */
+  public Result status(Request request, String FlagName) {
+    return ok(featureFlags.getFlagEnabled(request, FlagName) ? "true" : "false");
   }
 }

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -138,7 +138,7 @@ public final class FeatureFlags {
    *
    * <p>Returns false if the value is not present.
    */
-  private boolean getFlagEnabled(Request request, String flag) {
+  public boolean getFlagEnabled(Request request, String flag) {
     Optional<Boolean> maybeConfigValue = getFlagEnabledFromConfig(flag);
     if (maybeConfigValue.isEmpty()) {
       return false;

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -203,6 +203,7 @@ POST    /dev/seed/clear                  controllers.dev.DatabaseSeedController.
 GET     /dev/feature                  controllers.dev.FeatureFlagOverrideController.index(request: Request)
 GET     /dev/feature/:flag/disable     controllers.dev.FeatureFlagOverrideController.disable(request: Request, flag: String)
 GET     /dev/feature/:flag/enable      controllers.dev.FeatureFlagOverrideController.enable(request: Request, flag: String)
+GET     /dev/feature/:flag/status      controllers.dev.FeatureFlagOverrideController.status(request: Request, flag: String)
 
 ## Prometheus metrics export
 GET         /metrics          controllers.monitoring.MetricsController.getMetrics()

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -1,6 +1,7 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -13,6 +14,7 @@ import org.junit.Test;
 import play.Application;
 import play.Mode;
 import play.inject.guice.GuiceApplicationBuilder;
+import play.mvc.Result;
 import play.test.Helpers;
 
 public class FeatureFlagOverrideControllerTest {
@@ -95,5 +97,20 @@ public class FeatureFlagOverrideControllerTest {
   private void setupControllerInMode(Mode mode) {
     maybeApp = Optional.of(new GuiceApplicationBuilder().in(mode).build());
     controller = maybeApp.get().injector().instanceOf(FeatureFlagOverrideController.class);
+  }
+
+  @Test
+  public void status() {
+    setupControllerInMode(Mode.TEST);
+
+    Result enabledResult =
+        controller.status(fakeRequest().build(), "program_read_only_view_enabled");
+    assertEquals("true", Helpers.contentAsString(enabledResult));
+
+    Result diabledResult = controller.status(fakeRequest().build(), "intake_form_enabled");
+    assertEquals("false", Helpers.contentAsString(diabledResult));
+
+    Result noFeatureResult = controller.status(fakeRequest().build(), "no_flag_by_this_name");
+    assertEquals("false", Helpers.contentAsString(noFeatureResult));
   }
 }


### PR DESCRIPTION
### Description

This adds the ability to get the status of a feature flag. This will be useful for browser tests, so a test can check if a feature is enabled before running.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >