### PR TITLE
Fixes for bin/run-browser-tests-local

### DIFF
--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -29,6 +29,8 @@ emulators::set_localstack_emulator_vars
 #   1: "$@" - full args array for the script
 #######################################
 function set_args() {
+  # Default for browser tests running in Docker
+  export BASE_URL="http://civiform:9000"
   while [ "${1:-}" != "" ]; do
     case "$1" in
       "--help")
@@ -47,6 +49,9 @@ Options:
 
 --azure Use the Azure emulator (Azurite) for simulating cloud storage for file
         upload and download. Also use localstack, since we need that for SES.
+
+--local Set BASE_URL to http://localhost:9999 to enable running
+        bin/run-browser-tests-local
 EOF
         exit 0
         ;;
@@ -68,6 +73,10 @@ EOF
       "--aws")
         emulators::ensure_only_one_cloud_provider_flag aws
         # Already defaulted to AWS.
+        ;;
+
+      "--local")
+        export BASE_URL="http://localhost:9999"
         ;;
     esac
 

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -10,6 +10,10 @@ services:
     ports:
       - 10000:10000
 
+  dev-oidc:
+    ports:
+      - 3390:3390
+
   civiform:
     image: civiform-dev
     restart: always
@@ -25,9 +29,9 @@ services:
       - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - APPLICANT_REGISTER_URI=http://dev-oidc:3390/
       - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
-      - BASE_URL=http://civiform:9000
+      - BASE_URL=${BASE_URL:-http://civiform:9000}
       - LOCALSTACK_URL=http://localhost.localstack.cloud:4566
       - CIVIFORM_TIME_ZONE_ID
       - CIVIFORM_ADMIN_REPORTING_UI_ENABLED=true
     command: ~runBrowserTestsServer
-    entrypoint: ./entrypoint.sh
+    entrypoint: ./entrypoint.sh -jvm-debug "0.0.0.0:9457"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # container name in their /etc/hosts file for the web brower to load the auth url.
   # EG: 127.0.0.1 dev-oidc
   dev-oidc:
-    image: civiform/oidc-provider
+    image: civiform-oidc-provider
     restart: always
     expose:
       - 3390

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -28,11 +28,17 @@ const configuration = {
         'http://civiform:9000/callback/generic-oidc',
         'http://civiform:9000/callback/AdClient',
         'http://civiform:9000',
+        // Local browser tests
+        'http://localhost:9999/callback/OidcClient',
+        'http://localhost:9999/callback/generic-oidc',
+        'http://localhost:9999/callback/AdClient',
+        'http://localhost:9999',
       ],
       post_logout_redirect_uris: [
         'http://localhost:9000/',
         'http://localhost:19001/',
         'http://civiform:9000/',
+        'http://localhost:9999/',
       ],
     },
     {
@@ -62,11 +68,17 @@ const configuration = {
         'http://civiform:9000/callback/generic-oidc',
         'http://civiform:9000/callback/AdClient',
         'http://civiform:9000',
+        // Local browser tests
+        'http://localhost:9999/callback/OidcClient',
+        'http://localhost:9999/callback/generic-oidc',
+        'http://localhost:9999/callback/AdClient',
+        'http://localhost:9999',
       ],
       post_logout_redirect_uris: [
         'http://localhost:9000/',
         'http://localhost:19001/',
         'http://civiform:9000/',
+        'http://localhost:9999/'
       ],
     },
   ],


### PR DESCRIPTION
This fixes several issues found with running PWDEBUG=1 bin/run-browser-tests-local.

1. This adds a --local flag to bin/run-browser-test-env, which sets BASE_URL to http://localhost:9999, which the local browser tests expect.  Otherwise, upon logout, it will attempt to go to civiform:9000 instead and fail.

2. This exposes port 3390 on the dev-oidc container. This is necessary for the app to be able to redirect there when running the tests locally. Note that this will likely collide with a running instance of bin/run-dev, and we can probably fix things up somehow to have it point to a different port, but this works for a first pass.

3. This adds the flag for starting the JVM debugger on port 9457 to allow connecting the debugger during browser tests.

4. This updates the test_oidc_provider.js file to add the paths for localhost:9999 as allowed redirect URIs. 

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/application.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
