### PR TITLE
Pin localstack image to 1.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 
 services:
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:1.4.0
     profiles: ['aws', 'emulator']
     expose:
       - '4566'


### PR DESCRIPTION
The latest version of the localstack image broke file uploads during tests. It appears to be due to some networking changes (https://github.com/localstack/localstack/commit/02c9b8ff2d0e6c38ae6f32f5dd44fdd33f4c4f99). Others are also having networking issues with this image. If it doesn't get resolved, we'll dig deeper to figure out how to unpin this.