### PR TITLE
Fix broken program details link for Common Intake Form.

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -100,7 +100,6 @@ public final class ApplicantProgramsController extends CiviFormController {
             relevantPrograms -> {
               Optional<ProgramDefinition> programDefinition =
                   relevantPrograms.allPrograms().stream()
-                      .filter(applicantProgramData -> applicantProgramData != null)
                       .map(ApplicantProgramData::program)
                       .filter(program -> program.id() == programId)
                       .findFirst();

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -5,12 +5,10 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static views.components.ToastMessage.ToastType.ALERT;
 
 import auth.ProfileUtils;
-import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.i18n.MessagesApi;
@@ -101,11 +99,8 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenApplyAsync(
             relevantPrograms -> {
               Optional<ProgramDefinition> programDefinition =
-                  Stream.of(
-                          relevantPrograms.inProgress(),
-                          relevantPrograms.submitted(),
-                          relevantPrograms.unapplied())
-                      .flatMap(ImmutableList::stream)
+                  relevantPrograms.allPrograms().stream()
+                      .filter(applicantProgramData -> applicantProgramData != null)
                       .map(ApplicantProgramData::program)
                       .filter(program -> program.id() == programId)
                       .findFirst();

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1367,6 +1367,20 @@ public final class ApplicantService {
 
       abstract ApplicationPrograms build();
     }
+
+    /** Returns all relevant programs for the applicant. */
+    public ImmutableList<ApplicantProgramData> allPrograms() {
+      ImmutableList.Builder<ApplicantProgramData> allPrograms =
+          new ImmutableList.Builder<ApplicantProgramData>();
+
+      if (commonIntakeForm().isPresent()) {
+        allPrograms.add(commonIntakeForm().get());
+      }
+      allPrograms.addAll(inProgress());
+      allPrograms.addAll(submitted());
+      allPrograms.addAll(unapplied());
+      return allPrograms.build();
+    }
   }
 
   /**

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -11,6 +11,7 @@ import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
 
 import controllers.WithMockedProfiles;
+import featureflags.FeatureFlag;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -116,6 +117,20 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     Program program = resourceCreator().insertActiveProgram("program");
 
     Request request = addCSRFToken(fakeRequest()).build();
+    Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result))
+        .contains(routes.ApplicantProgramsController.view(currentApplicant.id, program.id).url());
+  }
+
+  @Test
+  public void index_withCommonIntakeform_includesStartHereButtonWithRedirect() {
+    Program program = resourceCreator().insertActiveCommonIntakeForm("benefits");
+
+    Request request =
+        addCSRFToken(fakeRequest().session(FeatureFlag.INTAKE_FORM_ENABLED.toString(), "true"))
+            .build();
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -1736,6 +1736,12 @@ public class ApplicantServiceTest extends ResetPostgres {
         .containsExactly(Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.allPrograms())
+        .containsExactlyInAnyOrder(
+            result.commonIntakeForm().get(),
+            result.inProgress().get(0),
+            result.submitted().get(0),
+            result.unapplied().get(0));
   }
 
   @Test
@@ -1783,6 +1789,9 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isFalse();
+    assertThat(result.allPrograms())
+        .containsExactlyInAnyOrder(
+            result.inProgress().get(0), result.submitted().get(0), result.unapplied().get(0));
   }
 
   @Test


### PR DESCRIPTION
### Description

The default program details link on the applicant program index view was broken because the common intake form was excluded from the list of programs used to generate the link.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #4480
