### PR TITLE
Temporary fix for program index page

### DIFF
--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -1896,6 +1896,10 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withEligibilityDefinition(eligibilityDef)
             .build();
 
+    Question q = new Question(questionDefinition);
+    q.refresh();
+    versionRepository.getActiveVersion().addQuestion(q).save();
+
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraft.id)
         .toCompletableFuture()
@@ -2260,6 +2264,11 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
+    originalProgram.getVersions().stream()
+        .findAny()
+        .orElseThrow()
+        .addQuestion(testQuestionBank.applicantFavoriteColor())
+        .save();
 
     Account adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
     Application submittedApplication =


### PR DESCRIPTION
Because some of the programs are not in the active version, and we need to sync the questions for each program to calculate eligibility state, we must sync each program with a version it is associated with. This is a quick fix to utilize the ReadOnlyVersionedQuestionService instead of the ReadOnlyCurrentQuestionService.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4507
