### PR TITLE
Remove `isAdminReportingUiEnabled()`

### DIFF
--- a/server/app/featureflags/FeatureFlags.java
+++ b/server/app/featureflags/FeatureFlags.java
@@ -1,7 +1,6 @@
 package featureflags;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static featureflags.FeatureFlag.ADMIN_REPORTING_UI_ENABLED;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.typesafe.config.Config;
@@ -27,15 +26,9 @@ public final class FeatureFlags {
     this.config = checkNotNull(config);
   }
 
-  public boolean areOverridesEnabled() {
+  public boolean overridesEnabled() {
     return config.hasPath(FeatureFlag.FEATURE_FLAG_OVERRIDES_ENABLED.toString())
         && config.getBoolean(FeatureFlag.FEATURE_FLAG_OVERRIDES_ENABLED.toString());
-  }
-
-  /** If the reporting view in the admin UI is enabled */
-  // TODO(MichaelZetune): remove and have clients call getFlagEnabled directly.
-  public boolean isAdminReportingUiEnabled() {
-    return config.getBoolean(ADMIN_REPORTING_UI_ENABLED.toString());
   }
 
   public ImmutableSortedMap<FeatureFlag, Boolean> getAllFlagsSorted(Request request) {
@@ -51,7 +44,8 @@ public final class FeatureFlags {
 
   /**
    * Returns the current setting for {@code flag} from {@link Config} if present, allowing for an
-   * overriden value from the session cookie.
+   * overriden value from the session cookie. If overrides are disabled or request is null, does not
+   * check for overrides in the session.
    *
    * <p>Returns false if the value is not present.
    */
@@ -62,7 +56,7 @@ public final class FeatureFlags {
     }
     Boolean configValue = maybeConfigValue.get();
 
-    if (!areOverridesEnabled()) {
+    if (!overridesEnabled() || request == null) {
       return configValue;
     }
 

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -1,5 +1,6 @@
 package views.admin;
 
+import static featureflags.FeatureFlag.ADMIN_REPORTING_UI_ENABLED;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.nav;
@@ -145,7 +146,7 @@ public final class AdminLayout extends BaseHtmlLayout {
     // Once feature flag is removed for reporting the program admin nav will include
     // links for programs and reporting.
     if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN)
-        && !getFeatureFlags().isAdminReportingUiEnabled()) {
+        && !getFeatureFlags().getFlagEnabled(/* request=*/ null, ADMIN_REPORTING_UI_ENABLED)) {
       return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));
     }
 
@@ -157,7 +158,10 @@ public final class AdminLayout extends BaseHtmlLayout {
           .with(questionsHeaderLink)
           .with(intermediariesHeaderLink)
           .with(apiKeysHeaderLink)
-          .with(getFeatureFlags().isAdminReportingUiEnabled() ? reportingHeaderLink : null);
+          .with(
+              getFeatureFlags().getFlagEnabled(/* request=*/ null, ADMIN_REPORTING_UI_ENABLED)
+                  ? reportingHeaderLink
+                  : null);
     }
 
     return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -143,10 +143,12 @@ public final class AdminLayout extends BaseHtmlLayout {
         headerLink(
             "API keys", apiKeysLink, NavPage.API_KEYS.equals(activeNavPage) ? activeNavStyle : "");
 
+    boolean adminReportingUIEnabled =
+        getFeatureFlags().getFlagEnabledNoSessionOverrides(ADMIN_REPORTING_UI_ENABLED);
+
     // Once feature flag is removed for reporting the program admin nav will include
     // links for programs and reporting.
-    if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN)
-        && !getFeatureFlags().getFlagEnabled(/* request=*/ null, ADMIN_REPORTING_UI_ENABLED)) {
+    if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN) && !adminReportingUIEnabled) {
       return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));
     }
 
@@ -158,10 +160,7 @@ public final class AdminLayout extends BaseHtmlLayout {
           .with(questionsHeaderLink)
           .with(intermediariesHeaderLink)
           .with(apiKeysHeaderLink)
-          .with(
-              getFeatureFlags().getFlagEnabled(/* request=*/ null, ADMIN_REPORTING_UI_ENABLED)
-                  ? reportingHeaderLink
-                  : null);
+          .with(adminReportingUIEnabled ? reportingHeaderLink : null);
     }
 
     return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));

--- a/server/app/views/dev/FeatureFlagView.java
+++ b/server/app/views/dev/FeatureFlagView.java
@@ -60,7 +60,7 @@ public class FeatureFlagView extends BaseHtmlView {
                         configureCell(td(Boolean.toString(isDevOrStagingEnvironment)))),
                 tr().with(
                         configureCell(td("Configuration: ")),
-                        configureCell(td(Boolean.toString(featureFlags.areOverridesEnabled())))));
+                        configureCell(td(Boolean.toString(featureFlags.overridesEnabled())))));
 
     // Create per flag view.
     Map<FeatureFlag, Boolean> sortedFlags = featureFlags.getAllFlagsSorted(request);


### PR DESCRIPTION
### Description

A follow up to #4447 where we remove the final helper method for flags. Since we don't want to check the request for session overrides for Admin UI, we allow the request to be null in `getFlagEnabled()`.
