### PR TITLE
Remove the option to set eligibility criteria from the common intake form.

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -484,9 +484,9 @@ describe('program creation', () => {
       'cif',
       'desc',
       'https://usa.gov',
-      /* hidden=*/ false,
+      /* hidden= */ false,
       'admin description',
-      /* isCommonIntake =*/ false,
+      /* isCommonIntake= */ false,
     )
 
     await adminPrograms.gotoEditDraftProgramPage('cif')
@@ -505,9 +505,9 @@ describe('program creation', () => {
       'cif',
       'desc',
       'https://usa.gov',
-      /* hidden=*/ false,
+      /* hidden= */ false,
       'admin description',
-      /* isCommonIntake =*/ true,
+      /* isCommonIntake= */ true,
     )
 
     await adminPrograms.gotoEditDraftProgramPage('cif')

--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -471,4 +471,46 @@ describe('program creation', () => {
     )
     expect(await commonIntakeFormInput.isChecked()).toBe(true)
   })
+
+  it('regular program has eligibility conditions', async () => {
+    const {page, adminPrograms} = ctx
+
+    await enableFeatureFlag(page, 'intake_form_enabled')
+    await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+
+    await loginAsAdmin(page)
+
+    await adminPrograms.addProgram(
+      'cif',
+      'desc',
+      'https://usa.gov',
+      /* hidden=*/ false,
+      'admin description',
+      /* isCommonIntake =*/ false,
+    )
+
+    await adminPrograms.gotoEditDraftProgramPage('cif')
+    expect(await page.innerText('main')).toContain('Eligibility')
+  })
+
+  it('common intake form does not have eligibility conditions', async () => {
+    const {page, adminPrograms} = ctx
+
+    await enableFeatureFlag(page, 'intake_form_enabled')
+    await enableFeatureFlag(page, 'program_eligibility_conditions_enabled')
+
+    await loginAsAdmin(page)
+
+    await adminPrograms.addProgram(
+      'cif',
+      'desc',
+      'https://usa.gov',
+      /* hidden=*/ false,
+      'admin description',
+      /* isCommonIntake =*/ true,
+    )
+
+    await adminPrograms.gotoEditDraftProgramPage('cif')
+    expect(await page.innerText('main')).not.toContain('Eligibility')
+  })
 })

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -37,6 +37,7 @@ import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramDefinition.Direction;
 import services.program.ProgramQuestionDefinition;
+import services.program.ProgramType;
 import services.program.predicate.PredicateDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.StaticContentQuestionDefinition;
@@ -172,6 +173,7 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
                                     blockDescriptionEditModal.getButton(),
                                     blockDeleteScreenModal.getButton(),
                                     featureFlags.isProgramEligibilityConditionsEnabled(request),
+                                    featureFlags.isIntakeFormEnabled(request),
                                     request))));
 
     // Add top level UI that is only visible in the editable version.
@@ -366,6 +368,7 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
       ButtonTag blockDescriptionModalButton,
       ButtonTag blockDeleteModalButton,
       boolean isProgramEligibilityConditionsEnabled,
+      boolean isIntakeFormFeatureEnabled,
       Request request) {
     // A block can only be deleted when it has no repeated blocks. Same is true for removing the
     // enumerator question from the block.
@@ -388,7 +391,9 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
             allQuestions);
 
     Optional<DivTag> maybeEligibilityPredicateDisplay = Optional.empty();
-    if (isProgramEligibilityConditionsEnabled) {
+    if (isProgramEligibilityConditionsEnabled
+        && (!isIntakeFormFeatureEnabled
+            || !program.programType().equals(ProgramType.COMMON_INTAKE_FORM))) {
       maybeEligibilityPredicateDisplay =
           Optional.of(
               renderEligibilityPredicate(


### PR DESCRIPTION
### Description

If a program is marked as the common intake form, the admin should not be able to add eligibility criteria to it.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)

### Issue(s) this completes

Fixes #4386
