### PR TITLE
Update bin/fmt to Handle Git Worktrees

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -35,11 +35,6 @@ if [[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]]; th
   repotype="worktree"
 fi
 
-echo "gitdir: ${gitdir}"
-echo "repotype: ${repotype}"
-echo "interactive_flag: ${interactive_flag}"
-echo "CI: ${CI}"
-
 # If repotype is a directory then the git repository was created by with the common `git clone` way
 # which is just a single working tree pointing at the current branch. Is is the more common way
 # in which folks clone a repository.
@@ -65,9 +60,8 @@ if [[ "${repotype}" == "not-worktree" ]]; then
 #   > bin/fmt
 elif [[ "${repotype}" == "worktree" ]]; then
   worktree_root="$(dirname "${gitdir}")"
-  echo "worktree_root: ${worktree_root}"
 
-  docker run --rm "${interactive_flag}" \
+  docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
     -v "${worktree_root}:${worktree_root}" \
     civiform/formatter \

--- a/bin/fmt
+++ b/bin/fmt
@@ -42,6 +42,7 @@ fi
 #   > git clone git@github.com:civiform/civiform.git
 #   > cd ./civiform
 #   > git checkout -b new-branch-name
+#   > bin/fmt
 if [[ "${repotype}" == "not-worktree" ]]; then
   docker run --rm "${interactive_flag}" \
     -v "$(pwd):/code" \
@@ -53,8 +54,10 @@ if [[ "${repotype}" == "not-worktree" ]]; then
 # the fmt command will has access to other branches when it does a diff.
 # Example:
 #   > git clone --bare git@github.com:civiform/civiform.git
+#   > cd ./civiform
 #   > git worktree add -B new-branch-name ./new-branch-name
 #   > cd ./new-branch-name
+#   > bin/fmt
 elif [[ "${repotype}" == "worktree" ]]; then
   worktree_root="$(dirname "${gitdir}")"
 

--- a/bin/fmt
+++ b/bin/fmt
@@ -28,14 +28,14 @@ if [[ -n "${CI}" ]]; then
   interactive_flag=""
 fi
 
-gitdir="$(git rev-parse --show-toplevel)"
-repotype="not-worktree"
+readonly GIT_DIR="$(git rev-parse --show-toplevel)"
+repo_type="not-worktree"
 
 if [[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]]; then
-  repotype="worktree"
+  repo_type="worktree"
 fi
 
-# If repotype is a directory then the git repository was created by with the common `git clone` way
+# If repo_type is a directory then the git repository was created by with the common `git clone` way
 # which is just a single working tree pointing at the current branch. Is is the more common way
 # in which folks clone a repository.
 # Example:
@@ -43,13 +43,13 @@ fi
 #   > cd ./civiform
 #   > git checkout -b new-branch-name
 #   > bin/fmt
-if [[ "${repotype}" == "not-worktree" ]]; then
+if [[ "${repo_type}" == "not-worktree" ]]; then
   docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
     civiform/formatter \
     "$@"
 
-# If repotype is a file then the current folder was created with the command `git worktree add` which
+# If repo_type is a file then the current folder was created with the command `git worktree add` which
 # is a branch checked out in its own folder. For this we pass in the path of the worktree parent so
 # the fmt command will has access to other branches when it does a diff.
 # Example:
@@ -58,8 +58,8 @@ if [[ "${repotype}" == "not-worktree" ]]; then
 #   > git worktree add -B new-branch-name ./new-branch-name
 #   > cd ./new-branch-name
 #   > bin/fmt
-elif [[ "${repotype}" == "worktree" ]]; then
-  worktree_root="$(dirname "${gitdir}")"
+elif [[ "${repo_type}" == "worktree" ]]; then
+  worktree_root="$(dirname "${GIT_DIR}")"
 
   docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
@@ -67,6 +67,6 @@ elif [[ "${repotype}" == "worktree" ]]; then
     civiform/formatter \
     "$@"
 else
-  echo "Could not find the git work tree for ${gitdir}"
+  echo "Could not find the git work tree for ${GIT_DIR}"
   exit 1
 fi

--- a/bin/fmt
+++ b/bin/fmt
@@ -35,8 +35,10 @@ if [[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]]; th
   repotype="worktree"
 fi
 
-echo "gitdir ${gitdir}"
-echo "repotype ${repotype}"
+echo "gitdir: ${gitdir}"
+echo "repotype: ${repotype}"
+echo "interactive_flag: ${interactive_flag}"
+echo "CI: ${CI}"
 
 # If repotype is a directory then the git repository was created by with the common `git clone` way
 # which is just a single working tree pointing at the current branch. Is is the more common way
@@ -47,7 +49,7 @@ echo "repotype ${repotype}"
 #   > git checkout -b new-branch-name
 #   > bin/fmt
 if [[ "${repotype}" == "not-worktree" ]]; then
-  docker run --rm "${interactive_flag}" \
+  docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
     civiform/formatter \
     "$@"

--- a/bin/fmt
+++ b/bin/fmt
@@ -35,6 +35,9 @@ if [[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]]; th
   repotype="worktree"
 fi
 
+echo "gitdir ${gitdir}"
+echo "repotype ${repotype}"
+
 # If repotype is a directory then the git repository was created by with the common `git clone` way
 # which is just a single working tree pointing at the current branch. Is is the more common way
 # in which folks clone a repository.
@@ -60,6 +63,7 @@ if [[ "${repotype}" == "not-worktree" ]]; then
 #   > bin/fmt
 elif [[ "${repotype}" == "worktree" ]]; then
   worktree_root="$(dirname "${gitdir}")"
+  echo "worktree_root: ${worktree_root}"
 
   docker run --rm "${interactive_flag}" \
     -v "$(pwd):/code" \

--- a/bin/fmt
+++ b/bin/fmt
@@ -50,7 +50,7 @@ if [[ "${repotype}" == "not-worktree" ]]; then
     "$@"
 
 # If repotype is a file then the current folder was created with the command `git worktree add` which
-# is a branch checkout out in its own folder. For this we pass in the path of the worktree parent so
+# is a branch checked out in its own folder. For this we pass in the path of the worktree parent so
 # the fmt command will has access to other branches when it does a diff.
 # Example:
 #   > git clone --bare git@github.com:civiform/civiform.git

--- a/bin/fmt
+++ b/bin/fmt
@@ -28,7 +28,42 @@ if [[ -n "${CI}" ]]; then
   interactive_flag=""
 fi
 
-docker run --rm ${interactive_flag} \
-  -v "$(pwd):/code" \
-  civiform/formatter \
-  "$@"
+gitdir="$(git rev-parse --show-toplevel)"
+repotype="not-worktree"
+
+if [[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]]; then
+  repotype="worktree"
+fi
+
+# If repotype is a directory then the git repository was created by with the common `git clone` way
+# which is just a single working tree pointing at the current branch. Is is the more common way
+# in which folks clone a repository.
+# Example:
+#   > git clone git@github.com:civiform/civiform.git
+#   > cd ./civiform
+#   > git checkout -b new-branch-name
+if [[ "${repotype}" == "not-worktree" ]]; then
+  docker run --rm "${interactive_flag}" \
+    -v "$(pwd):/code" \
+    civiform/formatter \
+    "$@"
+
+# If repotype is a file then the current folder was created with the command `git worktree add` which
+# is a branch checkout out in its own folder. For this we pass in the path of the worktree parent so
+# the fmt command will has access to other branches when it does a diff.
+# Example:
+#   > git clone --bare git@github.com:civiform/civiform.git
+#   > git worktree add -B new-branch-name ./new-branch-name
+#   > cd ./new-branch-name
+elif [[ "${repotype}" == "worktree" ]]; then
+  worktree_root="$(dirname "${gitdir}")"
+
+  docker run --rm "${interactive_flag}" \
+    -v "$(pwd):/code" \
+    -v "${worktree_root}:${worktree_root}" \
+    civiform/formatter \
+    "$@"
+else
+  echo "Could not find the git work tree for ${gitdir}"
+  exit 1
+fi


### PR DESCRIPTION
### Description

The formatter code passes in the path to the code to docker. This would work fine if the code is cloned in the more common way with `git clone` and then selecting the active branch.

However if the repository were cloned as a bare repository and branches added as a separate `git worktree` the formatter wouldn't have access to the git repository metadata and would thus fail. This change checks if on a worktree or not and passes in the path to the git metadata if needed.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
