### PR TITLE
Show civiform image tag if CIVIFORM_VERSION is set to "latest"

### DIFF
--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -32,6 +32,7 @@ public class LoginForm extends BaseHtmlView {
 
   private final BaseHtmlLayout layout;
   private final String civiformImageTag;
+  private final String civiformVersion;
   private final boolean isDevOrStaging;
   private final boolean disableDemoModeLogins;
   private final boolean disableApplicantGuestLogin;
@@ -53,6 +54,7 @@ public class LoginForm extends BaseHtmlView {
     checkNotNull(deploymentType);
 
     this.civiformImageTag = config.getString("civiform_image_tag");
+    this.civiformVersion = config.getString("civiform_version");
     this.isDevOrStaging = deploymentType.isDevOrStaging();
     this.disableDemoModeLogins =
         this.isDevOrStaging && config.getBoolean("staging_disable_demo_mode_logins");
@@ -168,7 +170,14 @@ public class LoginForm extends BaseHtmlView {
                 "text-base")
             .with(p(adminPrompt).with(text(" ")).with(adminLink(messages)));
     if (featureFlags.showCiviformImageTagOnLandingPage(request)) {
-      footer.with(p("CiviForm version: " + civiformImageTag).withClasses("text-gray-600"));
+      // civiformVersion is the version the deployer requests, like "latest" or
+      // "v1.18.0". civiformImageTag is set by bin/build-prod and is a string
+      // like "SNAPSHOT-3af8997-1678895722".
+      String version = civiformVersion;
+      if (civiformVersion.equals("latest")) {
+        version = civiformImageTag;
+      }
+      footer.with(p("CiviForm version: " + version).withClasses("text-gray-600"));
     }
     content.with(footer);
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -480,8 +480,13 @@ ebean.default = "models.*"
 civiform.time.zoneid="America/Los_Angeles"
 civiform.time.zoneid=${?CIVIFORM_TIME_ZONE_ID}
 
+# The value of SNAPSHOT_TAG, set in bin/build-prod. For example: SNAPSHOT-3af8997-1678895722.
 civiform_image_tag = "dev"
 civiform_image_tag = ${?CIVIFORM_IMAGE_TAG}
+
+# The civiform version being deployed, can be "latest" or a version like "v1.18.0".
+civiform_version = "dev"
+civiform_version = ${?CIVIFORM_VERSION}
 
 # Secret salt for hashing API key secrets. The server will start with the
 # default value of "changeme" but the admin will not be able to create API keys


### PR DESCRIPTION
### Description

Deployments set CIVIFORM_VERSION in their civiform_config.sh file.  The value can be any valid docker tag, like "latest", "v1.18.0", or "SNAPSHOT-3af89974-1678907834".  Currently, if SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is true, the CIVIFORM_VERSION value is directly show.  This change makes it so that if the value is "latest", the snapshot version like "SNAPSHOT-3af89974-1678907834" is shown.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Manually tested at 200% size

### Issue(s) this completes

Part of https://github.com/civiform/civiform/issues/4270
