### PR TITLE
Add permissions for child workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,8 @@ jobs:
   update_environment_variable_documentation_markdown:
     needs: create_release # The generate markdown job relies on the release tag being added, so wait for bin/create-release to complete.
     uses: ./.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+    permissions:
+      contents: read
     with:
       release_number: ${{ github.event.inputs.release_number }}
     secrets:


### PR DESCRIPTION
### Description

The child workflow needs contents read. Looks like we need to explicitly pass it since it's not already allowed in the context.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
