### PR TITLE
Remove eligibility criteria for the common intake form.

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -15,6 +15,7 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
+import services.program.EligibilityNotValidForProgramTypeException;
 import services.program.IllegalPredicateOrderingException;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
@@ -318,7 +319,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     } catch (IllegalPredicateOrderingException
         | QuestionNotFoundException
-        | ProgramQuestionDefinitionNotFoundException e) {
+        | ProgramQuestionDefinitionNotFoundException
+        | EligibilityNotValidForProgramTypeException e) {
       return redirect(
               routes.AdminProgramBlockPredicatesController.editEligibility(
                   programId, blockDefinitionId))

--- a/server/app/services/program/EligibilityNotValidForProgramTypeException.java
+++ b/server/app/services/program/EligibilityNotValidForProgramTypeException.java
@@ -1,0 +1,12 @@
+package services.program;
+
+/**
+ * EligibilityNotValidForProgramType is thrown when eligibility predicates are attempted to be added
+ * to a Program that has a ProgramType that cannot have eligibility conditions.
+ */
+public class EligibilityNotValidForProgramTypeException extends Exception {
+
+  public EligibilityNotValidForProgramTypeException() {
+    super("Eligibility conditions cannot be set for this ProgramType.");
+  }
+}

--- a/server/app/services/program/EligibilityNotValidForProgramTypeException.java
+++ b/server/app/services/program/EligibilityNotValidForProgramTypeException.java
@@ -6,7 +6,9 @@ package services.program;
  */
 public class EligibilityNotValidForProgramTypeException extends Exception {
 
-  public EligibilityNotValidForProgramTypeException() {
-    super("Eligibility conditions cannot be set for this ProgramType.");
+  public EligibilityNotValidForProgramTypeException(ProgramType programType) {
+    super(
+        String.format(
+            "Eligibility conditions cannot be set for ProgramType %s", programType.toString()));
   }
 }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -307,11 +307,13 @@ public interface ProgramService {
    * @throws ProgramBlockDefinitionNotFoundException when blockDefinitionId does not correspond to a
    *     real Block.
    * @throws IllegalPredicateOrderingException if this predicate cannot be added to this block
+   * @throws EligibilityNotValidForProgramTypeException if this predicate cannot be added to this
+   *     ProgramType
    */
   ProgramDefinition setBlockEligibilityDefinition(
       long programId, long blockDefinitionId, Optional<EligibilityDefinition> eligibility)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
-          IllegalPredicateOrderingException;
+          IllegalPredicateOrderingException, EligibilityNotValidForProgramTypeException;
 
   /**
    * Remove the visibility {@link PredicateDefinition} for a block.

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -838,7 +838,7 @@ public final class ProgramServiceImpl implements ProgramService {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
     if (programDefinition.isCommonIntakeForm() && eligibility.isPresent()) {
-      throw new EligibilityNotValidForProgramTypeException();
+      throw new EligibilityNotValidForProgramTypeException(programDefinition.programType());
     }
 
     BlockDefinition blockDefinition =
@@ -875,7 +875,7 @@ public final class ProgramServiceImpl implements ProgramService {
     } catch (EligibilityNotValidForProgramTypeException e) {
       // Removing eligibility predicates should always be valid.
       throw new RuntimeException(
-          "Unexpected error: removing this predicate is not allowed for this ProgramType");
+          "Unexpected error: removing this predicate is not allowed for this ProgramType", e);
     }
   }
 

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -306,7 +306,7 @@ public final class ProgramServiceImpl implements ProgramService {
 
     if (programType.equals(ProgramType.COMMON_INTAKE_FORM)
         && !programDefinition.isCommonIntakeForm()) {
-      programDefinition = removeAllBlockEligibilityPredicates(programDefinition);
+      programDefinition = removeAllEligibilityPredicates(programDefinition);
     }
 
     Program program =
@@ -873,6 +873,7 @@ public final class ProgramServiceImpl implements ProgramService {
       // Removing a predicate should never invalidate another.
       throw new RuntimeException("Unexpected error: removing this predicate invalidates another");
     } catch (EligibilityNotValidForProgramTypeException e) {
+      // Removing eligibility predicates should always be valid.
       throw new RuntimeException(
           "Unexpected error: removing this predicate is not allowed for this ProgramType");
     }
@@ -1095,7 +1096,8 @@ public final class ProgramServiceImpl implements ProgramService {
         .getProgramDefinition();
   }
 
-  private ProgramDefinition removeAllBlockEligibilityPredicates(ProgramDefinition programDefinition)
+  /** Removes eligibility predicates from all blocks in this program. */
+  private ProgramDefinition removeAllEligibilityPredicates(ProgramDefinition programDefinition)
       throws ProgramNotFoundException {
     try {
       return updateProgramDefinitionWithBlockDefinitions(
@@ -1104,7 +1106,7 @@ public final class ProgramServiceImpl implements ProgramService {
               .map(block -> block.toBuilder().setEligibilityDefinition(Optional.empty()).build())
               .collect(ImmutableList.toImmutableList()));
     } catch (IllegalPredicateOrderingException e) {
-      return programDefinition;
+      throw new RuntimeException("Unexpected error: removing this predicate invalidates another");
     }
   }
 

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -1432,7 +1432,8 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
     assertThatExceptionOfType(EligibilityNotValidForProgramTypeException.class)
         .isThrownBy(
-            () -> ps.setBlockEligibilityDefinition(program.id(), 1L, Optional.of(eligibility)));
+            () -> ps.setBlockEligibilityDefinition(program.id(), 1L, Optional.of(eligibility)))
+        .withMessage("Eligibility conditions cannot be set for ProgramType COMMON_INTAKE_FORM");
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -703,7 +703,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void updateProgram_clearsEligibilityCondtionsWhenSettingCommonIntakeForm()
+  public void updateProgram_clearsEligibilityConditionsWhenSettingCommonIntakeForm()
       throws Exception {
     QuestionDefinition question = nameQuestion;
     EligibilityDefinition eligibility =
@@ -720,6 +720,8 @@ public class ProgramServiceImplTest extends ResetPostgres {
             .build();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withEligibilityDefinition(eligibility)
             .withBlock()
             .withEligibilityDefinition(eligibility)
             .buildDefinition();
@@ -740,12 +742,13 @@ public class ProgramServiceImplTest extends ResetPostgres {
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
-    assertThat(result.getResult().getBlockCount()).isEqualTo(1);
-    assertThat(result.getResult().getLastBlockDefinition().eligibilityDefinition()).isNotPresent();
+    assertThat(result.getResult().getBlockCount()).isEqualTo(2);
+    assertThat(result.getResult().getBlockDefinitionByIndex(0).get().eligibilityDefinition()).isNotPresent();
+    assertThat(result.getResult().getBlockDefinitionByIndex(1).get().eligibilityDefinition()).isNotPresent();
   }
 
   @Test
-  public void updateProgram_doesNotClearEligibilityCondtionsForDefaultProgram() throws Exception {
+  public void updateProgram_doesNotClearEligibilityConditionsForDefaultProgram() throws Exception {
     QuestionDefinition question = nameQuestion;
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -1403,7 +1406,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void setBlockEligibilityDefinition_throwsEligibilityNotValideForProgramTypeException()
+  public void setBlockEligibilityDefinition_throwsEligibilityNotValidForProgramTypeException()
       throws Exception {
     QuestionDefinition question = nameQuestion;
     EligibilityDefinition eligibility =

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -743,8 +743,10 @@ public class ProgramServiceImplTest extends ResetPostgres {
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
     assertThat(result.getResult().getBlockCount()).isEqualTo(2);
-    assertThat(result.getResult().getBlockDefinitionByIndex(0).get().eligibilityDefinition()).isNotPresent();
-    assertThat(result.getResult().getBlockDefinitionByIndex(1).get().eligibilityDefinition()).isNotPresent();
+    assertThat(result.getResult().getBlockDefinitionByIndex(0).get().eligibilityDefinition())
+        .isNotPresent();
+    assertThat(result.getResult().getBlockDefinitionByIndex(1).get().eligibilityDefinition())
+        .isNotPresent();
   }
 
   @Test


### PR DESCRIPTION
### Description

Fix for #4512.

1. Clears eligibility conditions when a program is set as the common intake form.
2. Adds some safeguards when adding eligibility conditions to make sure that they're not being set on the CIF -- there's no UI for this so it shouldn't ever happen, but just to be safe.
3. Adds a test for adding eligibility conditions in general since there was none.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #4512
