### PR TITLE
Hotfix: moved test up to be nested under dev check

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -854,6 +854,30 @@ describe('Applicant navigation flow', () => {
         await applicantQuestions.clickSubmit()
         await logout(page)
       })
+
+      it('clicking previous on address correction page takes you back to address entry page', async () => {
+        const {page, applicantQuestions} = ctx
+        await enableFeatureFlag(page, 'esri_address_correction_enabled')
+        await loginAsGuest(page)
+        await selectApplicantLanguage(page, 'English')
+        await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
+  
+        // Fill out application and submit.
+        await applicantQuestions.answerAddressQuestion(
+          '305 Harrison',
+          '',
+          'Seattle',
+          'WA',
+          '98109',
+        )
+        await applicantQuestions.clickNext()
+        await applicantQuestions.expectVerifyAddressPage()
+  
+        await applicantQuestions.clickPrevious()
+        await applicantQuestions.expectAddressPage()
+  
+        await logout(page)
+      })
     }
 
     it('address correction page does not show if feature is disabled', async () => {
@@ -877,30 +901,6 @@ describe('Applicant navigation flow', () => {
         '305 Harrison',
       )
       await applicantQuestions.clickSubmit()
-      await logout(page)
-    })
-
-    it('clicking previous on address correction page takes you back to address entry page', async () => {
-      const {page, applicantQuestions} = ctx
-      await enableFeatureFlag(page, 'esri_address_correction_enabled')
-      await loginAsGuest(page)
-      await selectApplicantLanguage(page, 'English')
-      await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
-
-      // Fill out application and submit.
-      await applicantQuestions.answerAddressQuestion(
-        '305 Harrison',
-        '',
-        'Seattle',
-        'WA',
-        '98109',
-      )
-      await applicantQuestions.clickNext()
-      await applicantQuestions.expectVerifyAddressPage()
-
-      await applicantQuestions.clickPrevious()
-      await applicantQuestions.expectAddressPage()
-
       await logout(page)
     })
   })

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -861,7 +861,7 @@ describe('Applicant navigation flow', () => {
         await loginAsGuest(page)
         await selectApplicantLanguage(page, 'English')
         await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
-  
+
         // Fill out application and submit.
         await applicantQuestions.answerAddressQuestion(
           '305 Harrison',
@@ -872,10 +872,10 @@ describe('Applicant navigation flow', () => {
         )
         await applicantQuestions.clickNext()
         await applicantQuestions.expectVerifyAddressPage()
-  
+
         await applicantQuestions.clickPrevious()
         await applicantQuestions.expectAddressPage()
-  
+
         await logout(page)
       })
     }


### PR DESCRIPTION
### Description

Prober tests are failing on AWS staging in part because we do not have an ESRI client and this test expects one. Moving this test up under the `isDevelopment` check makes it so that this test will not run on staging.
