### PR TITLE
Re-trigger address validation upon change to address

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -444,15 +444,19 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             v -> {
               DynamicForm form = formFactory.form().bindFromRequest(request);
               ImmutableMap<String, String> formData = cleanForm(form.rawData());
-
-              return applicantService.stageAndUpdateIfValid(
-                  applicantId,
-                  programId,
-                  blockId,
-                  formData,
-                  featureFlags.getFlagEnabled(
-                      request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED));
+              return applicantService.resetAddressCorrectionWhenAddressChanged(
+                  applicantId, programId, blockId, formData);
             },
+            httpExecutionContext.current())
+        .thenComposeAsync(
+            formData ->
+                applicantService.stageAndUpdateIfValid(
+                    applicantId,
+                    programId,
+                    blockId,
+                    formData,
+                    featureFlags.getFlagEnabled(
+                        request, ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED)),
             httpExecutionContext.current())
         .thenComposeAsync(
             roApplicantProgramService ->

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1519,4 +1519,48 @@ public final class ApplicantService {
               return suggestionsMaybe.get();
             });
   }
+
+  /**
+   * Checks for an {@link AddressQuestion} that has address correction enabled. If found and the
+   * data in the database differs from the submitted form data. Set the corrected, latitude, and
+   * longitude, and wellKnownId values to empty. This is done to allow triggering the address
+   * correction process again, but only when there have been changes.
+   *
+   * <p>Otherwise if no {@link AddressQuestion} or no changes to the address we return the untouched
+   * formdata
+   */
+  public CompletionStage<ImmutableMap<String, String>> resetAddressCorrectionWhenAddressChanged(
+      long applicantId, long programId, String blockId, ImmutableMap<String, String> formData) {
+    return getReadOnlyApplicantProgramService(applicantId, programId)
+        .thenComposeAsync(
+            roApplicantProgramService -> {
+              Optional<Block> blockMaybe = roApplicantProgramService.getBlock(blockId);
+
+              if (blockMaybe.isEmpty()) {
+                return CompletableFuture.failedFuture(
+                    new ProgramBlockNotFoundException(programId, blockId));
+              }
+
+              Optional<ApplicantQuestion> addressQuestionMaybe =
+                  blockMaybe.get().getAddressQuestionWithCorrectionEnabled();
+
+              if (addressQuestionMaybe.isPresent()) {
+                AddressQuestion addressQuestion =
+                    addressQuestionMaybe.get().createAddressQuestion();
+
+                if (addressQuestion.hasChanges(formData)) {
+                  return CompletableFuture.completedFuture(
+                      new ImmutableMap.Builder<String, String>()
+                          .putAll(formData)
+                          .put(addressQuestion.getCorrectedPath().toString(), "")
+                          .put(addressQuestion.getLatitudePath().toString(), "")
+                          .put(addressQuestion.getLongitudePath().toString(), "")
+                          .put(addressQuestion.getWellKnownIdPath().toString(), "")
+                          .build());
+                }
+              }
+
+              return CompletableFuture.completedFuture(formData);
+            });
+  }
 }

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1544,20 +1544,22 @@ public final class ApplicantService {
               Optional<ApplicantQuestion> addressQuestionMaybe =
                   blockMaybe.get().getAddressQuestionWithCorrectionEnabled();
 
-              if (addressQuestionMaybe.isPresent()) {
-                AddressQuestion addressQuestion =
-                    addressQuestionMaybe.get().createAddressQuestion();
+              if (addressQuestionMaybe.isEmpty()) {
+                return CompletableFuture.completedFuture(formData);
+              }
 
-                if (addressQuestion.hasChanges(formData)) {
-                  return CompletableFuture.completedFuture(
-                      new ImmutableMap.Builder<String, String>()
-                          .putAll(formData)
-                          .put(addressQuestion.getCorrectedPath().toString(), "")
-                          .put(addressQuestion.getLatitudePath().toString(), "")
-                          .put(addressQuestion.getLongitudePath().toString(), "")
-                          .put(addressQuestion.getWellKnownIdPath().toString(), "")
-                          .build());
-                }
+              AddressQuestion addressQuestion =
+                  addressQuestionMaybe.get().createAddressQuestion();
+
+              if (addressQuestion.hasChanges(formData)) {
+                return CompletableFuture.completedFuture(
+                    new ImmutableMap.Builder<String, String>()
+                        .putAll(formData)
+                        .put(addressQuestion.getCorrectedPath().toString(), "")
+                        .put(addressQuestion.getLatitudePath().toString(), "")
+                        .put(addressQuestion.getLongitudePath().toString(), "")
+                        .put(addressQuestion.getWellKnownIdPath().toString(), "")
+                        .build());
               }
 
               return CompletableFuture.completedFuture(formData);

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1548,8 +1548,7 @@ public final class ApplicantService {
                 return CompletableFuture.completedFuture(formData);
               }
 
-              AddressQuestion addressQuestion =
-                  addressQuestionMaybe.get().createAddressQuestion();
+              AddressQuestion addressQuestion = addressQuestionMaybe.get().createAddressQuestion();
 
               if (addressQuestion.hasChanges(formData)) {
                 return CompletableFuture.completedFuture(

--- a/server/app/services/applicant/question/AddressQuestion.java
+++ b/server/app/services/applicant/question/AddressQuestion.java
@@ -3,7 +3,9 @@ package services.applicant.question;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -320,5 +322,37 @@ public final class AddressQuestion extends Question {
         getLongitudePath(),
         getWellKnownIdPath(),
         getServiceAreaPath());
+  }
+
+  /**
+   * Returns false if the formData matches the saved data (i.e. no changes). Returns true if the
+   * formData does not match the saved data (i.e. has changes)
+   */
+  public boolean hasChanges(ImmutableMap<String, String> formData) {
+    boolean hasAllRequiredPaths =
+        formData.containsKey(getStreetPath().toString())
+            && formData.containsKey(getLine2Path().toString())
+            && formData.containsKey(getCityPath().toString())
+            && formData.containsKey(getStatePath().toString())
+            && formData.containsKey(getZipPath().toString());
+
+    if (!hasAllRequiredPaths) {
+      return false;
+    }
+
+    BiFunction<Path, Optional<String>, Boolean> checkIfChanged =
+        (path, value) -> !Objects.equals(formData.get(path.toString()), value.orElse(""));
+
+    boolean hasChangesStreet = checkIfChanged.apply(getStreetPath(), getStreetValue());
+    boolean hasChangesLine2 = checkIfChanged.apply(getLine2Path(), getLine2Value());
+    boolean hasChangesCity = checkIfChanged.apply(getCityPath(), getCityValue());
+    boolean hasChangesState = checkIfChanged.apply(getStatePath(), getStateValue());
+    boolean hasChangesZip = checkIfChanged.apply(getZipPath(), getZipValue());
+
+    return hasChangesStreet
+        || hasChangesLine2
+        || hasChangesCity
+        || hasChangesState
+        || hasChangesZip;
   }
 }

--- a/server/app/services/applicant/question/AddressQuestion.java
+++ b/server/app/services/applicant/question/AddressQuestion.java
@@ -344,9 +344,9 @@ public final class AddressQuestion extends Question {
         (path, value) -> !Objects.equals(formData.get(path.toString()), value.orElse(""));
 
     return checkIfChanged.apply(getStreetPath(), getStreetValue())
-      || checkIfChanged.apply(getLine2Path(), getLine2Value())
-      || checkIfChanged.apply(getCityPath(), getCityValue())
-      || checkIfChanged.apply(getStatePath(), getStateValue())
-      || checkIfChanged.apply(getZipPath(), getZipValue());
+        || checkIfChanged.apply(getLine2Path(), getLine2Value())
+        || checkIfChanged.apply(getCityPath(), getCityValue())
+        || checkIfChanged.apply(getStatePath(), getStateValue())
+        || checkIfChanged.apply(getZipPath(), getZipValue());
   }
 }

--- a/server/app/services/applicant/question/AddressQuestion.java
+++ b/server/app/services/applicant/question/AddressQuestion.java
@@ -343,16 +343,10 @@ public final class AddressQuestion extends Question {
     BiFunction<Path, Optional<String>, Boolean> checkIfChanged =
         (path, value) -> !Objects.equals(formData.get(path.toString()), value.orElse(""));
 
-    boolean hasChangesStreet = checkIfChanged.apply(getStreetPath(), getStreetValue());
-    boolean hasChangesLine2 = checkIfChanged.apply(getLine2Path(), getLine2Value());
-    boolean hasChangesCity = checkIfChanged.apply(getCityPath(), getCityValue());
-    boolean hasChangesState = checkIfChanged.apply(getStatePath(), getStateValue());
-    boolean hasChangesZip = checkIfChanged.apply(getZipPath(), getZipValue());
-
-    return hasChangesStreet
-        || hasChangesLine2
-        || hasChangesCity
-        || hasChangesState
-        || hasChangesZip;
+    return checkIfChanged.apply(getStreetPath(), getStreetValue())
+      || checkIfChanged.apply(getLine2Path(), getLine2Value())
+      || checkIfChanged.apply(getCityPath(), getCityValue())
+      || checkIfChanged.apply(getStatePath(), getStateValue())
+      || checkIfChanged.apply(getZipPath(), getZipValue());
   }
 }

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -274,4 +274,68 @@ public class AddressQuestionTest {
       new Object[] {"111 A St", "Unit B", "", "", "", "111 A St\nUnit B"}
     };
   }
+
+  @Test
+  public void hasChanges_returnsFalse() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerAddressQuestion(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        "PO Box 123",
+        "Line 2",
+        "Seattle",
+        "WA",
+        "98101",
+        "true",
+        10.1,
+        -20.1,
+        1000L,
+        "Seattle_InArea_1234");
+
+    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+
+    ImmutableMap<String, String> formData =
+        new ImmutableMap.Builder<String, String>()
+            .put(addressQuestion.getStreetPath().toString(), "PO Box 123")
+            .put(addressQuestion.getLine2Path().toString(), "Line 2")
+            .put(addressQuestion.getCityPath().toString(), "Seattle")
+            .put(addressQuestion.getStatePath().toString(), "WA")
+            .put(addressQuestion.getZipPath().toString(), "98101")
+            .build();
+
+    assertThat(addressQuestion.hasChanges(formData)).isEqualTo(false);
+  }
+
+  @Test
+  public void hasChanges_returnsTrue() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerAddressQuestion(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        "PO Box 123",
+        "Line 2",
+        "Seattle",
+        "WA",
+        "98101",
+        "true",
+        10.1,
+        -20.1,
+        1000L,
+        "Seattle_InArea_1234");
+
+    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+
+    ImmutableMap<String, String> formData =
+        new ImmutableMap.Builder<String, String>()
+            .put(addressQuestion.getStreetPath().toString(), "PO Box 456")
+            .put(addressQuestion.getLine2Path().toString(), "Line 3")
+            .put(addressQuestion.getCityPath().toString(), "Portland")
+            .put(addressQuestion.getStatePath().toString(), "OR")
+            .put(addressQuestion.getZipPath().toString(), "97086")
+            .build();
+
+    assertThat(addressQuestion.hasChanges(formData)).isEqualTo(true);
+  }
 }


### PR DESCRIPTION
### Description

Allows re-triggering address validation if the user makes a change to their address. The corrected, lat, long, and wellKnownId values are reset, which clears the flow to be picked up as normal by the address correction process.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #4310
