### PR TITLE
Only format python files if they have changes

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -36,6 +36,13 @@ function get_modified_ts_files() {
   ) | grep -E ".+\.ts$"
 }
 
+function get_modified_python_files() {
+  (
+    get_tracked_modified_files
+    get_untracked_files
+  ) | grep -E ".+\.py$"
+}
+
 if [[ -z $(get_modified_java_files) ]]; then
   echo 'No modified java files found'
 else
@@ -75,11 +82,15 @@ shfmt -bn -ci -i 2 -w -l \
   $(shfmt -f . | grep -v -e /node_modules)
 echo 'Done formatting shell'
 
-echo 'Start format env-var-docs python'
-yapf \
-  --verbose \
-  --style='{based_on_style: google, SPLIT_BEFORE_FIRST_ARGUMENT:true}' \
-  --in-place \
-  --recursive \
-  --exclude env-var-docs/venv \
-  env-var-docs
+if [[ -z $(get_modified_python_files) ]]; then
+  echo 'No modified python files found'
+else
+  echo 'Start format python'
+  yapf \
+    --verbose \
+    --style='{based_on_style: google, SPLIT_BEFORE_FIRST_ARGUMENT:true}' \
+    --in-place \
+    --recursive \
+    --exclude env-var-docs/venv \
+    .
+fi


### PR DESCRIPTION
### Description

Updates formatter script to only format python files if there are changes to them.

Part of https://github.com/civiform/civiform/issues/2985.

Tested: build the formatter image with this change, ran with no python changes.  "No modified python files found" was printed.  I changed a python file and re-ran, python formatting was triggered.
