### PR TITLE
Fixes for bin/run-browser-tests-local

### DIFF
--- a/bin/lib/docker.sh
+++ b/bin/lib/docker.sh
@@ -52,7 +52,7 @@ function docker::compose_browser_test() {
 }
 
 #######################################
-# Runs docker compose with the browser test local development settings.
+# Runs docker compose with the browser test development settings.
 # Arguments:
 #   @: arguments for compose
 #######################################
@@ -61,6 +61,20 @@ function docker::compose_browser_test_dev() {
     -f docker-compose.yml \
     -f browser-test/browser-test-compose.yml \
     -f browser-test/browser-test-compose.dev.yml \
+    "$@"
+}
+
+#######################################
+# Runs docker compose with the browser test local development settings.
+# Arguments:
+#   @: arguments for compose
+#######################################
+function docker::compose_browser_test_dev_local() {
+  docker compose \
+    -f docker-compose.yml \
+    -f browser-test/browser-test-compose.yml \
+    -f browser-test/browser-test-compose.dev.yml \
+    -f browser-test/browser-test-compose.dev_local.yml \
     "$@"
 }
 

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -13,6 +13,11 @@ truth::declare_var_false continuous_integration
 # tests also require localstack for SES email sending.
 truth::declare_var_false both_emulators
 
+# Default to not running browser tests in local mode, which
+# exposes port 3390 of the OIDC container, as this may conflict
+# with other concurrently running stacks.
+truth::declare_var_false local
+
 # Default to using Localstack emulator.
 emulators::set_localstack_emulator_vars
 
@@ -29,6 +34,8 @@ emulators::set_localstack_emulator_vars
 #   1: "$@" - full args array for the script
 #######################################
 function set_args() {
+  # Default for browser tests running in Docker
+  export BASE_URL="http://civiform:9000"
   while [ "${1:-}" != "" ]; do
     case "$1" in
       "--help")
@@ -47,6 +54,9 @@ Options:
 
 --azure Use the Azure emulator (Azurite) for simulating cloud storage for file
         upload and download. Also use localstack, since we need that for SES.
+
+--local Set BASE_URL to http://localhost:9999 to enable running
+        bin/run-browser-tests-local
 EOF
         exit 0
         ;;
@@ -69,6 +79,11 @@ EOF
         emulators::ensure_only_one_cloud_provider_flag aws
         # Already defaulted to AWS.
         ;;
+
+      "--local")
+        export BASE_URL="http://localhost:9999"
+        truth::enable local
+        ;;
     esac
 
     shift
@@ -85,8 +100,13 @@ function compose_browser_test() {
   local use_dev_env="$1"
   shift 1
   if truth::is_enabled use_dev_env; then
-    echo "docker::compose_browser_test_dev" "$@"
-    docker::compose_browser_test_dev "$@"
+    if truth::is_enabled local; then
+      echo "docker::compose_browser_test_dev_local"
+      docker::compose_browser_test_dev_local "$@"
+    else
+      echo "docker::compose_browser_test_dev" "$@"
+      docker::compose_browser_test_dev "$@"
+    fi
   else
     echo "docker::compose_browser_test" "$@"
     docker::compose_browser_test "$@"

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -8,6 +8,7 @@ source bin/lib.sh
 # image and produce different screenshots.
 export DISABLE_SCREENSHOTS=true
 export BASE_URL=http://localhost:9999
+export LOCALSTACK_URL=http://localhost.localstack.cloud:6645
 
 cd browser-test
 bin/wait_for_server_start_and_run_tests.sh "$@"

--- a/browser-test/browser-test-compose.dev_local.yml
+++ b/browser-test/browser-test-compose.dev_local.yml
@@ -1,0 +1,7 @@
+# Builds on browser-test-compose.dev.yml
+# Expose port 3390 for OIDC container. May conflict with other stacks.
+version: '3.4'
+services:
+  dev-oidc:
+    ports:
+      - 3390:3390

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -25,9 +25,9 @@ services:
       - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - APPLICANT_REGISTER_URI=http://dev-oidc:3390/
       - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
-      - BASE_URL=http://civiform:9000
+      - BASE_URL=${BASE_URL:-http://civiform:9000}
       - LOCALSTACK_URL=http://localhost.localstack.cloud:4566
       - CIVIFORM_TIME_ZONE_ID
       - CIVIFORM_ADMIN_REPORTING_UI_ENABLED=true
     command: ~runBrowserTestsServer
-    entrypoint: ./entrypoint.sh
+    entrypoint: ./entrypoint.sh -jvm-debug "0.0.0.0:9457"

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -28,11 +28,17 @@ const configuration = {
         'http://civiform:9000/callback/generic-oidc',
         'http://civiform:9000/callback/AdClient',
         'http://civiform:9000',
+        // Local browser tests
+        'http://localhost:9999/callback/OidcClient',
+        'http://localhost:9999/callback/generic-oidc',
+        'http://localhost:9999/callback/AdClient',
+        'http://localhost:9999',
       ],
       post_logout_redirect_uris: [
         'http://localhost:9000/',
         'http://localhost:19001/',
         'http://civiform:9000/',
+        'http://localhost:9999/',
       ],
     },
     {
@@ -62,11 +68,17 @@ const configuration = {
         'http://civiform:9000/callback/generic-oidc',
         'http://civiform:9000/callback/AdClient',
         'http://civiform:9000',
+        // Local browser tests
+        'http://localhost:9999/callback/OidcClient',
+        'http://localhost:9999/callback/generic-oidc',
+        'http://localhost:9999/callback/AdClient',
+        'http://localhost:9999',
       ],
       post_logout_redirect_uris: [
         'http://localhost:9000/',
         'http://localhost:19001/',
         'http://civiform:9000/',
+        'http://localhost:9999/',
       ],
     },
   ],


### PR DESCRIPTION
This fixes several issues found with running `bin/run-browser-tests-local`.

1. Adds a `--local` flag to `bin/run-browser-test-env`, which sets `BASE_URL` to `http://localhost:9999`, which the local browser tests expect. Otherwise, upon logout, it will attempt to go to `civiform:9000` instead and fail. It also includes an additional compose file that exposes port 3390, as local tests will need to be able to talk to dev-oidc directly for redirects. Because this will conflict with `bin/run-dev`, this is not enabled by default.

2. Sets `LOCALSTACK_URL` to point to port 6645 in `bin/run-browser-tests-local`, which is what is specified in `browser-test-compose.yml`.

3. Adds the flag for starting the JVM debugger on port 9457 to allow connecting the debugger during browser tests.

4. Updates the `test_oidc_provider.js` file to add the paths for `localhost:9999` as allowed redirect URIs.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
