### PR TITLE
Fix flakiness in `admin_predicates_test.ts` by waiting for the popup before clicking a link

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -266,8 +266,10 @@ describe('create and edit predicates', () => {
     await applicantQuestions.expectIneligiblePage()
     await validateScreenshot(page, 'ineligible')
 
-    await page.click('text=program details')
+    // Begin waiting for the popup before clicking the link, otherwise
+    // the popup may fire before the wait is registered, causing the test to flake.
     const popupPromise = page.waitForEvent('popup')
+    await page.click('text=program details')
     const popup = await popupPromise
     const popupURL = await popup.evaluate('location.href')
 


### PR DESCRIPTION
### Description

Based on #4217, `admin_predicates.test.ts` has been known to be flaky. Unfortunately, running `bin/find-flakey-browser-tests -n 5 -t src/admin_predicates.test.ts` does not expose the flakiness on my local machine.

However, this is the same problem we observed in `application_navigation.test.ts`, so apply the same exact fix as in #4539; hopefully it will do the trick.

## Issues

Relates to #4217
