### PR TITLE
Hotfix for Seattle staging

### DIFF
--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -61,31 +61,12 @@ describe('applicant program index page', () => {
 
     await validateAccessibility(page)
 
-    await page.click('#login-button')
-    const loginPage = page.url()
-    expect(loginPage).toMatch(/dev-oidc.*\//)
-
-    await applicantQuestions.gotoApplicantHomePage()
-    await logout(page)
-  })
-
-  it('shows create account button for guest users', async () => {
-    const {page, applicantQuestions} = ctx
-    await loginAsGuest(page)
-    await selectApplicantLanguage(
-      page,
-      'English',
-      /* assertProgramIndexPage= */ true,
-    )
-
-    await validateAccessibility(page)
-
-    // Create account does not work in dev because accounts are created implicitly when logging in.
-    // Instead, just check for the existence of the button.
+    // We cannot check that the login/create account buttons redirect the user to a particular
+    // URL because it varies between environments, so just check for their existence.
+    expect(await page.textContent('#login-button')).toContain('Log in')
     expect(await page.textContent('#create-account')).toContain(
       'Create account',
     )
-
     await applicantQuestions.gotoApplicantHomePage()
     await logout(page)
   })


### PR DESCRIPTION
### Description

We check the regex for `dev-oidc`, but this is a mistake because it varies between environments. Avoid checking the URL. Originally appeared in #4619 

### Issue(s) this completes

Fixes issue related to #4619.
