### PR TITLE
Limit number of calls on program admin index page

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -86,7 +86,7 @@ public final class AdminProgramController extends CiviFormController {
     Optional<CiviFormProfile> profileMaybe = profileUtils.currentUserProfile(request);
     return ok(
         listView.render(
-            programService.getActiveAndDraftPrograms(),
+            programService.getActiveAndDraftProgramsWithoutQuestionLoad(),
             questionService.getReadOnlyQuestionServiceSync().getActiveAndDraftQuestions(),
             request,
             profileMaybe));

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -30,7 +30,7 @@ public final class ActiveAndDraftPrograms {
    * state. Since a ProgramService argument is included, we will get the full program definition,
    * which includes the question definitions.
    */
-  public static ActiveAndDraftPrograms buildFromCurrentVersionsWithProgramServiceQuestionLoad(
+  public static ActiveAndDraftPrograms buildFromCurrentVersionsSynced(
       ProgramService service, VersionRepository repository) {
     return new ActiveAndDraftPrograms(
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.of(service));
@@ -41,7 +41,7 @@ public final class ActiveAndDraftPrograms {
    * state. These programs won't include the question definition, since ProgramService is not
    * provided.
    */
-  public static ActiveAndDraftPrograms buildFromCurrentVersionsWithoutQuestionLoad(
+  public static ActiveAndDraftPrograms buildFromCurrentVersionsUnsynced(
       VersionRepository repository) {
     return new ActiveAndDraftPrograms(
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.empty());

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -27,7 +27,8 @@ public final class ActiveAndDraftPrograms {
 
   /**
    * Queries the existing active and draft versions and builds a snapshotted view of the program
-   * state.
+   * state. Since a ProgramService argument is included, we will get the full program definition,
+   * which includes the question definitions.
    */
   public static ActiveAndDraftPrograms buildFromCurrentVersions(
       ProgramService service, VersionRepository repository) {
@@ -35,6 +36,11 @@ public final class ActiveAndDraftPrograms {
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.of(service));
   }
 
+  /**
+   * Queries the existing active and draft versions and builds a snapshotted view of the program
+   * state. These programs won't include the question definition, since ProgramService is not
+   * provided.
+   */
   public static ActiveAndDraftPrograms buildFromCurrentVersions(VersionRepository repository) {
     return new ActiveAndDraftPrograms(
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.empty());

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -48,8 +48,8 @@ public final class ActiveAndDraftPrograms {
         checkNotNull(active).getPrograms().stream()
             .map(
                 program ->
-                    service.isPresent()
-                        ? getProgramDefinition(checkNotNull(service.get()), program.id)
+                    service.isPresent() && service.get() != null
+                        ? getProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
@@ -58,8 +58,8 @@ public final class ActiveAndDraftPrograms {
         checkNotNull(draft).getPrograms().stream()
             .map(
                 program ->
-                    service.isPresent()
-                        ? getProgramDefinition(checkNotNull(service.get()), program.id)
+                    service.isPresent() && service.get() != null
+                        ? getProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -48,7 +48,7 @@ public final class ActiveAndDraftPrograms {
         checkNotNull(active).getPrograms().stream()
             .map(
                 program ->
-                    service.isPresent() && service.get() != null
+                    service.isPresent()
                         ? getProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
@@ -58,7 +58,7 @@ public final class ActiveAndDraftPrograms {
         checkNotNull(draft).getPrograms().stream()
             .map(
                 program ->
-                    service.isPresent() && service.get() != null
+                    service.isPresent()
                         ? getProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -30,7 +30,7 @@ public final class ActiveAndDraftPrograms {
    * state. Since a ProgramService argument is included, we will get the full program definition,
    * which includes the question definitions.
    */
-  public static ActiveAndDraftPrograms buildFromCurrentVersions(
+  public static ActiveAndDraftPrograms buildFromCurrentVersionsWithProgramServiceQuestionLoad(
       ProgramService service, VersionRepository repository) {
     return new ActiveAndDraftPrograms(
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.of(service));
@@ -41,7 +41,8 @@ public final class ActiveAndDraftPrograms {
    * state. These programs won't include the question definition, since ProgramService is not
    * provided.
    */
-  public static ActiveAndDraftPrograms buildFromCurrentVersions(VersionRepository repository) {
+  public static ActiveAndDraftPrograms buildFromCurrentVersionsWithoutQuestionLoad(
+      VersionRepository repository) {
     return new ActiveAndDraftPrograms(
         repository.getActiveVersion(), repository.getDraftVersion(), Optional.empty());
   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -44,7 +44,10 @@ public interface ProgramService {
   /** Get the data object about the programs that are in the active or draft version. */
   ActiveAndDraftPrograms getActiveAndDraftPrograms();
 
-  /** Get the data object about the programs that are in the active or draft version without the full question definitions attached to the programs. */
+  /**
+   * Get the data object about the programs that are in the active or draft version without the full
+   * question definitions attached to the programs.
+   */
   ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad();
 
   /**

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -44,6 +44,7 @@ public interface ProgramService {
   /** Get the data object about the programs that are in the active or draft version. */
   ActiveAndDraftPrograms getActiveAndDraftPrograms();
 
+  /** Get the data object about the programs that are in the active or draft version without the full question definitions attached to the programs. */
   ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad();
 
   /**

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -44,6 +44,8 @@ public interface ProgramService {
   /** Get the data object about the programs that are in the active or draft version. */
   ActiveAndDraftPrograms getActiveAndDraftPrograms();
 
+  ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad();
+
   /**
    * Sync all {@link QuestionDefinition}s in a list of {@link ProgramDefinition}s asynchronously, by
    * querying for questions then updating each {@link ProgramDefinition}s.

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -97,12 +97,13 @@ public final class ProgramServiceImpl implements ProgramService {
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftPrograms() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersions(this, versionRepository);
+    return ActiveAndDraftPrograms.buildFromCurrentVersionsWithProgramServiceQuestionLoad(
+        this, versionRepository);
   }
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersions(versionRepository);
+    return ActiveAndDraftPrograms.buildFromCurrentVersionsWithoutQuestionLoad(versionRepository);
   }
 
   @Override

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -97,13 +97,13 @@ public final class ProgramServiceImpl implements ProgramService {
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftPrograms() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersionsWithProgramServiceQuestionLoad(
+    return ActiveAndDraftPrograms.buildFromCurrentVersionsSynced(
         this, versionRepository);
   }
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersionsWithoutQuestionLoad(versionRepository);
+    return ActiveAndDraftPrograms.buildFromCurrentVersionsUnsynced(versionRepository);
   }
 
   @Override

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -97,8 +97,7 @@ public final class ProgramServiceImpl implements ProgramService {
 
   @Override
   public ActiveAndDraftPrograms getActiveAndDraftPrograms() {
-    return ActiveAndDraftPrograms.buildFromCurrentVersionsSynced(
-        this, versionRepository);
+    return ActiveAndDraftPrograms.buildFromCurrentVersionsSynced(this, versionRepository);
   }
 
   @Override

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -101,6 +101,11 @@ public final class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
+  public ActiveAndDraftPrograms getActiveAndDraftProgramsWithoutQuestionLoad() {
+    return ActiveAndDraftPrograms.buildFromCurrentVersions(versionRepository);
+  }
+
+  @Override
   public CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(long id) {
     return programRepository
         .lookupProgram(id)

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -130,7 +130,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     ImmutableList<ProgramDefinition> draftPrograms =
         ps.getActiveAndDraftProgramsWithoutQuestionLoad().getDraftPrograms();
     ImmutableList<ProgramDefinition> activePrograms =
-      ps.getActiveAndDraftProgramsWithoutQuestionLoad().getActivePrograms();
+        ps.getActiveAndDraftProgramsWithoutQuestionLoad().getActivePrograms();
 
     ProgramDefinition draftProgramDef = draftPrograms.get(0);
     assertThat(draftProgramDef.getBlockCount()).isEqualTo(2);

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -108,6 +108,39 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
+  public void getActiveAndDraftProgramsWithoutQuestionLoad_hasBasicProgramInfo() {
+    QuestionDefinition questionOne = nameQuestion;
+    QuestionDefinition questionTwo = addressQuestion;
+    QuestionDefinition questionThree = colorQuestion;
+
+    ProgramBuilder.newDraftProgram("program1")
+        .withBlock()
+        .withRequiredQuestionDefinition(questionOne)
+        .withRequiredQuestionDefinition(questionTwo)
+        .withBlock()
+        .withRequiredQuestionDefinition(questionThree)
+        .buildDefinition();
+    ProgramBuilder.newActiveProgram("program2")
+        .withBlock()
+        .withRequiredQuestionDefinition(questionTwo)
+        .withBlock()
+        .withRequiredQuestionDefinition(questionOne)
+        .buildDefinition();
+
+    ImmutableList<ProgramDefinition> draftPrograms =
+        ps.getActiveAndDraftProgramsWithoutQuestionLoad().getDraftPrograms();
+    ImmutableList<ProgramDefinition> activePrograms =
+      ps.getActiveAndDraftProgramsWithoutQuestionLoad().getActivePrograms();
+
+    ProgramDefinition draftProgramDef = draftPrograms.get(0);
+    assertThat(draftProgramDef.getBlockCount()).isEqualTo(2);
+    assertThat(draftProgramDef.getQuestionCount()).isEqualTo(3);
+    ProgramDefinition activeProgramDef = activePrograms.get(0);
+    assertThat(activeProgramDef.getBlockCount()).isEqualTo(2);
+    assertThat(activeProgramDef.getQuestionCount()).isEqualTo(2);
+  }
+
+  @Test
   public void createProgram_setsId() {
     assertThat(ps.getActiveAndDraftPrograms().getActivePrograms()).isEmpty();
     assertThat(ps.getActiveAndDraftPrograms().getDraftPrograms()).isEmpty();
@@ -494,6 +527,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     ProgramDefinition found = ps.getProgramDefinition(updatedProgram.id());
 
     assertThat(ps.getActiveAndDraftPrograms().getDraftPrograms()).hasSize(1);
+    assertThat(ps.getActiveAndDraftProgramsWithoutQuestionLoad().getDraftPrograms()).hasSize(1);
     assertThat(found.adminName()).isEqualTo(updatedProgram.adminName());
     assertThat(found.lastModifiedTime().isPresent()).isTrue();
     assertThat(originalProgram.lastModifiedTime().isPresent()).isTrue();


### PR DESCRIPTION
### Description

Create a version of ActiveAndDraftPrograms that doesn't load the question data. This is called to load the CiviForm admin program index page, but we don't need the questions when we load the programs there.

This makes the page load ~150 ms, which is over a 10X improvement.

This change reduces the number of database calls for an index page with 31 programs from [671](https://docs.google.com/document/d/13FqPvA1yUoEuCw8DNAMEalM2wq8eCUU1DsSFOUBbRlM/edit) to [14](https://docs.google.com/document/d/1JHvo17lyPmRRQ_EyYsqKdNgUsfoJ0-IiPmy2A11R6Jo/edit).

## Release notes

Improve load time of the CiviForm admin index page

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4608
