### PR TITLE
Hide settings link for common intake form.

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -186,8 +186,6 @@ export class AdminPrograms {
     return this.programCardSelector(programName, lifecycle) + ' ' + selector
   }
 
-  async programSettingsLinkInDropdownIsVisible(programName: string) {}
-
   async gotoDraftProgramManageStatusesPage(programName: string) {
     await this.gotoAdminProgramsPage()
     await this.expectDraftProgram(programName)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -186,6 +186,8 @@ export class AdminPrograms {
     return this.programCardSelector(programName, lifecycle) + ' ' + selector
   }
 
+  async programSettingsLinkInDropdownIsVisible(programName: string) {}
+
   async gotoDraftProgramManageStatusesPage(programName: string) {
     await this.gotoAdminProgramsPage()
     await this.expectDraftProgram(programName)

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -484,6 +484,9 @@ public final class ProgramIndexView extends BaseHtmlView {
         && featureFlags.getFlagEnabled(request, NONGATED_ELIGIBILITY_ENABLED))) {
       return Optional.empty();
     }
+    if (program.isCommonIntakeForm()) {
+      return Optional.empty();
+    }
     String linkDestination = routes.AdminProgramController.editProgramSettings(program.id()).url();
     ButtonTag button =
         makeSvgTextButton("Settings", Icons.SETTINGS)


### PR DESCRIPTION
### Description

The only setting available currently is for non-gating eligibility, but eligibility criteria can't be set for the common intake form. So, this hides the settings link to avoid confusion.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >