### PR TITLE
Add generate_markdown.py script to release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,3 +31,12 @@ jobs:
 
       - name: Run bin/create-release
         run: 'GH_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/create-release ${{ github.event.inputs.commit_sha }} ${{ github.event.inputs.release_number }}'
+
+      - name: Run bin/env-var-docs-generate-markdown
+        env:
+          LOCAL_OUTPUT: false
+          RELEASE_VERSION: ${{ github.event.inputs.release_number }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_AUTOMATION_BOT_ACCESS_TOKEN_TODO }}
+          TARGET_REPO: civiform/docs
+          TARGET_PATH: docs/it-manual/sre-playbook/server-environment-variables
+        run: bin/env-var-docs-generate-markdown

--- a/bin/env-var-docs-generate-markdown
+++ b/bin/env-var-docs-generate-markdown
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+# DOC: Runs env-var-docs/generate_markdown.py.
+# DOC:
+# DOC: Writes generated markdown to stdout by default. To enable submitting to
+# DOC: the docs repository, set LOCAL_OUTPUT=false and provide values for
+# DOC: RELEASE_VERSION, GITHUB_ACCESS_TOKEN, TARGET_REPO, and TARGET_PATH.
+
+source bin/lib.sh
+
+if [[ ! -d env-var-docs/venv ]]; then
+  echo "ERROR: venv directory does not exist. First run 'bin/env-var-docs-create-venv' then run this script."
+  exit 1
+fi
+
+source env-var-docs/venv/bin/activate
+
+local_output=${LOCAL_OUTPUT:-true}
+export LOCAL_OUTPUT=${local_output}
+export ENV_VAR_DOCS_PATH=server/conf/env-var-docs.json
+
+echo "Running env-var-docs/generate_markdown.py with LOCAL_OUTPUT=${LOCAL_OUTPUT}..."
+python env-var-docs/generate_markdown.py

--- a/env-var-docs/README.md
+++ b/env-var-docs/README.md
@@ -40,11 +40,13 @@ server is deployed.
 
 ### Running locally
 
-To run check_vars_documented.py and run_regex_tests.py locally:
+Before running any scripts, a python virtual environment (venv) must be
+created: `bin/env-var-docs-create-venv`.
 
-1. First ensure a python virtual environment (venv) is created to run the
-   scripts in: `bin/env-var-docs-create-venv`.
-1. Run `bin/env-var-docs-check-vars`.
+To run check_vars_documented.py and run_regex_tests.py:
+`bin/env-var-docs-check-vars`.
+
+To run generate_markdown.py locally: `bin/env-var-docs-generate-markdown`.
 
 ## Developer setup
 

--- a/env-var-docs/generate_markdown.py
+++ b/env-var-docs/generate_markdown.py
@@ -1,0 +1,155 @@
+"""Generates markdown from an environment variable documentation file and write it to a github repository.
+
+Requires the following variables to be present in the environment:
+    ENV_VAR_DOCS_PATH: the path to env-var-docs.json.
+
+If LOCAL_OUTPUT is set, markdown will be written to stdout instead of GitHub.
+
+If LOCAL_OUTPUT is not set, the following variables must be set:
+    RELEASE_VERSION: CiviForm version being released. 
+    GITHUB_ACCESS_TOKEN: personal access token to call github API with.
+    TARGET_REPO: the target github repository in 'owner/repo-name' format.
+    TARGET_PATH: the relative path within TARGET_REPO to write the file to.
+"""
+
+import dataclasses
+import env_var_docs.parser
+import env_var_docs.errors_formatter
+import github
+import os
+import sys
+import typing
+
+
+def errorexit(msg):
+    """Logs a message and exits"""
+    sys.stderr.write(msg + "\n")
+    exit(1)
+
+
+@dataclasses.dataclass
+class Config:
+    docs_path: str
+    version: str
+    local_output: bool
+    access_token: str
+    repo: str
+    repo_path: str
+
+
+def make_config() -> Config:
+    """Returns a Config by reading variables set in the environment. See docs
+    at the beginning of this file for required and optional variables.
+
+    Exits if any there are any validation errors.
+    """
+    if "ENV_VAR_DOCS_PATH" not in os.environ:
+        errorexit(
+            "ENV_VAR_DOCS_PATH must be present in the environment variables")
+
+    docs = os.environ["ENV_VAR_DOCS_PATH"]
+    if not os.path.isfile(docs):
+        errorexit(f"'{docs}' does not point to a file")
+
+    local = (os.environ.get("LOCAL_OUTPUT", "false") == "true")
+    if not local:
+        try:
+            version = os.environ["RELEASE_VERSION"]
+            token = os.environ["GITHUB_ACCESS_TOKEN"]
+            repo = os.environ["TARGET_REPO"]
+            path = os.environ["TARGET_PATH"]
+            if path[0:1] == "/":
+                errorexit("f{path} must be a relative path")
+        except KeyError as e:
+            errorexit(
+                f"Either LOCAL_OUTPUT=true must be set or {e.args[0]} must be present in the environment variables"
+            )
+    else:
+        version = token = repo = path = ""
+
+    return Config(docs, version, local, token, repo, path)
+
+
+def main():
+    config = make_config()
+    with open(config.docs_path) as docs_file:
+        markdown, parse_errors = generate_markdown(docs_file)
+        if len(parse_errors) != 0:
+            msg = f"{config.docs_path} is invalid:\n"
+            msg += env_var_docs.errors_formatter.format(parse_errors)
+            errorexit(msg)
+
+    if config.local_output:
+        print(markdown)
+        exit()
+
+    gh = github.Github(config.access_token)
+    repo = gh.get_repo(config.repo)
+
+    # If file exists, update it, if not, create it.
+    path = f"{config.repo_path}/{config.version}.md"
+    msg = f"Adds server environment variable documentation for {config.version}"
+    try:
+        file = repo.get_contents(path)
+        if isinstance(file, list):
+            errorexit(
+                f"{file_path} returns multiple files in the repo, aborting")
+
+        res = repo.update_file(path, msg, markdown, file.sha)
+    except github.GithubException.UnknownObjectException:
+        res = repo.create_file(path, msg, markdown, branch="main")
+
+    print(
+        f"https://github.com/blob/main/{config.repo}/{path} updated in commit {res['commit']}"
+    )
+
+
+def generate_markdown(
+    docs_file: typing.TextIO
+) -> tuple[str | None, list[env_var_docs.parser.NodeParseError]]:
+    out = ""
+
+    def output(node: env_var_docs.parser.Node):
+        nonlocal out  # Need to declare out nonlocal otherwise it gets shadowed.
+        out += f"{'#' * node.level} {node.name}\n\n"
+
+        group = None
+        if isinstance(node.details, env_var_docs.parser.Group):
+            group = node.details
+        var = None
+        if isinstance(node.details, env_var_docs.parser.Variable):
+            var = node.details
+
+        desc = ""
+        if group is not None:
+            desc = group.group_description
+        if var is not None:
+            desc = var.description
+            if var.required:
+                desc += " **Required**."
+        out += (desc + "\n\n")
+
+        if var is not None:
+            out += f"- Type: {var.type}\n"
+            if var.values is not None:
+                out += "- Allowed values:\n"
+                for val in var.values:
+                    out += f"   - {val}\n"
+            if var.regex is not None:
+                out += f"- Validation regular expression: `{var.regex}`\n"
+            if var.regex_tests is not None:
+                out += "- Regular expression examples:\n"
+                for test in var.regex_tests:
+                    msg = "should match" if test.should_match else "should not match"
+                    out += f"   - `{test.val}` {msg}.\n"
+            out += "\n"
+
+    errors = env_var_docs.parser.visit(docs_file, output)
+    if len(errors) != 0:
+        return None, errors
+
+    return out, []
+
+
+if __name__ == "__main__":
+    main()

--- a/env-var-docs/generate_markdown_test.py
+++ b/env-var-docs/generate_markdown_test.py
@@ -1,0 +1,292 @@
+from generate_markdown import make_config, generate_markdown
+import contextlib
+import io
+import os
+import tempfile
+import textwrap
+import unittest
+
+
+class TestMakeConfig(unittest.TestCase):
+
+    def setUp(self):
+        os.environ = {}
+
+    def test_no_env_vars(self):
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+            make_config()
+        self.assertTrue(
+            "ENV_VAR_DOCS_PATH must be present in the environment variables" in
+            stderr.getvalue())
+
+    def test_no_env_var_docs_path(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            os.environ["LOCAL_OUTPUT"] = "true"
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                make_config()
+            self.assertTrue(
+                "ENV_VAR_DOCS_PATH must be present in the environment variables"
+                in stderr.getvalue())
+
+    def test_env_var_docs_not_file(self):
+        os.environ["ENV_VAR_DOCS_PATH"] = "some/file"
+
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                stderr):
+            make_config()
+        self.assertTrue("'some/file' does not point to a file" in stderr.getvalue())
+
+    def test_local_mode_config_returned(self):
+        with tempfile.NamedTemporaryFile() as envvar:
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["LOCAL_OUTPUT"] = "true"
+            got = make_config()
+            self.assertEqual(got.docs_path, envvar.name)
+            self.assertEqual(got.local_output, True)
+            self.assertEqual(got.version, "")
+            self.assertEqual(got.access_token, "")
+            self.assertEqual(got.repo, "")
+            self.assertEqual(got.repo_path, "")
+
+    def test_no_release_version(self):
+        with tempfile.NamedTemporaryFile() as envvar:
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["GITHUB_ACCESS_TOKEN"] = "ABCD"
+            os.environ["TARGET_REPO"] = "civiform/docs"
+            os.environ["TARGET_PATH"] = "/path/to/dir"
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                make_config()
+            self.assertTrue("RELEASE_VERSION must be present in the environment variables" in stderr.getvalue())
+
+    def test_github_mode_absolute_path(self):
+        with tempfile.NamedTemporaryFile() as envvar:
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["RELEASE_VERSION"] = "v0.0.1"
+            os.environ["GITHUB_ACCESS_TOKEN"] = "ABCD"
+            os.environ["TARGET_REPO"] = "civiform/docs"
+            os.environ["TARGET_PATH"] = "/path/to/dir"
+
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(
+                    stderr):
+                make_config()
+            self.assertTrue("must be a relative path" in stderr.getvalue())
+
+
+    def test_github_mode_config_returned(self):
+        with tempfile.NamedTemporaryFile() as envvar:
+            os.environ["ENV_VAR_DOCS_PATH"] = envvar.name
+            os.environ["RELEASE_VERSION"] = "v0.0.1"
+            os.environ["GITHUB_ACCESS_TOKEN"] = "ABCD"
+            os.environ["TARGET_REPO"] = "civiform/docs"
+            os.environ["TARGET_PATH"] = "path/to/dir"
+            got = make_config()
+            self.assertEqual(got.docs_path, envvar.name)
+            self.assertEqual(got.version, "v0.0.1")
+            self.assertEqual(got.local_output, False)
+            self.assertEqual(got.access_token, "ABCD")
+            self.assertEqual(got.repo, "civiform/docs")
+            self.assertEqual(got.repo_path, "path/to/dir")
+
+
+class TestGenerateMarkdown(unittest.TestCase):
+
+    def test_no_docs(self):
+        with io.StringIO("{}") as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, "")
+
+    def test_minimal_doc(self):
+        input = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string"
+            }
+        }
+        """
+        expected = """\
+        # MY_VAR
+
+        A var.
+
+        - Type: string
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_doc_with_required(self):
+        input = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string",
+                "required": true
+            }
+        }
+        """
+        expected = """\
+        # MY_VAR
+
+        A var. **Required**.
+
+        - Type: string
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_doc_with_values(self):
+        input = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string",
+                "values": ["one", "two"]
+            }
+        }
+        """
+        expected = """\
+        # MY_VAR
+
+        A var.
+
+        - Type: string
+        - Allowed values:
+           - one
+           - two
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_doc_with_regex(self):
+        input = """
+        {
+            "MY_VAR": {
+                "description": "A var.",
+                "type": "string",
+                "regex": "^must_match$",
+                "regex_tests": [
+                    { "val": "must_match", "should_match": true },
+                    { "val": "can_match", "should_match": false }
+                ]
+            }
+        }
+        """
+        expected = """\
+        # MY_VAR
+
+        A var.
+
+        - Type: string
+        - Validation regular expression: `^must_match$`
+        - Regular expression examples:
+           - `must_match` should match.
+           - `can_match` should not match.
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_group(self):
+        input = """
+        {
+            "My group": {
+                "group_description": "A group.",
+                "members": {}
+            }
+        }
+        """
+        expected = """\
+        # My group
+
+        A group.
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_group_in_group(self):
+        input = """
+        {
+            "My group": {
+                "group_description": "A group.",
+                "members": {
+                    "My sub group": {
+                        "group_description": "A sub group.",
+                        "members": {}
+                    }
+                }
+            }
+        }
+        """
+        expected = """\
+        # My group
+
+        A group.
+
+        ## My sub group
+
+        A sub group.
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+    def test_var_in_group(self):
+        input = """
+        {
+            "My group": {
+                "group_description": "A group.",
+                "members": {
+                    "MY_VAR": {
+                        "description": "A var.",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+        """
+        expected = """\
+        # My group
+
+        A group.
+
+        ## MY_VAR
+
+        A var.
+
+        - Type: string
+
+        """
+        with io.StringIO(input) as f:
+            got, gotErrors = generate_markdown(f)
+            self.assertEqual(gotErrors, [])
+            self.assertEqual(got, textwrap.dedent(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

Adds a python script that generates markdown from the server/config/env-var-docs.json file.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [ ] Create a civiform-github-automation github user account with a personal access token that has write access to civiform/docs.