### PR TITLE
Add missing type field in generate markdown action

### DIFF
--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -37,9 +37,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
-        run: civiform-main/bin/env-var-docs-create-venv
-
       - name: Run bin/env-var-docs-generate-markdown
         env:
           LOCAL_OUTPUT: false
@@ -50,4 +47,5 @@ jobs:
           TARGET_PATH: docs/it-manual/sre-playbook/server-environment-variables
         run: |
           cd civiform-main # must run bin scripts from repo root.
+          bin/env-var-docs-create-venv
           bin/env-var-docs-generate-markdown

--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -7,11 +7,13 @@ on:
       release_number:
         description: 'The release number to generate/update env var docs markdown for, v1.2.3 for example. IMPORTANT: the release number must already be a tag in this repo.'
         required: true
+        type: string
   workflow_call:
     inputs:
       release_number:
         description: 'The release number to generate/update env var docs markdown for, v1.2.3 for example. IMPORTANT: the release number must already be a tag in this repo.'
         required: true
+        type: string
     secrets:
       AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN:
         required: true

--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -43,9 +43,11 @@ jobs:
       - name: Run bin/env-var-docs-generate-markdown
         env:
           LOCAL_OUTPUT: false
-          ENV_VAR_DOCS_PATH: civiform-release/server/conf/env-var-docs.json
+          ENV_VAR_DOCS_PATH: ${{ github.workspace }}/civiform-release/server/conf/env-var-docs.json
           RELEASE_VERSION: ${{ inputs.release_number }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN }}
           TARGET_REPO: civiform/docs
           TARGET_PATH: docs/it-manual/sre-playbook/server-environment-variables
-        run: civiform-main/bin/env-var-docs-generate-markdown
+        run: |
+          cd civiform-main # must run bin scripts from repo root.
+          bin/env-var-docs-generate-markdown

--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -42,7 +42,7 @@ jobs:
           LOCAL_OUTPUT: false
           ENV_VAR_DOCS_PATH: ${{ github.workspace }}/civiform-release/server/conf/env-var-docs.json
           RELEASE_VERSION: ${{ inputs.release_number }}
-          GITHUB_ACCESS_TOKEN: ${{ secrets.AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}
           TARGET_REPO: civiform/docs
           TARGET_PATH: docs/it-manual/sre-playbook/server-environment-variables
         run: |

--- a/bin/env-var-docs-generate-markdown
+++ b/bin/env-var-docs-generate-markdown
@@ -22,5 +22,5 @@ export LOCAL_OUTPUT=${local_output}
 docs_path=${ENV_VAR_DOCS_PATH:-server/conf/env-var-docs.json}
 export ENV_VAR_DOCS_PATH=${docs_path}
 
-echo "Running env-var-docs/generate_markdown.py with LOCAL_OUTPUT=${LOCAL_OUTPUT}..."
+echo "Running env-var-docs/generate_markdown.py with LOCAL_OUTPUT=${LOCAL_OUTPUT}, ENV_VAR_DOCS_PATH=${ENV_VAR_DOCS_PATH}..."
 python env-var-docs/generate_markdown.py

--- a/env-var-docs/generate_markdown.py
+++ b/env-var-docs/generate_markdown.py
@@ -86,7 +86,7 @@ def main():
         print(markdown)
         exit()
 
-    gh = github.Github()
+    gh = github.Github(config.access_token)
     repo = gh.get_repo(config.repo)
 
     # If file exists, update it, if not, create it.


### PR DESCRIPTION
### Description

Fixes https://github.com/civiform/civiform/actions/runs/4577666227

```
[Invalid workflow file: .github/workflows/generate_env_var_docs_markdown_for_release.yaml#L13](https://github.com/civiform/civiform/actions/runs/4577666227/workflow)
The workflow is not valid. .github/workflows/generate_env_var_docs_markdown_for_release.yaml (Line: 13, Col: 9): Required property is missing: type
```



Tested: https://github.com/civiform/civiform/actions/runs/4578474596/jobs/8085130230