### PR TITLE
Clean up `messages` files

### DIFF
--- a/server/conf/messages.am
+++ b/server/conf/messages.am
@@ -6,270 +6,150 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+adminValidation.multiOptionEmpty=ባለብዙ አማራጭ ጥያቄዎች ባዶ አማራጮች ሊኖሯቸው አይችሉም።
+ariaLabel.answer=መልስ {0}
+ariaLabel.begin=እዚህ ይጀምሩ። {0}
+ariaLabel.edit={0}ን አርትዕ
+banner.errorSavingApplication=ማመልከቻን በማስቀመጥ ላይ ስህተት
+button.addEntity={0}ን አክል
+button.apply=አመልክት
+button.applySr=ወደ {0} አመልክት
+button.chooseFile=ፋይል ይምረጡ
+button.continue=ቀጥል
+button.continueSr=ወደ {0} ማመልከትን ቀጥል
+button.createAccount=መለያ ፍጠር
+button.deleteFile=ሰርዝ
+button.edit=አርትዕ
+button.editAddress=አድራሻን አርትዕ ያድርጉ
+button.editSr=ወደ {0} ያስገቡትን ማመልከቻ ያርትዑ
+button.goBackAndEdit=ይመለሱ እና አርትዕ ያድርጉ
+button.guestLogin=እንደ እንግዳ ቀጥል
+button.keepFile=ቀጥል
+button.login=ግባ
+button.logout=ውጣ
+button.nextScreen=አስቀምጥ እና ቀጣይ
+button.previousScreen=ቀዳሚ
+button.removeEntity={0}ን አስወግድ
+button.review=ገምግም
+button.saveAndConfirm=ያስቀምጡ እና ያረጋግጡ
+button.skipFileUpload=ዝለል
+button.submit=አስገባ
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=ውጣ
-
-footer.supportLinkDescription=ለቴክኒካዊ ድጋፍ፣ እውቂያ
-
-guest=እንግዳ
-
-label.languageSr=ቋንቋ ይምረጡ
-
-header.userName=እንደ {0} ሆነው ገብተዋል
-
-validation.isRequired=ይህ ጥያቄ አስፈላጊ ነው።
-
-validation.invalidInput=እባክዎ ትክክለኛ ግብዓት ያስገቡ።
-
-validation.errorAnnouncementSr=በቅጹ ውስጥ ስህተቶች አሉ። እባክዎ ከመቀጠልዎ በፊት ያስተካክሉ።
-
-content.requiredFieldsAnnotation=ማስታወሻ፦ የ* ምልክት የተደረገባቸው መስኮች ያስፈልጋሉ።
-
-content.mobileFileUploadHelp=በእርስዎ ስልክ ላይ? እንዲሁም «ፋይልን ምረጥ» የስልክ ካሜራዎን ሰነዶችን ለመስቀል እንዲጠቀሙበት ያስችልዎታል።
-
-title.login=ግባ
-
-content.loginPrompt=እባክዎ በ{0} መለያዎ ይግቡ
-
-button.login=ግባ
-
-content.alternativeLoginPrompt=መለያ የለዎትም?
-
-content.or=ወይም
-
-button.createAccount=መለያ ፍጠር
-
-button.guestLogin=እንደ እንግዳ ቀጥል
-
-content.loginDisabledPrompt=በመለያ መግባት በአሁኑ ጊዜ ተሰናክሏል
-
-content.adminLoginPrompt=ሌላ ነገር እየፈለጉ ነው?
-
-link.adminLogin=የአስተዳዳሪ መግቢያ
-
-input.fileAlreadyUploaded=የተሰቀለ ፋይል፦ {0}
-
-button.deleteFile=ሰርዝ
-
-button.keepFile=ቀጥል
-
-button.nextScreen=አስቀምጥ እና ቀጣይ
-
-button.previousScreen=ቀዳሚ
-
-button.review=ገምግም
-
-button.skipFileUpload=ዝለል
-
-toast.localeNotSupported=እናዝናለን፣ ይህ ፕሮግራም ሙሉ በሙሉ ወደ እንግሊዝኛ አልተተረጎመም።
-
-link.allDone=ሁሉንም ጨርሼያለሁ
-
-link.applyToAnotherProgram=ወደ ሌላ ፕሮግራም ያመልክቱ
-
-link.createAccountOrSignIn=መለያ ይፍጠሩ ወይም ይግቡ
-
-button.apply=አመልክት
-
-button.applySr=ወደ {0} አመልክት
-
-button.edit=አርትዕ
-
-button.editSr=ወደ {0} ያስገቡትን ማመልከቻ ያርትዑ
-
-button.continueSr=ወደ {0} ማመልከትን ቀጥል
-
-content.submittedDate={0} ገብቷል
-
-content.benefits=ጥቅማጥቅሞችን ያግኙ
-
-content.description1=CiviForm መረጃን እንደገና በመጠቀም በአንድ ጊዜ ለበርካታ ጥቅማጥቅሞች እንዲያመለክቱ ያስችለዎታል።
-
-content.description2=ከታች ማመልከቻ በመምረጥ ይጀምሩ።
-
-link.programDetails=የፕሮግራም ዝርዝሮች
-
-link.programDetailsSr=የ{0} ፕሮግራም ዝርዝሮች
-
-title.programs=ፕሮግራሞች እና አገልግሎቶች
-
-title.status=ሁኔታ
-
-title.inProgressProgramsUpdated=በሂደት ላይ
-
-title.activeProgramsUpdated=ያልተጀመሩ
-
-title.submittedPrograms=የገቡ
-
-toast.applicationSaved=በተሳካ ሁኔታ የተቀመጠ ማመልከቻ፦ የማመልከቻ መታወቂያ {0}
-
-toast.programCompleted=ማመልከቻው ቀድሞውኑ ተጠናቅቋል።
-
-button.submit=አስገባ
-
-button.continue=ቀጥል
-
-toast.applicationOutOfDate=በመተግበሪያው ላይ ዝማኔ ተደርጓል፣ ለመቀጠል እባክዎ ይገምግሙ እና ጥያቄዎችን ይመልሱ
-
-content.notEligible=ብቁ አይደለም
-
-content.doesNotQualify=ብቁ አይደለም
-
-link.edit=አርትዕ
-link.answer=መልስ
-
-content.previouslyAnsweredOn=ቀደም ሲል በ{0} ላይ መልስ ተሰጥቷል
-
-ariaLabel.begin=እዚህ ይጀምሩ። {0}
-
-ariaLabel.edit={0}ን አርትዕ
-
-ariaLabel.answer=መልስ {0}
-
-title.programSummary=የፕሮግራም ማመልከቻ ማጠቃለያ
-
-title.applicantNotEligible=እርስዎ ጥያቄዎች በሰጧቸው ምላሾች መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ።
-
-title.applicantNotEligibleTi=እርስዎ ለሚከተሉት ጥያቄዎች በሰጧቸው ምላሾች መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ።
-
-content.eligibilityCriteria=ለብቁነት መስፈርት እባክዎ {0}ን ዋቢ ያድርጉ
-
-content.changeAnswersForEligibility=መልሶችዎን ለማርትዕ ወደ ቀዳሚ ገጽ መመለስ ይችላሉ። ወይም ለሌላ ፕሮግራም ያመልክቱ።
-
-button.goBackAndEdit=ይመለሱ እና አርትዕ ያድርጉ
-
-toast.mayQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
-
-toast.mayQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
-
-tag.mayQualify=ብቁ ሊሆኑ ይችላሉ
-
-tag.mayQualifyTi=ደንበኛዎ ብቁ ሊሆኑ ይችላሉ
-
-tag.mayNotQualify=ብቁ ላይሆኑ ይችላሉ
-
-tag.mayNotQualifyTi=ደንበኛዎ ብቁ ላይሆኑ ይችላሉ
-
-title.cannotCheckEligibility=በዚህ ጊዜ ለ{0} የእርስዎን ብቁነት ማረጋገጥ አንችልም።
-
-title.cannotCheckEligibilityTi=በዚህ ጊዜ ለ{0} የደንበኛዎን ብቁነት ማረጋገጥ አንችልም።
-
-content.cannotCheckEligibility=ይህን ችግር በፍጥነት ለማስተካከል እየሰራን ነው። በኋላ ላይ እንደገና ይሞክሩ።
-
 button.viewAllPrograms=ሁሉንም ፕሮግራሞች ይመልከቱ
-
-toast.mayNotQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ። መረጃዎ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
-
-toast.mayNotQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ። የደንበኛዎ መረጃ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
-
-banner.errorSavingApplication=ማመልከቻን በማስቀመጥ ላይ ስህተት
-
-title.applicationConfirmation=የማመልከቻ ማረጋገጫ
-
+content.addressEntered=የገባ አድራሻ፦
+content.addressEnteredWithQuestionName={0} ገብቷል፦
+content.adminLoginPrompt=ሌላ ነገር እየፈለጉ ነው?
+content.alternativeLoginPrompt=መለያ የለዎትም?
+content.benefits=ጥቅማጥቅሞችን ያግኙ
+content.cannotCheckEligibility=ይህን ችግር በፍጥነት ለማስተካከል እየሰራን ነው። በኋላ ላይ እንደገና ይሞክሩ።
+content.changeAnswersForEligibility=መልሶችዎን ለማርትዕ ወደ ቀዳሚ ገጽ መመለስ ይችላሉ። ወይም ለሌላ ፕሮግራም ያመልክቱ።
 content.confirmed=ለ{0} በማመልከትዎ እናመሰግናለን። ማመልከቻዎ ደርሷል፣ እና የማመልከቻ መታወቂያዎ {1} ነው።
-
-title.createAnAccount=መለያ ይፍጠሩ ወይም ይግቡ
-
+content.description1=CiviForm መረጃን እንደገና በመጠቀም በአንድ ጊዜ ለበርካታ ጥቅማጥቅሞች እንዲያመለክቱ ያስችለዎታል።
+content.description2=ከታች ማመልከቻ በመምረጥ ይጀምሩ።
+content.doesNotQualify=ብቁ አይደለም
+content.eligibilityCriteria=ለብቁነት መስፈርት እባክዎ {0}ን ዋቢ ያድርጉ
+content.foundSimilarAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም ነገር ግን የሆነ ተመሳሳይ ነገር አግኝተናል።
+content.loginDisabledPrompt=በመለያ መግባት በአሁኑ ጊዜ ተሰናክሏል
+content.loginPrompt=እባክዎ በ{0} መለያዎ ይግቡ
+content.mobileFileUploadHelp=በእርስዎ ስልክ ላይ? እንዲሁም «ፋይልን ምረጥ» የስልክ ካሜራዎን ሰነዶችን ለመስቀል እንዲጠቀሙበት ያስችልዎታል።
+content.noValidAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም። እባክዎ ለመቀጠል አድራሻዎን ያርትዑ።
+content.notEligible=ብቁ አይደለም
+content.or=ወይም
 content.pleaseCreateAccount=አሁን ወደ የከተማ መለያ ውስጥ ከገቡ መረጃዎ ይቀመጥ እና በማንኛውም ጊዜ በመመለስ የወደፊት ማመልከቻዎችን ማጠናቀቅ ይችላሉ። አስቀድመው መለያ ከሌለዎት የመግቢያ ገጹ እንዲመዘገቡ ያስችልዎታል። አስቀድመው ያስገቡትን ማንኛውም ውሂብ አያጡም።
-
+content.previouslyAnsweredOn=ቀደም ሲል በ{0} ላይ መልስ ተሰጥቷል
+content.requiredFieldsAnnotation=ማስታወሻ፦ የ* ምልክት የተደረገባቸው መስኮች ያስፈልጋሉ።
+content.submittedDate={0} ገብቷል
+content.suggestedAddress=የተጠቆመው አድራሻ፦
+content.suggestedAddresses=የተጠቆሙ አድራሻዎች፦
+dialog.confirmDelete=ይህን {0} ማስወገድ እንደሚፈልጉ እርግጠኛ ነዎት? ይህ ለውጥ «ቀጣይ»ን ከተጫኑ በኋላ ይቀመጣል፣ እና ከዚህ {0} ጋር የተጎዳኘ ሁሉም ውሂብ ይጠፋል።
+email.applicationReceivedBody=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል። የአመልካች መታወቂያዎ {1} ነው፣ እና የማመልከቻ መታወቂያው {2} ነው
+email.applicationReceivedSubject=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል
+email.loginToCiviform=ወደ CiviForm {0} ላይ በመለያ ይግቡ
+email.tiApplicationSubmittedBody=እንደ {1} ያስገቡት የ{0} ፕሮግራም ማመልከቻ ደርሷል፣ እና የማመልከቻ መታወቂያው {2} ነው።
+email.tiApplicationSubmittedSubject=ለ{0} ፕሮግራም አመልካች {1}ን በመወከል ማመልከቻ አስገብተዋል
+email.tiManageYourClients=ደንበኛዎችዎን በ{0} ላይ ያስተዳድሩ።
+error.notFoundDescription=እባክዎ ወደ ኋላ ይመለሱ ወይም ወደ {0} ይመለሱ
+error.notFoundDescriptionLink=መነሻ ገጽ
+error.notFoundTitle=ለመጎብኘት የሞከሩትን ገጽ ማግኘት አልቻልንም
+footer.supportLinkDescription=ለቴክኒካዊ ድጋፍ፣ እውቂያ
+guest=እንግዳ
+header.userName=እንደ {0} ሆነው ገብተዋል
+input.fileAlreadyUploaded=የተሰቀለ ፋይል፦ {0}
 label.addressLine2=አፓርታማ፣ ጥቅል፣ ወዘተ (አማራጭ)
 label.city=ከተማ
-label.state=ግዛት
-label.selectState=ክልል ይምረጡ
-label.street=አድራሻ
-label.zipcode=ዚፕ ኮድ
-
-validation.streetRequired=እባክዎ ትክክለኛ የጎዳና ስም እና ቁጥር ያስገቡ።
-validation.cityRequired=እባክዎ ከተማ ያስገቡ።
-validation.currencyMisformatted=ምንዛሬ ከሚከተሉት ቅርጸቶች አንዱ መሆን አለበት፦ 1000 1,000 1000.30 1,000.30
-validation.stateRequired=እባክዎ ክልል ያስገቡ።
-validation.invalidZipcode=እባክዎ ትክክለኛ ባለ5 አኃዝ ዚፕ ኮድ ያስገቡ።
-validation.noPoBox=እባክዎ ትክክለኛ አድራሻ ያስገቡ። የፖስታ ሳጥን ቁጥሮችን አንቀበልም።
-
-title.verifyAddress=አድራሻን ያረጋግጡ
-
-content.foundSimilarAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም ነገር ግን የሆነ ተመሳሳይ ነገር አግኝተናል።
-
-content.addressEntered=የገባ አድራሻ፦
-
-content.addressEnteredWithQuestionName={0} ገብቷል፦
-
-content.suggestedAddress=የተጠቆመው አድራሻ፦
-
-content.suggestedAddresses=የተጠቆሙ አድራሻዎች፦
-
-button.editAddress=አድራሻን አርትዕ ያድርጉ
-
-button.saveAndConfirm=ያስቀምጡ እና ያረጋግጡ
-
-title.noValidAddress=ምንም የሚሠሩ አድራሻዎች አልተገኙም
-
-content.noValidAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም። እባክዎ ለመቀጠል አድራሻዎን ያርትዑ።
-
-placeholder.noDropdownSelection=አንድ አማራጭ ይምረጡ፡-
-
-validation.dateMisformatted=እባክዎ በዓዓዓዓ/ወወ/ቀቀ ቅርጸት ቀን ያስገቡ።
-
-button.addEntity={0}ን አክል
-
-button.removeEntity={0}ን አስወግድ
-
-dialog.confirmDelete=ይህን {0} ማስወገድ እንደሚፈልጉ እርግጠኛ ነዎት? ይህ ለውጥ «ቀጣይ»ን ከተጫኑ በኋላ ይቀመጣል፣ እና ከዚህ {0} ጋር የተጎዳኘ ሁሉም ውሂብ ይጠፋል።
-
-validation.entityNameRequired=እባክዎ ለእያንዳንዱ መስመር እሴት ያስገቡ።
-
-validation.duplicateEntityName=እባክዎ ለእያንዳንዱ መስመር ልዩ እሴት ያስገቡ።
-
-placeholder.entityName={0} ስም
-
-validation.fileRequired=እባክዎ ፋይል ይምረጡ።
-
-button.chooseFile=ፋይል ይምረጡ
-
-validation.idTooLong=ቢበዛ {0} ቁምፊዎችን መያዝ አለበት።
-validation.idTooShort=ቢያንስ {0} ቁምፊዎችን መያዝ አለበት።
-validation.numberRequired=ቁጥሮችን ብቻ መያዝ አለበት።
-
-validation.tooFewSelections=እባክዎ ቢያንስ {0} ይምረጡ።
-validation.tooManySelections=እባክዎ ከ{0} ያነሰ ይምረጡ።
-
 label.firstName=መጠሪያ ስም
+label.languageSr=ቋንቋ ይምረጡ
 label.lastName=የአያት ስም
 label.middleName=የአባት ስም
-
+label.selectState=ክልል ይምረጡ
+label.state=ግዛት
+label.street=አድራሻ
+label.zipcode=ዚፕ ኮድ
+link.adminLogin=የአስተዳዳሪ መግቢያ
+link.allDone=ሁሉንም ጨርሼያለሁ
+link.answer=መልስ
+link.applyToAnotherProgram=ወደ ሌላ ፕሮግራም ያመልክቱ
+link.createAccountOrSignIn=መለያ ይፍጠሩ ወይም ይግቡ
+link.edit=አርትዕ
+link.programDetails=የፕሮግራም ዝርዝሮች
+link.programDetailsSr=የ{0} ፕሮግራም ዝርዝሮች
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+placeholder.entityName={0} ስም
 placeholder.firstName=መጠሪያ ስም
 placeholder.lastName=የአያት ስም
 placeholder.middleName=የአባት ስም
-
+placeholder.noDropdownSelection=አንድ አማራጭ ይምረጡ፡-
+tag.mayNotQualify=ብቁ ላይሆኑ ይችላሉ
+tag.mayNotQualifyTi=ደንበኛዎ ብቁ ላይሆኑ ይችላሉ
+tag.mayQualify=ብቁ ሊሆኑ ይችላሉ
+tag.mayQualifyTi=ደንበኛዎ ብቁ ሊሆኑ ይችላሉ
+title.activeProgramsUpdated=ያልተጀመሩ
+title.applicantNotEligible=እርስዎ ጥያቄዎች በሰጧቸው ምላሾች መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ።
+title.applicantNotEligibleTi=እርስዎ ለሚከተሉት ጥያቄዎች በሰጧቸው ምላሾች መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ።
+title.applicationConfirmation=የማመልከቻ ማረጋገጫ
+title.cannotCheckEligibility=በዚህ ጊዜ ለ{0} የእርስዎን ብቁነት ማረጋገጥ አንችልም።
+title.cannotCheckEligibilityTi=በዚህ ጊዜ ለ{0} የደንበኛዎን ብቁነት ማረጋገጥ አንችልም።
+title.createAnAccount=መለያ ይፍጠሩ ወይም ይግቡ
+title.inProgressProgramsUpdated=በሂደት ላይ
+title.login=ግባ
+title.noValidAddress=ምንም የሚሠሩ አድራሻዎች አልተገኙም
+title.programSummary=የፕሮግራም ማመልከቻ ማጠቃለያ
+title.programs=ፕሮግራሞች እና አገልግሎቶች
+title.status=ሁኔታ
+title.submittedPrograms=የገቡ
+title.verifyAddress=አድራሻን ያረጋግጡ
+toast.applicationOutOfDate=በመተግበሪያው ላይ ዝማኔ ተደርጓል፣ ለመቀጠል እባክዎ ይገምግሙ እና ጥያቄዎችን ይመልሱ
+toast.applicationSaved=በተሳካ ሁኔታ የተቀመጠ ማመልከቻ፦ የማመልከቻ መታወቂያ {0}
+toast.localeNotSupported=እናዝናለን፣ ይህ ፕሮግራም ሙሉ በሙሉ ወደ እንግሊዝኛ አልተተረጎመም።
+toast.mayNotQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ። መረጃዎ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
+toast.mayNotQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ። የደንበኛዎ መረጃ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
+toast.mayQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
+toast.mayQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
+toast.programCompleted=ማመልከቻው ቀድሞውኑ ተጠናቅቋል።
+validation.cityRequired=እባክዎ ከተማ ያስገቡ።
+validation.currencyMisformatted=ምንዛሬ ከሚከተሉት ቅርጸቶች አንዱ መሆን አለበት፦ 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=እባክዎ በዓዓዓዓ/ወወ/ቀቀ ቅርጸት ቀን ያስገቡ።
+validation.duplicateEntityName=እባክዎ ለእያንዳንዱ መስመር ልዩ እሴት ያስገቡ።
+validation.entityNameRequired=እባክዎ ለእያንዳንዱ መስመር እሴት ያስገቡ።
+validation.errorAnnouncementSr=በቅጹ ውስጥ ስህተቶች አሉ። እባክዎ ከመቀጠልዎ በፊት ያስተካክሉ።
+validation.fileRequired=እባክዎ ፋይል ይምረጡ።
 validation.firstNameRequired=እባክዎ የመጠሪያ ስምዎን ያስገቡ።
+validation.idTooLong=ቢበዛ {0} ቁምፊዎችን መያዝ አለበት።
+validation.idTooShort=ቢያንስ {0} ቁምፊዎችን መያዝ አለበት።
+validation.invalidInput=እባክዎ ትክክለኛ ግብዓት ያስገቡ።
+validation.invalidZipcode=እባክዎ ትክክለኛ ባለ5 አኃዝ ዚፕ ኮድ ያስገቡ።
+validation.isRequired=ይህ ጥያቄ አስፈላጊ ነው።
 validation.lastNameRequired=እባክዎ የአያት ስምዎን ያስገቡ።
-
+validation.noPoBox=እባክዎ ትክክለኛ አድራሻ ያስገቡ። የፖስታ ሳጥን ቁጥሮችን አንቀበልም።
+validation.numberNonInteger=ቁጥር አዎንታዊ ሙሉ ቁጥር መሆን አለበት እና መያዝ የሚችለው ከ0-9 ቁጥራዊ ቁምፊዎችን ብቻ ነው።
+validation.numberRequired=ቁጥሮችን ብቻ መያዝ አለበት።
 validation.numberTooBig=ቢበዛ {0} መሆን አለበት።
 validation.numberTooSmall=ቢያንስ {0} መሆን አለበት።
-validation.numberNonInteger=ቁጥር አዎንታዊ ሙሉ ቁጥር መሆን አለበት እና መያዝ የሚችለው ከ0-9 ቁጥራዊ ቁምፊዎችን ብቻ ነው።
-
+validation.stateRequired=እባክዎ ክልል ያስገቡ።
+validation.streetRequired=እባክዎ ትክክለኛ የጎዳና ስም እና ቁጥር ያስገቡ።
 validation.textTooLong=ቢበዛ {0} ቁምፊዎችን መያዝ አለበት።
 validation.textTooShort=ቢያንስ {0} ቁምፊዎችን መያዝ አለበት።
-
-adminValidation.multiOptionEmpty=ባለብዙ አማራጭ ጥያቄዎች ባዶ አማራጮች ሊኖሯቸው አይችሉም።
-
-error.notFoundTitle=ለመጎብኘት የሞከሩትን ገጽ ማግኘት አልቻልንም
-error.notFoundDescription=እባክዎ ወደ ኋላ ይመለሱ ወይም ወደ {0} ይመለሱ
-error.notFoundDescriptionLink=መነሻ ገጽ
-
-email.loginToCiviform=ወደ CiviForm {0} ላይ በመለያ ይግቡ
-
-email.applicationReceivedSubject=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል
-
-email.applicationReceivedBody=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል። የአመልካች መታወቂያዎ {1} ነው፣ እና የማመልከቻ መታወቂያው {2} ነው
-
-email.tiApplicationSubmittedSubject=ለ{0} ፕሮግራም አመልካች {1}ን በመወከል ማመልከቻ አስገብተዋል
-
-email.tiApplicationSubmittedBody=እንደ {1} ያስገቡት የ{0} ፕሮግራም ማመልከቻ ደርሷል፣ እና የማመልከቻ መታወቂያው {2} ነው።
-
-email.tiManageYourClients=ደንበኛዎችዎን በ{0} ላይ ያስተዳድሩ።
+validation.tooFewSelections=እባክዎ ቢያንስ {0} ይምረጡ።
+validation.tooManySelections=እባክዎ ከ{0} ያነሰ ይምረጡ።

--- a/server/conf/messages.am
+++ b/server/conf/messages.am
@@ -12,286 +12,171 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=ውጣ
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=ለቴክኒካዊ ድጋፍ፣ እውቂያ
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=እንግዳ
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=ቋንቋ ይምረጡ
 
-# Message with user's name to show who you are logged in as.
 header.userName=እንደ {0} ሆነው ገብተዋል
 
-# Error message to answer a required question
 validation.isRequired=ይህ ጥያቄ አስፈላጊ ነው።
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=እባክዎ ትክክለኛ ግብዓት ያስገቡ።
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=በቅጹ ውስጥ ስህተቶች አሉ። እባክዎ ከመቀጠልዎ በፊት ያስተካክሉ።
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=ማስታወሻ፦ የ* ምልክት የተደረገባቸው መስኮች ያስፈልጋሉ።
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=በእርስዎ ስልክ ላይ? እንዲሁም «ፋይልን ምረጥ» የስልክ ካሜራዎን ሰነዶችን ለመስቀል እንዲጠቀሙበት ያስችልዎታል።
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=ግባ
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=እባክዎ በ{0} መለያዎ ይግቡ
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=ግባ
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=መለያ የለዎትም?
 
-# The text between creating a new account, and becoming a guest
 content.or=ወይም
 
-# The text on the button for applicants to create a new account.
 button.createAccount=መለያ ፍጠር
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=እንደ እንግዳ ቀጥል
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=በመለያ መግባት በአሁኑ ጊዜ ተሰናክሏል
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=ሌላ ነገር እየፈለጉ ነው?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=የአስተዳዳሪ መግቢያ
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=የተሰቀለ ፋይል፦ {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=ሰርዝ
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=ቀጥል
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=አስቀምጥ እና ቀጣይ
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=ቀዳሚ
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=ገምግም
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=ዝለል
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=እናዝናለን፣ ይህ ፕሮግራም ሙሉ በሙሉ ወደ እንግሊዝኛ አልተተረጎመም።
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=ሁሉንም ጨርሼያለሁ
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=ወደ ሌላ ፕሮግራም ያመልክቱ
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=መለያ ይፍጠሩ ወይም ይግቡ
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=አመልክት
 
-# The text read for screen readers.
 button.applySr=ወደ {0} አመልክት
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=አርትዕ
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=ወደ {0} ያስገቡትን ማመልከቻ ያርትዑ
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=ወደ {0} ማመልከትን ቀጥል
 
-# Text describing the date the application was last submitted.
 content.submittedDate={0} ገብቷል
 
-# "Get benefits" floating text
 content.benefits=ጥቅማጥቅሞችን ያግኙ
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm መረጃን እንደገና በመጠቀም በአንድ ጊዜ ለበርካታ ጥቅማጥቅሞች እንዲያመለክቱ ያስችለዎታል።
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=ከታች ማመልከቻ በመምረጥ ይጀምሩ።
 
-# Link text to read more about a program.
 link.programDetails=የፕሮግራም ዝርዝሮች
 
-# The same text, read for screen readers.
 link.programDetailsSr=የ{0} ፕሮግራም ዝርዝሮች
 
-# The title of the page for the list of programs.
 title.programs=ፕሮግራሞች እና አገልግሎቶች
 
-# For the badge on the program list index denoting the current status of an application
 title.status=ሁኔታ
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=በሂደት ላይ
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=ያልተጀመሩ
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=የገቡ
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=በተሳካ ሁኔታ የተቀመጠ ማመልከቻ፦ የማመልከቻ መታወቂያ {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=ማመልከቻው ቀድሞውኑ ተጠናቅቋል።
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=አስገባ
 
-# Continue application button
 button.continue=ቀጥል
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=በመተግበሪያው ላይ ዝማኔ ተደርጓል፣ ለመቀጠል እባክዎ ይገምግሙ እና ጥያቄዎችን ይመልሱ
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=ብቁ አይደለም
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=ብቁ አይደለም
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=አርትዕ
 link.answer=መልስ
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=ቀደም ሲል በ{0} ላይ መልስ ተሰጥቷል
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=እዚህ ይጀምሩ። {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit={0}ን አርትዕ
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=መልስ {0}
 
-# Program Summary Title
 title.programSummary=የፕሮግራም ማመልከቻ ማጠቃለያ
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=እርስዎ ጥያቄዎች በሰጧቸው ምላሾች መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ።
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=እርስዎ ለሚከተሉት ጥያቄዎች በሰጧቸው ምላሾች መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ።
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=ለብቁነት መስፈርት እባክዎ {0}ን ዋቢ ያድርጉ
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=መልሶችዎን ለማርትዕ ወደ ቀዳሚ ገጽ መመለስ ይችላሉ። ወይም ለሌላ ፕሮግራም ያመልክቱ።
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=ይመለሱ እና አርትዕ ያድርጉ
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ሊሆኑ ይችላሉ። ለመቀጠል ማመልከቻውን መሙላትዎን ይቀጥሉ።
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=ብቁ ሊሆኑ ይችላሉ
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=ደንበኛዎ ብቁ ሊሆኑ ይችላሉ
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=ብቁ ላይሆኑ ይችላሉ
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=ደንበኛዎ ብቁ ላይሆኑ ይችላሉ
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=በዚህ ጊዜ ለ{0} የእርስዎን ብቁነት ማረጋገጥ አንችልም።
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=በዚህ ጊዜ ለ{0} የደንበኛዎን ብቁነት ማረጋገጥ አንችልም።
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=ይህን ችግር በፍጥነት ለማስተካከል እየሰራን ነው። በኋላ ላይ እንደገና ይሞክሩ።
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=ሁሉንም ፕሮግራሞች ይመልከቱ
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ። መረጃዎ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=በምላሾችዎ መሰረት ደንበኛዎ ለ{0} ብቁ ላይሆኑ ይችላሉ። የደንበኛዎ መረጃ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=ማመልከቻን በማስቀመጥ ላይ ስህተት
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=የማመልከቻ ማረጋገጫ
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=ለ{0} በማመልከትዎ እናመሰግናለን። ማመልከቻዎ ደርሷል፣ እና የማመልከቻ መታወቂያዎ {1} ነው።
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=መለያ ይፍጠሩ ወይም ይግቡ
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=አሁን ወደ የከተማ መለያ ውስጥ ከገቡ መረጃዎ ይቀመጥ እና በማንኛውም ጊዜ በመመለስ የወደፊት ማመልከቻዎችን ማጠናቀቅ ይችላሉ። አስቀድመው መለያ ከሌለዎት የመግቢያ ገጹ እንዲመዘገቡ ያስችልዎታል። አስቀድመው ያስገቡትን ማንኛውም ውሂብ አያጡም።
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=አፓርታማ፣ ጥቅል፣ ወዘተ (አማራጭ)
 label.city=ከተማ
 label.state=ግዛት
@@ -299,7 +184,6 @@ label.selectState=ክልል ይምረጡ
 label.street=አድራሻ
 label.zipcode=ዚፕ ኮድ
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=እባክዎ ትክክለኛ የጎዳና ስም እና ቁጥር ያስገቡ።
 validation.cityRequired=እባክዎ ከተማ ያስገቡ።
 validation.currencyMisformatted=ምንዛሬ ከሚከተሉት ቅርጸቶች አንዱ መሆን አለበት፦ 1000 1,000 1000.30 1,000.30
@@ -307,165 +191,85 @@ validation.stateRequired=እባክዎ ክልል ያስገቡ።
 validation.invalidZipcode=እባክዎ ትክክለኛ ባለ5 አኃዝ ዚፕ ኮድ ያስገቡ።
 validation.noPoBox=እባክዎ ትክክለኛ አድራሻ ያስገቡ። የፖስታ ሳጥን ቁጥሮችን አንቀበልም።
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=አድራሻን ያረጋግጡ
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም ነገር ግን የሆነ ተመሳሳይ ነገር አግኝተናል።
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=የገባ አድራሻ፦
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName={0} ገብቷል፦
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=የተጠቆመው አድራሻ፦
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=የተጠቆሙ አድራሻዎች፦
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=አድራሻን አርትዕ ያድርጉ
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=ያስቀምጡ እና ያረጋግጡ
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=ምንም የሚሠሩ አድራሻዎች አልተገኙም
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=የሰጡትን አድራሻ ማረጋገጥ አልቻልንም። እባክዎ ለመቀጠል አድራሻዎን ያርትዑ።
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=አንድ አማራጭ ይምረጡ፡-
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=እባክዎ በዓዓዓዓ/ወወ/ቀቀ ቅርጸት ቀን ያስገቡ።
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity={0}ን አክል
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity={0}ን አስወግድ
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=ይህን {0} ማስወገድ እንደሚፈልጉ እርግጠኛ ነዎት? ይህ ለውጥ «ቀጣይ»ን ከተጫኑ በኋላ ይቀመጣል፣ እና ከዚህ {0} ጋር የተጎዳኘ ሁሉም ውሂብ ይጠፋል።
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=እባክዎ ለእያንዳንዱ መስመር እሴት ያስገቡ።
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=እባክዎ ለእያንዳንዱ መስመር ልዩ እሴት ያስገቡ።
 
-# The placeholder text for enumerator fields
 placeholder.entityName={0} ስም
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=እባክዎ ፋይል ይምረጡ።
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=ፋይል ይምረጡ
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=ቢበዛ {0} ቁምፊዎችን መያዝ አለበት።
 validation.idTooShort=ቢያንስ {0} ቁምፊዎችን መያዝ አለበት።
 validation.numberRequired=ቁጥሮችን ብቻ መያዝ አለበት።
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=እባክዎ ቢያንስ {0} ይምረጡ።
 validation.tooManySelections=እባክዎ ከ{0} ያነሰ ይምረጡ።
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=መጠሪያ ስም
 label.lastName=የአያት ስም
 label.middleName=የአባት ስም
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=መጠሪያ ስም
 placeholder.lastName=የአያት ስም
 placeholder.middleName=የአባት ስም
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=እባክዎ የመጠሪያ ስምዎን ያስገቡ።
 validation.lastNameRequired=እባክዎ የአያት ስምዎን ያስገቡ።
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=ቢበዛ {0} መሆን አለበት።
 validation.numberTooSmall=ቢያንስ {0} መሆን አለበት።
 validation.numberNonInteger=ቁጥር አዎንታዊ ሙሉ ቁጥር መሆን አለበት እና መያዝ የሚችለው ከ0-9 ቁጥራዊ ቁምፊዎችን ብቻ ነው።
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=ቢበዛ {0} ቁምፊዎችን መያዝ አለበት።
 validation.textTooShort=ቢያንስ {0} ቁምፊዎችን መያዝ አለበት።
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=ባለብዙ አማራጭ ጥያቄዎች ባዶ አማራጮች ሊኖሯቸው አይችሉም።
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=ለመጎብኘት የሞከሩትን ገጽ ማግኘት አልቻልንም
 error.notFoundDescription=እባክዎ ወደ ኋላ ይመለሱ ወይም ወደ {0} ይመለሱ
 error.notFoundDescriptionLink=መነሻ ገጽ
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=ወደ CiviForm {0} ላይ በመለያ ይግቡ
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=የ{0} ፕሮግራም ማመልከቻዎ ደርሷል። የአመልካች መታወቂያዎ {1} ነው፣ እና የማመልከቻ መታወቂያው {2} ነው
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=ለ{0} ፕሮግራም አመልካች {1}ን በመወከል ማመልከቻ አስገብተዋል
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=እንደ {1} ያስገቡት የ{0} ፕሮግራም ማመልከቻ ደርሷል፣ እና የማመልከቻ መታወቂያው {2} ነው።
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=ደንበኛዎችዎን በ{0} ላይ ያስተዳድሩ።

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -7,279 +7,152 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # -------------------------------------------------------------------------------------------------- #
 
-button.logout=Logout
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-button.untranslatedSubmit=Submit
-
-footer.supportLinkDescription=For technical support, contact
-
-guest=Guest
-
-label.languageSr=Choose a language
-
-header.userName=Logged in as {0}
-
-validation.isRequired=This question is required.
-
-validation.invalidInput=Please enter valid input.
-
-validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
-
-content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
-
-content.mobileFileUploadHelp=On your phone? “Choose File” also allows you to use your phone camera to upload documents.
-
-title.login=Login
-
-content.loginPrompt=Please log in with your {0} account
-
-button.login=Log in
-
-content.alternativeLoginPrompt=Don''t have an account?
-
-content.or=or
-
-button.createAccount=Create account
-
-button.guestLogin=Continue as guest
-
-content.loginDisabledPrompt=Account login currently disabled
-
-content.adminLoginPrompt=Looking for something else?
-
-link.adminLogin=Admin login
-
-input.fileAlreadyUploaded=File uploaded: {0}
-
-button.deleteFile=Delete
-
-button.keepFile=Continue
-
-button.nextScreen=Save and next
-
-button.previousScreen=Previous
-
-button.review=Review
-
-button.skipFileUpload=Skip
-
-toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
-
-link.allDone=I''m all done
-
-link.applyToAnotherProgram=Apply to another program
-
-link.createAccountOrSignIn=Create account or sign in
-
-button.apply=Apply
-
-button.applySr=Apply to {0}
-
-button.edit=Edit
-
-button.editSr=Edit submitted application to {0}
-
-button.continueSr=Continue application to {0}
-
-content.submittedDate=Submitted {0}
-
-content.benefits=Get benefits
-
-content.description1=CiviForm lets you apply for many benefits at once by reusing information.
-
-content.description2=Get started by choosing an application below.
-
-link.programDetails=Program details
-
-link.programDetailsSr=Program details for {0}
-
-title.programs=Programs & services
-
-title.status=Status
-
-title.inProgressProgramsUpdated=In progress
-
-title.activeProgramsUpdated=Not started
-
-title.submittedPrograms=Submitted
-
-title.status=Status
-
-toast.applicationSaved=Successfully saved application: application ID {0}
-
-toast.programCompleted=Application was already completed.
-
-button.submit=Submit
-
-button.continue=Continue
-
-toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
-
-content.notEligible=Not Eligible
-
-content.doesNotQualify=Does not qualify
-
-link.edit=Edit
-link.answer=Answer
-
-content.previouslyAnsweredOn=Previously answered on {0}
-
+adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 ariaLabel.answer=Answer {0}
-
 ariaLabel.begin=Start here. {0}
-
 ariaLabel.edit=Edit {0}
-
-title.programSummary=Program application summary
-
-title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
-
-title.applicantNotEligibleTi=Based on your responses to the following questions, your client may not qualify for the {0}.
-
-content.eligibilityCriteria=For eligibility criteria please refer to {0}
-
-content.changeAnswersForEligibility=You can return to the previous page to edit your answers. Or apply to another program.
-
-button.goBackAndEdit=Go back and edit
-
-toast.mayQualifyTi=Based on your responses, your client may qualify for the {0}. To proceed, continue filling out the application.
-
-toast.mayQualify=Based on your responses, you may qualify for the {0}. To proceed, continue filling out the application.
-
-tag.mayQualify=You may qualify
-
-tag.mayQualifyTi=Your client may qualify
-
-tag.mayNotQualify=You may not qualify
-
-tag.mayNotQualifyTi=Your client may not qualify
-
-title.cannotCheckEligibility=At this time, we are unable to check your eligibility for the {0}.
-
-title.cannotCheckEligibilityTi=At this time, we are unable to check your client''s eligibility for the {0}.
-
-content.cannotCheckEligibility=We’re working to fix this issue quickly. Try again at a later time.
-
-button.viewAllPrograms=View all programs
-
-toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
-
-toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
-
 banner.errorSavingApplication=Error saving application
-
-title.applicationConfirmation=Application confirmation
-
+button.addEntity=Add {0}
+button.apply=Apply
+button.applySr=Apply to {0}
+button.chooseFile=Choose File
+button.continue=Continue
+button.continueSr=Continue application to {0}
+button.createAccount=Create account
+button.deleteFile=Delete
+button.edit=Edit
+button.editAddress=Edit address
+button.editSr=Edit submitted application to {0}
+button.goBackAndEdit=Go back and edit
+button.guestLogin=Continue as guest
+button.keepFile=Continue
+button.login=Log in
+button.logout=Logout
+button.nextScreen=Save and next
+button.previousScreen=Previous
+button.removeEntity=Remove {0}
+button.review=Review
+button.saveAndConfirm=Save and confirm
+button.skipFileUpload=Skip
+button.submit=Submit
+button.untranslatedSubmit=Submit
+button.viewAllPrograms=View all programs
+content.addressEntered=Address entered:
+content.addressEnteredWithQuestionName={0} entered:
+content.adminLoginPrompt=Looking for something else?
+content.alternativeLoginPrompt=Don''t have an account?
+content.benefits=Get benefits
+content.cannotCheckEligibility=We’re working to fix this issue quickly. Try again at a later time.
+content.changeAnswersForEligibility=You can return to the previous page to edit your answers. Or apply to another program.
 content.confirmed=Thank you for applying to {0}.  Your application has been received, and your application ID is {1}.
-
-title.createAnAccount=Create an account or sign in
-
+content.description1=CiviForm lets you apply for many benefits at once by reusing information.
+content.description2=Get started by choosing an application below.
+content.doesNotQualify=Does not qualify
+content.eligibilityCriteria=For eligibility criteria please refer to {0}
+content.foundSimilarAddress=We could not verify the address that you provided, but found something similar.
+content.loginDisabledPrompt=Account login currently disabled
+content.loginPrompt=Please log in with your {0} account
+content.mobileFileUploadHelp=On your phone? “Choose File” also allows you to use your phone camera to upload documents.
+content.noValidAddress=We could not verify the address that you provided. Please edit your address to continue.
+content.notEligible=Not Eligible
+content.or=or
 content.pleaseCreateAccount=If you sign into a city account now, your information will be saved and you''ll be able to return at any time to complete future applications.  If you do not already have an account, the login page will allow you to register.  You won''t lose any data you''ve already entered.
-
+content.previouslyAnsweredOn=Previously answered on {0}
+content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
+content.submittedDate=Submitted {0}
+content.suggestedAddress=Suggested address:
+content.suggestedAddresses=Suggested addresses:
+dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
+email.applicationReceivedBody=Your application to program {0} has been received. Your applicant ID is {1} and the application ID is {2}
+email.applicationReceivedSubject=Your application to program {0} is received
+email.applicationUpdateSubject=An update on your application {0}
+email.loginToCiviform=Log in to Civiform at {0}
+email.tiApplicationSubmittedBody=The application to program {0} as applicant {1} has been received, and the application ID is {2}.
+email.tiApplicationSubmittedSubject=You submitted an application for program {0} on behalf of applicant {1}
+email.tiApplicationUpdateBody=The status for applicant {0} on program {1} has changed to {2}.
+email.tiApplicationUpdateSubject=An update on the application for program {0} on behalf of applicant {1}
+email.tiManageYourClients=Manage your clients at {0}.
+error.notFoundDescription=Please go back or return to the {0}
+error.notFoundDescriptionLink=homepage
+error.notFoundTitle=We were unable to find the page you tried to visit
+footer.supportLinkDescription=For technical support, contact
+guest=Guest
+header.userName=Logged in as {0}
+input.fileAlreadyUploaded=File uploaded: {0}
 label.addressLine2=Apartment, suite, etc. (optional)
 label.city=City
-label.state=State
-label.selectState=Select State
-label.street=Address
-label.zipcode=ZIP Code
-
-validation.streetRequired=Please enter valid street name and number.
-validation.cityRequired=Please enter city.
-validation.currencyMisformatted=Currency must be one of the following formats: 1000 1,000 1000.30 1,000.30
-validation.stateRequired=Please enter state.
-validation.invalidZipcode=Please enter valid 5-digit ZIP code.
-validation.noPoBox=Please enter a valid address. We do not accept PO Boxes.
-
-title.verifyAddress=Verify address
-
-content.foundSimilarAddress=We could not verify the address that you provided, but found something similar.
-
-content.addressEntered=Address entered:
-
-content.addressEnteredWithQuestionName={0} entered:
-
-content.suggestedAddress=Suggested address:
-
-content.suggestedAddresses=Suggested addresses:
-
-button.editAddress=Edit address
-
-button.saveAndConfirm=Save and confirm
-
-title.noValidAddress=No valid address found
-
-content.noValidAddress=We could not verify the address that you provided. Please edit your address to continue.
-
-placeholder.noDropdownSelection=Choose an option:
-
-
-validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
-
-button.addEntity=Add {0}
-
-button.removeEntity=Remove {0}
-
-dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
-
-validation.entityNameRequired=Please enter a value for each line.
-
-validation.duplicateEntityName=Please enter a unique value for each line.
-
-placeholder.entityName={0} name
-
-validation.fileRequired=Please select a file.
-
-button.chooseFile=Choose File
-
-validation.idTooLong=Must contain at most {0} characters.
-validation.idTooShort=Must contain at least {0} characters.
-validation.numberRequired=Must contain only numbers.
-
-validation.tooFewSelections=Please select at least {0}.
-validation.tooManySelections=Please select fewer than {0}.
-
 label.firstName=First name
+label.languageSr=Choose a language
 label.lastName=Last name
 label.middleName=Middle name
-
+label.selectLanguage=Please select your preferred language.
+label.selectState=Select State
+label.state=State
+label.street=Address
+label.zipcode=ZIP Code
+link.adminLogin=Admin login
+link.allDone=I''m all done
+link.answer=Answer
+link.applyToAnotherProgram=Apply to another program
+link.createAccountOrSignIn=Create account or sign in
+link.edit=Edit
+link.programDetails=Program details
+link.programDetailsSr=Program details for {0}
+placeholder.entityName={0} name
 placeholder.firstName=First name
 placeholder.lastName=Last name
 placeholder.middleName=Middle name
-
+placeholder.noDropdownSelection=Choose an option:
+tag.mayNotQualify=You may not qualify
+tag.mayNotQualifyTi=Your client may not qualify
+tag.mayQualify=You may qualify
+tag.mayQualifyTi=Your client may qualify
+title.activeProgramsUpdated=Not started
+title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
+title.applicantNotEligibleTi=Based on your responses to the following questions, your client may not qualify for the {0}.
+title.applicationConfirmation=Application confirmation
+title.cannotCheckEligibility=At this time, we are unable to check your eligibility for the {0}.
+title.cannotCheckEligibilityTi=At this time, we are unable to check your client''s eligibility for the {0}.
+title.createAnAccount=Create an account or sign in
+title.inProgressProgramsUpdated=In progress
+title.login=Login
+title.noValidAddress=No valid address found
+title.programSummary=Program application summary
+title.programs=Programs & services
+title.status=Status
+title.status=Status
+title.submittedPrograms=Submitted
+title.verifyAddress=Verify address
+toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
+toast.applicationSaved=Successfully saved application: application ID {0}
+toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
+toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
+toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
+toast.mayQualify=Based on your responses, you may qualify for the {0}. To proceed, continue filling out the application.
+toast.mayQualifyTi=Based on your responses, your client may qualify for the {0}. To proceed, continue filling out the application.
+toast.programCompleted=Application was already completed.
+validation.cityRequired=Please enter city.
+validation.currencyMisformatted=Currency must be one of the following formats: 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
+validation.duplicateEntityName=Please enter a unique value for each line.
+validation.entityNameRequired=Please enter a value for each line.
+validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
+validation.fileRequired=Please select a file.
 validation.firstNameRequired=Please enter your first name.
+validation.idTooLong=Must contain at most {0} characters.
+validation.idTooShort=Must contain at least {0} characters.
+validation.invalidInput=Please enter valid input.
+validation.invalidZipcode=Please enter valid 5-digit ZIP code.
+validation.isRequired=This question is required.
 validation.lastNameRequired=Please enter your last name.
-
+validation.noPoBox=Please enter a valid address. We do not accept PO Boxes.
+validation.numberNonInteger=Number must be a positive whole number and can only contain numeric characters 0-9.
+validation.numberRequired=Must contain only numbers.
 validation.numberTooBig=Must be at most {0}.
 validation.numberTooSmall=Must be at least {0}.
-validation.numberNonInteger=Number must be a positive whole number and can only contain numeric characters 0-9.
-
+validation.stateRequired=Please enter state.
+validation.streetRequired=Please enter valid street name and number.
 validation.textTooLong=Must contain at most {0} characters.
 validation.textTooShort=Must contain at least {0} characters.
-
-adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
-
-error.notFoundTitle=We were unable to find the page you tried to visit
-error.notFoundDescription=Please go back or return to the {0}
-error.notFoundDescriptionLink=homepage
-
-email.loginToCiviform=Log in to Civiform at {0}
-
-email.applicationReceivedSubject=Your application to program {0} is received
-
-email.applicationReceivedBody=Your application to program {0} has been received. Your applicant ID is {1} and the application ID is {2}
-
-email.tiApplicationSubmittedSubject=You submitted an application for program {0} on behalf of applicant {1}
-
-email.tiApplicationSubmittedBody=The application to program {0} as applicant {1} has been received, and the application ID is {2}.
-
-email.tiManageYourClients=Manage your clients at {0}.
-
-email.applicationUpdateSubject=An update on your application {0}
-
-email.tiApplicationUpdateSubject=An update on the application for program {0} on behalf of applicant {1}
-
-email.tiApplicationUpdateBody=The status for applicant {0} on program {1} has changed to {2}.
+validation.tooFewSelections=Please select at least {0}.
+validation.tooManySelections=Please select fewer than {0}.

--- a/server/conf/messages.en-US
+++ b/server/conf/messages.en-US
@@ -7,11 +7,6 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # -------------------------------------------------------------------------------------------------- #
 
-#-------------------------------------------------------------#
-# GENERAL - contains text that corresponds to multiple views. #
-#-------------------------------------------------------------#
-
-# The text on the button an applicant clicks to log out of their session.
 button.logout=Logout
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
@@ -20,286 +15,171 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=For technical support, contact
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=Guest
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Choose a language
 
-# Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}
 
-# Error message to answer a required question
 validation.isRequired=This question is required.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Please enter valid input.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=On your phone? “Choose File” also allows you to use your phone camera to upload documents.
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=Login
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Please log in with your {0} account
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=Log in
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=Don''t have an account?
 
-# The text between creating a new account, and becoming a guest
 content.or=or
 
-# The text on the button for applicants to create a new account.
 button.createAccount=Create account
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=Continue as guest
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Account login currently disabled
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=Looking for something else?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Admin login
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=File uploaded: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Delete
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Continue
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Save and next
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Previous
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Review
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Skip
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=I''m all done
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Apply to another program
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Create account or sign in
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Apply
 
-# The text read for screen readers.
 button.applySr=Apply to {0}
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Edit
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=Edit submitted application to {0}
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=Continue application to {0}
 
-# Text describing the date the application was last submitted.
 content.submittedDate=Submitted {0}
 
-# "Get benefits" floating text
 content.benefits=Get benefits
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm lets you apply for many benefits at once by reusing information.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=Get started by choosing an application below.
 
-# Link text to read more about a program.
 link.programDetails=Program details
 
-# The same text, read for screen readers.
 link.programDetailsSr=Program details for {0}
 
-# The title of the page for the list of programs.
 title.programs=Programs & services
 
-# For the badge on the program list index denoting the current status of an application
 title.status=Status
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=In progress
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Not started
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Submitted
 
-# Badge on an application that has a status assigned to it
 title.status=Status
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: application ID {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Application was already completed.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=Submit
 
-# Continue application button
 button.continue=Continue
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=Not Eligible
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Does not qualify
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Edit
 link.answer=Answer
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Previously answered on {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Answer {0}
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=Start here. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
 
-# Program Summary Title
 title.programSummary=Program application summary
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client''s behalf. This text includes the program name.
 title.applicantNotEligibleTi=Based on your responses to the following questions, your client may not qualify for the {0}.
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=For eligibility criteria please refer to {0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=You can return to the previous page to edit your answers. Or apply to another program.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Go back and edit
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client''s behalf.
 toast.mayQualifyTi=Based on your responses, your client may qualify for the {0}. To proceed, continue filling out the application.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Based on your responses, you may qualify for the {0}. To proceed, continue filling out the application.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=You may qualify
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayQualifyTi=Your client may qualify
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=You may not qualify
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Your client may not qualify
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=At this time, we are unable to check your eligibility for the {0}.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
 title.cannotCheckEligibilityTi=At this time, we are unable to check your client''s eligibility for the {0}.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=We’re working to fix this issue quickly. Try again at a later time.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=View all programs
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client''s behalf.
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Error saving application
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=Application confirmation
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=Thank you for applying to {0}.  Your application has been received, and your application ID is {1}.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Create an account or sign in
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=If you sign into a city account now, your information will be saved and you''ll be able to return at any time to complete future applications.  If you do not already have an account, the login page will allow you to register.  You won''t lose any data you''ve already entered.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Apartment, suite, etc. (optional)
 label.city=City
 label.state=State
@@ -307,7 +187,6 @@ label.selectState=Select State
 label.street=Address
 label.zipcode=ZIP Code
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Please enter valid street name and number.
 validation.cityRequired=Please enter city.
 validation.currencyMisformatted=Currency must be one of the following formats: 1000 1,000 1000.30 1,000.30
@@ -315,174 +194,92 @@ validation.stateRequired=Please enter state.
 validation.invalidZipcode=Please enter valid 5-digit ZIP code.
 validation.noPoBox=Please enter a valid address. We do not accept PO Boxes.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=Verify address
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=We could not verify the address that you provided, but found something similar.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Address entered:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName={0} entered:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Suggested address:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Suggested addresses:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=Edit address
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=Save and confirm
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=No valid address found
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=We could not verify the address that you provided. Please edit your address to continue.
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Choose an option:
 
 
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=Add {0}
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Remove {0}
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Please enter a value for each line.
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Please enter a unique value for each line.
 
-# The placeholder text for enumerator fields
 placeholder.entityName={0} name
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Please select a file.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Choose File
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Must contain at most {0} characters.
 validation.idTooShort=Must contain at least {0} characters.
 validation.numberRequired=Must contain only numbers.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Please select at least {0}.
 validation.tooManySelections=Please select fewer than {0}.
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=First name
 label.lastName=Last name
 label.middleName=Middle name
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=First name
 placeholder.lastName=Last name
 placeholder.middleName=Middle name
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Please enter your first name.
 validation.lastNameRequired=Please enter your last name.
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=Must be at most {0}.
 validation.numberTooSmall=Must be at least {0}.
 validation.numberNonInteger=Number must be a positive whole number and can only contain numeric characters 0-9.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Must contain at most {0} characters.
 validation.textTooShort=Must contain at least {0} characters.
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=We were unable to find the page you tried to visit
 error.notFoundDescription=Please go back or return to the {0}
 error.notFoundDescriptionLink=homepage
 
-#-------------------------------------------------------------#
-# EMAILS - boilerplate text contained in emails sent to users #
-#-------------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=Log in to Civiform at {0}
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Your application to program {0} is received
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Your application to program {0} has been received. Your applicant ID is {1} and the application ID is {2}
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=You submitted an application for program {0} on behalf of applicant {1}
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=The application to program {0} as applicant {1} has been received, and the application ID is {2}.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Manage your clients at {0}.
 
-# Subject of the email sent to an applicant when the status of their application has changed
 email.applicationUpdateSubject=An update on your application {0}
 
-# Subject of the email sent to a TI when they change the status of an application
 email.tiApplicationUpdateSubject=An update on the application for program {0} on behalf of applicant {1}
 
-# Body of the email sent to a TI when they change the status of an application
 email.tiApplicationUpdateBody=The status for applicant {0} on program {1} has changed to {2}.

--- a/server/conf/messages.es-US
+++ b/server/conf/messages.es-US
@@ -6,271 +6,150 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+adminValidation.multiOptionEmpty=Las preguntas con varias respuestas no pueden tener opciones vacías.
+ariaLabel.answer=Responder {0}
+ariaLabel.begin=Comienza aquí. {0}
+ariaLabel.edit=Editar {0}
+banner.errorSavingApplication=Se produjo un error cuando se guardaba la inscripción
+button.addEntity=Agregar {0}
+button.apply=Solicitar
+button.applySr=Solicitar {0}
+button.chooseFile=Elegir archivo
+button.continue=Continuar
+button.continueSr=Continuar la solicitud para {0}
+button.createAccount=Crear cuenta
+button.deleteFile=Borrar
+button.edit=Editar
+button.editAddress=Editar dirección
+button.editSr=Editar la solicitud enviada a {0}
+button.goBackAndEdit=Volver y editar
+button.guestLogin=Continuar como invitado
+button.keepFile=Continuar
+button.login=Acceder
+button.logout=Salir
+button.nextScreen=Guardar y continuar
+button.previousScreen=Anterior
+button.removeEntity=Quitar {0}
+button.review=Revisar
+button.saveAndConfirm=Guardar y confirmar
+button.skipFileUpload=Omitir
+button.submit=Enviar
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=Salir
-
+button.viewAllPrograms=Ver todos los programas
+content.addressEntered=Dirección ingresada:
+content.addressEnteredWithQuestionName=Se ingresó {0}:
+content.adminLoginPrompt=¿Estás buscando otra cosa?
+content.alternativeLoginPrompt=¿No tienes una cuenta?
+content.benefits=Obtén beneficios
+content.cannotCheckEligibility=Estamos trabajando para resolver este problema lo más rápido posible. Vuelve a intentarlo más tarde.
+content.changeAnswersForEligibility=Puedes regresar a la página anterior para editar tus respuestas. También puedes inscribirte en otro programa.
+content.confirmed=Gracias por solicitar {0}. Recibimos tu solicitud y el ID de la solicitud es {1}.
+content.description1=CiviForm te permite reutilizar la información para solicitar varios beneficios a la vez.
+content.description2=Elige una de las solicitudes a continuación para comenzar.
+content.doesNotQualify=No califica
+content.eligibilityCriteria=Si quieres consultar los criterios de elegibilidad, visita {0}
+content.foundSimilarAddress=No pudimos verificar la dirección que proporcionaste, pero encontramos resultados similares.
+content.loginDisabledPrompt=Se inhabilitó el acceso a la cuenta por el momento
+content.loginPrompt=Accede con tu cuenta {0}
+content.mobileFileUploadHelp=¿Estás usando el teléfono? "Elegir archivo" también te permite usar la cámara del teléfono para cargar documentos.
+content.noValidAddress=No pudimos verificar la dirección que proporcionaste. Para continuar, edita la dirección
+content.notEligible=No apto
+content.or=o
+content.pleaseCreateAccount=Si accedes a una cuenta municipal ahora, se guardará tu información y podrás regresar en cualquier momento para completar solicitudes en el futuro. Si no tienes una cuenta, la página de acceso te permitirá registrarte. No perderás los datos que ya ingresaste.
+content.previouslyAnsweredOn=Ya se respondió el {0}
+content.requiredFieldsAnnotation=Nota: Los campos marcados con * son obligatorios.
+content.submittedDate=Enviada el {0}
+content.suggestedAddress=Dirección sugerida:
+content.suggestedAddresses=Direcciones sugeridas:
+dialog.confirmDelete=¿Confirmas que quieres quitar esta {0}? Se guardará este cambio cuando hagas clic en "Siguiente" y se perderán todos los datos asociados con esta {0}.
+email.applicationReceivedBody=Recibimos tu solicitud para el programa {0}. Tu ID de solicitante es {1} y el ID de solicitud es {2}
+email.applicationReceivedSubject=Recibimos tu solicitud para el programa {0}
+email.loginToCiviform=Accede a CiviForm en {0}
+email.tiApplicationSubmittedBody=Recibimos la solicitud al programa {0} para el solicitante {1} y el ID de solicitud es {2}.
+email.tiApplicationSubmittedSubject=Enviaste una solicitud para el programa {0} en nombre del solicitante {1}
+email.tiManageYourClients=Administra tus clientes en {0}.
+error.notFoundDescription=Regresa a {0}
+error.notFoundDescriptionLink=página de inicio
+error.notFoundTitle=No Pudimos encontrar la página que intentó visitar
 footer.supportLinkDescription=Para recibir asistencia técnica, comunícate con
 guest=Invitado
-
-label.languageSr=Elegir un idioma
-
 header.userName=Accediste como {0}
-
-validation.isRequired=Esta pregunta es obligatoria.
-
-validation.invalidInput=Ingresa una entrada válida.
-
-validation.errorAnnouncementSr=Hay errores en el formulario. Corrígelos antes de continuar.
-
-content.requiredFieldsAnnotation=Nota: Los campos marcados con * son obligatorios.
-
-content.mobileFileUploadHelp=¿Estás usando el teléfono? "Elegir archivo" también te permite usar la cámara del teléfono para cargar documentos.
-
-title.login=Acceso
-
-content.loginPrompt=Accede con tu cuenta {0}
-
-button.login=Acceder
-
-content.alternativeLoginPrompt=¿No tienes una cuenta?
-
-content.or=o
-
-button.createAccount=Crear cuenta
-
-button.guestLogin=Continuar como invitado
-
-content.loginDisabledPrompt=Se inhabilitó el acceso a la cuenta por el momento
-
-content.adminLoginPrompt=¿Estás buscando otra cosa?
-link.adminLogin=Acceso de administrador
-
 input.fileAlreadyUploaded=Archivo subido: {0}
-
-button.deleteFile=Borrar
-
-button.keepFile=Continuar
-
-button.nextScreen=Guardar y continuar
-
-button.previousScreen=Anterior
-
-button.review=Revisar
-
-button.skipFileUpload=Omitir
-
-toast.localeNotSupported=Lo sentimos, este programa no está traducido por completo al inglés.
-
-link.allDone=Listo
-
-link.applyToAnotherProgram=Solicitar otro programa
-
-link.createAccountOrSignIn=Crear una cuenta o acceder
-
-button.apply=Solicitar
-
-button.applySr=Solicitar {0}
-
-button.edit=Editar
-
-button.editSr=Editar la solicitud enviada a {0}
-
-button.continueSr=Continuar la solicitud para {0}
-
-content.submittedDate=Enviada el {0}
-
-content.benefits=Obtén beneficios
-
-content.description1=CiviForm te permite reutilizar la información para solicitar varios beneficios a la vez.
-
-content.description2=Elige una de las solicitudes a continuación para comenzar.
-
-link.programDetails=Detalles del programa
-
-link.programDetailsSr=Detalles del programa para {0}
-
-title.programs=Programas y servicios
-
-title.status=Estado
-
-title.inProgressProgramsUpdated=En curso
-
-title.activeProgramsUpdated=Sin comenzar
-
-title.submittedPrograms=Enviados
-
-toast.applicationSaved=Solicitud guardada con éxito: ID de la solicitud {0}
-
-toast.programCompleted=Ya se completó la solicitud.
-
-button.submit=Enviar
-
-button.continue=Continuar
-
-toast.applicationOutOfDate=Se actualizó la aplicación; revisa y responde las preguntas para proceder
-
-content.notEligible=No apto
-
-content.doesNotQualify=No califica
-
-link.edit=Editar
-link.answer=Responder
-
-content.previouslyAnsweredOn=Ya se respondió el {0}
-
-ariaLabel.begin=Comienza aquí. {0}
-
-ariaLabel.edit=Editar {0}
-
-ariaLabel.answer=Responder {0}
-
-title.programSummary=Resumen de la inscripción al programa
-
-title.applicantNotEligible=Según tus respuestas a las siguientes preguntas, es posible que no califiques para {0}.
-
-title.applicantNotEligibleTi=Según tus respuestas a las siguientes preguntas, es posible que tu cliente no califique para {0}.
-
-content.eligibilityCriteria=Si quieres consultar los criterios de elegibilidad, visita {0}
-
-content.changeAnswersForEligibility=Puedes regresar a la página anterior para editar tus respuestas. También puedes inscribirte en otro programa.
-
-button.goBackAndEdit=Volver y editar
-
-toast.mayQualifyTi=Según tus respuestas, es posible que tu cliente califique para {0}. Para continuar, completa la inscripción.
-
-toast.mayQualify=Según tus respuestas, es posible que califiques para {0}. Para continuar, completa la inscripción.
-
-tag.mayQualify=Es posible que califiques
-
-tag.mayQualifyTi=Es posible que tu cliente califique
-
-tag.mayNotQualify=Es posible que no califiques
-
-tag.mayNotQualifyTi=Es posible que tu cliente no califique
-
-title.cannotCheckEligibility=Por el momento, no podemos revisar tu elegibilidad para {0}.
-
-title.cannotCheckEligibilityTi=Por el momento, no podemos revisar la elegibilidad de tu cliente para {0}.
-
-content.cannotCheckEligibility=Estamos trabajando para resolver este problema lo más rápido posible. Vuelve a intentarlo más tarde.
-
-button.viewAllPrograms=Ver todos los programas
-
-toast.mayNotQualify=Según tus respuestas, es posible que no califiques para {0}. Si cambió la información, puedes editar tus respuestas y continuar con la inscripción.
-
-toast.mayNotQualifyTi=Según tus respuestas, es posible que tu cliente no califique para {0}. Si cambió la información de tu cliente, puedes editar las respuestas y continuar con la inscripción.
-
-banner.errorSavingApplication=Se produjo un error cuando se guardaba la inscripción
-
-title.applicationConfirmation=Confirmación de la solicitud
-
-content.confirmed=Gracias por solicitar {0}. Recibimos tu solicitud y el ID de la solicitud es {1}.
-
-title.createAnAccount=Crea una cuenta o accede
-
-content.pleaseCreateAccount=Si accedes a una cuenta municipal ahora, se guardará tu información y podrás regresar en cualquier momento para completar solicitudes en el futuro. Si no tienes una cuenta, la página de acceso te permitirá registrarte. No perderás los datos que ya ingresaste.
-
 label.addressLine2=Departamento, suite, etc. (opcional)
 label.city=Ciudad
-label.state=Estado
-label.selectState=Selecciona un estado
-label.street=Dirección
-label.zipcode=Código postal
-
-
-validation.streetRequired=Ingresa un nombre y un número de calle válidos.
-validation.cityRequired=Ingresa una ciudad.
-validation.currencyMisformatted=La moneda debe tener uno de estos formatos: 1000 1,000 1000.30 1,000.30
-validation.stateRequired=Ingresa un estado.
-validation.invalidZipcode=Ingresa un código postal válido de 5 dígitos.
-validation.noPoBox=Ingresa una dirección válida. No aceptamos apartados postales.
-
-title.verifyAddress=Verifica la dirección
-
-content.foundSimilarAddress=No pudimos verificar la dirección que proporcionaste, pero encontramos resultados similares.
-
-content.addressEntered=Dirección ingresada:
-
-content.addressEnteredWithQuestionName=Se ingresó {0}:
-
-content.suggestedAddress=Dirección sugerida:
-
-content.suggestedAddresses=Direcciones sugeridas:
-
-button.editAddress=Editar dirección
-
-button.saveAndConfirm=Guardar y confirmar
-
-title.noValidAddress=No se encontró ninguna dirección válida
-
-content.noValidAddress=No pudimos verificar la dirección que proporcionaste. Para continuar, edita la dirección
-
-placeholder.noDropdownSelection=Elige una opción:
-
-
-validation.dateMisformatted=Ingresa una fecha en el formato AAAA/MM/DD.
-
-button.addEntity=Agregar {0}
-
-button.removeEntity=Quitar {0}
-
-dialog.confirmDelete=¿Confirmas que quieres quitar esta {0}? Se guardará este cambio cuando hagas clic en "Siguiente" y se perderán todos los datos asociados con esta {0}.
-
-validation.entityNameRequired=Ingresa un valor para cada línea.
-
-validation.duplicateEntityName=Ingresa un valor único para cada línea.
-
-placeholder.entityName=Nombre de {0}
-
-validation.fileRequired=Elige un archivo.
-
-button.chooseFile=Elegir archivo
-
-validation.idTooLong=Debe tener menos de {0} caracteres.
-validation.idTooShort=Debe tener más de {0} caracteres.
-
-validation.tooFewSelections=Elige al menos {0} opción.
-validation.tooManySelections=Elige menos de {0} opciones.
-
 label.firstName=Nombre
+label.languageSr=Elegir un idioma
 label.lastName=Apellido
 label.middleName=Segundo nombre
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=Selecciona un estado
+label.state=Estado
+label.street=Dirección
+label.zipcode=Código postal
+link.adminLogin=Acceso de administrador
+link.allDone=Listo
+link.answer=Responder
+link.applyToAnotherProgram=Solicitar otro programa
+link.createAccountOrSignIn=Crear una cuenta o acceder
+link.edit=Editar
+link.programDetails=Detalles del programa
+link.programDetailsSr=Detalles del programa para {0}
+placeholder.entityName=Nombre de {0}
 placeholder.firstName=Nombre
 placeholder.lastName=Apellido
 placeholder.middleName=Segundo nombre
-
+placeholder.noDropdownSelection=Elige una opción:
+tag.mayNotQualify=Es posible que no califiques
+tag.mayNotQualifyTi=Es posible que tu cliente no califique
+tag.mayQualify=Es posible que califiques
+tag.mayQualifyTi=Es posible que tu cliente califique
+title.activeProgramsUpdated=Sin comenzar
+title.applicantNotEligible=Según tus respuestas a las siguientes preguntas, es posible que no califiques para {0}.
+title.applicantNotEligibleTi=Según tus respuestas a las siguientes preguntas, es posible que tu cliente no califique para {0}.
+title.applicationConfirmation=Confirmación de la solicitud
+title.cannotCheckEligibility=Por el momento, no podemos revisar tu elegibilidad para {0}.
+title.cannotCheckEligibilityTi=Por el momento, no podemos revisar la elegibilidad de tu cliente para {0}.
+title.createAnAccount=Crea una cuenta o accede
+title.inProgressProgramsUpdated=En curso
+title.login=Acceso
+title.noValidAddress=No se encontró ninguna dirección válida
+title.programSummary=Resumen de la inscripción al programa
+title.programs=Programas y servicios
+title.status=Estado
+title.submittedPrograms=Enviados
+title.verifyAddress=Verifica la dirección
+toast.applicationOutOfDate=Se actualizó la aplicación; revisa y responde las preguntas para proceder
+toast.applicationSaved=Solicitud guardada con éxito: ID de la solicitud {0}
+toast.localeNotSupported=Lo sentimos, este programa no está traducido por completo al inglés.
+toast.mayNotQualify=Según tus respuestas, es posible que no califiques para {0}. Si cambió la información, puedes editar tus respuestas y continuar con la inscripción.
+toast.mayNotQualifyTi=Según tus respuestas, es posible que tu cliente no califique para {0}. Si cambió la información de tu cliente, puedes editar las respuestas y continuar con la inscripción.
+toast.mayQualify=Según tus respuestas, es posible que califiques para {0}. Para continuar, completa la inscripción.
+toast.mayQualifyTi=Según tus respuestas, es posible que tu cliente califique para {0}. Para continuar, completa la inscripción.
+toast.programCompleted=Ya se completó la solicitud.
+validation.cityRequired=Ingresa una ciudad.
+validation.currencyMisformatted=La moneda debe tener uno de estos formatos: 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=Ingresa una fecha en el formato AAAA/MM/DD.
+validation.duplicateEntityName=Ingresa un valor único para cada línea.
+validation.entityNameRequired=Ingresa un valor para cada línea.
+validation.errorAnnouncementSr=Hay errores en el formulario. Corrígelos antes de continuar.
+validation.fileRequired=Elige un archivo.
 validation.firstNameRequired=Ingresa tu nombre.
+validation.idTooLong=Debe tener menos de {0} caracteres.
+validation.idTooShort=Debe tener más de {0} caracteres.
+validation.invalidInput=Ingresa una entrada válida.
+validation.invalidZipcode=Ingresa un código postal válido de 5 dígitos.
+validation.isRequired=Esta pregunta es obligatoria.
 validation.lastNameRequired=Ingresa tu apellido.
-
-validation.numberTooBig=El número debe ser menor que {0}.
-validation.numberTooSmall=El número debe ser mayor que {0}.
+validation.noPoBox=Ingresa una dirección válida. No aceptamos apartados postales.
 validation.numberNonInteger=El número debe ser positivo y entero y solo puede contener caracteres numéricos entre 0 y 9.
 validation.numberRequired=Solo debe contener números.
-
+validation.numberTooBig=El número debe ser menor que {0}.
+validation.numberTooSmall=El número debe ser mayor que {0}.
+validation.stateRequired=Ingresa un estado.
+validation.streetRequired=Ingresa un nombre y un número de calle válidos.
 validation.textTooLong=Debe tener menos de {0} caracteres.
 validation.textTooShort=Debe tener más de {0} caracteres.
-
-adminValidation.multiOptionEmpty=Las preguntas con varias respuestas no pueden tener opciones vacías.
-
-error.notFoundTitle=No Pudimos encontrar la página que intentó visitar
-error.notFoundDescription=Regresa a {0}
-error.notFoundDescriptionLink=página de inicio
-
-email.loginToCiviform=Accede a CiviForm en {0}
-
-email.applicationReceivedSubject=Recibimos tu solicitud para el programa {0}
-
-email.applicationReceivedBody=Recibimos tu solicitud para el programa {0}. Tu ID de solicitante es {1} y el ID de solicitud es {2}
-
-email.tiApplicationSubmittedSubject=Enviaste una solicitud para el programa {0} en nombre del solicitante {1}
-
-email.tiApplicationSubmittedBody=Recibimos la solicitud al programa {0} para el solicitante {1} y el ID de solicitud es {2}.
-
-email.tiManageYourClients=Administra tus clientes en {0}.
+validation.tooFewSelections=Elige al menos {0} opción.
+validation.tooManySelections=Elige menos de {0} opciones.

--- a/server/conf/messages.es-US
+++ b/server/conf/messages.es-US
@@ -6,9 +6,6 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-#-------------------------------------------------------------#
-# GENERAL - contains text that corresponds to multiple views. #
-#-------------------------------------------------------------#
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 label.selectLanguage=Please select your preferred language.
@@ -16,284 +13,169 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=Salir
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=Para recibir asistencia técnica, comunícate con
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=Invitado
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Elegir un idioma
 
-# Message with user's name to show who you are logged in as.
 header.userName=Accediste como {0}
 
-# Error message to answer a required question
 validation.isRequired=Esta pregunta es obligatoria.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Ingresa una entrada válida.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=Hay errores en el formulario. Corrígelos antes de continuar.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Nota: Los campos marcados con * son obligatorios.
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=¿Estás usando el teléfono? "Elegir archivo" también te permite usar la cámara del teléfono para cargar documentos.
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=Acceso
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Accede con tu cuenta {0}
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=Acceder
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=¿No tienes una cuenta?
 
-# The text between creating a new account, and becoming a guest
 content.or=o
 
-# The text on the button for applicants to create a new account.
 button.createAccount=Crear cuenta
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=Continuar como invitado
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Se inhabilitó el acceso a la cuenta por el momento
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=¿Estás buscando otra cosa?
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Acceso de administrador
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=Archivo subido: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Borrar
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Continuar
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Guardar y continuar
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Anterior
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Revisar
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Omitir
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=Lo sentimos, este programa no está traducido por completo al inglés.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=Listo
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Solicitar otro programa
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Crear una cuenta o acceder
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Solicitar
 
-# The text read for screen readers.
 button.applySr=Solicitar {0}
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Editar
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=Editar la solicitud enviada a {0}
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=Continuar la solicitud para {0}
 
-# Text describing the date the application was last submitted.
 content.submittedDate=Enviada el {0}
 
-# "Get benefits" floating text
 content.benefits=Obtén beneficios
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm te permite reutilizar la información para solicitar varios beneficios a la vez.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=Elige una de las solicitudes a continuación para comenzar.
 
-# Link text to read more about a program.
 link.programDetails=Detalles del programa
 
-# The same text, read for screen readers.
 link.programDetailsSr=Detalles del programa para {0}
 
-# The title of the page for the list of programs.
 title.programs=Programas y servicios
 
-# For the badge on the program list index denoting the current status of an application
 title.status=Estado
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=En curso
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Sin comenzar
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Enviados
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Solicitud guardada con éxito: ID de la solicitud {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Ya se completó la solicitud.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=Enviar
 
-# Continue application button
 button.continue=Continuar
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Se actualizó la aplicación; revisa y responde las preguntas para proceder
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=No apto
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=No califica
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Editar
 link.answer=Responder
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Ya se respondió el {0}
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=Comienza aquí. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Editar {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Responder {0}
 
-# Program Summary Title
 title.programSummary=Resumen de la inscripción al programa
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Según tus respuestas a las siguientes preguntas, es posible que no califiques para {0}.
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=Según tus respuestas a las siguientes preguntas, es posible que tu cliente no califique para {0}.
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=Si quieres consultar los criterios de elegibilidad, visita {0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=Puedes regresar a la página anterior para editar tus respuestas. También puedes inscribirte en otro programa.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Volver y editar
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=Según tus respuestas, es posible que tu cliente califique para {0}. Para continuar, completa la inscripción.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Según tus respuestas, es posible que califiques para {0}. Para continuar, completa la inscripción.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=Es posible que califiques
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=Es posible que tu cliente califique
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=Es posible que no califiques
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=Es posible que tu cliente no califique
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=Por el momento, no podemos revisar tu elegibilidad para {0}.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=Por el momento, no podemos revisar la elegibilidad de tu cliente para {0}.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=Estamos trabajando para resolver este problema lo más rápido posible. Vuelve a intentarlo más tarde.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=Ver todos los programas
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Según tus respuestas, es posible que no califiques para {0}. Si cambió la información, puedes editar tus respuestas y continuar con la inscripción.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Según tus respuestas, es posible que tu cliente no califique para {0}. Si cambió la información de tu cliente, puedes editar las respuestas y continuar con la inscripción.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Se produjo un error cuando se guardaba la inscripción
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=Confirmación de la solicitud
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=Gracias por solicitar {0}. Recibimos tu solicitud y el ID de la solicitud es {1}.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Crea una cuenta o accede
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=Si accedes a una cuenta municipal ahora, se guardará tu información y podrás regresar en cualquier momento para completar solicitudes en el futuro. Si no tienes una cuenta, la página de acceso te permitirá registrarte. No perderás los datos que ya ingresaste.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Departamento, suite, etc. (opcional)
 label.city=Ciudad
 label.state=Estado
@@ -302,7 +184,6 @@ label.street=Dirección
 label.zipcode=Código postal
 
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Ingresa un nombre y un número de calle válidos.
 validation.cityRequired=Ingresa una ciudad.
 validation.currencyMisformatted=La moneda debe tener uno de estos formatos: 1000 1,000 1000.30 1,000.30
@@ -310,164 +191,86 @@ validation.stateRequired=Ingresa un estado.
 validation.invalidZipcode=Ingresa un código postal válido de 5 dígitos.
 validation.noPoBox=Ingresa una dirección válida. No aceptamos apartados postales.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=Verifica la dirección
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=No pudimos verificar la dirección que proporcionaste, pero encontramos resultados similares.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Dirección ingresada:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName=Se ingresó {0}:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Dirección sugerida:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Direcciones sugeridas:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=Editar dirección
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=Guardar y confirmar
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=No se encontró ninguna dirección válida
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=No pudimos verificar la dirección que proporcionaste. Para continuar, edita la dirección
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Elige una opción:
 
 
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=Ingresa una fecha en el formato AAAA/MM/DD.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=Agregar {0}
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Quitar {0}
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=¿Confirmas que quieres quitar esta {0}? Se guardará este cambio cuando hagas clic en "Siguiente" y se perderán todos los datos asociados con esta {0}.
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Ingresa un valor para cada línea.
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Ingresa un valor único para cada línea.
 
-# The placeholder text for enumerator fields
 placeholder.entityName=Nombre de {0}
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Elige un archivo.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Elegir archivo
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Debe tener menos de {0} caracteres.
 validation.idTooShort=Debe tener más de {0} caracteres.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Elige al menos {0} opción.
 validation.tooManySelections=Elige menos de {0} opciones.
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=Nombre
 label.lastName=Apellido
 label.middleName=Segundo nombre
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=Nombre
 placeholder.lastName=Apellido
 placeholder.middleName=Segundo nombre
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Ingresa tu nombre.
 validation.lastNameRequired=Ingresa tu apellido.
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=El número debe ser menor que {0}.
 validation.numberTooSmall=El número debe ser mayor que {0}.
 validation.numberNonInteger=El número debe ser positivo y entero y solo puede contener caracteres numéricos entre 0 y 9.
 validation.numberRequired=Solo debe contener números.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Debe tener menos de {0} caracteres.
 validation.textTooShort=Debe tener más de {0} caracteres.
 
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Las preguntas con varias respuestas no pueden tener opciones vacías.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=No Pudimos encontrar la página que intentó visitar
 error.notFoundDescription=Regresa a {0}
 error.notFoundDescriptionLink=página de inicio
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=Accede a CiviForm en {0}
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Recibimos tu solicitud para el programa {0}
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Recibimos tu solicitud para el programa {0}. Tu ID de solicitante es {1} y el ID de solicitud es {2}
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=Enviaste una solicitud para el programa {0} en nombre del solicitante {1}
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=Recibimos la solicitud al programa {0} para el solicitante {1} y el ID de solicitud es {2}.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Administra tus clientes en {0}.

--- a/server/conf/messages.ko
+++ b/server/conf/messages.ko
@@ -6,270 +6,151 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
 
+adminValidation.multiOptionEmpty=객관식 질문의 옵션은 비워둘 수 없습니다.
+ariaLabel.answer={0}에 답변
+ariaLabel.begin=여기서 시작합니다. {0}
+ariaLabel.edit={0} 편집
+banner.errorSavingApplication=애플리케이션을 저장하는 중 오류가 발생함
+button.addEntity={0} 추가
+button.apply=신청
+button.applySr={0} 신청
+button.chooseFile=파일 선택
+button.continue=계속
+button.continueSr={0} 신청 계속하기
+button.createAccount=계정 만들기
+button.deleteFile=삭제
+button.edit=편집
+button.editAddress=주소 수정
+button.editSr={0}에 제출된 신청서 편집
+button.goBackAndEdit=돌아가서 수정
+button.guestLogin=게스트로 계속
+button.keepFile=계속
+button.login=로그인
+button.logout=로그아웃
+button.nextScreen=저장 후 다음으로 이동
+button.previousScreen=이전
+button.removeEntity={0} 삭제
+button.review=검토
+button.saveAndConfirm=저장 및 확인
+button.skipFileUpload=건너뛰기
+button.submit=제출
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=로그아웃
-
-footer.supportLinkDescription=기술 지원 관련 문의는 다음으로 문의하세요
-
-guest=게스트
-
-label.languageSr=언어 선택
-
-header.userName={0}(으)로 로그인됨
-
-validation.isRequired=이 질문은 필수입니다.
-
-validation.invalidInput=유효한 내용을 입력하세요.
-
-validation.errorAnnouncementSr=양식에 오류가 있습니다.
-
-content.requiredFieldsAnnotation=참고: * 표시된 필드는 필수입니다.
-
-content.mobileFileUploadHelp=휴대전화를 사용 중이신가요? '파일 선택'을 사용하여 휴대전화 카메라로 문서를 업로드할 수도 있습니다.
-
-title.login=로그인
-
-content.loginPrompt={0} 계정으로 로그인하세요.
-
-button.login=로그인
-
-content.alternativeLoginPrompt=계정이 없나요?
-
-content.or=또는
-
-button.createAccount=계정 만들기
-
-button.guestLogin=게스트로 계속
-
-content.loginDisabledPrompt=계정 로그인이 현재 사용 중지됨
-
-content.adminLoginPrompt=다른 내용을 찾고 있나요?
-
-link.adminLogin=관리자 로그인
-
-input.fileAlreadyUploaded=업로드된 파일: {0}
-
-button.deleteFile=삭제
-
-button.keepFile=계속
-
-button.nextScreen=저장 후 다음으로 이동
-
-button.previousScreen=이전
-
-button.review=검토
-
-button.skipFileUpload=건너뛰기
-
-toast.localeNotSupported=이 프로그램은 영어로 완전히 번역되어 있지 않습니다.
-
-link.allDone=모두 완료했습니다
-
-link.applyToAnotherProgram=다른 프로그램 신청
-
-link.createAccountOrSignIn=계정 만들기 또는 로그인
-
-button.apply=신청
-
-button.applySr={0} 신청
-
-button.edit=편집
-
-button.editSr={0}에 제출된 신청서 편집
-
-button.continueSr={0} 신청 계속하기
-
-content.submittedDate=제출 날짜: {0}
-
-content.benefits=혜택 받기
-
-content.description1=CiviForm을 통해 정보를 재사용하여 다양한 혜택을 한 번에 신청할 수 있습니다.
-
-content.description2=아래에서 신청서를 선택하여 작성을 시작합니다.
-
-link.programDetails=프로그램 세부정보
-
-link.programDetailsSr={0}의 프로그램 세부정보
-
-title.programs=프로그램 및 서비스
-
-title.inProgressProgramsUpdated=진행 중
-
-title.status=상태
-
-title.activeProgramsUpdated=시작 안 함
-
-title.submittedPrograms=제출됨
-
-toast.applicationSaved=신청서 저장됨: 신청서 ID {0}
-
-toast.programCompleted=신청서가 이미 작성되어 있습니다.
-
-button.submit=제출
-
-button.continue=계속
-
-toast.applicationOutOfDate=신청서가 업데이트되었습니다. 계속하려면 질문을 검토하고 답변해 주세요.
-
-content.notEligible=제출을 위해 확인 필요
-
-content.doesNotQualify=자격요건을 충족하지 않음
-
-link.edit=편집
-link.answer=답변
-
-content.previouslyAnsweredOn={0}에 답변됨
-
-ariaLabel.begin=여기서 시작합니다. {0}
-
-ariaLabel.edit={0} 편집
-
-ariaLabel.answer={0}에 답변
-
-title.programSummary=프로그램 신청 요약
-
-title.applicantNotEligible={0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 답변 때문일 수 있습니다
-
-title.applicantNotEligibleTi=고객이 {0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 귀하의 답변 때문일 수 있습니다
-
-content.eligibilityCriteria=자격 기준은 {0}을(를) 참고하세요.
-
-content.changeAnswersForEligibility=이전 페이지로 돌아가 응답을 수정할 수 있습니다. 또는 다른 프로그램을 신청하세요.
-
-button.goBackAndEdit=돌아가서 수정
-
-toast.mayQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
-
-toast.mayQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
-
-tag.mayQualify=자격요건을 충족할 수 있음
-
-tag.mayQualifyTi=클라이언트가 자격요건을 충족할 수 있음
-
-tag.mayNotQualify=자격요건을 충족하지 않을 수 있음
-
-tag.mayNotQualifyTi=클라이언트가 자격요건을 충족하지 않을 수 있음
-
-title.cannotCheckEligibility=현재 {0}에 대한 귀하의 자격을 확인할 수 없습니다.
-
-title.cannotCheckEligibilityTi=현재 {0}에 대한 클라이언트의 자격을 확인할 수 없습니다.
-
-content.cannotCheckEligibility=이 문제를 신속히 해결하기 위해 노력하는 중입니다. 잠시 후 다시 시도해 주세요.
-
 button.viewAllPrograms=모든 프로그램 보기
-
-toast.mayNotQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족하지 않을 수도 있습니다. 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
-
-toast.mayNotQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족하지 않을 수도 있습니다. 클라이언트의 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
-
-banner.errorSavingApplication=애플리케이션을 저장하는 중 오류가 발생함
-
-title.applicationConfirmation=애플리케이션 확인
-
+content.addressEntered=입력된 주소:
+content.addressEnteredWithQuestionName=입력된 {0}:
+content.adminLoginPrompt=다른 내용을 찾고 있나요?
+content.alternativeLoginPrompt=계정이 없나요?
+content.benefits=혜택 받기
+content.cannotCheckEligibility=이 문제를 신속히 해결하기 위해 노력하는 중입니다. 잠시 후 다시 시도해 주세요.
+content.changeAnswersForEligibility=이전 페이지로 돌아가 응답을 수정할 수 있습니다. 또는 다른 프로그램을 신청하세요.
 content.confirmed={0}에 신청해 주셔서 감사합니다. 신청을 접수했으며 신청 ID는 {1}입니다.
-
-title.createAnAccount=계정 만들기 또는 로그인
-
+content.description1=CiviForm을 통해 정보를 재사용하여 다양한 혜택을 한 번에 신청할 수 있습니다.
+content.description2=아래에서 신청서를 선택하여 작성을 시작합니다.
+content.doesNotQualify=자격요건을 충족하지 않음
+content.eligibilityCriteria=자격 기준은 {0}을(를) 참고하세요.
+content.foundSimilarAddress=제공된 주소를 확인할 수 없지만 비슷한 주소를 발견했습니다.
+content.loginDisabledPrompt=계정 로그인이 현재 사용 중지됨
+content.loginPrompt={0} 계정으로 로그인하세요.
+content.mobileFileUploadHelp=휴대전화를 사용 중이신가요? '파일 선택'을 사용하여 휴대전화 카메라로 문서를 업로드할 수도 있습니다.
+content.noValidAddress=제공된 주소를 확인할 수 없습니다. 계속하려면 주소를 수정하세요.
+content.notEligible=제출을 위해 확인 필요
+content.or=또는
 content.pleaseCreateAccount=시 계정에 로그인하면 정보가 저장되며 나중에 언제든지 돌아와서 신청서를 마저 작성할 수 있습니다. 아직 계정이 없다면 로그인 페이지에서 계정을 새로 등록할 수 있습니다. 이미 입력한 데이터는 그대로 유지됩니다.
-
+content.previouslyAnsweredOn={0}에 답변됨
+content.requiredFieldsAnnotation=참고: * 표시된 필드는 필수입니다.
+content.submittedDate=제출 날짜: {0}
+content.suggestedAddress=추천 주소:
+content.suggestedAddresses=추천 주소:
+dialog.confirmDelete=이 {0}을(를) 삭제하시겠습니까? '다음'을 클릭하면 이 변경사항이 저장되고 이 {0}에 연결된 모든 데이터가 손실됩니다.
+email.applicationReceivedBody={0} 프로그램에 대한 신청서가 접수되었습니다. 귀하의 신청자 ID는 {1}이며 신청서 ID는 {2}입니다.
+email.applicationReceivedSubject={0} 프로그램 신청서 접수됨
+email.loginToCiviform={0}에서 CiviForm에 로그인합니다.
+email.tiApplicationSubmittedBody={1} 신청자로서 제출한 {0} 프로그램에 대한 신청서가 접수되었으며 신청서 ID는 {2}입니다.
+email.tiApplicationSubmittedSubject={1} 신청자를 대신하여 {0} 프로그램에 대한 신청서를 제출하셨습니다
+email.tiManageYourClients={0}에서 고객 관리하기
+error.notFoundDescription=뒤로 이동하거나 {0} 페이지로 돌아가세요.
+error.notFoundDescriptionLink=홈페이지
+error.notFoundTitle=방문하려는 페이지를 찾지 못했습니다
+footer.supportLinkDescription=기술 지원 관련 문의는 다음으로 문의하세요
+guest=게스트
+header.userName={0}(으)로 로그인됨
+input.fileAlreadyUploaded=업로드된 파일: {0}
 label.addressLine2=아파트 등(선택사항)
 label.city=시/군/구
-label.state=주/도
-label.selectState=주 선택
-label.street=주소
-label.zipcode=우편번호
-
-validation.streetRequired=유효한 도로명과 번호를 입력하세요.
-validation.cityRequired=시/군/구를 입력하세요.
-validation.currencyMisformatted=통화는 1000 1,000 1000.30 1,000.30과 같은 형식이어야 합니다.
-validation.stateRequired=시/도를 입력하세요.
-validation.invalidZipcode=유효한 5자리 우편번호를 입력하세요.
-validation.noPoBox=유효한 주소를 입력하세요. 사서함은 주소 정보로 등록할 수 없습니다.
-
-title.verifyAddress=주소 확인
-
-content.foundSimilarAddress=제공된 주소를 확인할 수 없지만 비슷한 주소를 발견했습니다.
-
-content.addressEntered=입력된 주소:
-
-content.addressEnteredWithQuestionName=입력된 {0}:
-
-content.suggestedAddress=추천 주소:
-
-content.suggestedAddresses=추천 주소:
-
-button.editAddress=주소 수정
-
-button.saveAndConfirm=저장 및 확인
-
-title.noValidAddress=유효한 주소를 찾을 수 없습니다
-
-content.noValidAddress=제공된 주소를 확인할 수 없습니다. 계속하려면 주소를 수정하세요.
-
-placeholder.noDropdownSelection=다음 중 옵션을 선택하세요.
-
-validation.dateMisformatted=YYYY/MM/DD 형식으로 날짜를 입력하세요.
-
-button.addEntity={0} 추가
-
-button.removeEntity={0} 삭제
-
-dialog.confirmDelete=이 {0}을(를) 삭제하시겠습니까? '다음'을 클릭하면 이 변경사항이 저장되고 이 {0}에 연결된 모든 데이터가 손실됩니다.
-
-validation.entityNameRequired=각 줄에 값을 입력하세요.
-
-validation.duplicateEntityName=각 줄에 고유한 값을 입력하세요.
-
-placeholder.entityName={0} 이름
-
-validation.fileRequired=파일을 선택하세요.
-
-button.chooseFile=파일 선택
-
-validation.idTooLong=최대 {0}자(영문 기준)를 포함해야 합니다.
-validation.idTooShort=최소 {0}자(영문 기준)를 포함해야 합니다.
-validation.numberRequired=숫자만 포함해야 합니다.
-
-validation.tooFewSelections={0}개 이상 선택하세요.
-validation.tooManySelections={0}개보다 적게 선택하세요.
-
 label.firstName=이름
+label.languageSr=언어 선택
 label.lastName=성
 label.middleName=중간 이름
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=주 선택
+label.state=주/도
+label.street=주소
+label.zipcode=우편번호
+link.adminLogin=관리자 로그인
+link.allDone=모두 완료했습니다
+link.answer=답변
+link.applyToAnotherProgram=다른 프로그램 신청
+link.createAccountOrSignIn=계정 만들기 또는 로그인
+link.edit=편집
+link.programDetails=프로그램 세부정보
+link.programDetailsSr={0}의 프로그램 세부정보
+placeholder.entityName={0} 이름
 placeholder.firstName=이름
 placeholder.lastName=성
 placeholder.middleName=중간 이름
-
+placeholder.noDropdownSelection=다음 중 옵션을 선택하세요.
+tag.mayNotQualify=자격요건을 충족하지 않을 수 있음
+tag.mayNotQualifyTi=클라이언트가 자격요건을 충족하지 않을 수 있음
+tag.mayQualify=자격요건을 충족할 수 있음
+tag.mayQualifyTi=클라이언트가 자격요건을 충족할 수 있음
+title.activeProgramsUpdated=시작 안 함
+title.applicantNotEligible={0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 답변 때문일 수 있습니다
+title.applicantNotEligibleTi=고객이 {0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 귀하의 답변 때문일 수 있습니다
+title.applicationConfirmation=애플리케이션 확인
+title.cannotCheckEligibility=현재 {0}에 대한 귀하의 자격을 확인할 수 없습니다.
+title.cannotCheckEligibilityTi=현재 {0}에 대한 클라이언트의 자격을 확인할 수 없습니다.
+title.createAnAccount=계정 만들기 또는 로그인
+title.inProgressProgramsUpdated=진행 중
+title.login=로그인
+title.noValidAddress=유효한 주소를 찾을 수 없습니다
+title.programSummary=프로그램 신청 요약
+title.programs=프로그램 및 서비스
+title.status=상태
+title.submittedPrograms=제출됨
+title.verifyAddress=주소 확인
+toast.applicationOutOfDate=신청서가 업데이트되었습니다. 계속하려면 질문을 검토하고 답변해 주세요.
+toast.applicationSaved=신청서 저장됨: 신청서 ID {0}
+toast.localeNotSupported=이 프로그램은 영어로 완전히 번역되어 있지 않습니다.
+toast.mayNotQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족하지 않을 수도 있습니다. 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
+toast.mayNotQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족하지 않을 수도 있습니다. 클라이언트의 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
+toast.mayQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
+toast.mayQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
+toast.programCompleted=신청서가 이미 작성되어 있습니다.
+validation.cityRequired=시/군/구를 입력하세요.
+validation.currencyMisformatted=통화는 1000 1,000 1000.30 1,000.30과 같은 형식이어야 합니다.
+validation.dateMisformatted=YYYY/MM/DD 형식으로 날짜를 입력하세요.
+validation.duplicateEntityName=각 줄에 고유한 값을 입력하세요.
+validation.entityNameRequired=각 줄에 값을 입력하세요.
+validation.errorAnnouncementSr=양식에 오류가 있습니다.
+validation.fileRequired=파일을 선택하세요.
 validation.firstNameRequired=이름을 입력하세요.
+validation.idTooLong=최대 {0}자(영문 기준)를 포함해야 합니다.
+validation.idTooShort=최소 {0}자(영문 기준)를 포함해야 합니다.
+validation.invalidInput=유효한 내용을 입력하세요.
+validation.invalidZipcode=유효한 5자리 우편번호를 입력하세요.
+validation.isRequired=이 질문은 필수입니다.
 validation.lastNameRequired=성을 입력하세요.
-
+validation.noPoBox=유효한 주소를 입력하세요. 사서함은 주소 정보로 등록할 수 없습니다.
+validation.numberNonInteger=숫자는 양의 정수여야 하며, 0~9의 숫자만 포함해야 합니다.
+validation.numberRequired=숫자만 포함해야 합니다.
 validation.numberTooBig=최댓값은 {0}입니다.
 validation.numberTooSmall=최솟값은 {0}입니다.
-validation.numberNonInteger=숫자는 양의 정수여야 하며, 0~9의 숫자만 포함해야 합니다.
-
+validation.stateRequired=시/도를 입력하세요.
+validation.streetRequired=유효한 도로명과 번호를 입력하세요.
 validation.textTooLong=최대 {0}자(영문 기준)를 포함해야 합니다.
 validation.textTooShort=최소 {0}자(영문 기준)를 포함해야 합니다.
-
-adminValidation.multiOptionEmpty=객관식 질문의 옵션은 비워둘 수 없습니다.
-
-error.notFoundTitle=방문하려는 페이지를 찾지 못했습니다
-error.notFoundDescription=뒤로 이동하거나 {0} 페이지로 돌아가세요.
-error.notFoundDescriptionLink=홈페이지
-
-email.loginToCiviform={0}에서 CiviForm에 로그인합니다.
-
-email.applicationReceivedSubject={0} 프로그램 신청서 접수됨
-
-email.applicationReceivedBody={0} 프로그램에 대한 신청서가 접수되었습니다. 귀하의 신청자 ID는 {1}이며 신청서 ID는 {2}입니다.
-
-email.tiApplicationSubmittedSubject={1} 신청자를 대신하여 {0} 프로그램에 대한 신청서를 제출하셨습니다
-
-email.tiApplicationSubmittedBody={1} 신청자로서 제출한 {0} 프로그램에 대한 신청서가 접수되었으며 신청서 ID는 {2}입니다.
-
-email.tiManageYourClients={0}에서 고객 관리하기
+validation.tooFewSelections={0}개 이상 선택하세요.
+validation.tooManySelections={0}개보다 적게 선택하세요.

--- a/server/conf/messages.ko
+++ b/server/conf/messages.ko
@@ -12,287 +12,171 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=로그아웃
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=기술 지원 관련 문의는 다음으로 문의하세요
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=게스트
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=언어 선택
 
-# Message with user's name to show who you are logged in as.
 header.userName={0}(으)로 로그인됨
 
-# Error message to answer a required question
 validation.isRequired=이 질문은 필수입니다.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=유효한 내용을 입력하세요.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=양식에 오류가 있습니다.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=참고: * 표시된 필드는 필수입니다.
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=휴대전화를 사용 중이신가요? '파일 선택'을 사용하여 휴대전화 카메라로 문서를 업로드할 수도 있습니다.
 
-
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=로그인
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt={0} 계정으로 로그인하세요.
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=로그인
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=계정이 없나요?
 
-# The text between creating a new account, and becoming a guest
 content.or=또는
 
-# The text on the button for applicants to create a new account.
 button.createAccount=계정 만들기
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=게스트로 계속
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=계정 로그인이 현재 사용 중지됨
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=다른 내용을 찾고 있나요?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=관리자 로그인
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=업로드된 파일: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=삭제
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=계속
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=저장 후 다음으로 이동
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=이전
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=검토
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=건너뛰기
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=이 프로그램은 영어로 완전히 번역되어 있지 않습니다.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=모두 완료했습니다
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=다른 프로그램 신청
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=계정 만들기 또는 로그인
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=신청
 
-# The text read for screen readers.
 button.applySr={0} 신청
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=편집
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr={0}에 제출된 신청서 편집
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr={0} 신청 계속하기
 
-# Text describing the date the application was last submitted.
 content.submittedDate=제출 날짜: {0}
 
-# "Get benefits" floating text
 content.benefits=혜택 받기
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm을 통해 정보를 재사용하여 다양한 혜택을 한 번에 신청할 수 있습니다.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=아래에서 신청서를 선택하여 작성을 시작합니다.
 
-# Link text to read more about a program.
 link.programDetails=프로그램 세부정보
 
-# The same text, read for screen readers.
 link.programDetailsSr={0}의 프로그램 세부정보
 
-# The title of the page for the list of programs.
 title.programs=프로그램 및 서비스
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=진행 중
 
-# For the badge on the program list index denoting the current status of an application
 title.status=상태
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=시작 안 함
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=제출됨
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=신청서 저장됨: 신청서 ID {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=신청서가 이미 작성되어 있습니다.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=제출
 
-# Continue application button
 button.continue=계속
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=신청서가 업데이트되었습니다. 계속하려면 질문을 검토하고 답변해 주세요.
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=제출을 위해 확인 필요
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=자격요건을 충족하지 않음
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=편집
 link.answer=답변
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn={0}에 답변됨
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=여기서 시작합니다. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit={0} 편집
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer={0}에 답변
 
-# Program Summary Title
 title.programSummary=프로그램 신청 요약
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible={0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 답변 때문일 수 있습니다
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=고객이 {0}의 자격요건을 충족하지 못한 것은 다음 질문에 대한 귀하의 답변 때문일 수 있습니다
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=자격 기준은 {0}을(를) 참고하세요.
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=이전 페이지로 돌아가 응답을 수정할 수 있습니다. 또는 다른 프로그램을 신청하세요.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=돌아가서 수정
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족할 수도 있습니다. 계속하려면 신청서를 이어서 작성하세요.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=자격요건을 충족할 수 있음
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=클라이언트가 자격요건을 충족할 수 있음
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=자격요건을 충족하지 않을 수 있음
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=클라이언트가 자격요건을 충족하지 않을 수 있음
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=현재 {0}에 대한 귀하의 자격을 확인할 수 없습니다.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=현재 {0}에 대한 클라이언트의 자격을 확인할 수 없습니다.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=이 문제를 신속히 해결하기 위해 노력하는 중입니다. 잠시 후 다시 시도해 주세요.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=모든 프로그램 보기
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족하지 않을 수도 있습니다. 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=응답을 토대로 클라이언트가 {0}의 자격요건을 충족하지 않을 수도 있습니다. 클라이언트의 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=애플리케이션을 저장하는 중 오류가 발생함
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=애플리케이션 확인
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed={0}에 신청해 주셔서 감사합니다. 신청을 접수했으며 신청 ID는 {1}입니다.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=계정 만들기 또는 로그인
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=시 계정에 로그인하면 정보가 저장되며 나중에 언제든지 돌아와서 신청서를 마저 작성할 수 있습니다. 아직 계정이 없다면 로그인 페이지에서 계정을 새로 등록할 수 있습니다. 이미 입력한 데이터는 그대로 유지됩니다.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=아파트 등(선택사항)
 label.city=시/군/구
 label.state=주/도
@@ -300,7 +184,6 @@ label.selectState=주 선택
 label.street=주소
 label.zipcode=우편번호
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=유효한 도로명과 번호를 입력하세요.
 validation.cityRequired=시/군/구를 입력하세요.
 validation.currencyMisformatted=통화는 1000 1,000 1000.30 1,000.30과 같은 형식이어야 합니다.
@@ -308,165 +191,85 @@ validation.stateRequired=시/도를 입력하세요.
 validation.invalidZipcode=유효한 5자리 우편번호를 입력하세요.
 validation.noPoBox=유효한 주소를 입력하세요. 사서함은 주소 정보로 등록할 수 없습니다.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=주소 확인
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=제공된 주소를 확인할 수 없지만 비슷한 주소를 발견했습니다.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=입력된 주소:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName=입력된 {0}:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=추천 주소:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=추천 주소:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=주소 수정
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=저장 및 확인
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=유효한 주소를 찾을 수 없습니다
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=제공된 주소를 확인할 수 없습니다. 계속하려면 주소를 수정하세요.
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=다음 중 옵션을 선택하세요.
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=YYYY/MM/DD 형식으로 날짜를 입력하세요.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity={0} 추가
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity={0} 삭제
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=이 {0}을(를) 삭제하시겠습니까? '다음'을 클릭하면 이 변경사항이 저장되고 이 {0}에 연결된 모든 데이터가 손실됩니다.
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=각 줄에 값을 입력하세요.
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=각 줄에 고유한 값을 입력하세요.
 
-# The placeholder text for enumerator fields
 placeholder.entityName={0} 이름
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=파일을 선택하세요.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=파일 선택
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=최대 {0}자(영문 기준)를 포함해야 합니다.
 validation.idTooShort=최소 {0}자(영문 기준)를 포함해야 합니다.
 validation.numberRequired=숫자만 포함해야 합니다.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections={0}개 이상 선택하세요.
 validation.tooManySelections={0}개보다 적게 선택하세요.
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=이름
 label.lastName=성
 label.middleName=중간 이름
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=이름
 placeholder.lastName=성
 placeholder.middleName=중간 이름
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=이름을 입력하세요.
 validation.lastNameRequired=성을 입력하세요.
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=최댓값은 {0}입니다.
 validation.numberTooSmall=최솟값은 {0}입니다.
 validation.numberNonInteger=숫자는 양의 정수여야 하며, 0~9의 숫자만 포함해야 합니다.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=최대 {0}자(영문 기준)를 포함해야 합니다.
 validation.textTooShort=최소 {0}자(영문 기준)를 포함해야 합니다.
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=객관식 질문의 옵션은 비워둘 수 없습니다.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=방문하려는 페이지를 찾지 못했습니다
 error.notFoundDescription=뒤로 이동하거나 {0} 페이지로 돌아가세요.
 error.notFoundDescriptionLink=홈페이지
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform={0}에서 CiviForm에 로그인합니다.
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject={0} 프로그램 신청서 접수됨
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody={0} 프로그램에 대한 신청서가 접수되었습니다. 귀하의 신청자 ID는 {1}이며 신청서 ID는 {2}입니다.
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject={1} 신청자를 대신하여 {0} 프로그램에 대한 신청서를 제출하셨습니다
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody={1} 신청자로서 제출한 {0} 프로그램에 대한 신청서가 접수되었으며 신청서 ID는 {2}입니다.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients={0}에서 고객 관리하기

--- a/server/conf/messages.so
+++ b/server/conf/messages.so
@@ -5,274 +5,153 @@
 # To type an apostrophe in a message, please type two. Example: can't -> can''t
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
+
+adminValidation.multiOptionEmpty=Su''aalaha xulashada badan ma yeelan karaan ikhtiyaaro madhan.
+ariaLabel.answer=Jawaab {0}
+ariaLabel.begin=Halkan ka bilow. {0}
+ariaLabel.edit=Wax ka beddel {0}
+banner.errorSavingApplication=Khalad ayaa ka imaaday kadib kaydinta codsiga
+button.addEntity=Ku dar {0}
+button.apply=Codso
+button.applySr=Ka Codso {0}
+button.chooseFile=Dooro Fayl
+button.continue=Sii wad
+button.continueSr=U sii wad codsiga ila {0}
+button.createAccount=Akoon samayso
+button.deleteFile=Tirtir
+button.edit=Tifatir
+button.editAddress=Wax ka beddel cinwaanka
+button.editSr=Wax ka beddel codsiga loo gudbiyay {0}
+button.goBackAndEdit=Dib u noqo oo wax ka beddel
+button.guestLogin=Ku sii wad marti ahaan
+button.keepFile=Sii wad
+button.login=Halkan ka gal
 # The text on the button an applicant clicks to log out of their session.
 button.logout=ka bixida
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+button.nextScreen=Tan Xiga
+button.previousScreen=Hore
+button.removeEntity=Ka saar {0}
+button.review=Dib u eeg
+button.saveAndConfirm=Kaydi oo xaqiiji
+button.skipFileUpload=Ka bood
+button.submit=Gudbi
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-footer.supportLinkDescription=Taageero farsamo, la xidhiidh
-
+button.viewAllPrograms=Arag barnaamijyada oo dhan
+content.addressEntered=Cinwaanka waa la geliyay:
+content.addressEnteredWithQuestionName={0} la geliyay:
+content.adminLoginPrompt=Wax kale miyaad raadinaysay?
+content.alternativeLoginPrompt=Akoon ma lihid?
+content.benefits=Hel faa''iidooyin
+content.cannotCheckEligibility=Waxaanu ka shaqaynaynaa hagaajinta dhibkan si degdeg ah. Isku day mar kale wakhti dambe.
+content.changeAnswersForEligibility=Waxaad ku soo laaban kartaa boggii hore si aad wax uuga bedesho jawaabahaaga. Ama codso barnaamij kale.
+content.confirmed= Waad ku mahadsan tahay inaad soo gudbisay codsiga {0}. Codsigaagii waa la helay, ID gaaga waa {1}.
+content.description1=CiviForm wuxuu kuu ogolaanayaa inaad codsato faa''iidooyin badan hal mar adiga oo dib u isticmaalaya macluumaadka.
+content.description2=Ku bilow doorashada codsiga hoos.
+content.doesNotQualify=Uma qalmo
+content.eligibilityCriteria=Heerka qiimaynta u qalmida fadlan tixraac {0}
+content.foundSimilarAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay, laakiin waxaanu helnay shay la mid ah.
+content.loginDisabledPrompt=Gelitaanka koontada hadda waa la xidhay
+content.loginPrompt=Fadlan ku gal akoonkaaga Magaalada {0}
+content.mobileFileUploadHelp=Telefoonkaaga? “Choose File” sidoo kale waxuu kuu oggolaanayaa inaad isticmaasho kamarada telefoonkaaga si aad u soo geliso dukumintiyo.
+content.noValidAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay. Fadlan wax ka beddel cinwaankaada si aad horay ugu sii socoto.
+content.notEligible=Uma Qalmo
+content.or=ama
+content.pleaseCreateAccount=Haddii aad hadda gasho city akoonka, macluumaadkaaga waa la kaydin doonaa oo waxaad awoodi doontaa inaad soo noqoto wakhti kasta si aad u buuxiso codsiyada mustaqbalka. Haddii aanad hore u lahayn akoon, bogga galitaanka internetka ayaa kuu ogolaanaya inaad isdiiwaangeliso. Ma lumin doontid wax xog ah oo aad hore u gelisay.
+content.previouslyAnsweredOn=Hore loogaga jawaabay {0}
+content.requiredFieldsAnnotation=Fiiro: Qaybaha ku calaamadsan * waa loo baahan yahay
+content.submittedDate=La gudbiyay {0}
+content.suggestedAddress=Cinwaanka la soo jeediyay:
+content.suggestedAddresses=Cinwaanada la soo jeediyay:
+dialog.confirmDelete=Ma hubtaa inaad doonayso inaad tan saarto {0}? Isbeddelkan waa la keydin doonaa ka dib markaad gujiso ''Kan XIga'' oo dhammaan xogta la xiriirta tan waa lumin doonaa.
+email.applicationReceivedBody=Codsigaaga barnaamijka {0} waa la helay. Aqoonsiga codsadahaagu waa {1} iyo Aqoonsiga codsigu waa {2}
+email.applicationReceivedSubject=Codsigaaga barnaamijka {0} waa la helay
+email.loginToCiviform=Ka soo gal CiviForm-ka xaga {0}
+email.tiApplicationSubmittedBody=Codsiga barnaamijka {0} ka codsade ahaan {1} waa la helay, oo Aqoonsiga codsiguna waa {2}.
+email.tiApplicationSubmittedSubject=Waxaad soo gudbisay codsiga barnaamijka {0} addoo metelaya codsadaha {1}
+email.tiManageYourClients=Ka maamul macaamiishaada xaga {0}.
+error.notFoundDescription=Fadlan dib ugu noqo ama ku noqo {0}
+error.notFoundDescriptionLink=bogga internatka
+error.notFoundTitle=Waanu awoodi waynay inaan helno bogga aad isku dayday inaad booqato
+footer.supportLinkDescription=Taageero farsamo, la xidhiidh\
 # TODO(#1918): Translate.
 guest=Guest
-
-label.languageSr=Dooro luqad
-
 header.userName=U soo gal sidii {0}
-
-validation.isRequired=Su''aashan ayaa loo baahan yahay.
-
-validation.invalidInput=Fadlan geli qiimaha sadar kasta.
-
-validation.errorAnnouncementSr=Khaladaad ayaa ku jira foomka Fadlan hagaaji ka hor inta aanad sii wadin.
-
-content.requiredFieldsAnnotation=Fiiro: Qaybaha ku calaamadsan * waa loo baahan yahay
-
-content.mobileFileUploadHelp=Telefoonkaaga? “Choose File” sidoo kale waxuu kuu oggolaanayaa inaad isticmaasho kamarada telefoonkaaga si aad u soo geliso dukumintiyo.
-
-title.login=Soo gal
-
-content.loginPrompt=Fadlan ku gal akoonkaaga Magaalada {0}
-
-button.login=Halkan ka gal
-
-content.alternativeLoginPrompt=Akoon ma lihid?
-
-content.or=ama
-
-button.createAccount=Akoon samayso
-
-button.guestLogin=Ku sii wad marti ahaan
-
-content.loginDisabledPrompt=Gelitaanka koontada hadda waa la xidhay
-
-content.adminLoginPrompt=Wax kale miyaad raadinaysay?
-
-link.adminLogin=Admin login
-
 input.fileAlreadyUploaded=Faylka la soo geliyay: {0}
-
-button.deleteFile=Tirtir
-
-button.keepFile=Sii wad
-
-button.nextScreen=Tan Xiga
-
-button.previousScreen=Hore
-
-button.review=Dib u eeg
-
-button.skipFileUpload=Ka bood
-
-toast.localeNotSupported=Waan ka xunnahay, barnaamijkan si buuxda looguma turjuman luqadda aad doorbidayso.
-
-link.allDone=Waan dhameeyay
-
-link.applyToAnotherProgram=Codso barnaamij kale
-
-link.createAccountOrSignIn=Akoon samee ama gal oo sign in garee
-
-button.apply=Codso
-
-button.applySr=Ka Codso {0}
-
-button.edit=Tifatir
-
-button.editSr=Wax ka beddel codsiga loo gudbiyay {0}
-
-button.continueSr=U sii wad codsiga ila {0}
-
-content.submittedDate=La gudbiyay {0}
-
-content.benefits=Hel faa''iidooyin
-
-content.description1=CiviForm wuxuu kuu ogolaanayaa inaad codsato faa''iidooyin badan hal mar adiga oo dib u isticmaalaya macluumaadka.
-
-content.description2=Ku bilow doorashada codsiga hoos.
-
-link.programDetails=Faahfaahinta barnaamijka
-
-link.programDetailsSr=Faahfaahinta barnaamijka ee {0}
-
-title.programs=Barnaamijyada iyo adeegyada
-
-toast.applicationSaved=Codsiga si guul leh loo keydiyay: ID codsiga {0}
-
-title.status=Heerka
-
-title.inProgressProgramsUpdated=Socda hadda
-
-title.activeProgramsUpdated=Lama bilaabin
-
-title.submittedPrograms=La gudbiyay
-
-toast.programCompleted=Codsiga mar hore ayaa la dhammaystiray.
-
-button.submit=Gudbi
-
-button.continue=Sii wad
-
-toast.applicationOutOfDate=Waxaa jirtay cusboonaysiin lagu sameeyay app-ka, fadlan dib u eeg oo ka jawaab su'aalaha si aad horay ugu sii socoto
-
-content.notEligible=Uma Qalmo
-
-content.doesNotQualify=Uma qalmo
-
-link.edit=Wax ka beddel
-link.answer=Jawaab
-
-content.previouslyAnsweredOn=Hore loogaga jawaabay {0}
-
-ariaLabel.begin=Halkan ka bilow. {0}
-
-ariaLabel.edit=Wax ka beddel {0}
-
-ariaLabel.answer=Jawaab {0}
-
-title.programSummary=Soo koobida barnaamijka codsiga
-
-title.applicantNotEligible=Iyaddoo ku salaysan jawaabaha su'aalaha soo socda, waxa dhici karta inaanad u qalmin {0}.
-
-title.applicantNotEligibleTi=Iyaddoo ku salaysan jawaabahaaga su'aalaha soo socda, macmiilkaagu waxa laga yaabaa inuusan u qalmin {0}.
-
-content.eligibilityCriteria=Heerka qiimaynta u qalmida fadlan tixraac {0}
-
-content.changeAnswersForEligibility=Waxaad ku soo laaban kartaa boggii hore si aad wax uuga bedesho jawaabahaaga. Ama codso barnaamij kale.
-
-button.goBackAndEdit=Dib u noqo oo wax ka beddel
-
-toast.mayQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inuu u qalmo {0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
-
-toast.mayQualify=Iyada oo ku saleysan jawaabahaaga, waxaad u qalmi kartaa{0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
-
-tag.mayQualify=Waxa dhici karta inaad u qalanto
-
-tag.mayQualifyTi=Macmiilkaaga waxa dhici karta inuu u qalmo
-
-tag.mayNotQualify=Waxa dhici karta inaanad u qalmin
-
-tag.mayNotQualifyTi=Macmiilkaaga waxa dhici karta inuusan u qalmin
-
-title.cannotCheckEligibility=Wakhtigan, ma awoodno hubinta u qalmidaada {0}.
-
-title.cannotCheckEligibilityTi=Wakhtigan, ma awoodno hubinta u qalmida macmiilkaaga {0}.
-
-content.cannotCheckEligibility=Waxaanu ka shaqaynaynaa hagaajinta dhibkan si degdeg ah. Isku day mar kale wakhti dambe.
-
-button.viewAllPrograms=Arag barnaamijyada oo dhan
-
-toast.mayNotQualify=Iyaddoo ku salaysan jawaabahaaga, waxa dhici karta inaanad u qalmin {0}. Haddi imacluumaadkaagu uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
-
-toast.mayNotQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inaanu u qalmin {0}. Haddi imacluumaadka macmiilku uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
-
-banner.errorSavingApplication=Khalad ayaa ka imaaday kadib kaydinta codsiga
-
-title.applicationConfirmation=AXaqiijinta codsiga
-
-content.confirmed= Waad ku mahadsan tahay inaad soo gudbisay codsiga {0}. Codsigaagii waa la helay, ID gaaga waa {1}.
-
-title.createAnAccount=Akoon samee ama gal oo sign in garee
-
-content.pleaseCreateAccount=Haddii aad hadda gasho city akoonka, macluumaadkaaga waa la kaydin doonaa oo waxaad awoodi doontaa inaad soo noqoto wakhti kasta si aad u buuxiso codsiyada mustaqbalka. Haddii aanad hore u lahayn akoon, bogga galitaanka internetka ayaa kuu ogolaanaya inaad isdiiwaangeliso. Ma lumin doontid wax xog ah oo aad hore u gelisay.
-
 label.addressLine2=Dabaqa, qolal, iwm. (ikhtiyaar)
 label.city=Magaalada
-label.state=Gobolka
-label.selectState=Dooro Gobolka
-label.street=Cinwaan
-label.zipcode=Siib Koodhka
-
-validation.streetRequired=Fadlan gali magaca wadada saxda ah iyo lambarka.
-validation.cityRequired=Fadlan magaalada gali.
-validation.currencyMisformatted=Lacagtu waa inay noqotaa mid ka mid ah qaababka soo socda: 1000 1,000 1000.30 1,000.30
-validation.stateRequired=Fadlan geli gobolka.
-validation.invalidZipcode=Fadlan geli sib koodhka shanta lambarka ah oo saxsan.
-validation.noPoBox=Fadlan gali ciwaan saxda ah.Ma aqbalno sanduuqyada boostada (PO BOX).
-
-title.verifyAddress=Xaqiiji cinwaanka
-
-content.foundSimilarAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay, laakiin waxaanu helnay shay la mid ah.
-
-content.addressEntered=Cinwaanka waa la geliyay:
-
-content.addressEnteredWithQuestionName={0} la geliyay:
-
-content.suggestedAddress=Cinwaanka la soo jeediyay:
-
-content.suggestedAddresses=Cinwaanada la soo jeediyay:
-
-button.editAddress=Wax ka beddel cinwaanka
-
-button.saveAndConfirm=Kaydi oo xaqiiji
-
-title.noValidAddress=Lama helin cinwaan ansax ah
-
-content.noValidAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay. Fadlan wax ka beddel cinwaankaada si aad horay ugu sii socoto.
-
-placeholder.noDropdownSelection=Dooro ikhtiyaar:
-
-
-validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
-
-button.addEntity=Ku dar {0}
-
-button.removeEntity=Ka saar {0}
-
-dialog.confirmDelete=Ma hubtaa inaad doonayso inaad tan saarto {0}? Isbeddelkan waa la keydin doonaa ka dib markaad gujiso ''Kan XIga'' oo dhammaan xogta la xiriirta tan waa lumin doonaa.
-
-validation.entityNameRequired=Fadlan geli qiimaha sadar kasta.
-
-validation.duplicateEntityName=Fadlan geli qiime u gaar ah sadar kasta.
-
-placeholder.entityName=Naanaysta {0}
-
-validation.fileRequired=Fadlan dooro fayl.
-
-button.chooseFile=Dooro Fayl
-
-validation.idTooLong=Waa in uu ka kooban yahay ugu badnaan {0} xaraf.
-
-validation.idTooShort=Waa in uu ka kooban yahay ugu yaraan {0} xaraf.
-validation.numberRequired=Waa in ay ka koobnaadaan tirooyin oo kaliya.
-
-validation.tooFewSelections=Fadlan dooro ugu yaraan {0}.
-validation.tooManySelections=Fadlan dooro wax ka yar {0}
-
 label.firstName=Magaca hore
+label.languageSr=Dooro luqad
 label.lastName=Magaca dambe
 label.middleName=Magaca dhexe
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=Dooro Gobolka
+label.state=Gobolka
+label.street=Cinwaan
+label.zipcode=Siib Koodhka
+link.adminLogin=Admin login
+link.allDone=Waan dhameeyay
+link.answer=Jawaab
+link.applyToAnotherProgram=Codso barnaamij kale
+link.createAccountOrSignIn=Akoon samee ama gal oo sign in garee
+link.edit=Wax ka beddel
+link.programDetails=Faahfaahinta barnaamijka
+link.programDetailsSr=Faahfaahinta barnaamijka ee {0}
+placeholder.entityName=Naanaysta {0}
 placeholder.firstName=Magaca hore
 placeholder.lastName=Magaca dambe
 placeholder.middleName=Magaca dhexe
-
+placeholder.noDropdownSelection=Dooro ikhtiyaar:
+tag.mayNotQualify=Waxa dhici karta inaanad u qalmin
+tag.mayNotQualifyTi=Macmiilkaaga waxa dhici karta inuusan u qalmin
+tag.mayQualify=Waxa dhici karta inaad u qalanto
+tag.mayQualifyTi=Macmiilkaaga waxa dhici karta inuu u qalmo
+title.activeProgramsUpdated=Lama bilaabin
+title.applicantNotEligible=Iyaddoo ku salaysan jawaabaha su'aalaha soo socda, waxa dhici karta inaanad u qalmin {0}.
+title.applicantNotEligibleTi=Iyaddoo ku salaysan jawaabahaaga su'aalaha soo socda, macmiilkaagu waxa laga yaabaa inuusan u qalmin {0}.
+title.applicationConfirmation=AXaqiijinta codsiga
+title.cannotCheckEligibility=Wakhtigan, ma awoodno hubinta u qalmidaada {0}.
+title.cannotCheckEligibilityTi=Wakhtigan, ma awoodno hubinta u qalmida macmiilkaaga {0}.
+title.createAnAccount=Akoon samee ama gal oo sign in garee
+title.inProgressProgramsUpdated=Socda hadda
+title.login=Soo gal
+title.noValidAddress=Lama helin cinwaan ansax ah
+title.programSummary=Soo koobida barnaamijka codsiga
+title.programs=Barnaamijyada iyo adeegyada
+title.status=Heerka
+title.submittedPrograms=La gudbiyay
+title.verifyAddress=Xaqiiji cinwaanka
+toast.applicationOutOfDate=Waxaa jirtay cusboonaysiin lagu sameeyay app-ka, fadlan dib u eeg oo ka jawaab su'aalaha si aad horay ugu sii socoto
+toast.applicationSaved=Codsiga si guul leh loo keydiyay: ID codsiga {0}
+toast.localeNotSupported=Waan ka xunnahay, barnaamijkan si buuxda looguma turjuman luqadda aad doorbidayso.
+toast.mayNotQualify=Iyaddoo ku salaysan jawaabahaaga, waxa dhici karta inaanad u qalmin {0}. Haddi imacluumaadkaagu uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
+toast.mayNotQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inaanu u qalmin {0}. Haddi imacluumaadka macmiilku uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
+toast.mayQualify=Iyada oo ku saleysan jawaabahaaga, waxaad u qalmi kartaa{0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
+toast.mayQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inuu u qalmo {0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
+toast.programCompleted=Codsiga mar hore ayaa la dhammaystiray.
+validation.cityRequired=Fadlan magaalada gali.
+validation.currencyMisformatted=Lacagtu waa inay noqotaa mid ka mid ah qaababka soo socda: 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
+validation.duplicateEntityName=Fadlan geli qiime u gaar ah sadar kasta.
+validation.entityNameRequired=Fadlan geli qiimaha sadar kasta.
+validation.errorAnnouncementSr=Khaladaad ayaa ku jira foomka Fadlan hagaaji ka hor inta aanad sii wadin.
+validation.fileRequired=Fadlan dooro fayl.
 validation.firstNameRequired=Fadlan gali magacaga koowaad.
+validation.idTooLong=Waa in uu ka kooban yahay ugu badnaan {0} xaraf.
+validation.idTooShort=Waa in uu ka kooban yahay ugu yaraan {0} xaraf.
+validation.invalidInput=Fadlan geli qiimaha sadar kasta.
+validation.invalidZipcode=Fadlan geli sib koodhka shanta lambarka ah oo saxsan.
+validation.isRequired=Su''aashan ayaa loo baahan yahay.
 validation.lastNameRequired=Fadlan geli magacaaga dambe.
-
+validation.noPoBox=Fadlan gali ciwaan saxda ah.Ma aqbalno sanduuqyada boostada (PO BOX).
+validation.numberNonInteger=Fadlan geli qiimaha sadar kasta.
+validation.numberRequired=Waa in ay ka koobnaadaan tirooyin oo kaliya.
 validation.numberTooBig=Waa inuu noqdaa ugu badnaan {0}.
 validation.numberTooSmall=Waa inuu ahaadaa ugu yaraan {0}.
-validation.numberNonInteger=Fadlan geli qiimaha sadar kasta.
-
+validation.stateRequired=Fadlan geli gobolka.
+validation.streetRequired=Fadlan gali magaca wadada saxda ah iyo lambarka.
 validation.textTooLong=Waa in uu ka kooban yahay ugu badnaan {0} xaraf.
 validation.textTooShort=Waa in uu ka kooban yahay ugu yaraan {0} xaraf.
-
-adminValidation.multiOptionEmpty=Su''aalaha xulashada badan ma yeelan karaan ikhtiyaaro madhan.
-
-error.notFoundTitle=Waanu awoodi waynay inaan helno bogga aad isku dayday inaad booqato
-error.notFoundDescription=Fadlan dib ugu noqo ama ku noqo {0}
-error.notFoundDescriptionLink=bogga internatka
-
-email.loginToCiviform=Ka soo gal CiviForm-ka xaga {0}
-
-email.applicationReceivedSubject=Codsigaaga barnaamijka {0} waa la helay
-
-email.applicationReceivedBody=Codsigaaga barnaamijka {0} waa la helay. Aqoonsiga codsadahaagu waa {1} iyo Aqoonsiga codsigu waa {2}
-
-email.tiApplicationSubmittedSubject=Waxaad soo gudbisay codsiga barnaamijka {0} addoo metelaya codsadaha {1}
-
-email.tiApplicationSubmittedBody=Codsiga barnaamijka {0} ka codsade ahaan {1} waa la helay, oo Aqoonsiga codsiguna waa {2}.
-
-email.tiManageYourClients=Ka maamul macaamiishaada xaga {0}.
+validation.tooFewSelections=Fadlan dooro ugu yaraan {0}.
+validation.tooManySelections=Fadlan dooro wax ka yar {0}

--- a/server/conf/messages.so
+++ b/server/conf/messages.so
@@ -14,285 +14,170 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=Taageero farsamo, la xidhiidh
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 # TODO(#1918): Translate.
 guest=Guest
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Dooro luqad
 
-# Message with user's name to show who you are logged in as.
 header.userName=U soo gal sidii {0}
 
-# Error message to answer a required question
 validation.isRequired=Su''aashan ayaa loo baahan yahay.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Fadlan geli qiimaha sadar kasta.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=Khaladaad ayaa ku jira foomka Fadlan hagaaji ka hor inta aanad sii wadin.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Fiiro: Qaybaha ku calaamadsan * waa loo baahan yahay
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=Telefoonkaaga? “Choose File” sidoo kale waxuu kuu oggolaanayaa inaad isticmaasho kamarada telefoonkaaga si aad u soo geliso dukumintiyo.
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=Soo gal
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Fadlan ku gal akoonkaaga Magaalada {0}
 
-
-# The text on the button an applicant clicks to log in to their session.
 button.login=Halkan ka gal
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=Akoon ma lihid?
 
-# The text between creating a new account, and becoming a guest
 content.or=ama
 
-# The text on the button for applicants to create a new account.
 button.createAccount=Akoon samayso
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=Ku sii wad marti ahaan
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Gelitaanka koontada hadda waa la xidhay
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=Wax kale miyaad raadinaysay?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Admin login
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=Faylka la soo geliyay: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Tirtir
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Sii wad
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Tan Xiga
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Hore
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Dib u eeg
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Ka bood
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=Waan ka xunnahay, barnaamijkan si buuxda looguma turjuman luqadda aad doorbidayso.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=Waan dhameeyay
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Codso barnaamij kale
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Akoon samee ama gal oo sign in garee
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Codso
 
-# The text read for screen readers.
 button.applySr=Ka Codso {0}
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Tifatir
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=Wax ka beddel codsiga loo gudbiyay {0}
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=U sii wad codsiga ila {0}
 
-# Text describing the date the application was last submitted.
 content.submittedDate=La gudbiyay {0}
 
-# "Get benefits" floating text
 content.benefits=Hel faa''iidooyin
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm wuxuu kuu ogolaanayaa inaad codsato faa''iidooyin badan hal mar adiga oo dib u isticmaalaya macluumaadka.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=Ku bilow doorashada codsiga hoos.
 
-# Link text to read more about a program.
 link.programDetails=Faahfaahinta barnaamijka
 
-# The same text, read for screen readers.
 link.programDetailsSr=Faahfaahinta barnaamijka ee {0}
 
-# The title of the page for the list of programs.
 title.programs=Barnaamijyada iyo adeegyada
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Codsiga si guul leh loo keydiyay: ID codsiga {0}
 
-# For the badge on the program list index denoting the current status of an application
 title.status=Heerka
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=Socda hadda
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Lama bilaabin
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=La gudbiyay
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Codsiga mar hore ayaa la dhammaystiray.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=Gudbi
 
-# Continue application button
 button.continue=Sii wad
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Waxaa jirtay cusboonaysiin lagu sameeyay app-ka, fadlan dib u eeg oo ka jawaab su'aalaha si aad horay ugu sii socoto
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=Uma Qalmo
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Uma qalmo
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Wax ka beddel
 link.answer=Jawaab
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Hore loogaga jawaabay {0}
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=Halkan ka bilow. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Wax ka beddel {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Jawaab {0}
 
-# Program Summary Title
 title.programSummary=Soo koobida barnaamijka codsiga
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Iyaddoo ku salaysan jawaabaha su'aalaha soo socda, waxa dhici karta inaanad u qalmin {0}.
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=Iyaddoo ku salaysan jawaabahaaga su'aalaha soo socda, macmiilkaagu waxa laga yaabaa inuusan u qalmin {0}.
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=Heerka qiimaynta u qalmida fadlan tixraac {0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=Waxaad ku soo laaban kartaa boggii hore si aad wax uuga bedesho jawaabahaaga. Ama codso barnaamij kale.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Dib u noqo oo wax ka beddel
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inuu u qalmo {0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Iyada oo ku saleysan jawaabahaaga, waxaad u qalmi kartaa{0}. Si aad horay ugu sii socoto, sii wad buuxinta codsiga.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=Waxa dhici karta inaad u qalanto
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=Macmiilkaaga waxa dhici karta inuu u qalmo
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=Waxa dhici karta inaanad u qalmin
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=Macmiilkaaga waxa dhici karta inuusan u qalmin
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=Wakhtigan, ma awoodno hubinta u qalmidaada {0}.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=Wakhtigan, ma awoodno hubinta u qalmida macmiilkaaga {0}.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=Waxaanu ka shaqaynaynaa hagaajinta dhibkan si degdeg ah. Isku day mar kale wakhti dambe.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=Arag barnaamijyada oo dhan
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Iyaddoo ku salaysan jawaabahaaga, waxa dhici karta inaanad u qalmin {0}. Haddi imacluumaadkaagu uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Iyaddoo ku salaysan jawaabahaaga, macmiilkaagu waxa dhici karta inaanu u qalmin {0}. Haddi imacluumaadka macmiilku uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Khalad ayaa ka imaaday kadib kaydinta codsiga
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=AXaqiijinta codsiga
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed= Waad ku mahadsan tahay inaad soo gudbisay codsiga {0}. Codsigaagii waa la helay, ID gaaga waa {1}.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Akoon samee ama gal oo sign in garee
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=Haddii aad hadda gasho city akoonka, macluumaadkaaga waa la kaydin doonaa oo waxaad awoodi doontaa inaad soo noqoto wakhti kasta si aad u buuxiso codsiyada mustaqbalka. Haddii aanad hore u lahayn akoon, bogga galitaanka internetka ayaa kuu ogolaanaya inaad isdiiwaangeliso. Ma lumin doontid wax xog ah oo aad hore u gelisay.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Dabaqa, qolal, iwm. (ikhtiyaar)
 label.city=Magaalada
 label.state=Gobolka
@@ -300,7 +185,6 @@ label.selectState=Dooro Gobolka
 label.street=Cinwaan
 label.zipcode=Siib Koodhka
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Fadlan gali magaca wadada saxda ah iyo lambarka.
 validation.cityRequired=Fadlan magaalada gali.
 validation.currencyMisformatted=Lacagtu waa inay noqotaa mid ka mid ah qaababka soo socda: 1000 1,000 1000.30 1,000.30
@@ -308,169 +192,87 @@ validation.stateRequired=Fadlan geli gobolka.
 validation.invalidZipcode=Fadlan geli sib koodhka shanta lambarka ah oo saxsan.
 validation.noPoBox=Fadlan gali ciwaan saxda ah.Ma aqbalno sanduuqyada boostada (PO BOX).
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=Xaqiiji cinwaanka
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay, laakiin waxaanu helnay shay la mid ah.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Cinwaanka waa la geliyay:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName={0} la geliyay:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Cinwaanka la soo jeediyay:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Cinwaanada la soo jeediyay:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=Wax ka beddel cinwaanka
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=Kaydi oo xaqiiji
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=Lama helin cinwaan ansax ah
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay. Fadlan wax ka beddel cinwaankaada si aad horay ugu sii socoto.
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Dooro ikhtiyaar:
 
 
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=Ku dar {0}
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Ka saar {0}
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=Ma hubtaa inaad doonayso inaad tan saarto {0}? Isbeddelkan waa la keydin doonaa ka dib markaad gujiso ''Kan XIga'' oo dhammaan xogta la xiriirta tan waa lumin doonaa.
 
-
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Fadlan geli qiimaha sadar kasta.
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Fadlan geli qiime u gaar ah sadar kasta.
 
-# The placeholder text for enumerator fields
 placeholder.entityName=Naanaysta {0}
 
-
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Fadlan dooro fayl.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Dooro Fayl
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Waa in uu ka kooban yahay ugu badnaan {0} xaraf.
 
 validation.idTooShort=Waa in uu ka kooban yahay ugu yaraan {0} xaraf.
 validation.numberRequired=Waa in ay ka koobnaadaan tirooyin oo kaliya.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Fadlan dooro ugu yaraan {0}.
 validation.tooManySelections=Fadlan dooro wax ka yar {0}
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=Magaca hore
 label.lastName=Magaca dambe
 label.middleName=Magaca dhexe
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=Magaca hore
 placeholder.lastName=Magaca dambe
 placeholder.middleName=Magaca dhexe
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Fadlan gali magacaga koowaad.
 validation.lastNameRequired=Fadlan geli magacaaga dambe.
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=Waa inuu noqdaa ugu badnaan {0}.
 validation.numberTooSmall=Waa inuu ahaadaa ugu yaraan {0}.
 validation.numberNonInteger=Fadlan geli qiimaha sadar kasta.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Waa in uu ka kooban yahay ugu badnaan {0} xaraf.
 validation.textTooShort=Waa in uu ka kooban yahay ugu yaraan {0} xaraf.
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Su''aalaha xulashada badan ma yeelan karaan ikhtiyaaro madhan.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=Waanu awoodi waynay inaan helno bogga aad isku dayday inaad booqato
 error.notFoundDescription=Fadlan dib ugu noqo ama ku noqo {0}
 error.notFoundDescriptionLink=bogga internatka
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=Ka soo gal CiviForm-ka xaga {0}
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Codsigaaga barnaamijka {0} waa la helay
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Codsigaaga barnaamijka {0} waa la helay. Aqoonsiga codsadahaagu waa {1} iyo Aqoonsiga codsigu waa {2}
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=Waxaad soo gudbisay codsiga barnaamijka {0} addoo metelaya codsadaha {1}
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=Codsiga barnaamijka {0} ka codsade ahaan {1} waa la helay, oo Aqoonsiga codsiguna waa {2}.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Ka maamul macaamiishaada xaga {0}.

--- a/server/conf/messages.tl
+++ b/server/conf/messages.tl
@@ -12,286 +12,172 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=Mag-logout
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=Para sa suporta na pang teknikal, tawagan
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 # TODO(#1918): Translate.
 guest=Guest
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Pumili ng wika
 
-# Message with user's name to show who you are logged in as.
 header.userName=Nakalog-in bilang {0}
 
-# Error message to answer a required question
 validation.isRequired=Ang tanong na ito ay kinakailangan.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Maaari lamang ay maglagay ng halaga para sa bawat linya.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=May mga error sa form. Ayusin ang mga iyon bago magpatuloy.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Tandaan: Kinakailangan ang mga field na may *.
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=Ginagamit ang iyong telepono? Binibigyang-daan ka rin ng “Pumili ng File” na gamitin ang camera ng iyong telepono para mag-upload ng mga dokumento.
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
 
-# Title of the login page.
 title.login=Mag log in
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Maari lamang maglog-in gamit ang inyong account sa Lungsod ng {0}
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=Maglog-in
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=Walang account?
 
-# The text between creating a new account, and becoming a guest
 content.or=o
 
-# The text on the button for applicants to create a new account.
 button.createAccount=Gumawa ng account
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=Magpatuloy bilang panauhin
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Kasalukuyang naka-disable ang pag-log in sa account
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=Naghahanap ng iba?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Admin login
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=Na-upload na ang file: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Burahin
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Ipagpatuloy
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Susunod
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Nakaraang
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Pagsusuri
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Laktawan
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=Ikinalulungkot namin, Ang programa na ito ay hindi lubos na naisalin sa inyong ninanais na wika.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=Ako ay tapos na
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Mag-aplay sa ibang programa
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Gumawa ng account o magsign-in
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Mag-aplay
 
-# The text read for screen readers.
 button.applySr=Mag-aplay sa {0}
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=I-edit
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=I-edit ang isinumiteng aplikasyon sa {0}
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=Ipagpatuloy ang aplikasyon sa {0}
 
-# Text describing the date the application was last submitted.
 content.submittedDate=Isinumite noong {0}
 
-# "Get benefits" floating text
 content.benefits=Kumuha ng mga benepisyo
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=Pinahihintulutan ng CiviForm na makapag-aplay kayo para sa maraming mga benepisyo ng minsanan lamang sa pamamagitan ng paggamit muli ng impormasyon.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=Magsimula sa pamamagitan ng pagpili ng aplikasyon sa ibaba.
 
-# Link text to read more about a program.
 link.programDetails=Mga detalya ng programa
 
-# The same text, read for screen readers.
 link.programDetailsSr=Mga detalya ng programa para sa {0}
 
-# The title of the page for the list of programs.
 title.programs=Mga programa at mga serbisyo
 
-# For the badge on the program list index denoting the current status of an application
 title.status=Status
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=Kasalukuyang ginagawa
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Hindi sinimulan
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Isinumite
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: Matagumpay na nai-save ang aplikasyon: ID ng aplikasyon {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Nakumpleto na ang aplikasyon.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=Isumite
 
-# Continue application button
 button.continue=Magsimula dito
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Nagkaroon ng update sa application, pakisuri at sagutan ang mga sagot para magpatuloy
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=Hindi Kwalipikado
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Hindi kwalipikado
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=I-edit
 link.answer=Sagot
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Sinagutan noong {0}
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=Magsimula rito. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=I-edit {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Sagot {0}
 
-# Program Summary Title
 title.programSummary=Buod ng application para sa programa
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi ka kwalipikado para sa {0}.
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi kwalipikado ang client mo para sa {0}.
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=Para sa mga pamantayan sa pagiging kwalipikado, sumangguni sa {0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=Puwede kang bumalik sa nakaraang page para i-edit ang iyong mga sagot. O mag-apply sa isa pang programa.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Bumalik at i-edit
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=Batay sa iyong mga tugon, posibleng kwalipikado ang iyong kliyente para sa {0}. Para magpatuloy, patuloy na punan ang application.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Batay sa iyong mga tugon, posibleng kwalipikado ka para sa {0}. Para magpatuloy, patuloy na punan ang application.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=Posibleng kwalipikado ka
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=Posibleng kwalipikado ang iyong kliyente
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=Posibleng hindi ka kwalipikado
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=Posibleng hindi kwalipikado ang iyong kliyente
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=Sa ngayon, hindi namin masuri ang pagiging kwalipikado mo para sa {0}.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=Sa ngayon, hindi namin masuri ang pagiging kwalipikado ng iyong kliyente para sa {0}.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=Nagsisikap kami para mabilis na maayos ang isyung ito. Subukan ulit sa ibang pagkakataon.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=Tingnan ang lahat ng programa
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Batay sa iyong mga tugon, posibleng hindi ka kwalipikado para sa {0}. Kung nagbago ang iyong impormasyon, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Batay sa iyong mga tugon, posibleng hindi kwalipikado ang kliyente mo para sa {0}. Kung nagbago ang iyong impormasyon ng kliyente, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Nagka-error sa pag-save ng application
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=Pagkumpirma ng aplikasyon
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=Salamat sa pag-aplay sa {0}.  Ang inyong aplikasyon ay natanggap na, at ang ID ng application ninyo ay {1}.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Gumawa ng account o magsign-in
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=Kung kayo ay magsign-in ngayon sa isang account ng lungsod, ang inyong impormasyon ay maitatabi at maaring balikan anumang oras upang makumpleto ang mga aplikasyon sa hinaharap. Kung kayo ay wala pang account, pahihintulutan kayo ng pahina ng log-in upang makapagrehistro. Hindi kayo mawawalan ng anumang data na inyo nang nailagay.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Apartment, suite, atbp. (opsyonal)
 label.city=Lungsod
 label.state=Estado
@@ -299,7 +185,6 @@ label.selectState=Pumili ng Estado
 label.street=Address
 label.zipcode=Zip code
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Maaari lamang na ilagay ang wasto na pangalan ng kalye, at ang numero.
 validation.cityRequired=Maaari lamang na ilagay ang Lungsod.
 validation.currencyMisformatted=Ang currency ay dapat nasa isa sa mga sumusunod na format: 1000 1,000 1000.30 1,000.30
@@ -307,166 +192,85 @@ validation.stateRequired=Maaari lamang na ilagay ang Estado.
 validation.invalidZipcode=Maaari lamang na ilagay ang 5-bilang na ZIP code.
 validation.noPoBox=Maaari lamang na ilagay ang wasto na adres. Kami ay hindi natanggap ng mga PO Box.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=I-verify ang address
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=Hindi namin ma-verify ang ibinigay mong address, pero may nakita kaming katulad nito.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Inilagay na address:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName=Inilagay na {0}:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Iminumungkahing address:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Mga iminumungkahing address:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=I-edit ang address
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=I-save at kumpirmahin
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=Walang nakitang valid na address
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=Hindi namin ma-verify ang ibinigay mong address. Paki-edit ang address mo para magpatuloy.
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Pumili ng opsyon:
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=Idagdag {0}
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Alisin {0}
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=Kayo ba ay sigurado sa nais na alisin {0}? Ang pagbabago na ito ay maitatala matapos mong i-click ang "Next" at lahat ng mga data na nauugnay dito ay mawawala.
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Maaari lamang ay maglagay ng halaga para sa bawat linya.
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Maaari lamang ay maglagay ng natatangi na halaga para sa bawat linya.
 
-
-# The placeholder text for enumerator fields
 placeholder.entityName={0} Palayaw
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Maaari lamang ay pumili ng file.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Pumili ng File
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Dapat ay naglalaman ng hindi hihigit sa {0} na mga character.
 validation.idTooShort=Dapat ay naglalaman ng hindi bababa sa {0} na mga character.
 validation.numberRequired=Dapat ay naglalaman lamang ng mga numero.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Maaari lamang na pumili ng hindi bababa sa {0}.
 validation.tooManySelections=Maaari lamang na pumili ng mas-kaunti sa {0}.
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=Pangalan
 label.lastName=Apelyido
 label.middleName=Gitnang pangalan
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=Pangalan
 placeholder.lastName=Apelyido
 placeholder.middleName=Gitnang pangalan
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Maaari lamang na ilagay ang inyong pangalan.
 validation.lastNameRequired=Maaari lamang na ilagay ang inyong apelyido.
 
-
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=Dapat ay hindi hihigit sa {0}.
 validation.numberTooSmall=Dapat ay hindi bababa sa {0}.
 validation.numberNonInteger=Dapat ay naglalaman lamang ng mga numero.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Dapat ay naglalaman ng hindi hihigit sa {0} na mga character.
 validation.textTooShort=Dapat ay naglalaman ng hindi bababa sa {0} na mga character.
 
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Ang mga katanungan na maraming pagpipiliang opsyon ay hindi maaaring magkaroon ng mga blanko na mga opsyon.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=Hindi namin nahanap ang page na sinubukan mong puntahan
 error.notFoundDescription=Bumalik o pumunta ulit sa {0}
 error.notFoundDescriptionLink=homepage
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=Mag-log in sa CiviForm sa {0}
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Natanggap na ang iyong aplikasyon sa programang {0}
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Natanggap na ang aplikasyon mo sa programang {0}. {1} ang applicant ID mo at {2} ang application ID
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=Nagsumite ka ng aplikasyon para sa programang {0} sa ngalan ng aplikanteng si {1}
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=Natanggap na ang aplikasyon sa programang {0} bilang aplikanteng si {1}, at {2} ang application ID.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Pamahalaan ang iyong mga client sa {0}.

--- a/server/conf/messages.tl
+++ b/server/conf/messages.tl
@@ -6,271 +6,151 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+adminValidation.multiOptionEmpty=Ang mga katanungan na maraming pagpipiliang opsyon ay hindi maaaring magkaroon ng mga blanko na mga opsyon.
+ariaLabel.answer=Sagot {0}
+ariaLabel.begin=Magsimula rito. {0}
+ariaLabel.edit=I-edit {0}
+banner.errorSavingApplication=Nagka-error sa pag-save ng application
+button.addEntity=Idagdag {0}
+button.apply=Mag-aplay
+button.applySr=Mag-aplay sa {0}
+button.chooseFile=Pumili ng File
+button.continue=Magsimula dito
+button.continueSr=Ipagpatuloy ang aplikasyon sa {0}
+button.createAccount=Gumawa ng account
+button.deleteFile=Burahin
+button.edit=I-edit
+button.editAddress=I-edit ang address
+button.editSr=I-edit ang isinumiteng aplikasyon sa {0}
+button.goBackAndEdit=Bumalik at i-edit
+button.guestLogin=Magpatuloy bilang panauhin
+button.keepFile=Ipagpatuloy
+button.login=Maglog-in
+button.logout=Mag-logout
+button.nextScreen=Susunod
+button.previousScreen=Nakaraang
+button.removeEntity=Alisin {0}
+button.review=Pagsusuri
+button.saveAndConfirm=I-save at kumpirmahin
+button.skipFileUpload=Laktawan
+button.submit=Isumite
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=Mag-logout
-
+button.viewAllPrograms=Tingnan ang lahat ng programa
+content.addressEntered=Inilagay na address:
+content.addressEnteredWithQuestionName=Inilagay na {0}:
+content.adminLoginPrompt=Naghahanap ng iba?
+content.alternativeLoginPrompt=Walang account?
+content.benefits=Kumuha ng mga benepisyo
+content.cannotCheckEligibility=Nagsisikap kami para mabilis na maayos ang isyung ito. Subukan ulit sa ibang pagkakataon.
+content.changeAnswersForEligibility=Puwede kang bumalik sa nakaraang page para i-edit ang iyong mga sagot. O mag-apply sa isa pang programa.
+content.confirmed=Salamat sa pag-aplay sa {0}.  Ang inyong aplikasyon ay natanggap na, at ang ID ng application ninyo ay {1}.
+content.description1=Pinahihintulutan ng CiviForm na makapag-aplay kayo para sa maraming mga benepisyo ng minsanan lamang sa pamamagitan ng paggamit muli ng impormasyon.
+content.description2=Magsimula sa pamamagitan ng pagpili ng aplikasyon sa ibaba.
+content.doesNotQualify=Hindi kwalipikado
+content.eligibilityCriteria=Para sa mga pamantayan sa pagiging kwalipikado, sumangguni sa {0}
+content.foundSimilarAddress=Hindi namin ma-verify ang ibinigay mong address, pero may nakita kaming katulad nito.
+content.loginDisabledPrompt=Kasalukuyang naka-disable ang pag-log in sa account
+content.loginPrompt=Maari lamang maglog-in gamit ang inyong account sa Lungsod ng {0}
+content.mobileFileUploadHelp=Ginagamit ang iyong telepono? Binibigyang-daan ka rin ng “Pumili ng File” na gamitin ang camera ng iyong telepono para mag-upload ng mga dokumento.
+content.noValidAddress=Hindi namin ma-verify ang ibinigay mong address. Paki-edit ang address mo para magpatuloy.
+content.notEligible=Hindi Kwalipikado
+content.or=o
+content.pleaseCreateAccount=Kung kayo ay magsign-in ngayon sa isang account ng lungsod, ang inyong impormasyon ay maitatabi at maaring balikan anumang oras upang makumpleto ang mga aplikasyon sa hinaharap. Kung kayo ay wala pang account, pahihintulutan kayo ng pahina ng log-in upang makapagrehistro. Hindi kayo mawawalan ng anumang data na inyo nang nailagay.
+content.previouslyAnsweredOn=Sinagutan noong {0}
+content.requiredFieldsAnnotation=Tandaan: Kinakailangan ang mga field na may *.
+content.submittedDate=Isinumite noong {0}
+content.suggestedAddress=Iminumungkahing address:
+content.suggestedAddresses=Mga iminumungkahing address:
+dialog.confirmDelete=Kayo ba ay sigurado sa nais na alisin {0}? Ang pagbabago na ito ay maitatala matapos mong i-click ang "Next" at lahat ng mga data na nauugnay dito ay mawawala.
+email.applicationReceivedBody=Natanggap na ang aplikasyon mo sa programang {0}. {1} ang applicant ID mo at {2} ang application ID
+email.applicationReceivedSubject=Natanggap na ang iyong aplikasyon sa programang {0}
+email.loginToCiviform=Mag-log in sa CiviForm sa {0}
+email.tiApplicationSubmittedBody=Natanggap na ang aplikasyon sa programang {0} bilang aplikanteng si {1}, at {2} ang application ID.
+email.tiApplicationSubmittedSubject=Nagsumite ka ng aplikasyon para sa programang {0} sa ngalan ng aplikanteng si {1}
+email.tiManageYourClients=Pamahalaan ang iyong mga client sa {0}.
+error.notFoundDescription=Bumalik o pumunta ulit sa {0}
+error.notFoundDescriptionLink=homepage
+error.notFoundTitle=Hindi namin nahanap ang page na sinubukan mong puntahan
 footer.supportLinkDescription=Para sa suporta na pang teknikal, tawagan
-
 # TODO(#1918): Translate.
 guest=Guest
-
-label.languageSr=Pumili ng wika
-
 header.userName=Nakalog-in bilang {0}
-
-validation.isRequired=Ang tanong na ito ay kinakailangan.
-
-validation.invalidInput=Maaari lamang ay maglagay ng halaga para sa bawat linya.
-
-validation.errorAnnouncementSr=May mga error sa form. Ayusin ang mga iyon bago magpatuloy.
-
-content.requiredFieldsAnnotation=Tandaan: Kinakailangan ang mga field na may *.
-
-content.mobileFileUploadHelp=Ginagamit ang iyong telepono? Binibigyang-daan ka rin ng “Pumili ng File” na gamitin ang camera ng iyong telepono para mag-upload ng mga dokumento.
-
-title.login=Mag log in
-
-content.loginPrompt=Maari lamang maglog-in gamit ang inyong account sa Lungsod ng {0}
-
-button.login=Maglog-in
-
-content.alternativeLoginPrompt=Walang account?
-
-content.or=o
-
-button.createAccount=Gumawa ng account
-
-button.guestLogin=Magpatuloy bilang panauhin
-
-content.loginDisabledPrompt=Kasalukuyang naka-disable ang pag-log in sa account
-
-content.adminLoginPrompt=Naghahanap ng iba?
-
-link.adminLogin=Admin login
-
 input.fileAlreadyUploaded=Na-upload na ang file: {0}
-
-button.deleteFile=Burahin
-
-button.keepFile=Ipagpatuloy
-
-button.nextScreen=Susunod
-
-button.previousScreen=Nakaraang
-
-button.review=Pagsusuri
-
-button.skipFileUpload=Laktawan
-
-toast.localeNotSupported=Ikinalulungkot namin, Ang programa na ito ay hindi lubos na naisalin sa inyong ninanais na wika.
-
-link.allDone=Ako ay tapos na
-
-link.applyToAnotherProgram=Mag-aplay sa ibang programa
-
-link.createAccountOrSignIn=Gumawa ng account o magsign-in
-
-button.apply=Mag-aplay
-
-button.applySr=Mag-aplay sa {0}
-
-button.edit=I-edit
-
-button.editSr=I-edit ang isinumiteng aplikasyon sa {0}
-
-button.continueSr=Ipagpatuloy ang aplikasyon sa {0}
-
-content.submittedDate=Isinumite noong {0}
-
-content.benefits=Kumuha ng mga benepisyo
-
-content.description1=Pinahihintulutan ng CiviForm na makapag-aplay kayo para sa maraming mga benepisyo ng minsanan lamang sa pamamagitan ng paggamit muli ng impormasyon.
-
-content.description2=Magsimula sa pamamagitan ng pagpili ng aplikasyon sa ibaba.
-
-link.programDetails=Mga detalya ng programa
-
-link.programDetailsSr=Mga detalya ng programa para sa {0}
-
-title.programs=Mga programa at mga serbisyo
-
-title.status=Status
-
-title.inProgressProgramsUpdated=Kasalukuyang ginagawa
-
-title.activeProgramsUpdated=Hindi sinimulan
-
-title.submittedPrograms=Isinumite
-
-toast.applicationSaved=Successfully saved application: Matagumpay na nai-save ang aplikasyon: ID ng aplikasyon {0}
-
-toast.programCompleted=Nakumpleto na ang aplikasyon.
-
-button.submit=Isumite
-
-button.continue=Magsimula dito
-
-toast.applicationOutOfDate=Nagkaroon ng update sa application, pakisuri at sagutan ang mga sagot para magpatuloy
-
-content.notEligible=Hindi Kwalipikado
-
-content.doesNotQualify=Hindi kwalipikado
-
-link.edit=I-edit
-link.answer=Sagot
-
-content.previouslyAnsweredOn=Sinagutan noong {0}
-
-ariaLabel.begin=Magsimula rito. {0}
-
-ariaLabel.edit=I-edit {0}
-
-ariaLabel.answer=Sagot {0}
-
-title.programSummary=Buod ng application para sa programa
-
-title.applicantNotEligible=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi ka kwalipikado para sa {0}.
-
-title.applicantNotEligibleTi=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi kwalipikado ang client mo para sa {0}.
-
-content.eligibilityCriteria=Para sa mga pamantayan sa pagiging kwalipikado, sumangguni sa {0}
-
-content.changeAnswersForEligibility=Puwede kang bumalik sa nakaraang page para i-edit ang iyong mga sagot. O mag-apply sa isa pang programa.
-
-button.goBackAndEdit=Bumalik at i-edit
-
-toast.mayQualifyTi=Batay sa iyong mga tugon, posibleng kwalipikado ang iyong kliyente para sa {0}. Para magpatuloy, patuloy na punan ang application.
-
-toast.mayQualify=Batay sa iyong mga tugon, posibleng kwalipikado ka para sa {0}. Para magpatuloy, patuloy na punan ang application.
-
-tag.mayQualify=Posibleng kwalipikado ka
-
-tag.mayQualifyTi=Posibleng kwalipikado ang iyong kliyente
-
-tag.mayNotQualify=Posibleng hindi ka kwalipikado
-
-tag.mayNotQualifyTi=Posibleng hindi kwalipikado ang iyong kliyente
-
-title.cannotCheckEligibility=Sa ngayon, hindi namin masuri ang pagiging kwalipikado mo para sa {0}.
-
-title.cannotCheckEligibilityTi=Sa ngayon, hindi namin masuri ang pagiging kwalipikado ng iyong kliyente para sa {0}.
-
-content.cannotCheckEligibility=Nagsisikap kami para mabilis na maayos ang isyung ito. Subukan ulit sa ibang pagkakataon.
-
-button.viewAllPrograms=Tingnan ang lahat ng programa
-
-toast.mayNotQualify=Batay sa iyong mga tugon, posibleng hindi ka kwalipikado para sa {0}. Kung nagbago ang iyong impormasyon, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
-
-toast.mayNotQualifyTi=Batay sa iyong mga tugon, posibleng hindi kwalipikado ang kliyente mo para sa {0}. Kung nagbago ang iyong impormasyon ng kliyente, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
-
-banner.errorSavingApplication=Nagka-error sa pag-save ng application
-
-title.applicationConfirmation=Pagkumpirma ng aplikasyon
-
-content.confirmed=Salamat sa pag-aplay sa {0}.  Ang inyong aplikasyon ay natanggap na, at ang ID ng application ninyo ay {1}.
-
-title.createAnAccount=Gumawa ng account o magsign-in
-
-content.pleaseCreateAccount=Kung kayo ay magsign-in ngayon sa isang account ng lungsod, ang inyong impormasyon ay maitatabi at maaring balikan anumang oras upang makumpleto ang mga aplikasyon sa hinaharap. Kung kayo ay wala pang account, pahihintulutan kayo ng pahina ng log-in upang makapagrehistro. Hindi kayo mawawalan ng anumang data na inyo nang nailagay.
-
 label.addressLine2=Apartment, suite, atbp. (opsyonal)
 label.city=Lungsod
-label.state=Estado
-label.selectState=Pumili ng Estado
-label.street=Address
-label.zipcode=Zip code
-
-validation.streetRequired=Maaari lamang na ilagay ang wasto na pangalan ng kalye, at ang numero.
-validation.cityRequired=Maaari lamang na ilagay ang Lungsod.
-validation.currencyMisformatted=Ang currency ay dapat nasa isa sa mga sumusunod na format: 1000 1,000 1000.30 1,000.30
-validation.stateRequired=Maaari lamang na ilagay ang Estado.
-validation.invalidZipcode=Maaari lamang na ilagay ang 5-bilang na ZIP code.
-validation.noPoBox=Maaari lamang na ilagay ang wasto na adres. Kami ay hindi natanggap ng mga PO Box.
-
-title.verifyAddress=I-verify ang address
-
-content.foundSimilarAddress=Hindi namin ma-verify ang ibinigay mong address, pero may nakita kaming katulad nito.
-
-content.addressEntered=Inilagay na address:
-
-content.addressEnteredWithQuestionName=Inilagay na {0}:
-
-content.suggestedAddress=Iminumungkahing address:
-
-content.suggestedAddresses=Mga iminumungkahing address:
-
-button.editAddress=I-edit ang address
-
-button.saveAndConfirm=I-save at kumpirmahin
-
-title.noValidAddress=Walang nakitang valid na address
-
-content.noValidAddress=Hindi namin ma-verify ang ibinigay mong address. Paki-edit ang address mo para magpatuloy.
-
-placeholder.noDropdownSelection=Pumili ng opsyon:
-
-validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
-
-button.addEntity=Idagdag {0}
-
-button.removeEntity=Alisin {0}
-
-dialog.confirmDelete=Kayo ba ay sigurado sa nais na alisin {0}? Ang pagbabago na ito ay maitatala matapos mong i-click ang "Next" at lahat ng mga data na nauugnay dito ay mawawala.
-
-validation.entityNameRequired=Maaari lamang ay maglagay ng halaga para sa bawat linya.
-
-validation.duplicateEntityName=Maaari lamang ay maglagay ng natatangi na halaga para sa bawat linya.
-
-placeholder.entityName={0} Palayaw
-
-validation.fileRequired=Maaari lamang ay pumili ng file.
-
-button.chooseFile=Pumili ng File
-
-validation.idTooLong=Dapat ay naglalaman ng hindi hihigit sa {0} na mga character.
-validation.idTooShort=Dapat ay naglalaman ng hindi bababa sa {0} na mga character.
-validation.numberRequired=Dapat ay naglalaman lamang ng mga numero.
-
-validation.tooFewSelections=Maaari lamang na pumili ng hindi bababa sa {0}.
-validation.tooManySelections=Maaari lamang na pumili ng mas-kaunti sa {0}.
-
 label.firstName=Pangalan
+label.languageSr=Pumili ng wika
 label.lastName=Apelyido
 label.middleName=Gitnang pangalan
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=Pumili ng Estado
+label.state=Estado
+label.street=Address
+label.zipcode=Zip code
+link.adminLogin=Admin login
+link.allDone=Ako ay tapos na
+link.answer=Sagot
+link.applyToAnotherProgram=Mag-aplay sa ibang programa
+link.createAccountOrSignIn=Gumawa ng account o magsign-in
+link.edit=I-edit
+link.programDetails=Mga detalya ng programa
+link.programDetailsSr=Mga detalya ng programa para sa {0}
+placeholder.entityName={0} Palayaw
 placeholder.firstName=Pangalan
 placeholder.lastName=Apelyido
 placeholder.middleName=Gitnang pangalan
-
+placeholder.noDropdownSelection=Pumili ng opsyon:
+tag.mayNotQualify=Posibleng hindi ka kwalipikado
+tag.mayNotQualifyTi=Posibleng hindi kwalipikado ang iyong kliyente
+tag.mayQualify=Posibleng kwalipikado ka
+tag.mayQualifyTi=Posibleng kwalipikado ang iyong kliyente
+title.activeProgramsUpdated=Hindi sinimulan
+title.applicantNotEligible=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi ka kwalipikado para sa {0}.
+title.applicantNotEligibleTi=Batay sa iyong mga sagot sa mga sumusunod na tanong, posibleng hindi kwalipikado ang client mo para sa {0}.
+title.applicationConfirmation=Pagkumpirma ng aplikasyon
+title.cannotCheckEligibility=Sa ngayon, hindi namin masuri ang pagiging kwalipikado mo para sa {0}.
+title.cannotCheckEligibilityTi=Sa ngayon, hindi namin masuri ang pagiging kwalipikado ng iyong kliyente para sa {0}.
+title.createAnAccount=Gumawa ng account o magsign-in
+title.inProgressProgramsUpdated=Kasalukuyang ginagawa
+title.login=Mag log in
+title.noValidAddress=Walang nakitang valid na address
+title.programSummary=Buod ng application para sa programa
+title.programs=Mga programa at mga serbisyo
+title.status=Status
+title.submittedPrograms=Isinumite
+title.verifyAddress=I-verify ang address
+toast.applicationOutOfDate=Nagkaroon ng update sa application, pakisuri at sagutan ang mga sagot para magpatuloy
+toast.applicationSaved=Successfully saved application: Matagumpay na nai-save ang aplikasyon: ID ng aplikasyon {0}
+toast.localeNotSupported=Ikinalulungkot namin, Ang programa na ito ay hindi lubos na naisalin sa inyong ninanais na wika.
+toast.mayNotQualify=Batay sa iyong mga tugon, posibleng hindi ka kwalipikado para sa {0}. Kung nagbago ang iyong impormasyon, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
+toast.mayNotQualifyTi=Batay sa iyong mga tugon, posibleng hindi kwalipikado ang kliyente mo para sa {0}. Kung nagbago ang iyong impormasyon ng kliyente, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
+toast.mayQualify=Batay sa iyong mga tugon, posibleng kwalipikado ka para sa {0}. Para magpatuloy, patuloy na punan ang application.
+toast.mayQualifyTi=Batay sa iyong mga tugon, posibleng kwalipikado ang iyong kliyente para sa {0}. Para magpatuloy, patuloy na punan ang application.
+toast.programCompleted=Nakumpleto na ang aplikasyon.
+validation.cityRequired=Maaari lamang na ilagay ang Lungsod.
+validation.currencyMisformatted=Ang currency ay dapat nasa isa sa mga sumusunod na format: 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
+validation.duplicateEntityName=Maaari lamang ay maglagay ng natatangi na halaga para sa bawat linya.
+validation.entityNameRequired=Maaari lamang ay maglagay ng halaga para sa bawat linya.
+validation.errorAnnouncementSr=May mga error sa form. Ayusin ang mga iyon bago magpatuloy.
+validation.fileRequired=Maaari lamang ay pumili ng file.
 validation.firstNameRequired=Maaari lamang na ilagay ang inyong pangalan.
+validation.idTooLong=Dapat ay naglalaman ng hindi hihigit sa {0} na mga character.
+validation.idTooShort=Dapat ay naglalaman ng hindi bababa sa {0} na mga character.
+validation.invalidInput=Maaari lamang ay maglagay ng halaga para sa bawat linya.
+validation.invalidZipcode=Maaari lamang na ilagay ang 5-bilang na ZIP code.
+validation.isRequired=Ang tanong na ito ay kinakailangan.
 validation.lastNameRequired=Maaari lamang na ilagay ang inyong apelyido.
-
+validation.noPoBox=Maaari lamang na ilagay ang wasto na adres. Kami ay hindi natanggap ng mga PO Box.
+validation.numberNonInteger=Dapat ay naglalaman lamang ng mga numero.
+validation.numberRequired=Dapat ay naglalaman lamang ng mga numero.
 validation.numberTooBig=Dapat ay hindi hihigit sa {0}.
 validation.numberTooSmall=Dapat ay hindi bababa sa {0}.
-validation.numberNonInteger=Dapat ay naglalaman lamang ng mga numero.
-
+validation.stateRequired=Maaari lamang na ilagay ang Estado.
+validation.streetRequired=Maaari lamang na ilagay ang wasto na pangalan ng kalye, at ang numero.
 validation.textTooLong=Dapat ay naglalaman ng hindi hihigit sa {0} na mga character.
 validation.textTooShort=Dapat ay naglalaman ng hindi bababa sa {0} na mga character.
-
-adminValidation.multiOptionEmpty=Ang mga katanungan na maraming pagpipiliang opsyon ay hindi maaaring magkaroon ng mga blanko na mga opsyon.
-
-error.notFoundTitle=Hindi namin nahanap ang page na sinubukan mong puntahan
-error.notFoundDescription=Bumalik o pumunta ulit sa {0}
-error.notFoundDescriptionLink=homepage
-
-email.loginToCiviform=Mag-log in sa CiviForm sa {0}
-
-email.applicationReceivedSubject=Natanggap na ang iyong aplikasyon sa programang {0}
-
-email.applicationReceivedBody=Natanggap na ang aplikasyon mo sa programang {0}. {1} ang applicant ID mo at {2} ang application ID
-
-email.tiApplicationSubmittedSubject=Nagsumite ka ng aplikasyon para sa programang {0} sa ngalan ng aplikanteng si {1}
-
-email.tiApplicationSubmittedBody=Natanggap na ang aplikasyon sa programang {0} bilang aplikanteng si {1}, at {2} ang application ID.
-
-email.tiManageYourClients=Pamahalaan ang iyong mga client sa {0}.
+validation.tooFewSelections=Maaari lamang na pumili ng hindi bababa sa {0}.
+validation.tooManySelections=Maaari lamang na pumili ng mas-kaunti sa {0}.

--- a/server/conf/messages.vi
+++ b/server/conf/messages.vi
@@ -12,286 +12,171 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=Đăng xuất
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=Để được hỗ trợ kỹ thuật, hãy liên hệ
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=Khách
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Chọn một ngôn ngữ
 
-# Message with user's name to show who you are logged in as.
 header.userName=Đã đăng nhập bằng {0}
 
-# Error message to answer a required question
 validation.isRequired=Đây là câu hỏi bắt buộc.
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Vui lòng nhập thông tin hợp lệ.
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=Có lỗi trong biểu mẫu. Vui lòng khắc phục trước khi tiếp tục.
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Lưu ý: Các trường có dấu * là bắt buộc.
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=Trên điện thoại của bạn? Tính năng "Chọn tệp" cũng cho phép bạn sử dụng camera của điện thoại để tải tài liệu lên.
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=Đăng nhập
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Vui lòng đăng nhập bằng tài khoản {0} của bạn
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=Đăng nhập
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=Bạn không có tài khoản?
 
-# The text between creating a new account, and becoming a guest
 content.or=hoặc
 
-# The text on the button for applicants to create a new account.
 button.createAccount=Tạo tài khoản
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=Tiếp tục với tư cách khách
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Tính năng đăng nhập vào tài khoản đang bị vô hiệu hóa
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=Bạn muốn thực hiện thao tác khác?
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Đăng nhập với tư cách quản trị viên
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=Tệp đã tải lên: {0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Xoá
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Tiếp tục
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Lưu và tiếp tục
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Trước
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Xem lại
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Bỏ qua
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=Rất tiếc, chương trình này chưa được dịch hết sang tiếng Việt.
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=Tôi đã hoàn thành
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Đăng ký một chương trình khác
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Tạo tài khoản hoặc đăng nhập
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Đăng ký
 
-# The text read for screen readers.
 button.applySr=Đăng ký {0}
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Chỉnh sửa
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=Chỉnh sửa đơn đăng ký đã gửi cho {0}
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=Tiếp tục đăng ký {0}
 
-# Text describing the date the application was last submitted.
 content.submittedDate=Đã gửi {0}
 
-# "Get benefits" floating text
 content.benefits=Nhận quyền lợi
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm cho phép bạn đăng ký nhận nhiều quyền lợi trong một lần nhờ việc tái sử dụng thông tin.
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=Bắt đầu bằng việc chọn một đơn đăng ký dưới đây.
 
-# Link text to read more about a program.
 link.programDetails=Chi tiết chương trình
 
-# The same text, read for screen readers.
 link.programDetailsSr=Chi tiết chương trình {0}
 
-# The title of the page for the list of programs.
 title.programs=Chương trình và dịch vụ
 
-# For the badge on the program list index denoting the current status of an application
 title.status=Trạng thái
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=Đang diễn ra
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Chưa bắt đầu
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Đã gửi
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Đã lưu thành công đơn đăng ký: mã đơn đăng ký {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Đăng ký thành công.
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=Gửi
 
-# Continue application button
 button.continue=Tiếp tục
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Ứng dụng này đã có bản cập nhật. Vui lòng xem và trả lời các câu hỏi để tiếp tục
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=Không đủ điều kiện
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Không đủ tiêu chuẩn
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Chỉnh sửa
 link.answer=Câu trả lời
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Trước đây đã trả lời vào {0}
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=Bắt đầu tại đây. {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Chỉnh sửa {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Câu trả lời {0}
 
-# Program Summary Title
 title.programSummary=Tóm tắt dữ liệu đăng ký tham gia chương trình
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Dựa trên câu trả lời của bạn cho các câu hỏi sau, bạn có thể không đủ tiêu chuẩn tham gia {0}.
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=Dựa trên câu trả lời của bạn cho các câu hỏi sau, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}.
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=Để biết điều kiện tham gia, vui lòng tham khảo {0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=Bạn có thể quay lại trang trước để chỉnh sửa câu trả lời của mình. Hoặc đăng ký tham gia một chương trình khác.
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Quay lại và chỉnh sửa
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Dựa trên câu trả lời của bạn, bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=Bạn có thể đủ tiêu chuẩn
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=Khách hàng của bạn có thể đủ tiêu chuẩn
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=Bạn có thể không đủ tiêu chuẩn
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=Khách hàng của bạn có thể không đủ tiêu chuẩn
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=Hiện tại, chúng tôi không thể kiểm tra xem bạn có đủ điều kiện tham gia {0} hay không.
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=Hiện tại, chúng tôi không thể kiểm tra xem khách hàng của bạn có đủ điều kiện tham gia {0} hay không.
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=Chúng tôi đang nỗ lực để nhanh chóng khắc phục sự cố này. Hãy thử lại sau.
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=Xem tất cả chương trình
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Dựa trên câu trả lời của bạn, bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của khách hàng của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Lỗi khi lưu đơn đăng ký
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=Xác nhận đơn đăng ký
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=Cảm ơn bạn đã đăng ký tham gia {0}. Chúng tôi đã nhận được đơn đăng ký của bạn và mã đơn đăng ký là {1}.
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Tạo tài khoản hoặc đăng nhập
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=Nếu bây giờ bạn đăng nhập vào tài khoản của thành phố, thông tin của bạn sẽ được lưu lại và bạn có thể trở lại bất cứ lúc nào để hoàn tất các đơn đăng ký sau này. Nếu chưa có tài khoản, bạn có thể đăng ký ở trang đăng nhập. Dữ liệu bạn đã nhập sẽ không bị mất.
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Căn hộ, phòng, v.v. (không bắt buộc)
 label.city=Thành phố
 label.state=Tiểu bang
@@ -299,7 +184,6 @@ label.selectState=Chọn tiểu bang
 label.street=Địa chỉ
 label.zipcode=Mã bưu chính
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Vui lòng nhập số nhà và tên đường hợp lệ.
 validation.cityRequired=Vui lòng nhập tên thành phố.
 validation.currencyMisformatted=Giá trị tiền tệ phải theo một trong những định dạng sau: 1000 1,000 1000.30 1,000.30
@@ -307,163 +191,83 @@ validation.stateRequired=Vui lòng nhập tên tiểu bang.
 validation.invalidZipcode=Vui lòng nhập mã bưu chính hợp lệ gồm 5 chữ số.
 validation.noPoBox=Vui lòng nhập một địa chỉ hợp lệ. Chúng tôi không chấp nhận hộp thư bưu điện.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=Xác minh địa chỉ
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp nhưng đã tìm thấy địa chỉ tương tự.
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Địa chỉ đã nhập:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName={0} đã nhập:
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Địa chỉ được đề xuất:
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Các địa chỉ được đề xuất:
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=Chỉnh sửa địa chỉ
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=Lưu và xác nhận
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=Không tìm thấy địa chỉ hợp lệ
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp. Vui lòng chỉnh sửa địa chỉ của bạn để tiếp tục.
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Chọn một phương án:
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=Vui lòng nhập ngày ở định dạng YYYY/MM/DD.
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=Thêm {0}
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Xoá {0}
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=Bạn có chắc chắn muốn xoá {0} này không? Chúng tôi sẽ lưu thay đổi khi bạn nhấp "Tiếp tục" và tất cả dữ liệu liên quan đến {0} này sẽ bị mất.
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Vui lòng nhập một giá trị cho mỗi dòng.
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Vui lòng nhập một giá trị riêng biệt cho mỗi dòng.
 
-# The placeholder text for enumerator fields
 placeholder.entityName=Tên {0}
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Vui lòng chọn một tệp.
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Chọn tệp
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Chỉ được dài tối đa {0} ký tự.
 validation.idTooShort=Phải có ít nhất {0} ký tự.
 validation.numberRequired=Chỉ được chứa chữ số.
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Vui lòng chọn ít nhất {0}.
 validation.tooManySelections=Vui lòng chọn ít hơn {0}.
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=Tên
 label.lastName=Họ
 label.middleName=Tên đệm
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=Tên
 placeholder.lastName=Họ
 placeholder.middleName=Tên đệm
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Vui lòng nhập tên của bạn.
 validation.lastNameRequired=Vui lòng nhập họ của bạn.
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=Không được lớn hơn {0}.
 validation.numberTooSmall=Không được nhỏ hơn {0}.
 validation.numberNonInteger=Phải là số nguyên dương và chỉ có thể chứa ký tự chữ số từ 0-9.
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Chỉ được dài tối đa {0} ký tự.
 validation.textTooShort=Phải có ít nhất {0} ký tự.
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Không được để lựa chọn trống trong câu hỏi có nhiều lựa chọn.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=Chúng tôi không tìm thấy trang mà bạn cố gắng truy cập
 error.notFoundDescription=Vui lòng quay lại hoặc chuyển đến {0}
 error.notFoundDescriptionLink=trang chủ
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=Đăng nhập vào CiviForm tại {0}
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn. Mã người đăng ký của bạn là {1} và mã đơn đăng ký là {2}
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=Bạn đã gửi đơn đăng ký tham gia chương trình {0} thay mặt cho người đăng ký {1}
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} với tư cách là người đăng ký {1}, và mã đơn đăng ký là {2}.
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Quản lý khách hàng của bạn tại {0}.

--- a/server/conf/messages.vi
+++ b/server/conf/messages.vi
@@ -6,268 +6,150 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+adminValidation.multiOptionEmpty=Không được để lựa chọn trống trong câu hỏi có nhiều lựa chọn.
+ariaLabel.answer=Câu trả lời {0}
+ariaLabel.begin=Bắt đầu tại đây. {0}
+ariaLabel.edit=Chỉnh sửa {0}
+banner.errorSavingApplication=Lỗi khi lưu đơn đăng ký
+button.addEntity=Thêm {0}
+button.apply=Đăng ký
+button.applySr=Đăng ký {0}
+button.chooseFile=Chọn tệp
+button.continue=Tiếp tục
+button.continueSr=Tiếp tục đăng ký {0}
+button.createAccount=Tạo tài khoản
+button.deleteFile=Xoá
+button.edit=Chỉnh sửa
+button.editAddress=Chỉnh sửa địa chỉ
+button.editSr=Chỉnh sửa đơn đăng ký đã gửi cho {0}
+button.goBackAndEdit=Quay lại và chỉnh sửa
+button.guestLogin=Tiếp tục với tư cách khách
+button.keepFile=Tiếp tục
+button.login=Đăng nhập
+button.logout=Đăng xuất
+button.nextScreen=Lưu và tiếp tục
+button.previousScreen=Trước
+button.removeEntity=Xoá {0}
+button.review=Xem lại
+button.saveAndConfirm=Lưu và xác nhận
+button.skipFileUpload=Bỏ qua
+button.submit=Gửi
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=Đăng xuất
-
-footer.supportLinkDescription=Để được hỗ trợ kỹ thuật, hãy liên hệ
-
-guest=Khách
-
-label.languageSr=Chọn một ngôn ngữ
-
-header.userName=Đã đăng nhập bằng {0}
-
-validation.isRequired=Đây là câu hỏi bắt buộc.
-
-validation.invalidInput=Vui lòng nhập thông tin hợp lệ.
-
-validation.errorAnnouncementSr=Có lỗi trong biểu mẫu. Vui lòng khắc phục trước khi tiếp tục.
-
-content.requiredFieldsAnnotation=Lưu ý: Các trường có dấu * là bắt buộc.
-
-content.mobileFileUploadHelp=Trên điện thoại của bạn? Tính năng "Chọn tệp" cũng cho phép bạn sử dụng camera của điện thoại để tải tài liệu lên.
-
-title.login=Đăng nhập
-
-content.loginPrompt=Vui lòng đăng nhập bằng tài khoản {0} của bạn
-
-button.login=Đăng nhập
-
-content.alternativeLoginPrompt=Bạn không có tài khoản?
-
-content.or=hoặc
-
-button.createAccount=Tạo tài khoản
-
-button.guestLogin=Tiếp tục với tư cách khách
-
-content.loginDisabledPrompt=Tính năng đăng nhập vào tài khoản đang bị vô hiệu hóa
-
-content.adminLoginPrompt=Bạn muốn thực hiện thao tác khác?
-
-link.adminLogin=Đăng nhập với tư cách quản trị viên
-
-input.fileAlreadyUploaded=Tệp đã tải lên: {0}
-
-button.deleteFile=Xoá
-
-button.keepFile=Tiếp tục
-
-button.nextScreen=Lưu và tiếp tục
-
-button.previousScreen=Trước
-
-button.review=Xem lại
-
-button.skipFileUpload=Bỏ qua
-
-toast.localeNotSupported=Rất tiếc, chương trình này chưa được dịch hết sang tiếng Việt.
-
-link.allDone=Tôi đã hoàn thành
-
-link.applyToAnotherProgram=Đăng ký một chương trình khác
-
-link.createAccountOrSignIn=Tạo tài khoản hoặc đăng nhập
-
-button.apply=Đăng ký
-
-button.applySr=Đăng ký {0}
-
-button.edit=Chỉnh sửa
-
-button.editSr=Chỉnh sửa đơn đăng ký đã gửi cho {0}
-
-button.continueSr=Tiếp tục đăng ký {0}
-
-content.submittedDate=Đã gửi {0}
-
-content.benefits=Nhận quyền lợi
-
-content.description1=CiviForm cho phép bạn đăng ký nhận nhiều quyền lợi trong một lần nhờ việc tái sử dụng thông tin.
-
-content.description2=Bắt đầu bằng việc chọn một đơn đăng ký dưới đây.
-
-link.programDetails=Chi tiết chương trình
-
-link.programDetailsSr=Chi tiết chương trình {0}
-
-title.programs=Chương trình và dịch vụ
-
-title.status=Trạng thái
-
-title.inProgressProgramsUpdated=Đang diễn ra
-
-title.activeProgramsUpdated=Chưa bắt đầu
-
-title.submittedPrograms=Đã gửi
-
-toast.applicationSaved=Đã lưu thành công đơn đăng ký: mã đơn đăng ký {0}
-
-toast.programCompleted=Đăng ký thành công.
-
-button.submit=Gửi
-
-button.continue=Tiếp tục
-
-toast.applicationOutOfDate=Ứng dụng này đã có bản cập nhật. Vui lòng xem và trả lời các câu hỏi để tiếp tục
-
-content.notEligible=Không đủ điều kiện
-
-content.doesNotQualify=Không đủ tiêu chuẩn
-
-link.edit=Chỉnh sửa
-link.answer=Câu trả lời
-
-content.previouslyAnsweredOn=Trước đây đã trả lời vào {0}
-
-ariaLabel.begin=Bắt đầu tại đây. {0}
-
-ariaLabel.edit=Chỉnh sửa {0}
-
-ariaLabel.answer=Câu trả lời {0}
-
-title.programSummary=Tóm tắt dữ liệu đăng ký tham gia chương trình
-
-title.applicantNotEligible=Dựa trên câu trả lời của bạn cho các câu hỏi sau, bạn có thể không đủ tiêu chuẩn tham gia {0}.
-
-title.applicantNotEligibleTi=Dựa trên câu trả lời của bạn cho các câu hỏi sau, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}.
-
-content.eligibilityCriteria=Để biết điều kiện tham gia, vui lòng tham khảo {0}
-
-content.changeAnswersForEligibility=Bạn có thể quay lại trang trước để chỉnh sửa câu trả lời của mình. Hoặc đăng ký tham gia một chương trình khác.
-
-button.goBackAndEdit=Quay lại và chỉnh sửa
-
-toast.mayQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
-
-toast.mayQualify=Dựa trên câu trả lời của bạn, bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
-
-tag.mayQualify=Bạn có thể đủ tiêu chuẩn
-
-tag.mayQualifyTi=Khách hàng của bạn có thể đủ tiêu chuẩn
-
-tag.mayNotQualify=Bạn có thể không đủ tiêu chuẩn
-
-tag.mayNotQualifyTi=Khách hàng của bạn có thể không đủ tiêu chuẩn
-
-title.cannotCheckEligibility=Hiện tại, chúng tôi không thể kiểm tra xem bạn có đủ điều kiện tham gia {0} hay không.
-
-title.cannotCheckEligibilityTi=Hiện tại, chúng tôi không thể kiểm tra xem khách hàng của bạn có đủ điều kiện tham gia {0} hay không.
-
-content.cannotCheckEligibility=Chúng tôi đang nỗ lực để nhanh chóng khắc phục sự cố này. Hãy thử lại sau.
-
 button.viewAllPrograms=Xem tất cả chương trình
-
-toast.mayNotQualify=Dựa trên câu trả lời của bạn, bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
-
-toast.mayNotQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của khách hàng của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
-
-banner.errorSavingApplication=Lỗi khi lưu đơn đăng ký
-
-title.applicationConfirmation=Xác nhận đơn đăng ký
-
+content.addressEntered=Địa chỉ đã nhập:
+content.addressEnteredWithQuestionName={0} đã nhập:
+content.adminLoginPrompt=Bạn muốn thực hiện thao tác khác?
+content.alternativeLoginPrompt=Bạn không có tài khoản?
+content.benefits=Nhận quyền lợi
+content.cannotCheckEligibility=Chúng tôi đang nỗ lực để nhanh chóng khắc phục sự cố này. Hãy thử lại sau.
+content.changeAnswersForEligibility=Bạn có thể quay lại trang trước để chỉnh sửa câu trả lời của mình. Hoặc đăng ký tham gia một chương trình khác.
 content.confirmed=Cảm ơn bạn đã đăng ký tham gia {0}. Chúng tôi đã nhận được đơn đăng ký của bạn và mã đơn đăng ký là {1}.
-
-title.createAnAccount=Tạo tài khoản hoặc đăng nhập
-
+content.description1=CiviForm cho phép bạn đăng ký nhận nhiều quyền lợi trong một lần nhờ việc tái sử dụng thông tin.
+content.description2=Bắt đầu bằng việc chọn một đơn đăng ký dưới đây.
+content.doesNotQualify=Không đủ tiêu chuẩn
+content.eligibilityCriteria=Để biết điều kiện tham gia, vui lòng tham khảo {0}
+content.foundSimilarAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp nhưng đã tìm thấy địa chỉ tương tự.
+content.loginDisabledPrompt=Tính năng đăng nhập vào tài khoản đang bị vô hiệu hóa
+content.loginPrompt=Vui lòng đăng nhập bằng tài khoản {0} của bạn
+content.mobileFileUploadHelp=Trên điện thoại của bạn? Tính năng "Chọn tệp" cũng cho phép bạn sử dụng camera của điện thoại để tải tài liệu lên.
+content.noValidAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp. Vui lòng chỉnh sửa địa chỉ của bạn để tiếp tục.
+content.notEligible=Không đủ điều kiện
+content.or=hoặc
 content.pleaseCreateAccount=Nếu bây giờ bạn đăng nhập vào tài khoản của thành phố, thông tin của bạn sẽ được lưu lại và bạn có thể trở lại bất cứ lúc nào để hoàn tất các đơn đăng ký sau này. Nếu chưa có tài khoản, bạn có thể đăng ký ở trang đăng nhập. Dữ liệu bạn đã nhập sẽ không bị mất.
-
+content.previouslyAnsweredOn=Trước đây đã trả lời vào {0}
+content.requiredFieldsAnnotation=Lưu ý: Các trường có dấu * là bắt buộc.
+content.submittedDate=Đã gửi {0}
+content.suggestedAddress=Địa chỉ được đề xuất:
+content.suggestedAddresses=Các địa chỉ được đề xuất:
+dialog.confirmDelete=Bạn có chắc chắn muốn xoá {0} này không? Chúng tôi sẽ lưu thay đổi khi bạn nhấp "Tiếp tục" và tất cả dữ liệu liên quan đến {0} này sẽ bị mất.
+email.applicationReceivedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn. Mã người đăng ký của bạn là {1} và mã đơn đăng ký là {2}
+email.applicationReceivedSubject=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn
+email.loginToCiviform=Đăng nhập vào CiviForm tại {0}
+email.tiApplicationSubmittedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} với tư cách là người đăng ký {1}, và mã đơn đăng ký là {2}.
+email.tiApplicationSubmittedSubject=Bạn đã gửi đơn đăng ký tham gia chương trình {0} thay mặt cho người đăng ký {1}
+email.tiManageYourClients=Quản lý khách hàng của bạn tại {0}.
+error.notFoundDescription=Vui lòng quay lại hoặc chuyển đến {0}
+error.notFoundDescriptionLink=trang chủ
+error.notFoundTitle=Chúng tôi không tìm thấy trang mà bạn cố gắng truy cập
+footer.supportLinkDescription=Để được hỗ trợ kỹ thuật, hãy liên hệ
+guest=Khách
+header.userName=Đã đăng nhập bằng {0}
+input.fileAlreadyUploaded=Tệp đã tải lên: {0}
 label.addressLine2=Căn hộ, phòng, v.v. (không bắt buộc)
 label.city=Thành phố
-label.state=Tiểu bang
-label.selectState=Chọn tiểu bang
-label.street=Địa chỉ
-label.zipcode=Mã bưu chính
-
-validation.streetRequired=Vui lòng nhập số nhà và tên đường hợp lệ.
-validation.cityRequired=Vui lòng nhập tên thành phố.
-validation.currencyMisformatted=Giá trị tiền tệ phải theo một trong những định dạng sau: 1000 1,000 1000.30 1,000.30
-validation.stateRequired=Vui lòng nhập tên tiểu bang.
-validation.invalidZipcode=Vui lòng nhập mã bưu chính hợp lệ gồm 5 chữ số.
-validation.noPoBox=Vui lòng nhập một địa chỉ hợp lệ. Chúng tôi không chấp nhận hộp thư bưu điện.
-
-title.verifyAddress=Xác minh địa chỉ
-
-content.foundSimilarAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp nhưng đã tìm thấy địa chỉ tương tự.
-
-content.addressEntered=Địa chỉ đã nhập:
-
-content.addressEnteredWithQuestionName={0} đã nhập:
-
-content.suggestedAddress=Địa chỉ được đề xuất:
-
-content.suggestedAddresses=Các địa chỉ được đề xuất:
-
-button.editAddress=Chỉnh sửa địa chỉ
-
-button.saveAndConfirm=Lưu và xác nhận
-
-title.noValidAddress=Không tìm thấy địa chỉ hợp lệ
-
-content.noValidAddress=Chúng tôi không thể xác minh địa chỉ do bạn cung cấp. Vui lòng chỉnh sửa địa chỉ của bạn để tiếp tục.
-
-placeholder.noDropdownSelection=Chọn một phương án:
-
-validation.dateMisformatted=Vui lòng nhập ngày ở định dạng YYYY/MM/DD.
-
-button.addEntity=Thêm {0}
-
-button.removeEntity=Xoá {0}
-
-dialog.confirmDelete=Bạn có chắc chắn muốn xoá {0} này không? Chúng tôi sẽ lưu thay đổi khi bạn nhấp "Tiếp tục" và tất cả dữ liệu liên quan đến {0} này sẽ bị mất.
-
-validation.entityNameRequired=Vui lòng nhập một giá trị cho mỗi dòng.
-validation.duplicateEntityName=Vui lòng nhập một giá trị riêng biệt cho mỗi dòng.
-
-placeholder.entityName=Tên {0}
-
-validation.fileRequired=Vui lòng chọn một tệp.
-
-button.chooseFile=Chọn tệp
-
-validation.idTooLong=Chỉ được dài tối đa {0} ký tự.
-validation.idTooShort=Phải có ít nhất {0} ký tự.
-validation.numberRequired=Chỉ được chứa chữ số.
-
-validation.tooFewSelections=Vui lòng chọn ít nhất {0}.
-validation.tooManySelections=Vui lòng chọn ít hơn {0}.
-
 label.firstName=Tên
+label.languageSr=Chọn một ngôn ngữ
 label.lastName=Họ
 label.middleName=Tên đệm
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=Chọn tiểu bang
+label.state=Tiểu bang
+label.street=Địa chỉ
+label.zipcode=Mã bưu chính
+link.adminLogin=Đăng nhập với tư cách quản trị viên
+link.allDone=Tôi đã hoàn thành
+link.answer=Câu trả lời
+link.applyToAnotherProgram=Đăng ký một chương trình khác
+link.createAccountOrSignIn=Tạo tài khoản hoặc đăng nhập
+link.edit=Chỉnh sửa
+link.programDetails=Chi tiết chương trình
+link.programDetailsSr=Chi tiết chương trình {0}
+placeholder.entityName=Tên {0}
 placeholder.firstName=Tên
 placeholder.lastName=Họ
 placeholder.middleName=Tên đệm
+placeholder.noDropdownSelection=Chọn một phương án:
+tag.mayNotQualify=Bạn có thể không đủ tiêu chuẩn
+tag.mayNotQualifyTi=Khách hàng của bạn có thể không đủ tiêu chuẩn
+tag.mayQualify=Bạn có thể đủ tiêu chuẩn
+tag.mayQualifyTi=Khách hàng của bạn có thể đủ tiêu chuẩn
+title.activeProgramsUpdated=Chưa bắt đầu
+title.applicantNotEligible=Dựa trên câu trả lời của bạn cho các câu hỏi sau, bạn có thể không đủ tiêu chuẩn tham gia {0}.
+title.applicantNotEligibleTi=Dựa trên câu trả lời của bạn cho các câu hỏi sau, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}.
+title.applicationConfirmation=Xác nhận đơn đăng ký
+title.cannotCheckEligibility=Hiện tại, chúng tôi không thể kiểm tra xem bạn có đủ điều kiện tham gia {0} hay không.
+title.cannotCheckEligibilityTi=Hiện tại, chúng tôi không thể kiểm tra xem khách hàng của bạn có đủ điều kiện tham gia {0} hay không.
+title.createAnAccount=Tạo tài khoản hoặc đăng nhập
+title.inProgressProgramsUpdated=Đang diễn ra
+title.login=Đăng nhập
+title.noValidAddress=Không tìm thấy địa chỉ hợp lệ
+title.programSummary=Tóm tắt dữ liệu đăng ký tham gia chương trình
+title.programs=Chương trình và dịch vụ
+title.status=Trạng thái
+title.submittedPrograms=Đã gửi
+title.verifyAddress=Xác minh địa chỉ
+toast.applicationOutOfDate=Ứng dụng này đã có bản cập nhật. Vui lòng xem và trả lời các câu hỏi để tiếp tục
+toast.applicationSaved=Đã lưu thành công đơn đăng ký: mã đơn đăng ký {0}
+toast.localeNotSupported=Rất tiếc, chương trình này chưa được dịch hết sang tiếng Việt.
+toast.mayNotQualify=Dựa trên câu trả lời của bạn, bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
+toast.mayNotQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của khách hàng của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
+toast.mayQualify=Dựa trên câu trả lời của bạn, bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
+toast.mayQualifyTi=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể đủ tiêu chuẩn tham gia {0}. Để tiếp tục, hãy tiếp tục điền vào đơn đăng ký.
+toast.programCompleted=Đăng ký thành công.
+validation.cityRequired=Vui lòng nhập tên thành phố.
+validation.currencyMisformatted=Giá trị tiền tệ phải theo một trong những định dạng sau: 1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=Vui lòng nhập ngày ở định dạng YYYY/MM/DD.
+validation.duplicateEntityName=Vui lòng nhập một giá trị riêng biệt cho mỗi dòng.
+validation.entityNameRequired=Vui lòng nhập một giá trị cho mỗi dòng.
+validation.errorAnnouncementSr=Có lỗi trong biểu mẫu. Vui lòng khắc phục trước khi tiếp tục.
+validation.fileRequired=Vui lòng chọn một tệp.
 validation.firstNameRequired=Vui lòng nhập tên của bạn.
+validation.idTooLong=Chỉ được dài tối đa {0} ký tự.
+validation.idTooShort=Phải có ít nhất {0} ký tự.
+validation.invalidInput=Vui lòng nhập thông tin hợp lệ.
+validation.invalidZipcode=Vui lòng nhập mã bưu chính hợp lệ gồm 5 chữ số.
+validation.isRequired=Đây là câu hỏi bắt buộc.
 validation.lastNameRequired=Vui lòng nhập họ của bạn.
-
+validation.noPoBox=Vui lòng nhập một địa chỉ hợp lệ. Chúng tôi không chấp nhận hộp thư bưu điện.
+validation.numberNonInteger=Phải là số nguyên dương và chỉ có thể chứa ký tự chữ số từ 0-9.
+validation.numberRequired=Chỉ được chứa chữ số.
 validation.numberTooBig=Không được lớn hơn {0}.
 validation.numberTooSmall=Không được nhỏ hơn {0}.
-validation.numberNonInteger=Phải là số nguyên dương và chỉ có thể chứa ký tự chữ số từ 0-9.
-
+validation.stateRequired=Vui lòng nhập tên tiểu bang.
+validation.streetRequired=Vui lòng nhập số nhà và tên đường hợp lệ.
 validation.textTooLong=Chỉ được dài tối đa {0} ký tự.
 validation.textTooShort=Phải có ít nhất {0} ký tự.
-
-adminValidation.multiOptionEmpty=Không được để lựa chọn trống trong câu hỏi có nhiều lựa chọn.
-
-error.notFoundTitle=Chúng tôi không tìm thấy trang mà bạn cố gắng truy cập
-error.notFoundDescription=Vui lòng quay lại hoặc chuyển đến {0}
-error.notFoundDescriptionLink=trang chủ
-
-email.loginToCiviform=Đăng nhập vào CiviForm tại {0}
-
-email.applicationReceivedSubject=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn
-
-email.applicationReceivedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} của bạn. Mã người đăng ký của bạn là {1} và mã đơn đăng ký là {2}
-
-email.tiApplicationSubmittedSubject=Bạn đã gửi đơn đăng ký tham gia chương trình {0} thay mặt cho người đăng ký {1}
-
-email.tiApplicationSubmittedBody=Chúng tôi đã nhận được đơn đăng ký tham gia chương trình {0} với tư cách là người đăng ký {1}, và mã đơn đăng ký là {2}.
-
-email.tiManageYourClients=Quản lý khách hàng của bạn tại {0}.
+validation.tooFewSelections=Vui lòng chọn ít nhất {0}.
+validation.tooManySelections=Vui lòng chọn ít hơn {0}.

--- a/server/conf/messages.zh-TW
+++ b/server/conf/messages.zh-TW
@@ -12,286 +12,171 @@ label.selectLanguage=Please select your preferred language.
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=登出
 
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=如需技術支援，請洽詢
 
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
 guest=訪客
 
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=選擇語言
 
-# Message with user's name to show who you are logged in as.
 header.userName=目前登入身分：{0}
 
-# Error message to answer a required question
 validation.isRequired=這是必答問題。
 
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=請輸入有效內容。
 
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=表單中出現錯誤，請修正錯誤再繼續。
 
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=注意：標有 * 的欄位為必填欄位。
 
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=如果您是使用手機操作，還可以透過「選擇檔案」按鈕用手機相機上傳文件。
 
-#-------------------------------------------------------------#
-# LOGIN - contains text that for login page.                  #
-#-------------------------------------------------------------#
-
-# Title of the login page.
 title.login=登錄
 
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=請使用「{0}」帳戶登入
 
-# The text on the button an applicant clicks to log in to their session.
 button.login=登入
 
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=還沒有帳戶嗎？
 
-# The text between creating a new account, and becoming a guest
 content.or=或
 
-# The text on the button for applicants to create a new account.
 button.createAccount=建立帳戶
 
-# The text on the button for guests to log in to their session.
 button.guestLogin=繼續以訪客身分使用
 
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=目前無法登入帳戶
 
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=需要其他協助嗎？
 
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=管理員登入
 
-#--------------------------------------------------------------------------#
-# PROGRAM FORM - contains text shown when filling out an application form. #
-#--------------------------------------------------------------------------#
-
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=已上傳檔案：{0}
 
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=刪除
 
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=繼續
 
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=儲存並繼續
 
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=上一個畫面
 
-# The text on the button an applicant clicks to jump to the review page.
 button.review=檢查
 
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=略過
 
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=很抱歉，本計畫未提供完整翻譯版。
 
-# A link that logs out a guest user after they submit an application.
 link.allDone=我完成了
 
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=申請其他計畫
 
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=建立或登入帳戶
 
-#----------------------------------------------------------------------------#
-# APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
-#----------------------------------------------------------------------------#
-
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=申請
 
-# The text read for screen readers.
 button.applySr=申請「{0}」
 
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=編輯
 
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=編輯已提交的「{0}」申請資料
 
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=繼續申請「{0}」
 
-# Text describing the date the application was last submitted.
 content.submittedDate=提交於 {0}
 
-# "Get benefits" floating text
 content.benefits=取得福利
 
-# Long form description of the CiviForm site shown to the applicant. Line 1.
 content.description1=CiviForm 支援重複使用相同資訊一次申請多項福利。
 
-# Long form description of the CiviForm site shown to the applicant. Line 2.
 content.description2=首先是在下方選擇申請項目。
 
-# Link text to read more about a program.
 link.programDetails=計畫詳情
 
-# The same text, read for screen readers.
 link.programDetailsSr=「{0}」計畫詳情
 
-# The title of the page for the list of programs.
 title.programs=計畫與服務
 
-# For the badge on the program list index denoting the current status of an application
 title.status=狀態
 
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=進行中
 
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=未開始
 
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=已提交
 
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=申請資料儲存成功：申請編號 {0}
 
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=已完成申請。
 
-#------------------------------------------------------------------------#
-# APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
-#------------------------------------------------------------------------#
-
-# Submit application button
 button.submit=提交
 
-# Continue application button
 button.continue=繼續
 
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=申請內容有所更新，如要繼續操作，請查看並回答問題
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
 content.notEligible=不符合資格
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=不符合資格
 
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=編輯
 link.answer=回答問題
 
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=已於 {0}回答
 
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
 ariaLabel.begin=從這裡開始作答。{0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=編輯「{0}」
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.answer=回答以下問題：{0}
 
-# Program Summary Title
 title.programSummary=計畫申請摘要
 
-#------------------------------------------------------------------------#
-# APPLICANT ELIGIBILITY - text related to applicant eligibility #
-#------------------------------------------------------------------------#
-
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=根據您對下列問題的回覆，您可能不符合「{0}」的資格。
 
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client's behalf. This text includes the program name.
 title.applicantNotEligibleTi=根據您對下列問題的回覆，您的客戶可能不符合「{0}」的資格。
 
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=如要瞭解資格條件，請參閱：{0}
 
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=您可以返回上一頁編輯回答，也可以申請其他計畫。
 
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=返回並編輯
 
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayQualifyTi=根據您的回覆，您的客戶可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
 
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=根據您的回覆，您可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
 
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=您可能符合資格
 
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayQualifyTi=您的客戶可能符合資格
 
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=您可能不符合資格
 
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client's behalf.
 tag.mayNotQualifyTi=您的客戶可能不符合資格
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
 title.cannotCheckEligibility=我們目前無法判斷您是否符合「{0}」的資格。
 
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client's behalf.
 title.cannotCheckEligibilityTi=我們目前無法判斷您的客戶是否符合「{0}」的資格。
 
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
 content.cannotCheckEligibility=我們會盡力在短時間內修正這個問題，請稍後再試。
 
-# Button that allows an applicant to view all programs.
 button.viewAllPrograms=查看所有計畫
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=根據您的回覆，您可能不符合「{0}」的資格。如果您的資訊有所變更，可以編輯回答並繼續進行申請流程。
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client's behalf.
 toast.mayNotQualifyTi=根據您的回覆，您的客戶可能不符合「{0}」的資格。如果客戶的資訊有所變更，您可以編輯回答並繼續進行申請流程。
 
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=儲存申請書時發生錯誤
 
-#---------------------------------------------------------------------------------------------#
-# APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
-#---------------------------------------------------------------------------------------------#
-
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=申請確認
 
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=感謝你申請「{0}」。我們已收到相關申請資料，申請編號為 {1}。
 
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=建立或登入帳戶
 
-# A message urging users to create an account to save their data.
 content.pleaseCreateAccount=如果現在登入城市帳戶，系統會儲存你的資訊，你之後隨時能使用這些資訊提出其他申請。如果你還沒有帳戶，可以在登入頁面註冊。已經輸入的資料並不會遺失。
 
-#----------------------------------------------------------#
-# ADDRESS QUESTION - text when viewing an address question #
-#----------------------------------------------------------#
-
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=公寓、套房等 (選填)
 label.city=城市
 label.state=州
@@ -299,7 +184,6 @@ label.selectState=請選取州
 label.street=地址
 label.zipcode=郵遞區號
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=請輸入有效的街道名稱和號碼。
 validation.cityRequired=請輸入城市。
 validation.currencyMisformatted=請使用下列其中一種貨幣格式：1000 1,000 1000.30 1,000.30
@@ -307,165 +191,85 @@ validation.stateRequired=請輸入州別。
 validation.invalidZipcode=請輸入有效的 5 位數郵遞區號。
 validation.noPoBox=請輸入有效地址，切勿提供郵政信箱。
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=驗證地址
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=我們無法驗證您提供的地址，但找到了類似的地址。
 
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=您輸入的地址：
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
 content.addressEnteredWithQuestionName=您輸入的{0}：
 
-# Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=建議的地址：
 
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=建議的地址：
 
-# Button to close the address correction dialog and allow applicant to edit address manually.
 button.editAddress=編輯地址
 
-# Button for applicant to save and confirm the address suggested in the dialog.
 button.saveAndConfirm=儲存並確認
 
-# Title on address correction dialog when no address is found.
 title.noValidAddress=找不到有效的網址
 
-# Content on address correction dialog when no address is found.
 content.noValidAddress=我們無法驗證您提供的地址。如要繼續操作，請編輯地址。
 
-#----------------------------------------------------------------------------------------------------------#
-# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
-#----------------------------------------------------------------------------------------------------------#
-
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=選擇一個選項：
 
-
-#----------------------------------------------------------------------------------------------------------#
-# DATE QUESTION - text shown when answering a question where a user must select date. #
-#----------------------------------------------------------------------------------------------------------#
 validation.dateMisformatted=日期格式必須為 YYYY/MM/DD。
 
-#--------------------------------------------------------------------------------------------------------#
-# ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
-#--------------------------------------------------------------------------------------------------------#
-
-# Text on a button an applicant would click to add another entity
 button.addEntity=新增「{0}」
 
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=移除「{0}」
 
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=確定要移除此「{0}」嗎？點選「下一步」後，系統就會儲存變更並移除與此「{0}」相關的所有資料。
 
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=請每行輸入一個值。
 
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=每行輸入的值不可重複。
 
-# The placeholder text for enumerator fields
 placeholder.entityName=「{0}」名稱
 
-#---------------------------------------------------------------------------------#
-# FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
-#---------------------------------------------------------------------------------#
-
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=請選取檔案。
 
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=選擇檔案
 
-#---------------------------------------------------------------------#
-# ID QUESTION - id specific to filling out a question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=長度不可超過 {0} 個字元。
 validation.idTooShort=長度不可少於 {0} 個字元。
 validation.numberRequired=只能輸入數字。
 
-#----------------------------------------------------------------------------------------------------------#
-# MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
-#----------------------------------------------------------------------------------------------------------#
-
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=請至少選取 {0} 項。
 validation.tooManySelections=最多只能選取 {0} 項。
 
-#---------------------------------------------------#
-# NAME QUESTION - text when viewing a name question #
-#---------------------------------------------------#
-
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=名字
 label.lastName=姓氏
 label.middleName=中間名
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=名字
 placeholder.lastName=姓氏
 placeholder.middleName=中間名
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=請輸入名字。
 validation.lastNameRequired=請輸入姓氏。
 
-#------------------------------------------------------------------------#
-# NUMBER QUESTION - text specific to answering a question with a number. #
-#------------------------------------------------------------------------#
-
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=數字不得大於 {0}。
 validation.numberTooSmall=數字不得小於 {0}。
 validation.numberNonInteger=數字必須為正整數，而且只含 0 到 9 的數值字元。
 
-#---------------------------------------------------------------------#
-# TEXT QUESTION - text specific to filling out a question with words. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=長度不可超過 {0} 個字元。
 validation.textTooShort=長度不可少於 {0} 個字元。
 
-
-#---------------------------------------------------------------------#
-# MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
-#---------------------------------------------------------------------#
-
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=多選題不得留空。
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
 error.notFoundTitle=我們找不到你嘗試前往的頁面
 error.notFoundDescription=請回到上一個頁面或返回 {0}
 error.notFoundDescriptionLink=首頁
 
-#-------------------------------------------------------#
-# Email - text specific to emails sent to users         #
-#-------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
 email.loginToCiviform=前往 {0} 登入 CiviForm
 
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=我們已收到您的「{0}」計畫申請書
 
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=我們已收到您的「{0}」計畫申請書。您的申請者 ID 為 {1}，申請 ID 為 {2}
 
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=您已代替申請者「{1}」提交「{0}」計畫的申請書
 
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=我們已收到您代替申請者「{1}」提交的「{0}」計畫申請書，申請 ID 為 {2}。
 
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=如要管理您的客戶，請前往 {0}。

--- a/server/conf/messages.zh-TW
+++ b/server/conf/messages.zh-TW
@@ -6,270 +6,150 @@
 # https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 # ------------------------------------------------------------------------------- #
 
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-label.selectLanguage=Please select your preferred language.
-
+adminValidation.multiOptionEmpty=多選題不得留空。
+ariaLabel.answer=回答以下問題：{0}
+ariaLabel.begin=從這裡開始作答。{0}
+ariaLabel.edit=編輯「{0}」
+banner.errorSavingApplication=儲存申請書時發生錯誤
+button.addEntity=新增「{0}」
+button.apply=申請
+button.applySr=申請「{0}」
+button.chooseFile=選擇檔案
+button.continue=繼續
+button.continueSr=繼續申請「{0}」
+button.createAccount=建立帳戶
+button.deleteFile=刪除
+button.edit=編輯
+button.editAddress=編輯地址
+button.editSr=編輯已提交的「{0}」申請資料
+button.goBackAndEdit=返回並編輯
+button.guestLogin=繼續以訪客身分使用
+button.keepFile=繼續
+button.login=登入
+button.logout=登出
+button.nextScreen=儲存並繼續
+button.previousScreen=上一個畫面
+button.removeEntity=移除「{0}」
+button.review=檢查
+button.saveAndConfirm=儲存並確認
+button.skipFileUpload=略過
+button.submit=提交
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-button.logout=登出
-
-footer.supportLinkDescription=如需技術支援，請洽詢
-
-guest=訪客
-
-label.languageSr=選擇語言
-
-header.userName=目前登入身分：{0}
-
-validation.isRequired=這是必答問題。
-
-validation.invalidInput=請輸入有效內容。
-
-validation.errorAnnouncementSr=表單中出現錯誤，請修正錯誤再繼續。
-
-content.requiredFieldsAnnotation=注意：標有 * 的欄位為必填欄位。
-
-content.mobileFileUploadHelp=如果您是使用手機操作，還可以透過「選擇檔案」按鈕用手機相機上傳文件。
-
-title.login=登錄
-
-content.loginPrompt=請使用「{0}」帳戶登入
-
-button.login=登入
-
-content.alternativeLoginPrompt=還沒有帳戶嗎？
-
-content.or=或
-
-button.createAccount=建立帳戶
-
-button.guestLogin=繼續以訪客身分使用
-
-content.loginDisabledPrompt=目前無法登入帳戶
-
-content.adminLoginPrompt=需要其他協助嗎？
-
-link.adminLogin=管理員登入
-
-input.fileAlreadyUploaded=已上傳檔案：{0}
-
-button.deleteFile=刪除
-
-button.keepFile=繼續
-
-button.nextScreen=儲存並繼續
-
-button.previousScreen=上一個畫面
-
-button.review=檢查
-
-button.skipFileUpload=略過
-
-toast.localeNotSupported=很抱歉，本計畫未提供完整翻譯版。
-
-link.allDone=我完成了
-
-link.applyToAnotherProgram=申請其他計畫
-
-link.createAccountOrSignIn=建立或登入帳戶
-
-button.apply=申請
-
-button.applySr=申請「{0}」
-
-button.edit=編輯
-
-button.editSr=編輯已提交的「{0}」申請資料
-
-button.continueSr=繼續申請「{0}」
-
-content.submittedDate=提交於 {0}
-
-content.benefits=取得福利
-
-content.description1=CiviForm 支援重複使用相同資訊一次申請多項福利。
-
-content.description2=首先是在下方選擇申請項目。
-
-link.programDetails=計畫詳情
-
-link.programDetailsSr=「{0}」計畫詳情
-
-title.programs=計畫與服務
-
-title.status=狀態
-
-title.inProgressProgramsUpdated=進行中
-
-title.activeProgramsUpdated=未開始
-
-title.submittedPrograms=已提交
-
-toast.applicationSaved=申請資料儲存成功：申請編號 {0}
-
-toast.programCompleted=已完成申請。
-
-button.submit=提交
-
-button.continue=繼續
-
-toast.applicationOutOfDate=申請內容有所更新，如要繼續操作，請查看並回答問題
-
-content.notEligible=不符合資格
-
-content.doesNotQualify=不符合資格
-
-link.edit=編輯
-link.answer=回答問題
-
-content.previouslyAnsweredOn=已於 {0}回答
-
-ariaLabel.begin=從這裡開始作答。{0}
-
-ariaLabel.edit=編輯「{0}」
-
-ariaLabel.answer=回答以下問題：{0}
-
-title.programSummary=計畫申請摘要
-
-title.applicantNotEligible=根據您對下列問題的回覆，您可能不符合「{0}」的資格。
-
-title.applicantNotEligibleTi=根據您對下列問題的回覆，您的客戶可能不符合「{0}」的資格。
-
-content.eligibilityCriteria=如要瞭解資格條件，請參閱：{0}
-
-content.changeAnswersForEligibility=您可以返回上一頁編輯回答，也可以申請其他計畫。
-
-button.goBackAndEdit=返回並編輯
-
-toast.mayQualifyTi=根據您的回覆，您的客戶可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
-
-toast.mayQualify=根據您的回覆，您可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
-
-tag.mayQualify=您可能符合資格
-
-tag.mayQualifyTi=您的客戶可能符合資格
-
-tag.mayNotQualify=您可能不符合資格
-
-tag.mayNotQualifyTi=您的客戶可能不符合資格
-
-title.cannotCheckEligibility=我們目前無法判斷您是否符合「{0}」的資格。
-
-title.cannotCheckEligibilityTi=我們目前無法判斷您的客戶是否符合「{0}」的資格。
-
-content.cannotCheckEligibility=我們會盡力在短時間內修正這個問題，請稍後再試。
-
 button.viewAllPrograms=查看所有計畫
-
-toast.mayNotQualify=根據您的回覆，您可能不符合「{0}」的資格。如果您的資訊有所變更，可以編輯回答並繼續進行申請流程。
-
-toast.mayNotQualifyTi=根據您的回覆，您的客戶可能不符合「{0}」的資格。如果客戶的資訊有所變更，您可以編輯回答並繼續進行申請流程。
-
-banner.errorSavingApplication=儲存申請書時發生錯誤
-
-title.applicationConfirmation=申請確認
-
+content.addressEntered=您輸入的地址：
+content.addressEnteredWithQuestionName=您輸入的{0}：
+content.adminLoginPrompt=需要其他協助嗎？
+content.alternativeLoginPrompt=還沒有帳戶嗎？
+content.benefits=取得福利
+content.cannotCheckEligibility=我們會盡力在短時間內修正這個問題，請稍後再試。
+content.changeAnswersForEligibility=您可以返回上一頁編輯回答，也可以申請其他計畫。
 content.confirmed=感謝你申請「{0}」。我們已收到相關申請資料，申請編號為 {1}。
-
-title.createAnAccount=建立或登入帳戶
-
+content.description1=CiviForm 支援重複使用相同資訊一次申請多項福利。
+content.description2=首先是在下方選擇申請項目。
+content.doesNotQualify=不符合資格
+content.eligibilityCriteria=如要瞭解資格條件，請參閱：{0}
+content.foundSimilarAddress=我們無法驗證您提供的地址，但找到了類似的地址。
+content.loginDisabledPrompt=目前無法登入帳戶
+content.loginPrompt=請使用「{0}」帳戶登入
+content.mobileFileUploadHelp=如果您是使用手機操作，還可以透過「選擇檔案」按鈕用手機相機上傳文件。
+content.noValidAddress=我們無法驗證您提供的地址。如要繼續操作，請編輯地址。
+content.notEligible=不符合資格
+content.or=或
 content.pleaseCreateAccount=如果現在登入城市帳戶，系統會儲存你的資訊，你之後隨時能使用這些資訊提出其他申請。如果你還沒有帳戶，可以在登入頁面註冊。已經輸入的資料並不會遺失。
-
+content.previouslyAnsweredOn=已於 {0}回答
+content.requiredFieldsAnnotation=注意：標有 * 的欄位為必填欄位。
+content.submittedDate=提交於 {0}
+content.suggestedAddress=建議的地址：
+content.suggestedAddresses=建議的地址：
+dialog.confirmDelete=確定要移除此「{0}」嗎？點選「下一步」後，系統就會儲存變更並移除與此「{0}」相關的所有資料。
+email.applicationReceivedBody=我們已收到您的「{0}」計畫申請書。您的申請者 ID 為 {1}，申請 ID 為 {2}
+email.applicationReceivedSubject=我們已收到您的「{0}」計畫申請書
+email.loginToCiviform=前往 {0} 登入 CiviForm
+email.tiApplicationSubmittedBody=我們已收到您代替申請者「{1}」提交的「{0}」計畫申請書，申請 ID 為 {2}。
+email.tiApplicationSubmittedSubject=您已代替申請者「{1}」提交「{0}」計畫的申請書
+email.tiManageYourClients=如要管理您的客戶，請前往 {0}。
+error.notFoundDescription=請回到上一個頁面或返回 {0}
+error.notFoundDescriptionLink=首頁
+error.notFoundTitle=我們找不到你嘗試前往的頁面
+footer.supportLinkDescription=如需技術支援，請洽詢
+guest=訪客
+header.userName=目前登入身分：{0}
+input.fileAlreadyUploaded=已上傳檔案：{0}
 label.addressLine2=公寓、套房等 (選填)
 label.city=城市
-label.state=州
-label.selectState=請選取州
-label.street=地址
-label.zipcode=郵遞區號
-
-validation.streetRequired=請輸入有效的街道名稱和號碼。
-validation.cityRequired=請輸入城市。
-validation.currencyMisformatted=請使用下列其中一種貨幣格式：1000 1,000 1000.30 1,000.30
-validation.stateRequired=請輸入州別。
-validation.invalidZipcode=請輸入有效的 5 位數郵遞區號。
-validation.noPoBox=請輸入有效地址，切勿提供郵政信箱。
-
-title.verifyAddress=驗證地址
-
-content.foundSimilarAddress=我們無法驗證您提供的地址，但找到了類似的地址。
-
-content.addressEntered=您輸入的地址：
-
-content.addressEnteredWithQuestionName=您輸入的{0}：
-
-content.suggestedAddress=建議的地址：
-
-content.suggestedAddresses=建議的地址：
-
-button.editAddress=編輯地址
-
-button.saveAndConfirm=儲存並確認
-
-title.noValidAddress=找不到有效的網址
-
-content.noValidAddress=我們無法驗證您提供的地址。如要繼續操作，請編輯地址。
-
-placeholder.noDropdownSelection=選擇一個選項：
-
-validation.dateMisformatted=日期格式必須為 YYYY/MM/DD。
-
-button.addEntity=新增「{0}」
-
-button.removeEntity=移除「{0}」
-
-dialog.confirmDelete=確定要移除此「{0}」嗎？點選「下一步」後，系統就會儲存變更並移除與此「{0}」相關的所有資料。
-
-validation.entityNameRequired=請每行輸入一個值。
-
-validation.duplicateEntityName=每行輸入的值不可重複。
-
-placeholder.entityName=「{0}」名稱
-
-validation.fileRequired=請選取檔案。
-
-button.chooseFile=選擇檔案
-
-validation.idTooLong=長度不可超過 {0} 個字元。
-validation.idTooShort=長度不可少於 {0} 個字元。
-validation.numberRequired=只能輸入數字。
-
-validation.tooFewSelections=請至少選取 {0} 項。
-validation.tooManySelections=最多只能選取 {0} 項。
-
 label.firstName=名字
+label.languageSr=選擇語言
 label.lastName=姓氏
 label.middleName=中間名
-
+# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
+label.selectLanguage=Please select your preferred language.
+label.selectState=請選取州
+label.state=州
+label.street=地址
+label.zipcode=郵遞區號
+link.adminLogin=管理員登入
+link.allDone=我完成了
+link.answer=回答問題
+link.applyToAnotherProgram=申請其他計畫
+link.createAccountOrSignIn=建立或登入帳戶
+link.edit=編輯
+link.programDetails=計畫詳情
+link.programDetailsSr=「{0}」計畫詳情
+placeholder.entityName=「{0}」名稱
 placeholder.firstName=名字
 placeholder.lastName=姓氏
 placeholder.middleName=中間名
-
+placeholder.noDropdownSelection=選擇一個選項：
+tag.mayNotQualify=您可能不符合資格
+tag.mayNotQualifyTi=您的客戶可能不符合資格
+tag.mayQualify=您可能符合資格
+tag.mayQualifyTi=您的客戶可能符合資格
+title.activeProgramsUpdated=未開始
+title.applicantNotEligible=根據您對下列問題的回覆，您可能不符合「{0}」的資格。
+title.applicantNotEligibleTi=根據您對下列問題的回覆，您的客戶可能不符合「{0}」的資格。
+title.applicationConfirmation=申請確認
+title.cannotCheckEligibility=我們目前無法判斷您是否符合「{0}」的資格。
+title.cannotCheckEligibilityTi=我們目前無法判斷您的客戶是否符合「{0}」的資格。
+title.createAnAccount=建立或登入帳戶
+title.inProgressProgramsUpdated=進行中
+title.login=登錄
+title.noValidAddress=找不到有效的網址
+title.programSummary=計畫申請摘要
+title.programs=計畫與服務
+title.status=狀態
+title.submittedPrograms=已提交
+title.verifyAddress=驗證地址
+toast.applicationOutOfDate=申請內容有所更新，如要繼續操作，請查看並回答問題
+toast.applicationSaved=申請資料儲存成功：申請編號 {0}
+toast.localeNotSupported=很抱歉，本計畫未提供完整翻譯版。
+toast.mayNotQualify=根據您的回覆，您可能不符合「{0}」的資格。如果您的資訊有所變更，可以編輯回答並繼續進行申請流程。
+toast.mayNotQualifyTi=根據您的回覆，您的客戶可能不符合「{0}」的資格。如果客戶的資訊有所變更，您可以編輯回答並繼續進行申請流程。
+toast.mayQualify=根據您的回覆，您可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
+toast.mayQualifyTi=根據您的回覆，您的客戶可能符合「{0}」的資格。如要繼續申請，請填妥申請書。
+toast.programCompleted=已完成申請。
+validation.cityRequired=請輸入城市。
+validation.currencyMisformatted=請使用下列其中一種貨幣格式：1000 1,000 1000.30 1,000.30
+validation.dateMisformatted=日期格式必須為 YYYY/MM/DD。
+validation.duplicateEntityName=每行輸入的值不可重複。
+validation.entityNameRequired=請每行輸入一個值。
+validation.errorAnnouncementSr=表單中出現錯誤，請修正錯誤再繼續。
+validation.fileRequired=請選取檔案。
 validation.firstNameRequired=請輸入名字。
+validation.idTooLong=長度不可超過 {0} 個字元。
+validation.idTooShort=長度不可少於 {0} 個字元。
+validation.invalidInput=請輸入有效內容。
+validation.invalidZipcode=請輸入有效的 5 位數郵遞區號。
+validation.isRequired=這是必答問題。
 validation.lastNameRequired=請輸入姓氏。
-
+validation.noPoBox=請輸入有效地址，切勿提供郵政信箱。
+validation.numberNonInteger=數字必須為正整數，而且只含 0 到 9 的數值字元。
+validation.numberRequired=只能輸入數字。
 validation.numberTooBig=數字不得大於 {0}。
 validation.numberTooSmall=數字不得小於 {0}。
-validation.numberNonInteger=數字必須為正整數，而且只含 0 到 9 的數值字元。
-
+validation.stateRequired=請輸入州別。
+validation.streetRequired=請輸入有效的街道名稱和號碼。
 validation.textTooLong=長度不可超過 {0} 個字元。
 validation.textTooShort=長度不可少於 {0} 個字元。
-
-adminValidation.multiOptionEmpty=多選題不得留空。
-
-error.notFoundTitle=我們找不到你嘗試前往的頁面
-error.notFoundDescription=請回到上一個頁面或返回 {0}
-error.notFoundDescriptionLink=首頁
-
-email.loginToCiviform=前往 {0} 登入 CiviForm
-
-email.applicationReceivedSubject=我們已收到您的「{0}」計畫申請書
-
-email.applicationReceivedBody=我們已收到您的「{0}」計畫申請書。您的申請者 ID 為 {1}，申請 ID 為 {2}
-
-email.tiApplicationSubmittedSubject=您已代替申請者「{1}」提交「{0}」計畫的申請書
-
-email.tiApplicationSubmittedBody=我們已收到您代替申請者「{1}」提交的「{0}」計畫申請書，申請 ID 為 {2}。
-
-email.tiManageYourClients=如要管理您的客戶，請前往 {0}。
+validation.tooFewSelections=請至少選取 {0} 項。
+validation.tooManySelections=最多只能選取 {0} 項。


### PR DESCRIPTION
### Description

Removes comments and whitespace, and alphabetizes lines in non-primary (not `messages`) messages files. `conf/MessagesTest.java` in the base branch enforces that no keys were lost in this process.

Although this review diffs against `mzetune/messages-test`, I will merge this PR into `main` once that base is merged in upon approval of #4516.

### Checklist

- [x] Removed comments and empty lines from all non-primary language files.
- [x] Alphabetized keys in non-primary language files
   * While we would like to enforce this in `MessagesTest.java`, it is not possible because the Java `Properties` class reads in the keys into a HashMap. So we alphabetize them now and can maintain this on a best-effort basis.

