### PR TITLE
Evaluate eligibility based on application rather than latest applicant data

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -842,10 +842,6 @@ public final class ApplicantService {
       ApplicantData applicantData, ProgramDefinition programDefinition) {
     ReadOnlyApplicantProgramService roAppProgramService =
         getReadOnlyApplicantProgramService(applicantData, programDefinition);
-    System.out.println("*** reemax");
-    System.out.println(roAppProgramService.isApplicationEligible());
-    System.out.println(roAppProgramService.isApplicationNotEligible());
-    System.out.println(applicantData);
     return programDefinition.hasEligibilityEnabled()
         ? Optional.of(!roAppProgramService.isApplicationNotEligible())
         : Optional.empty();

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -835,13 +835,31 @@ public final class ApplicantService {
   }
 
   /**
-   * Returns whether an application is maybe eligible for a program, and empty if there are no
-   * eligibility conditions for the program.
+   * Returns whether an applicant is maybe eligible for a program based on their latest answers, and
+   * empty if there are no eligibility conditions for the program.
    */
-  public Optional<Boolean> getOptionalEligibilityStatus(
+  public Optional<Boolean> getApplicantMayBeEligibleStatus(
       ApplicantData applicantData, ProgramDefinition programDefinition) {
     ReadOnlyApplicantProgramService roAppProgramService =
         getReadOnlyApplicantProgramService(applicantData, programDefinition);
+    System.out.println("*** reemax");
+    System.out.println(roAppProgramService.isApplicationEligible());
+    System.out.println(roAppProgramService.isApplicationNotEligible());
+    System.out.println(applicantData);
+    return programDefinition.hasEligibilityEnabled()
+        ? Optional.of(!roAppProgramService.isApplicationNotEligible())
+        : Optional.empty();
+  }
+
+  /**
+   * Returns whether or not an application is eligible for a program. This uses the answers at the
+   * time of the application rather than the applicant's latest answer to a question. Returns empty
+   * if there are no eligibility conditions for the program.
+   */
+  public Optional<Boolean> getApplicationEligibilityStatus(
+      Application application, ProgramDefinition programDefinition) {
+    ReadOnlyApplicantProgramService roAppProgramService =
+        getReadOnlyApplicantProgramService(application, programDefinition);
     return programDefinition.hasEligibilityEnabled()
         ? Optional.of(!roAppProgramService.isApplicationNotEligible())
         : Optional.empty();
@@ -911,7 +929,7 @@ public final class ApplicantService {
                     .setLatestSubmittedApplicationTime(latestSubmittedApplicationTime)
                     .setLatestApplicationLifecycleStage(Optional.of(LifecycleStage.DRAFT));
             applicantProgramDataBuilder.setIsProgramMaybeEligible(
-                getOptionalEligibilityStatus(
+                getApplicantMayBeEligibleStatus(
                     draftApp.getApplicant().getApplicantData(), programDefinition));
             if (programDefinition.isCommonIntakeForm()) {
               relevantPrograms.setCommonIntakeForm(applicantProgramDataBuilder.build());
@@ -968,7 +986,7 @@ public final class ApplicantService {
           if (!mostRecentApplicationsByProgram.isEmpty()) {
             Applicant applicant = applications.stream().findFirst().get().getApplicant();
             applicantProgramDataBuilder.setIsProgramMaybeEligible(
-                getOptionalEligibilityStatus(applicant.getApplicantData(), program));
+                getApplicantMayBeEligibleStatus(applicant.getApplicantData(), program));
           }
 
           if (program.isCommonIntakeForm()) {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -839,9 +839,9 @@ public final class ApplicantService {
    * empty if there are no eligibility conditions for the program.
    */
   public Optional<Boolean> getApplicantMayBeEligibleStatus(
-      ApplicantData applicantData, ProgramDefinition programDefinition) {
+      Applicant applicant, ProgramDefinition programDefinition) {
     ReadOnlyApplicantProgramService roAppProgramService =
-        getReadOnlyApplicantProgramService(applicantData, programDefinition);
+        getReadOnlyApplicantProgramService(applicant.getApplicantData(), programDefinition);
     return programDefinition.hasEligibilityEnabled()
         ? Optional.of(!roAppProgramService.isApplicationNotEligible())
         : Optional.empty();
@@ -925,8 +925,7 @@ public final class ApplicantService {
                     .setLatestSubmittedApplicationTime(latestSubmittedApplicationTime)
                     .setLatestApplicationLifecycleStage(Optional.of(LifecycleStage.DRAFT));
             applicantProgramDataBuilder.setIsProgramMaybeEligible(
-                getApplicantMayBeEligibleStatus(
-                    draftApp.getApplicant().getApplicantData(), programDefinition));
+                getApplicantMayBeEligibleStatus(draftApp.getApplicant(), programDefinition));
             if (programDefinition.isCommonIntakeForm()) {
               relevantPrograms.setCommonIntakeForm(applicantProgramDataBuilder.build());
             } else {
@@ -982,7 +981,7 @@ public final class ApplicantService {
           if (!mostRecentApplicationsByProgram.isEmpty()) {
             Applicant applicant = applications.stream().findFirst().get().getApplicant();
             applicantProgramDataBuilder.setIsProgramMaybeEligible(
-                getApplicantMayBeEligibleStatus(applicant.getApplicantData(), program));
+                getApplicantMayBeEligibleStatus(applicant, program));
           }
 
           if (program.isCommonIntakeForm()) {

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -180,8 +180,7 @@ public final class CsvExporterService {
 
           Optional<Boolean> optionalEligibilityStatus =
               shouldCheckEligibility
-                  ? applicantService.getOptionalEligibilityStatus(
-                      application.getApplicant().getApplicantData(), currentProgram.get())
+                  ? applicantService.getApplicationEligibilityStatus(application, programDefinition)
                   : Optional.empty();
 
           csvExporter.exportRecord(application, roApplicantService, optionalEligibilityStatus);

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -123,8 +123,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                             application,
                             /* displayStatus= */ allPossibleProgramApplicationStatuses.size() > 0,
                             hasEligibilityEnabled
-                                ? applicantService.getOptionalEligibilityStatus(
-                                    application.getApplicant().getApplicantData(), program)
+                                ? applicantService.getApplicationEligibilityStatus(
+                                    application, program)
                                 : Optional.empty(),
                             defaultStatus)))
             .withClasses("mt-6", StyleUtils.responsiveLarge("mt-12"), "mb-16", "ml-6", "mr-2");

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2862,10 +2862,9 @@ public class ApplicantServiceTest extends ResetPostgres {
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
         .toCompletableFuture()
         .join();
-    ApplicantData applicantData =
-        userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
+    applicant = userRepository.lookupApplicantSync(applicant.id).get();
 
-    assertThat(subject.getApplicantMayBeEligibleStatus(applicantData, programDefinition).get())
+    assertThat(subject.getApplicantMayBeEligibleStatus(applicant, programDefinition).get())
         .isFalse();
 
     // Applicant' answer gets changed to an eligible answer.
@@ -2878,9 +2877,9 @@ public class ApplicantServiceTest extends ResetPostgres {
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
         .toCompletableFuture()
         .join();
-    applicantData = userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
+    applicant = userRepository.lookupApplicantSync(applicant.id).get();
 
-    assertThat(subject.getApplicantMayBeEligibleStatus(applicantData, programDefinition).get())
+    assertThat(subject.getApplicantMayBeEligibleStatus(applicant, programDefinition).get())
         .isTrue();
   }
 


### PR DESCRIPTION
### Description

See #4414 for a description of the bug. The code was using applicant.applicantData() instead of application.applicantData() in some places, causing the applicant's latest answers to be evaluated for eligibility rather than their answers on the specific application.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #4414
