### PR TITLE
Enable reporting page for all deployments

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -28,6 +28,5 @@ services:
       - BASE_URL=${BASE_URL:-http://civiform:9000}
       - LOCALSTACK_URL=http://localhost.localstack.cloud:4566
       - CIVIFORM_TIME_ZONE_ID
-      - CIVIFORM_ADMIN_REPORTING_UI_ENABLED=true
     command: ~runBrowserTestsServer
     entrypoint: ./entrypoint.sh -jvm-debug "0.0.0.0:9457"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,6 @@ services:
     ports:
       - 9000:9000
       - 8457:8457
-    environment:
-      CIVIFORM_ADMIN_REPORTING_UI_ENABLED: true
 
   civiform-shell:
     image: civiform-dev

--- a/server/app/featureflags/FeatureFlag.java
+++ b/server/app/featureflags/FeatureFlag.java
@@ -17,7 +17,6 @@ public enum FeatureFlag {
 
   // Long lived feature flags.
   ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS,
-  ADMIN_REPORTING_UI_ENABLED,
   SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE,
 
   // Launch Flags, these will eventually be removed.

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -1,6 +1,5 @@
 package views.admin;
 
-import static featureflags.FeatureFlag.ADMIN_REPORTING_UI_ENABLED;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.nav;
@@ -143,15 +142,6 @@ public final class AdminLayout extends BaseHtmlLayout {
         headerLink(
             "API keys", apiKeysLink, NavPage.API_KEYS.equals(activeNavPage) ? activeNavStyle : "");
 
-    boolean adminReportingUIEnabled =
-        getFeatureFlags().getFlagEnabledNoSessionOverrides(ADMIN_REPORTING_UI_ENABLED);
-
-    // Once feature flag is removed for reporting the program admin nav will include
-    // links for programs and reporting.
-    if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN) && !adminReportingUIEnabled) {
-      return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));
-    }
-
     if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN)) {
       adminHeader.with(programsHeaderLink).with(reportingHeaderLink);
     } else {
@@ -160,7 +150,7 @@ public final class AdminLayout extends BaseHtmlLayout {
           .with(questionsHeaderLink)
           .with(intermediariesHeaderLink)
           .with(apiKeysHeaderLink)
-          .with(adminReportingUIEnabled ? reportingHeaderLink : null);
+          .with(reportingHeaderLink);
     }
 
     return adminHeader.with(headerLink("Logout", logoutLink, "float-right"));

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -450,10 +450,6 @@
         "description": "Enables the [program eligibility](https://github.com/civiform/civiform/issues/3744) feature.",
         "type": "bool"
       },
-      "CIVIFORM_ADMIN_REPORTING_UI_ENABLED": {
-        "description": "Enables the [in-app reporting feature](https://docs.google.com/document/d/1iXb58tt6j7CczPKyW18p0fUqv6SCVpoZqhqM84BKoYM/edit#heading=h.3c4zscx27v6u).",
-        "type": "bool"
-      },
       "FEATURE_FLAG_OVERRIDES_ENABLED": {
         "description": "Allows feature flags to be overridden via request cookies. Is used by browswer tests. Should only be enabled in test and staging deployments.",
         "type": "bool"

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -30,9 +30,6 @@ program_read_only_view_enabled = ${?PROGRAM_READ_ONLY_VIEW_ENABLED}
 program_eligibility_conditions_enabled = false
 program_eligibility_conditions_enabled = ${?PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED}
 
-admin_reporting_ui_enabled = false
-admin_reporting_ui_enabled = ${?CIVIFORM_ADMIN_REPORTING_UI_ENABLED}
-
 # If enabled allows for setting of feature flags via HTTP.
 # This is explicitly not recommended for production and intended to aid
 # development and pre-release evaluation of features. In fact it is unlikely to


### PR DESCRIPTION
### Description

The reporting page has been available behind the `CIVIFORM_ADMIN_REPORTING_UI_ENABLED` feature flag for a few weeks. Feedback has been positive so we are removing the feature flag and enabling it for all deployments.