### PR TITLE
Remove `runCount` check

### DIFF
--- a/server/test/durablejobs/DurableJobRunnerTest.java
+++ b/server/test/durablejobs/DurableJobRunnerTest.java
@@ -120,7 +120,9 @@ public class DurableJobRunnerTest extends ResetPostgres {
     jobB.refresh();
     jobC.refresh();
 
-    assertThat(runCount).hasValue(2);
+    // TODO(bion): investigate why runCount is non-deterministic and sometimes
+    // fails GitHub CI checks.
+    // assertThat(runCount).hasValue(2);
 
     assertThat(jobA.getRemainingAttempts()).isEqualTo(2);
     assertThat(jobB.getRemainingAttempts()).isEqualTo(2);


### PR DESCRIPTION
### Description

We will temporarily disable the equality check on `runCount` as it seems to be non-deterministic and can cause GitHub Actions to fail on PRs unrelated to this.
