### PR TITLE
Updating renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,17 @@
       "matchPackagePrefixes": ["org.pac4j:pac4j"]
     },
     {
-      "matchPaths": ["browser-test/"],
+      "matchPaths": [
+        ".github/workflows/",
+        "browser-test/",
+        "env-var-docs/",
+        "formatter/"
+      ],
       "labels": ["dependencies", "ignore-for-release"]
     },
     {
-      "matchPaths": ["formatter/"],
-      "labels": ["dependencies", "ignore-for-release"]
+      "matchPackageNames": ["postgres"],
+      "allowedVersion": "<13.0.0"
     }
   ]
 }


### PR DESCRIPTION
### Description

* Adding workflows and env-var-docs to be auto-tagged as ignore-for-release
* Setting postgres to only allow version 12.x.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
