### PR TITLE
Fix program admin header link

### DIFF
--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -105,6 +105,7 @@ public final class AdminLayout extends BaseHtmlLayout {
 
     String questionLink = controllers.admin.routes.AdminQuestionController.index().url();
     String programLink = controllers.admin.routes.AdminProgramController.index().url();
+    String programAdminProgramsLink = controllers.admin.routes.ProgramAdminController.index().url();
     String intermediaryLink = routes.TrustedIntermediaryManagementController.index().url();
     String apiKeysLink = controllers.admin.routes.AdminApiKeysController.index().url();
     String reportingLink = controllers.admin.routes.AdminReportingController.index().url();
@@ -126,6 +127,12 @@ public final class AdminLayout extends BaseHtmlLayout {
         headerLink(
             "Programs", programLink, NavPage.PROGRAMS.equals(activeNavPage) ? activeNavStyle : "");
 
+    ATag programAdminProgramsHeaderLink =
+        headerLink(
+            "Programs",
+            programAdminProgramsLink,
+            NavPage.PROGRAMS.equals(activeNavPage) ? activeNavStyle : "");
+
     ATag questionsHeaderLink =
         headerLink(
             "Questions",
@@ -143,7 +150,7 @@ public final class AdminLayout extends BaseHtmlLayout {
             "API keys", apiKeysLink, NavPage.API_KEYS.equals(activeNavPage) ? activeNavStyle : "");
 
     if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN)) {
-      adminHeader.with(programsHeaderLink).with(reportingHeaderLink);
+      adminHeader.with(programAdminProgramsHeaderLink).with(reportingHeaderLink);
     } else {
       adminHeader
           .with(programsHeaderLink)


### PR DESCRIPTION
### Description
For program admins, the Programs header link should link to the Program Admin's programs page, not the admin's program page.

## Release notes

### Checklist

#### General

- [n/a] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [n/a] Created tests which fail without the change (if possible)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

### Issue(s) this completes

Fixes #4643
