### PR TITLE
Remove call to getProgramDefinition from service for index page performance improvements

### DIFF
--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -97,7 +97,7 @@ public final class ProgramServiceImpl implements ProgramService {
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftPrograms() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersions(this, versionRepository);
+    return ActiveAndDraftPrograms.buildFromCurrentVersions(versionRepository);
   }
 
   @Override


### PR DESCRIPTION
### Description

Seattle admins noticed ~6 seconds of latency on the program index page. It was determined that much of this load was coming from looping through the programs and getting the definitions for each one, which loads all the questions each time a definition was fetched. 

Since we don't need to get the question definitions for the index page, we should be able to use the programDefinition provided on the Program class, which would enable us to remove all the calls for each program.

## Release notes

Improve CiviForm admin index page performance.

### Checklist

#### General

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
