### PR TITLE
Add option to customize the diffbase for bin/fmt.

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -1,14 +1,15 @@
 #! /usr/bin/env bash
 
 # DOC: Autoformat Java and TypeScript source files. Usually good to run before committing.
+# 
 # Run with -d <diffbase: branch or commit> flag to customize the diffbase. By default, the
-# diffbase is origin/main.
-# e.g.:
-#   Diff against your local main branch:
-#   bin/fmt -d main
+# diffbase is origin/main
+# Example usage:
+#   * Diff against your local main branch:
+#     bin/fmt -d main
 #
-#   Diff against a specific commit:
-#   bin/fmt -d 191b1d30c369d9971ed2bddb9438ea571f300ab8
+#   * Diff against a specific commit:
+#     bin/fmt -d 191b1d30c369d9971ed2bddb9438ea571f300ab8
 
 source bin/lib.sh
 docker::set_project_name_dev

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # DOC: Autoformat Java and TypeScript source files. Usually good to run before committing.
-# 
+#
 # Run with -d <diffbase: branch or commit> flag to customize the diffbase. By default, the
 # diffbase is origin/main
 # Example usage:

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,6 +1,14 @@
 #! /usr/bin/env bash
 
 # DOC: Autoformat Java and TypeScript source files. Usually good to run before committing.
+# Run with -d <diffbase: branch or commit> flag to customize the diffbase. By default, the
+# diffbase is origin/main.
+# e.g.:
+#   Diff against your local main branch:
+#   bin/fmt -d main
+#
+#   Diff against a specific commit:
+#   bin/fmt -d 191b1d30c369d9971ed2bddb9438ea571f300ab8
 
 source bin/lib.sh
 docker::set_project_name_dev
@@ -15,4 +23,5 @@ fi
 
 docker run --rm ${interactive_flag} \
   -v "$(pwd):/code" \
-  civiform/formatter
+  civiform/formatter \
+  "$@"

--- a/bin/fmt
+++ b/bin/fmt
@@ -10,6 +10,12 @@
 #
 #   * Diff against a specific commit:
 #     bin/fmt -d 191b1d30c369d9971ed2bddb9438ea571f300ab8
+#
+#   * Diff against the current commit:
+#     bin/fmt -d HEAD
+#
+#   * Diff against the previous commit:
+#     bin/fmt -d HEAD^
 
 source bin/lib.sh
 docker::set_project_name_dev

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -8,12 +8,22 @@ set -o pipefail
 git config --global --add safe.directory /code
 cd /code
 
+diffbase="origin/main"
+while getopts d: flag; do
+  case "${flag}" in
+    d)
+      diffbase="${OPTARG}"
+      ;;
+  esac
+done
+echo "Using diffbase ${diffbase}"
+
 # Gets the list of file paths for files that are tracked by git and have
 # changes relative to the main branch.
 function get_tracked_modified_files() {
   # Exclude deleted files:
   # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
-  git diff --diff-filter=d --name-only origin/main
+  git diff --diff-filter=d --name-only ${diffbase}
 }
 
 # Gets the list of file paths for files that are not tracked by git and are

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -50,8 +50,7 @@ WORKDIR $SERVER_DIR
 RUN npm install
 
 
-ENTRYPOINT ["/bin/bash"]
-CMD ["/code/formatter/fmt"]
+ENTRYPOINT ["/code/formatter/fmt"]
 
 VOLUME ["/code/browser-test/node_modules"]
 VOLUME ["/code/server/node_modules"]


### PR DESCRIPTION
### Description

Adds the ability to override the diffbase when running `bin/fmt` by passing in a `-d <diffbase>` flag

Sometimes there are a lot of diffs between your local changes and `origin/main`, which causes `bin/fmt` to format extra files unnecessarily. There's a workaround of rebasing before running the script, but this gives you more control since it also allows the diffbase to be a specific commit. For example, you could use this to just run the formatter on your most recently modified files after a code review. See https://github.com/civiform/civiform/issues/2985#issuecomment-1472559643 for full context.

Note that with the current implementation there are some ways this could be misused, e.g. if you run `bin/fmt -d --help`, it will think that `--help` is the diffbase and this won't work. This is an internal tool, however, and all misusing it does is make formatting not work for the person running it.

I'll update the CiviForm docs in a separate PR once this is submitted.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #2985
