### PR TITLE
Evenly distribute tests in `bin/run-browser-tests-ci-batch`

### DIFF
--- a/bin/run-browser-tests-ci-batch
+++ b/bin/run-browser-tests-ci-batch
@@ -4,43 +4,61 @@
 # DOC: 1-indexed batch number.
 
 import glob
-import math
 import subprocess
 import sys
 
 BATCH_COUNT = 10
 
 
-def bad_batch_number_input(batch_num_input):
+def handle_bad_input(batch_num_input):
     print(f"Invalid batch number: {batch_num_input}", file=sys.stderr)
     exit(1)
 
 
-if len(sys.argv) < 2:
-    bad_batch_number_input("none")
+# Gets the batch number from the command line arguments. The batch number is *one-indexed*.
+def get_batch_number():
+    if len(sys.argv) < 2:
+        handle_bad_input("none")
+    try:
+        batch_number = int(sys.argv[1])
+    except ValueError:
+        handle_bad_input(sys.argv[1])
+    if batch_number < 1 or batch_number > BATCH_COUNT:
+        handle_bad_input(batch_number)
+    return batch_number
 
-try:
-    batch_number = int(sys.argv[1])
-except ValueError:
-    bad_batch_number_input(sys.argv[1])
 
-if batch_number < 1 or batch_number > BATCH_COUNT:
-    bad_batch_number_input(batch_number)
+# Gets a list of all the test files in the browser-test directory.
+def get_all_test_files():
+    test_files = glob.glob('browser-test/src/*.test.ts')
+    test_files = [file.replace("browser-test/", "") for file in test_files]
+    test_files.sort()
+    return test_files
 
-test_files = glob.glob('browser-test/src/*.test.ts')
-test_files = [file.replace("browser-test/", "") for file in test_files]
-test_files.sort()
-batch_size = math.ceil(len(test_files) / BATCH_COUNT)
 
-batch_contents = test_files[(batch_number - 1) * batch_size:batch_number *
-                            batch_size]
+# Returns a subset of the test files, based on the batch number. This ensures we
+# are evenly distributing the test across all available GitHub Actions runners.
+#
+# Specifically, returns every BATCH_COUNT-th element in the test file, starting from
+# the (batch_number - 1)th element.
+def get_batch():
+    all_test_files = get_all_test_files()
+    return all_test_files[get_batch_number() -
+                          1:len(all_test_files):BATCH_COUNT]
 
-print(f"Batch {batch_number} will run:")
-for item in batch_contents:
-    print(f"\t{item}")
 
-if batch_contents:
-    shell_command = ["./bin/run-browser-tests-ci"] + batch_contents
-    subprocess.run(shell_command, check=True)
-else:
-    print("No tests assigned to this batch.")
+# Prints a preview of the tests to be run.
+print(
+    f"Batch {get_batch_number()} will run the following from {len(get_all_test_files())} total tests:"
+)
+for test_file in get_batch():
+    print(f"   {test_file}")
+
+if not get_batch():
+    # get_batch() should never return an empty list.
+    # Exit with an error code now if that happens, cancelling the GitHub Action.
+    print("ERROR: No tests assigned to this batch.")
+    exit(1)
+
+shell_command = ["./bin/run-browser-tests-ci"] + get_batch()
+subprocess.run(shell_command, check=True)


### PR DESCRIPTION
### Description

This cleans up the `bin/run-browser-tests-ci-batch` script to:

* Modularize logic in functions
* Ensure that each GitHub runner participates in running tests.

Prior to this PR, if there were 45 tests and 10 runners, we would calculate the tests per runner as `batch_size = 45 // 10 = 5`. The first 9 runners would take 5 tests each, and the **10th runner would get none**.

Now, we assign a test to a given runner `N` if the index of the test index `i` satisfies the condition `i % BATCH_COUNT == N - 1`. For example if there are 45 tests and 10 runners,

* The "0th" runner will get tests 0, 10, 20, 30, and 40
* The "1st" runner will get tests 1, 11, 21, 31, 41
* ...
* The "8th" runner will get tests 8, 18, 28, 38
* The "9th" runner will get tests 9, 19, 29, 39

[Paste of all tests per batch after this PR](https://pastebin.com/BNX0VT7z)

In this case the first 5 runners get 5 tests each, and the last 5 runners get 4 tests each. This is a better distribution than before.
