### PR TITLE
Toasts should not auto hide by default

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -93,14 +93,12 @@ public class ApplicantProgramReviewController extends CiviFormController {
                   notEligibleBanner =
                       Optional.of(
                           new ToastMessage(
-                                  messages.at(
-                                      isTrustedIntermediary
-                                          ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
-                                          : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
-                                      roApplicantProgramService.getProgramTitle()),
-                                  ALERT)
-                              // Don't auto-hide the toast message.
-                              .setDuration(0));
+                              messages.at(
+                                  isTrustedIntermediary
+                                      ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
+                                      : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
+                                  roApplicantProgramService.getProgramTitle()),
+                              ALERT));
                 }
               } catch (ProgramNotFoundException e) {
                 return notFound(e.toString());

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -191,12 +191,7 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
     }
 
     // Add toast messages
-    request
-        .flash()
-        .get("error")
-        .map(ToastMessage::error)
-        .map(m -> m.setDuration(-1))
-        .ifPresent(htmlBundle::addToastMessages);
+    request.flash().get("error").map(ToastMessage::error).ifPresent(htmlBundle::addToastMessages);
     message.ifPresent(htmlBundle::addToastMessages);
 
     return layout.render(htmlBundle);

--- a/server/app/views/admin/programs/ProgramBlockPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramBlockPredicatesEditViewV2.java
@@ -241,9 +241,9 @@ public final class ProgramBlockPredicatesEditViewV2 extends ProgramBlockBaseView
 
     Http.Flash flash = request.flash();
     if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()));
     } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
     }
 
     return layout.renderCentered(htmlBundle);

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -140,9 +140,9 @@ public final class ProgramIndexView extends BaseHtmlView {
 
     Http.Flash flash = request.flash();
     if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()));
     } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
     }
 
     return layout.renderCentered(htmlBundle);

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -133,9 +133,9 @@ public final class ProgramStatusesView extends BaseHtmlView {
 
     Http.Flash flash = request.flash();
     if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.error(flash.get("error").get()));
     } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()).setDuration(-1));
+      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
     }
 
     return layout.renderCentered(htmlBundle);

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -157,7 +157,6 @@ public final class QuestionEditView extends BaseHtmlView {
 
     message
         .map(m -> m.setDismissible(true))
-        .map(m -> m.setDuration(ERROR_TOAST_DURATION))
         .map(ToastMessage::getContainerTag)
         .ifPresent(formContent::with);
 

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -57,9 +57,6 @@ public final class QuestionEditView extends BaseHtmlView {
   private static final String QUESTION_NAME_FIELD = "questionName";
   private static final String QUESTION_ENUMERATOR_FIELD = "enumeratorId";
 
-  // Setting a value of 0 causes the toast to be displayed indefinitely.
-  private static final int ERROR_TOAST_DURATION = 0;
-
   @Inject
   public QuestionEditView(
       AdminLayoutFactory layoutFactory,
@@ -110,7 +107,6 @@ public final class QuestionEditView extends BaseHtmlView {
 
     message
         .map(m -> m.setDismissible(true))
-        .map(m -> m.setDuration(ERROR_TOAST_DURATION))
         .map(ToastMessage::getContainerTag)
         .ifPresent(formContent::with);
 

--- a/server/app/views/components/ToastMessage.java
+++ b/server/app/views/components/ToastMessage.java
@@ -24,8 +24,8 @@ public final class ToastMessage {
 
   private String message;
 
-  /** Default duration is 3 seconds. */
-  private int duration = 3000;
+  /** Default duration is to not auto-hide. */
+  private int duration = 0;
 
   private boolean canDismiss = true;
 


### PR DESCRIPTION
### Description

Toasts should default to remain open, instead of auto hiding after 3 seconds.

## Release notes

Toasts should default to remain open, instead of auto hiding after 3 seconds.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4433
