### PR TITLE
Listen for popup event before clicking to fire it

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -144,10 +144,13 @@ describe('Applicant navigation flow', () => {
       const {page} = ctx
       await loginAsGuest(page)
       await selectApplicantLanguage(page, 'English')
+
+      // Begin waiting for the popup before clicking the link, otherwise
+      // the popup may fire before the wait is registered, causing the test to flake.
+      const popupPromise = page.waitForEvent('popup')
       await page.click(
         `.cf-application-card:has-text("${programName}") >> text='Program details'`,
       )
-      const popupPromise = page.waitForEvent('popup')
       const popup = await popupPromise
       const popupURL = await popup.evaluate('location.href')
 


### PR DESCRIPTION
### Description

This test has been flaking, [waiting for the popup event to fire](https://github.com/civiform/civiform/actions/runs/4557075631/jobs/8038245538). The problem is that the click event to open the popup was happening before the listener waiting for the popup event was registering, resulting in a race condition between the two. This PR registers the listener for the event before clicking the element to fire it, ensuring a consistent ordering of listener registration and event firing.

Confirmed fix by running the test 10x in a row with `bin/find-flakey-browser-tests -t src/application_navigation.test.ts`

### Issue(s) this completes

Contributes to https://github.com/civiform/civiform/issues/4217