### PR TITLE
bumped test timeout to 8 seconds

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -209,7 +209,7 @@ export const createTestContext = (clearDb = true): TestContext => {
     // Default timeout is 30s. It's too long given that civiform is not JS
     // heavy and all elements render quite quickly. Setting it to 5 sec so that
     // tests fail fast.
-    ctx.page.setDefaultTimeout(5000)
+    ctx.page.setDefaultTimeout(8000)
     ctx.adminQuestions = new AdminQuestions(ctx.page)
     ctx.adminPrograms = new AdminPrograms(ctx.page)
     ctx.adminApiKeys = new AdminApiKeys(ctx.page)


### PR DESCRIPTION
### Description

Prober tests have been [consistently failing on AWS staging deploys](https://github.com/civiform/civiform-staging-deploy/actions/runs/4556703251) because of an issue related to submitting applications. This PR bumps the timeout of tests to 8 seconds to unblock staging deploys. 

See latency spikes for the submit action in [this Grafana dashboard](https://g-f50cfd0cff.grafana-workspace.us-east-1.amazonaws.com/d/p5kGWLV4z/civiform-server?orgId=1). Spikes have not passed 8 seconds.