### PR TITLE
Remove FeatureFlag per-flag methods

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -1,5 +1,6 @@
 package auth;
 
+import static featureflags.FeatureFlag.ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
@@ -236,7 +237,7 @@ public class CiviFormProfile {
         .thenApply(
             account -> {
               if (account.getGlobalAdmin()
-                  && featureFlags.allowCiviformAdminAccessPrograms(request)) {
+                  && featureFlags.getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS)) {
                 return null;
               }
               if (account.getAdministeredProgramNames().stream()

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -1,6 +1,8 @@
 package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
 import static views.components.ToastMessage.ToastType.ERROR;
 
 import auth.Authorizers;
@@ -110,7 +112,7 @@ public final class AdminProgramController extends CiviFormController {
             program.getExternalLink(),
             program.getDisplayMode(),
             program.getIsCommonIntakeForm() ? ProgramType.COMMON_INTAKE_FORM : ProgramType.DEFAULT,
-            featureFlags.isIntakeFormEnabled(request));
+            featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED));
     if (result.isError()) {
       ToastMessage message = new ToastMessage(joinErrors(result.getErrors()), ERROR);
       return ok(newOneView.render(request, program, Optional.of(message)));
@@ -186,7 +188,7 @@ public final class AdminProgramController extends CiviFormController {
             programData.getIsCommonIntakeForm()
                 ? ProgramType.COMMON_INTAKE_FORM
                 : ProgramType.DEFAULT,
-            featureFlags.isIntakeFormEnabled(request));
+            featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED));
     if (result.isError()) {
       ToastMessage message = new ToastMessage(joinErrors(result.getErrors()), ERROR);
       return ok(editView.render(request, programDefinition, programData, Optional.of(message)));
@@ -215,7 +217,7 @@ public final class AdminProgramController extends CiviFormController {
       programService.setEligibilityIsGating(
           programId,
           programSettingsForm.getEligibilityIsGating(),
-          featureFlags.isNongatedEligibilityEnabled(request));
+          featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED));
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
     }

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -1,6 +1,10 @@
 package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.ESRI_ADDRESS_CORRECTION_ENABLED;
+import static featureflags.FeatureFlag.ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
@@ -175,7 +179,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                     programId,
                     blockId,
                     cleanForm(questionPathToValueMap),
-                    featureFlags.isEsriAddressServiceAreaValidationEnabled(request)),
+                    featureFlags.getFlagEnabled(
+                        request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED)),
             httpExecutionContext.current())
         .thenComposeAsync(
             roApplicantProgramService -> {
@@ -387,7 +392,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                               programId,
                               blockId,
                               fileUploadQuestionFormData.build(),
-                              featureFlags.isEsriAddressServiceAreaValidationEnabled(request)));
+                              featureFlags.getFlagEnabled(
+                                  request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED)));
             },
             httpExecutionContext.current())
         .thenComposeAsync(
@@ -435,7 +441,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                   programId,
                   blockId,
                   formData,
-                  featureFlags.isEsriAddressServiceAreaValidationEnabled(request));
+                  featureFlags.getFlagEnabled(
+                      request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED));
             },
             httpExecutionContext.current())
         .thenComposeAsync(
@@ -484,7 +491,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS))));
     }
 
-    if (featureFlags.isEsriAddressCorrectionEnabled(request)
+    if (featureFlags.getFlagEnabled(request, ESRI_ADDRESS_CORRECTION_ENABLED)
         && thisBlockUpdated.hasAddressWithCorrectionEnabled()) {
 
       AddressQuestion addressQuestion =
@@ -574,10 +581,10 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       ReadOnlyApplicantProgramService roApplicantProgramService,
       ProgramDefinition programDefinition,
       String blockId) {
-    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+    if (!featureFlags.getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED)) {
       return false;
     }
-    if (featureFlags.isNongatedEligibilityEnabled(request)
+    if (featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED)
         && !programDefinition.eligibilityIsGating()) {
       return false;
     }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -1,6 +1,8 @@
 package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
 import static views.components.ToastMessage.ToastType.ALERT;
 
 import auth.CiviFormProfile;
@@ -153,10 +155,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
   private boolean shouldShowNotEligibleBanner(
       Request request, ReadOnlyApplicantProgramService roApplicantProgramService, long programId)
       throws ProgramNotFoundException {
-    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+    if (!featureFlags.getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED)) {
       return false;
     }
-    if (featureFlags.isNongatedEligibilityEnabled(request)
+    if (featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED)
         && !programService.getProgramDefinition(programId).eligibilityIsGating()) {
       return false;
     }
@@ -188,8 +190,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 applicantId,
                 programId,
                 submittingProfile,
-                featureFlags.isProgramEligibilityConditionsEnabled(request),
-                featureFlags.isNongatedEligibilityEnabled(request))
+                featureFlags.getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED),
+                featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED))
             .toCompletableFuture();
     CompletableFuture<ReadOnlyApplicantProgramService> readOnlyApplicantProgramServiceFuture =
         applicantService

--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -2,15 +2,6 @@ package featureflags;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static featureflags.FeatureFlag.ADMIN_REPORTING_UI_ENABLED;
-import static featureflags.FeatureFlag.ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS;
-import static featureflags.FeatureFlag.ESRI_ADDRESS_CORRECTION_ENABLED;
-import static featureflags.FeatureFlag.ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED;
-import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
-import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
-import static featureflags.FeatureFlag.PHONE_QUESTION_TYPE_ENABLED;
-import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
-import static featureflags.FeatureFlag.PROGRAM_READ_ONLY_VIEW_ENABLED;
-import static featureflags.FeatureFlag.SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.typesafe.config.Config;
@@ -41,78 +32,10 @@ public final class FeatureFlags {
         && config.getBoolean(FeatureFlag.FEATURE_FLAG_OVERRIDES_ENABLED.toString());
   }
 
-  /**
-   * If the Eligibility Conditions feature is enabled.
-   *
-   * <p>Allows for overrides set in {@code request}.
-   */
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isProgramEligibilityConditionsEnabled(Request request) {
-    return getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED);
-  }
-
-  /** If the Eligibility Conditions feature is enabled in the system configuration. */
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isProgramEligibilityConditionsEnabled() {
-    return config.getBoolean(PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED.toString());
-  }
-
   /** If the reporting view in the admin UI is enabled */
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
+  // TODO(MichaelZetune): remove and have clients call getFlagEnabled directly.
   public boolean isAdminReportingUiEnabled() {
     return config.getBoolean(ADMIN_REPORTING_UI_ENABLED.toString());
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean allowCiviformAdminAccessPrograms(Request request) {
-    return getFlagEnabled(request, ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS);
-  }
-
-  /**
-   * If the CiviForm image tag is show on the landing page.
-   *
-   * <p>Allows for overrides set in {@code request}.
-   */
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean showCiviformImageTagOnLandingPage(Request request) {
-    return getFlagEnabled(request, SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE);
-  }
-
-  // If the UI can show a read only view of a program. Without this flag the
-  // only way to view a program is to start editing it.
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isReadOnlyProgramViewEnabled() {
-    return config.getBoolean(PROGRAM_READ_ONLY_VIEW_ENABLED.toString());
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isReadOnlyProgramViewEnabled(Request request) {
-    return getFlagEnabled(request, PROGRAM_READ_ONLY_VIEW_ENABLED);
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isEsriAddressCorrectionEnabled(Request request) {
-    return getFlagEnabled(request, ESRI_ADDRESS_CORRECTION_ENABLED);
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isEsriAddressServiceAreaValidationEnabled(Request request) {
-    return getFlagEnabled(request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED);
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isIntakeFormEnabled(Request request) {
-    return getFlagEnabled(request, INTAKE_FORM_ENABLED);
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isNongatedEligibilityEnabled(Request request) {
-    return getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED);
-  }
-
-  // TODO(#4447): remove and have clients call getFlagEnabled directly.
-  public boolean isPhoneQuestionTypeEnabled(Request request) {
-    return getFlagEnabled(request, PHONE_QUESTION_TYPE_ENABLED);
   }
 
   public ImmutableSortedMap<FeatureFlag, Boolean> getAllFlagsSorted(Request request) {

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -1,6 +1,7 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
@@ -189,7 +190,7 @@ public class LoginForm extends BaseHtmlView {
                 "text-base")
             .with(p(adminPrompt).with(text(" ")).with(adminLink(messages)));
 
-    if (featureFlags.showCiviformImageTagOnLandingPage(request)) {
+    if (featureFlags.getFlagEnabled(request, SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE)) {
       // civiformVersion is the version the deployer requests, like "latest" or
       // "v1.18.0". civiformImageTag is set by bin/build-prod and is a string
       // like "SNAPSHOT-3af8997-1678895722".

--- a/server/app/views/admin/programs/ProgramBlockEditView.java
+++ b/server/app/views/admin/programs/ProgramBlockEditView.java
@@ -1,6 +1,10 @@
 package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.ESRI_ADDRESS_CORRECTION_ENABLED;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.b;
 import static j2html.TagCreator.div;
@@ -172,8 +176,9 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
                                     csrfTag,
                                     blockDescriptionEditModal.getButton(),
                                     blockDeleteScreenModal.getButton(),
-                                    featureFlags.isProgramEligibilityConditionsEnabled(request),
-                                    featureFlags.isIntakeFormEnabled(request),
+                                    featureFlags.getFlagEnabled(
+                                        request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED),
+                                    featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED),
                                     request))));
 
     // Add top level UI that is only visible in the editable version.
@@ -550,7 +555,7 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
 
   private DivTag renderEmptyEligibilityPredicate(ProgramDefinition program, Request request) {
     DivTag emptyPredicateDiv;
-    if (featureFlags.isNongatedEligibilityEnabled(request)) {
+    if (featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED)) {
       ImmutableList.Builder<DomContent> emptyPredicateContentBuilder = ImmutableList.builder();
       if (program.eligibilityIsGating()) {
         emptyPredicateContentBuilder.add(
@@ -822,7 +827,7 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
 
     String toolTipText =
         "Enabling address correction will check the resident's address to ensure it is accurate.";
-    if (!featureFlags.isEsriAddressCorrectionEnabled(request)) {
+    if (!featureFlags.getFlagEnabled(request, ESRI_ADDRESS_CORRECTION_ENABLED)) {
       toolTipText +=
           " To use this feature, you will need to have your IT manager configure the GIS service.";
     }
@@ -882,7 +887,8 @@ public final class ProgramBlockEditView extends ProgramBlockBaseView {
         form(csrfTag)
             .withMethod(HttpVerbs.POST)
             .withCondOnsubmit(
-                !featureFlags.isEsriAddressCorrectionEnabled(request) || questionIsUsedInPredicate,
+                !featureFlags.getFlagEnabled(request, ESRI_ADDRESS_CORRECTION_ENABLED)
+                    || questionIsUsedInPredicate,
                 "return false;")
             .withCondOnsubmit(addressCorrectionEnabledQuestionAlreadyExists, "return false;")
             .withAction(toggleAddressCorrectionAction)

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -1,6 +1,7 @@
 package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
@@ -142,7 +143,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .setLabelText("Program note for administrative use only*")
             .setValue(adminDescription)
             .getTextareaTag());
-    if (featureFlags.isIntakeFormEnabled(request)) {
+    if (featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED)) {
       formTag.with(
           FieldWithLabel.checkbox()
               .setFieldName("isCommonIntakeForm")

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -1,6 +1,9 @@
 package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_READ_ONLY_VIEW_ENABLED;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.fieldset;
@@ -342,7 +345,7 @@ public final class ProgramIndexView extends BaseHtmlView {
           maybeRenderViewApplicationsLink(activeProgram.get(), profile, request);
       applicationsLink.ifPresent(activeRowExtraActions::add);
       if (draftProgram.isEmpty()) {
-        if (featureFlags.isReadOnlyProgramViewEnabled(request)) {
+        if (featureFlags.getFlagEnabled(request, PROGRAM_READ_ONLY_VIEW_ENABLED)) {
           activeRowExtraActions.add(
               renderEditLink(/* isActive = */ true, activeProgram.get(), request));
         } else {
@@ -350,7 +353,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         }
         activeRowExtraActions.add(renderManageProgramAdminsLink(activeProgram.get()));
       }
-      if (featureFlags.isReadOnlyProgramViewEnabled(request)) {
+      if (featureFlags.getFlagEnabled(request, PROGRAM_READ_ONLY_VIEW_ENABLED)) {
         activeRowActions.add(renderViewLink(activeProgram.get(), request));
       }
       activeRowActions.add(renderShareLink(activeProgram.get()));
@@ -477,8 +480,8 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   private Optional<ButtonTag> maybeRenderSettingsLink(
       Http.Request request, ProgramDefinition program) {
-    if (!(featureFlags.isProgramEligibilityConditionsEnabled(request)
-        && featureFlags.isNongatedEligibilityEnabled(request))) {
+    if (!(featureFlags.getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED)
+        && featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED))) {
       return Optional.empty();
     }
     String linkDestination = routes.AdminProgramController.editProgramSettings(program.id()).url();

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -1,6 +1,7 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.br;
 import static j2html.TagCreator.div;
@@ -127,7 +128,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
         .ifPresent(bundle::addToastMessages);
 
     String pageTitle =
-        featureFlags.isIntakeFormEnabled(params.request())
+        featureFlags.getFlagEnabled(params.request(), INTAKE_FORM_ENABLED)
                 && params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
             ? messages.at(MessageKey.TITLE_COMMON_INTAKE_SUMMARY.getKeyName())
             : messages.at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -1,6 +1,9 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
+import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
+import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
@@ -156,7 +159,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                 Math.max(relevantPrograms.unapplied().size(), relevantPrograms.submitted().size()),
                 relevantPrograms.inProgress().size()));
 
-    if (featureFlags.isIntakeFormEnabled(request)
+    if (featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED)
         && relevantPrograms.commonIntakeForm().isPresent()) {
       content.with(
           findServicesSection(
@@ -417,7 +420,7 @@ public final class ProgramIndexView extends BaseHtmlView {
    */
   private boolean shouldShowEligibilityTag(
       Http.Request request, ApplicantService.ApplicantProgramData cardData) {
-    if (!featureFlags.isProgramEligibilityConditionsEnabled(request)) {
+    if (!featureFlags.getFlagEnabled(request, PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED)) {
       return false;
     }
 
@@ -425,7 +428,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       return false;
     }
 
-    return !featureFlags.isNongatedEligibilityEnabled(request)
+    return !featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED)
         || cardData.program().eligibilityIsGating()
         || cardData.isProgramMaybeEligible().get();
   }

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -1,6 +1,7 @@
 package views.components;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static featureflags.FeatureFlag.INTAKE_FORM_ENABLED;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
@@ -172,7 +173,7 @@ public final class ProgramCardFactory {
 
   private boolean shouldShowCommonIntakeFormIndicator(
       Request request, ProgramDefinition displayProgram) {
-    return featureFlags.isIntakeFormEnabled(request)
+    return featureFlags.getFlagEnabled(request, INTAKE_FORM_ENABLED)
         && displayProgram.programType().equals(ProgramType.COMMON_INTAKE_FORM);
   }
 

--- a/server/test/featureflags/FeatureFlagsTest.java
+++ b/server/test/featureflags/FeatureFlagsTest.java
@@ -1,5 +1,7 @@
 package featureflags;
 
+import static featureflags.FeatureFlag.ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS;
+import static featureflags.FeatureFlag.PROGRAM_READ_ONLY_VIEW_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.fakeRequest;
 
@@ -37,7 +39,10 @@ public class FeatureFlagsTest {
   public void isEnabled_withNoConfig_withNoOverride_isNotEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.empty());
 
-    assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
+    assertThat(
+            featureFlags.getFlagEnabled(
+                fakeRequest().build(), FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
+        .isFalse();
   }
 
   @Test
@@ -46,8 +51,9 @@ public class FeatureFlagsTest {
 
     // Overrides only apply if the config is present.
     assertThat(
-            featureFlags.isProgramEligibilityConditionsEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
         .isFalse();
   }
 
@@ -55,14 +61,20 @@ public class FeatureFlagsTest {
   public void isEnabled_withFeatureDisabled_withNoOverride_isDisables() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesDisabledMap));
 
-    assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isFalse();
+    assertThat(
+            featureFlags.getFlagEnabled(
+                fakeRequest().build(), FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
+        .isFalse();
   }
 
   @Test
   public void isEnabled_withFeatureEnabled_withNoOverride_isEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
 
-    assertThat(featureFlags.isProgramEligibilityConditionsEnabled(fakeRequest().build())).isTrue();
+    assertThat(
+            featureFlags.getFlagEnabled(
+                fakeRequest().build(), FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
+        .isTrue();
   }
 
   @Test
@@ -71,8 +83,9 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags = new FeatureFlags(overridesEnabledConfig);
 
     assertThat(
-            featureFlags.isProgramEligibilityConditionsEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
         .isFalse();
   }
 
@@ -81,8 +94,9 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
 
     assertThat(
-            featureFlags.isProgramEligibilityConditionsEnabled(
-                fakeRequest().session(allFeaturesDisabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesDisabledMap).build(),
+                FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
         .isTrue();
   }
 
@@ -92,8 +106,9 @@ public class FeatureFlagsTest {
         new FeatureFlags(ConfigFactory.parseMap(allFeaturesAndOverridesEnabledMap));
 
     assertThat(
-            featureFlags.isProgramEligibilityConditionsEnabled(
-                fakeRequest().session(allFeaturesDisabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesDisabledMap).build(),
+                FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
         .isFalse();
   }
 
@@ -102,15 +117,17 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
 
     assertThat(
-            featureFlags.isProgramEligibilityConditionsEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED))
         .isTrue();
   }
 
   @Test
   public void programReadOnlyViewEnabled_withNoConfig_withNoOverride_isNotEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.empty());
-    assertThat(featureFlags.isReadOnlyProgramViewEnabled(fakeRequest().build())).isFalse();
+    assertThat(featureFlags.getFlagEnabled(fakeRequest().build(), PROGRAM_READ_ONLY_VIEW_ENABLED))
+        .isFalse();
   }
 
   @Test
@@ -118,15 +135,17 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.empty());
     // Overrides only apply if the config is present.
     assertThat(
-            featureFlags.isReadOnlyProgramViewEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                PROGRAM_READ_ONLY_VIEW_ENABLED))
         .isFalse();
   }
 
   @Test
   public void programReadOnlyViewEnabled_withFeatureEnabled_withNoOverride_isEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
-    assertThat(featureFlags.isReadOnlyProgramViewEnabled(fakeRequest().build())).isTrue();
+    assertThat(featureFlags.getFlagEnabled(fakeRequest().build(), PROGRAM_READ_ONLY_VIEW_ENABLED))
+        .isTrue();
   }
 
   @Test
@@ -135,8 +154,9 @@ public class FeatureFlagsTest {
     // A flag not in the config can not be overriden.
     FeatureFlags featureFlags = new FeatureFlags(overridesEnabledConfig);
     assertThat(
-            featureFlags.isReadOnlyProgramViewEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                PROGRAM_READ_ONLY_VIEW_ENABLED))
         .isFalse();
   }
 
@@ -145,8 +165,9 @@ public class FeatureFlagsTest {
       programReadOnlyViewEnabled_withFeatureEnabled_withOverridesDisabled_withDisabledOverride_isEnabled() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
     assertThat(
-            featureFlags.isReadOnlyProgramViewEnabled(
-                fakeRequest().session(allFeaturesDisabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesDisabledMap).build(),
+                PROGRAM_READ_ONLY_VIEW_ENABLED))
         .isTrue();
   }
 
@@ -156,8 +177,9 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags =
         new FeatureFlags(ConfigFactory.parseMap(allFeaturesAndOverridesEnabledMap));
     assertThat(
-            featureFlags.isReadOnlyProgramViewEnabled(
-                fakeRequest().session(allFeaturesDisabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesDisabledMap).build(),
+                PROGRAM_READ_ONLY_VIEW_ENABLED))
         .isFalse();
   }
 
@@ -167,14 +189,18 @@ public class FeatureFlagsTest {
     FeatureFlags featureFlags =
         new FeatureFlags(ConfigFactory.parseMap(allFeaturesAndOverridesEnabledMap));
     assertThat(
-            featureFlags.isReadOnlyProgramViewEnabled(
-                fakeRequest().session(allFeaturesEnabledMap).build()))
+            featureFlags.getFlagEnabled(
+                fakeRequest().session(allFeaturesEnabledMap).build(),
+                PROGRAM_READ_ONLY_VIEW_ENABLED))
         .isTrue();
   }
 
   @Test
   public void allowCiviformAdminAccessPrograms_isTrue() {
     FeatureFlags featureFlags = new FeatureFlags(ConfigFactory.parseMap(allFeaturesEnabledMap));
-    assertThat(featureFlags.allowCiviformAdminAccessPrograms(fakeRequest().build())).isTrue();
+    assertThat(
+            featureFlags.getFlagEnabled(
+                fakeRequest().build(), ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS))
+        .isTrue();
   }
 }


### PR DESCRIPTION
### Description

A follow-up to #4437. To further simplify the feature flag codebase and remove duplication, we remove all `getXEnabled()` style methods here.

Note we leave `isAdminReportingUiEnabled()` for a future PR as this is slightly more complex.
