### PR TITLE
Have child action inherit secrets

### DIFF
--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -14,9 +14,6 @@ on:
         description: 'The release number to generate/update env var docs markdown for, v1.2.3 for example. IMPORTANT: the release number must already be a tag in this repo.'
         required: true
         type: string
-    secrets:
-      AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN:
-        required: true
 
 jobs:
   generate_markdown:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,3 +37,4 @@ jobs:
     uses: ./.github/workflows/generate_env_var_docs_markdown_for_release.yaml
     with:
       release_number: ${{ github.event.inputs.release_number }}
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,5 +37,3 @@ jobs:
     uses: ./.github/workflows/generate_env_var_docs_markdown_for_release.yaml
     with:
       release_number: ${{ github.event.inputs.release_number }}
-    secrets:
-      AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTOMATION_GITHUB_BOT_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
### Description

Makes the call to the generate docs action inherit the secrets from the release action context. This should allow the generate docs action to run standalone and as a child action


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >


