### PR TITLE
Eligibility toast shouldn't be hidden unless manually dismissed

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -93,12 +93,14 @@ public class ApplicantProgramReviewController extends CiviFormController {
                   notEligibleBanner =
                       Optional.of(
                           new ToastMessage(
-                              messages.at(
-                                  isTrustedIntermediary
-                                      ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
-                                      : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
-                                  roApplicantProgramService.getProgramTitle()),
-                              ALERT));
+                                  messages.at(
+                                      isTrustedIntermediary
+                                          ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
+                                          : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
+                                      roApplicantProgramService.getProgramTitle()),
+                                  ALERT)
+                              // Don't auto-hide the toast message.
+                              .setDuration(0));
                 }
               } catch (ProgramNotFoundException e) {
                 return notFound(e.toString());


### PR DESCRIPTION
### Description

Eligibility toast shouldn't get hidden automatically. It should only get hidden if manually dismissed by applicant.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4412
