### PR TITLE
Fix batch test logic

### DIFF
--- a/bin/run-browser-tests-ci-batch
+++ b/bin/run-browser-tests-ci-batch
@@ -39,6 +39,8 @@ print(f"Batch {batch_number} will run:")
 for item in batch_contents:
     print(f"\t{item}")
 
-shell_command = ["./bin/run-browser-tests-ci"] + batch_contents
-
-subprocess.run(shell_command, check=True)
+if batch_contents:
+    shell_command = ["./bin/run-browser-tests-ci"] + batch_contents
+    subprocess.run(shell_command, check=True)
+else:
+    print("No tests assigned to this batch.")


### PR DESCRIPTION
### Description

There's a bug in `bin/run-browser-tests-ci-batch`. When the `len(tests)` is a multiple of the `BATCH_SIZE`, the last batch does not get any tests assigned to it. In other words, `batch_contents` is empty.

This would not be a big deal except for this code:

```
shell_command = ["./bin/run-browser-tests-ci"] + batch_contents
subprocess.run(shell_command, check=True)
```

which would run `./bin/run-browser-tests-ci` alone if `batch_contents` were empty, running all tests. In this PR, we skip running the command if `batch_contents` is empty.
