### PR TITLE
Remove `main` branch from pr_server.yaml

### DIFF
--- a/.github/workflows/pr_server.yaml
+++ b/.github/workflows/pr_server.yaml
@@ -8,8 +8,6 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - 'main'
     paths:
       - 'server/**'
       - 'bin/**'


### PR DESCRIPTION
### Description

Currently we don't run CI on PRs that have a base branch. We can fix this by letting GitHub run tests on all branches, not just `main`. This is helpful for stacked changes, where you would otherwise have to wait for the first change to be merged before you get CI feedback from GitHub.

<img width="1509" alt="image (1)" src="https://user-images.githubusercontent.com/30369272/226466799-a1839bc9-4e29-4ed2-a1f5-ca276941a64a.png">
