### PR TITLE
Adding job to handle typescript tests

### DIFF
--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -40,3 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'
+      
+  run_typescript_unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "skipping"'

--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'
-      
+
   run_typescript_unit_tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

This adds the run_typescript_unit_tests job to the test skip workflow. Currently the test skip route is getting blocked because of that new test is missing.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

