### PR TITLE
Add Feature Flag for New Login Form

### DIFF
--- a/server/app/featureflags/FeatureFlag.java
+++ b/server/app/featureflags/FeatureFlag.java
@@ -33,7 +33,10 @@ public enum FeatureFlag {
   NONGATED_ELIGIBILITY_ENABLED,
 
   // Phone number question type.
-  PHONE_QUESTION_TYPE_ENABLED;
+  PHONE_QUESTION_TYPE_ENABLED,
+
+  // New login form
+  NEW_LOGIN_FORM_ENABLED;
 
   /**
    * Returns a {@link FeatureFlag} for the given name. Matches based on the first matching flag,

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -1,6 +1,7 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.NEW_LOGIN_FORM_ENABLED;
 import static featureflags.FeatureFlag.SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
@@ -74,6 +75,21 @@ public class LoginForm extends BaseHtmlView {
   }
 
   public Content render(Http.Request request, Messages messages, Optional<String> message) {
+    if (featureFlags.getFlagEnabled(request, NEW_LOGIN_FORM_ENABLED)) {
+      return renderNewLoginPage(request, messages);
+    } else {
+      return renderOldLoginPage(request, messages);
+    }
+  }
+
+  // TODO(#4366): implement new login page.
+  private Content renderNewLoginPage(Http.Request unused1, Messages unused2) {
+    HtmlBundle htmlBundle = this.layout.getBundle();
+
+    return layout.render(htmlBundle);
+  }
+
+  private Content renderOldLoginPage(Http.Request request, Messages messages) {
     String title = messages.at(MessageKey.TITLE_LOGIN.getKeyName());
 
     HtmlBundle htmlBundle = this.layout.getBundle().setTitle(title);

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -53,3 +53,6 @@ nongated_eligibility_enabled = ${?NONGATED_ELIGIBILITY_ENABLED}
 phone_question_type_enabled = false
 phone_question_type_enabled = ${?PHONE_QUESTION_TYPE_ENABLED}
 
+# New login page flag
+new_login_form_enabled = false
+new_login_form_enabled = ${?NEW_LOGIN_FORM_ENABLED}


### PR DESCRIPTION
### Description

This PR adds a feature flag for the upcoming Login Form changes that are part of #4366. Since this change will significantly overhaul the login page, it's best to put it behind a flag we can easily turn off.

### Checklist

#### General

- [x] Add feature flag in `FeatureFlags.java`
- [x] Use the flag in `LoginForm.java` to point to the current login page and a new, empty login page.

#### User visible changes

None.

### Issue(s) this completes

Relates to #4366.
