### PR TITLE
Update browser test batch count to 10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        batch_number: [1, 2, 3, 4]
+        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - name: check out ${{ env.GITHUB_REF }}
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        batch_number: [1, 2, 3, 4]
+        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - name: check out ${{ env.GITHUB_REF }}

--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -23,7 +23,7 @@ jobs:
   run_browser_tests_aws:
     strategy:
       matrix:
-        batch_number: [1, 2, 3, 4]
+        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'
@@ -31,7 +31,7 @@ jobs:
   run_browser_tests_azure:
     strategy:
       matrix:
-        batch_number: [1, 2, 3, 4]
+        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'

--- a/bin/run-browser-tests-ci-batch
+++ b/bin/run-browser-tests-ci-batch
@@ -8,7 +8,7 @@ import math
 import subprocess
 import sys
 
-BATCH_COUNT = 4
+BATCH_COUNT = 10
 
 
 def bad_batch_number_input(batch_num_input):


### PR DESCRIPTION
### Description

This should improve our browser test runtime which has been taking upwards of 30 minutes on some PRs. We simply parallelize with 10 actions instead of 4.