### PR TITLE
Update the year in the oncall rotation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/oncall-rotation.md
+++ b/.github/ISSUE_TEMPLATE/oncall-rotation.md
@@ -1,7 +1,7 @@
 ---
 name: Oncall rotation
 about: Weekly oncall rotation checklist and log
-title: 'Oncall: 2022-XX-XX'
+title: 'Oncall: 2023-XX-XX'
 labels: ''
 assignees: ''
 ---


### PR DESCRIPTION
### Description

Update the year in the oncall rotation template from 2022 to 2023

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

