### PR TITLE
Address correction - previous button returns to address entry screen

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -849,6 +849,30 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.clickSubmit()
       await logout(page)
     })
+
+    it('clicking previous on address correction page takes you back to address entry page', async () => {
+      const {page, applicantQuestions} = ctx
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await loginAsGuest(page)
+      await selectApplicantLanguage(page, 'English')
+      await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerAddressQuestion(
+        '305 Harrison',
+        '',
+        'Seattle',
+        'WA',
+        '98109',
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.expectVerifyAddressPage()
+
+      await applicantQuestions.clickPrevious()
+      await applicantQuestions.expectAddressPage()
+
+      await logout(page)
+    })
   })
 
   // TODO: Add tests for "next" navigation

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -394,6 +394,10 @@ export class ApplicantQuestions {
     expect(await this.page.innerText('h2')).toContain('Verify address')
   }
 
+  async expectAddressPage() {
+    expect(await this.page.innerText('legend')).toContain('With Correction')
+  }
+
   async expectAddressHasBeenCorrected(
     questionText: string,
     answerText: string,

--- a/server/app/views/ApplicationBaseView.java
+++ b/server/app/views/ApplicationBaseView.java
@@ -56,6 +56,8 @@ public class ApplicationBaseView extends BaseHtmlView {
       return new AutoValue_ApplicationBaseView_Params.Builder();
     }
 
+    public abstract Builder toBuilder();
+
     public abstract boolean inReview();
 
     public abstract Http.Request request();

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -1,12 +1,12 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.h3;
 import static j2html.TagCreator.label;
-import static j2html.TagCreator.a;
 
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.routes;
@@ -35,7 +35,9 @@ import views.components.LinkElement;
 import views.style.ApplicantStyles;
 import views.style.StyleUtils;
 
-/** Renders a page asking the applicant to confirm their address from a list of corrected addresses. */ 
+/**
+ * Renders a page asking the applicant to confirm their address from a list of corrected addresses.
+ */
 public final class AddressCorrectionBlockView extends ApplicationBaseView {
   private static final String BLOCK_FORM_ID = "cf-block-form";
   private static final int MAX_SUGGESTIONS_TO_DISPLAY = 3;
@@ -226,10 +228,10 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
   @Override
   protected ATag renderPreviousButton(Params params) {
     String redirectUrl =
-          routes.ApplicantProgramBlocksController.previous(
-                  params.applicantId(), params.programId(), params.blockIndex(), params.inReview())
-              .url();
-   
+        routes.ApplicantProgramBlocksController.previous(
+                params.applicantId(), params.programId(), params.blockIndex(), params.inReview())
+            .url();
+
     return a().withHref(redirectUrl)
         .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
         .withClasses(ApplicantStyles.BUTTON_BLOCK_PREVIOUS)

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -1,7 +1,6 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
@@ -227,14 +226,9 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
 
   @Override
   protected ATag renderPreviousButton(Params params) {
-    String redirectUrl =
-        routes.ApplicantProgramBlocksController.previous(
-                params.applicantId(), params.programId(), params.blockIndex(), params.inReview())
-            .url();
-
-    return a().withHref(redirectUrl)
-        .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
-        .withClasses(ApplicantStyles.BUTTON_BLOCK_PREVIOUS)
-        .withId("cf-block-previous");
+    // Set the block index to the next block, so that the renderPreviousButton
+    // method will render the correct block.
+    Params newParams = params.toBuilder().setBlockIndex(params.blockIndex() + 1).build();
+    return super.renderPreviousButton(newParams);
   }
 }

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.h3;
 import static j2html.TagCreator.label;
+import static j2html.TagCreator.a;
 
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.routes;
@@ -34,7 +35,7 @@ import views.components.LinkElement;
 import views.style.ApplicantStyles;
 import views.style.StyleUtils;
 
-/** Renders a page indicating the applicant is not eligible for a program. */
+/** Renders a page asking the applicant to confirm their address from a list of corrected addresses. */ 
 public final class AddressCorrectionBlockView extends ApplicationBaseView {
   private static final String BLOCK_FORM_ID = "cf-block-form";
   private static final int MAX_SUGGESTIONS_TO_DISPLAY = 3;
@@ -220,5 +221,18 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
     return submitButton(params.messages().at(MessageKey.BUTTON_NEXT_SCREEN.getKeyName()))
         .withClasses(ApplicantStyles.BUTTON_BLOCK_NEXT)
         .withId("cf-block-submit");
+  }
+
+  @Override
+  protected ATag renderPreviousButton(Params params) {
+    String redirectUrl =
+          routes.ApplicantProgramBlocksController.previous(
+                  params.applicantId(), params.programId(), params.blockIndex(), params.inReview())
+              .url();
+   
+    return a().withHref(redirectUrl)
+        .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
+        .withClasses(ApplicantStyles.BUTTON_BLOCK_PREVIOUS)
+        .withId("cf-block-previous");
   }
 }


### PR DESCRIPTION
### Description

Added an override method for `renderPreviousButton` so that when the user clicks "Previous" it takes them back to the address entry page, and not to the previous question.

Before:

https://user-images.githubusercontent.com/24319951/226769050-a304315b-791c-4243-8b70-b2d3361286f5.mov

Now:

https://user-images.githubusercontent.com/24319951/226769068-497216d0-4237-4948-a81b-5153cb625c25.mov

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes [#4442](https://github.com/civiform/civiform/issues/4442)
