### PR TITLE
Set aria-required for required questions.

### DIFF
--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -131,6 +131,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                 FieldWithLabel.radio()
                     .setId("program-display-mode-public")
                     .setFieldName("displayMode")
+                    .setAriaRequired(true)
                     .setLabelText("Publicly visible")
                     .setValue(DisplayMode.PUBLIC.getValue())
                     .setChecked(displayMode.equals(DisplayMode.PUBLIC.getValue()))
@@ -138,6 +139,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                 FieldWithLabel.radio()
                     .setId("program-display-mode-hidden")
                     .setFieldName("displayMode")
+                    .setAriaRequired(true)
                     .setLabelText(
                         "Hide from applicants. Only individuals with the unique program link can"
                             + " access this program")
@@ -147,6 +149,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                 FieldWithLabel.radio()
                     .setId("program-display-mode-ti-only")
                     .setFieldName("displayMode")
+                    .setAriaRequired(true)
                     .setLabelText("Trusted Intermediaries ONLY")
                     .setValue(DisplayMode.TI_ONLY.getValue())
                     .setChecked(displayMode.equals(DisplayMode.TI_ONLY.getValue()))

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -396,6 +396,7 @@ public final class QuestionEditView extends BaseHtmlView {
                     span(".")),
             FieldWithLabel.radio()
                 .setDisabled(!submittable)
+                .setAriaRequired(true)
                 .setFieldName("questionExportState")
                 .setLabelText("Don't allow answers to be exported")
                 .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
@@ -403,6 +404,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .getRadioTag(),
             FieldWithLabel.radio()
                 .setDisabled(!submittable)
+                .setAriaRequired(true)
                 .setFieldName("questionExportState")
                 .setLabelText("Export exact answers")
                 .setValue(QuestionTag.DEMOGRAPHIC.getValue())
@@ -410,6 +412,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .getRadioTag(),
             FieldWithLabel.radio()
                 .setDisabled(!submittable)
+                .setAriaRequired(true)
                 .setFieldName("questionExportState")
                 .setLabelText("Export obfuscated answers")
                 .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -70,6 +70,7 @@ public class FieldWithLabel {
   private boolean checked = false;
   private boolean disabled = false;
   private boolean required = false;
+  private boolean ariaRequired = false;
   protected ImmutableList.Builder<String> referenceClassesBuilder = ImmutableList.builder();
   protected ImmutableList.Builder<String> styleClassesBuilder = ImmutableList.builder();
   private ImmutableList.Builder<String> ariaDescribedByBuilder = ImmutableList.builder();
@@ -284,6 +285,12 @@ public class FieldWithLabel {
    */
   public FieldWithLabel isRequired() {
     this.required = true;
+    setAriaRequired(true);
+    return this;
+  }
+
+  public FieldWithLabel setAriaRequired(boolean isRequired) {
+    this.ariaRequired = isRequired;
     return this;
   }
 
@@ -532,6 +539,9 @@ public class FieldWithLabel {
     fieldTag.condAttr(
         shouldForceAriaInvalid || fieldErrorsInfo.hasFieldErrors, "aria-invalid", "true");
     fieldTag.attr("maxlength", MAX_INPUT_TEXT_LENGTH);
+    if (ariaRequired) {
+      fieldTag.attr("aria-required", "true");
+    }
 
     generalApplyAttrsClassesToTag(fieldTag, hasFieldErrors);
 

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -289,6 +289,10 @@ public class FieldWithLabel {
     return this;
   }
 
+  /**
+   * Sets the aria-required attribute indicating whether or not the field is required without making
+   * any visible UI changes.
+   */
   public FieldWithLabel setAriaRequired(boolean isRequired) {
     this.ariaRequired = isRequired;
     return this;

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -101,6 +101,12 @@ public final class SelectWithLabel extends FieldWithLabel {
   }
 
   @Override
+  public SelectWithLabel setAriaRequired(boolean isRequired) {
+    super.setAriaRequired(isRequired);
+    return this;
+  }
+
+  @Override
   public SelectWithLabel setAriaDescribedByIds(ImmutableList<String> ariaDescribedByIds) {
     super.setAriaDescribedByIds(ariaDescribedByIds);
     return this;

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -42,7 +42,8 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
   @Override
   protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 
@@ -114,6 +115,13 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
       cityField.forceAriaInvalid();
       stateField.forceAriaInvalid();
       zipField.forceAriaInvalid();
+    }
+
+    if (!isOptional) {
+      streetAddressField.setAriaRequired(true);
+      cityField.setAriaRequired(true);
+      stateField.setAriaRequired(true);
+      zipField.setAriaRequired(true);
     }
 
     DivTag addressQuestionFormContent =

--- a/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantCompositeQuestionRenderer.java
@@ -30,7 +30,8 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
 
   protected abstract DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional);
 
   @Override
   protected final ContainerTag renderQuestionTag(
@@ -38,7 +39,8 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       ImmutableList<DomContent> questionTextDoms,
-      DivTag questionSecondaryTextDiv) {
+      DivTag questionSecondaryTextDiv,
+      boolean isOptional) {
     ContainerTag questionTag =
         fieldset()
             .attr("aria-describedby", StringUtils.join(ariaDescribedByIds, " "))
@@ -50,7 +52,7 @@ abstract class ApplicantCompositeQuestionRenderer extends ApplicantQuestionRende
                     .withClasses(
                         ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT))
             .with(questionSecondaryTextDiv)
-            .with(renderInputTags(params, validationErrors));
+            .with(renderInputTags(params, validationErrors, isOptional));
 
     return questionTag;
   }

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -51,7 +51,8 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       ImmutableList<DomContent> questionTextDoms,
-      DivTag questionSecondaryTextDiv);
+      DivTag questionSecondaryTextDiv,
+      boolean isOptional);
 
   @Override
   public final DivTag render(ApplicantQuestionRendererParams params) {
@@ -112,7 +113,8 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
             validationErrors,
             ariaDescribedByIds,
             questionTextDoms,
-            questionSecondaryTextDiv);
+            questionSecondaryTextDiv,
+            question.isOptional());
 
     return div()
         .withId(questionId)

--- a/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
+++ b/server/app/views/questiontypes/ApplicantSingleQuestionRenderer.java
@@ -26,7 +26,8 @@ abstract class ApplicantSingleQuestionRenderer extends ApplicantQuestionRenderer
   protected abstract DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds);
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional);
 
   @Override
   protected final ContainerTag renderQuestionTag(
@@ -34,7 +35,8 @@ abstract class ApplicantSingleQuestionRenderer extends ApplicantQuestionRenderer
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       ImmutableList<DomContent> questionTextDoms,
-      DivTag questionSecondaryTextDiv) {
+      DivTag questionSecondaryTextDiv,
+      boolean isOptional) {
     ContainerTag questionTag =
         div()
             .with(
@@ -43,7 +45,7 @@ abstract class ApplicantSingleQuestionRenderer extends ApplicantQuestionRenderer
                     .withClasses(
                         ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT))
             .with(questionSecondaryTextDiv)
-            .with(renderInputTag(params, validationErrors, ariaDescribedByIds));
+            .with(renderInputTag(params, validationErrors, ariaDescribedByIds, isOptional));
 
     return questionTag;
   }

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -34,7 +34,8 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
   @Override
   protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional) {
 
     boolean hasErrors = !validationErrors.isEmpty();
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
@@ -58,13 +59,18 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
                                 multiOptionQuestion.getSelectionPathAsArray(),
                                 option,
                                 multiOptionQuestion.optionIsSelected(option),
-                                hasErrors)));
+                                hasErrors,
+                                isOptional)));
 
     return checkboxQuestionFormContent;
   }
 
   private DivTag renderCheckboxOption(
-      String selectionPath, LocalizedQuestionOption option, boolean isSelected, boolean hasErrors) {
+      String selectionPath,
+      LocalizedQuestionOption option,
+      boolean isSelected,
+      boolean hasErrors,
+      boolean isOptional) {
     String id = "checkbox-" + question.getContextualizedPath() + "-" + option.id();
     LabelTag labelTag =
         label()
@@ -80,6 +86,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
                     .withValue(String.valueOf(option.id()))
                     .withCondChecked(isSelected)
                     .condAttr(hasErrors, "aria-invalid", "true")
+                    .condAttr(!isOptional, "aria-required", "true")
                     .withClasses(
                         StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.CHECKBOX)),
                 span(option.optionText()).withClasses(ReferenceClasses.MULTI_OPTION_VALUE));

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -28,7 +28,8 @@ public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =
@@ -36,6 +37,7 @@ public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
             .setFieldName(currencyQuestion.getCurrencyPath().toString())
             .addReferenceClass(ReferenceClasses.CURRENCY_VALUE)
             .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -29,13 +29,15 @@ public class DateQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =
         FieldWithLabel.date()
             .setFieldName(dateQuestion.getDatePath().toString())
             .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(dateQuestion.getDatePath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -32,7 +32,8 @@ public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 
@@ -40,6 +41,7 @@ public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
         new SelectWithLabel()
             .addReferenceClass("cf-dropdown-question")
             .setFieldName(singleSelectQuestion.getSelectionPath().toString())
+            .setAriaRequired(!isOptional)
             .setPlaceholderText(messages.at(MessageKey.DROPDOWN_PLACEHOLDER.getKeyName()))
             .setOptions(
                 singleSelectQuestion.getOptions().stream()

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -28,7 +28,8 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
     FieldWithLabel emailField =
@@ -36,6 +37,7 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setAutocomplete(Optional.of("email"))
             .setValue(emailQuestion.getEmailValue().orElse(""))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(emailQuestion.getEmailPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -52,7 +52,8 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
   @Override
   protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();
@@ -71,6 +72,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
               /* extraStyle= */ Optional.empty(),
               /* isDisabled= */ false,
               hasErrors,
+              isOptional,
               /* elementId= */ Optional.empty()));
     }
 
@@ -105,6 +107,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
                         // Do not submit this with the form.
                         /* isDisabled= */ true,
                         hasErrors,
+                        isOptional,
                         /* elementId= */ Optional.of(ENUMERATOR_FIELD_TEMPLATE_INPUT_ID))
                     .withId(ENUMERATOR_FIELD_TEMPLATE_ID))
             .withData(
@@ -133,6 +136,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
       Optional<String> extraStyle,
       boolean isDisabled,
       boolean hasErrors,
+      boolean isOptional,
       Optional<String> elementId) {
 
     String indexString = "";
@@ -144,6 +148,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
             .setFieldName(contextualizedPath.toString())
             .setValue(existingEntity)
             .setDisabled(isDisabled)
+            .setAriaRequired(!isOptional)
             .setLabelText(
                 messages.at(
                         MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -56,7 +56,8 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     Messages messages = params.messages();
     boolean hasErrors = !validationErrors.isEmpty();
     return div()

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -26,13 +26,15 @@ public class IdQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     IdQuestion idQuestion = question.createIdQuestion();
 
     FieldWithLabel idField =
         FieldWithLabel.input()
             .setFieldName(idQuestion.getIdPath().toString())
             .setValue(idQuestion.getIdValue().orElse(""))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(idQuestion.getIdPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -30,7 +30,8 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
   @Override
   protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 
@@ -40,6 +41,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
             .setLabelText(messages.at(MessageKey.NAME_LABEL_FIRST.getKeyName()))
             .setAutocomplete(Optional.of("given-name"))
             .setValue(nameQuestion.getFirstNameValue().orElse(""))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 messages,
                 validationErrors.getOrDefault(nameQuestion.getFirstNamePath(), ImmutableSet.of()))
@@ -62,6 +64,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
             .setLabelText(messages.at(MessageKey.NAME_LABEL_LAST.getKeyName()))
             .setAutocomplete(Optional.of("family-name"))
             .setValue(nameQuestion.getLastNameValue().orElse(""))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 messages,
                 validationErrors.getOrDefault(nameQuestion.getLastNamePath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -29,7 +29,8 @@ public class NumberQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =
@@ -38,6 +39,7 @@ public class NumberQuestionRenderer extends ApplicantSingleQuestionRenderer {
             .setScreenReaderText(question.getQuestionTextForScreenReader())
             .setMin(numberQuestion.getQuestionDefinition().getMin())
             .setMax(numberQuestion.getQuestionDefinition().getMax())
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(numberQuestion.getNumberPath(), ImmutableSet.of()))

--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -30,7 +30,8 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     PhoneQuestion phoneQuestion = question.createPhoneQuestion();
 
     Messages messages = params.messages();
@@ -48,6 +49,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
                             .setLabel(messages.at(MessageKey.PHONE_LABEL_COUNTRY_CODE.getKeyName()))
                             .setOptions(COUNTRY_OPTIONS)
                             .build()))
+                .setAriaRequired(!isOptional)
                 .setFieldErrors(
                     messages,
                     validationErrors.getOrDefault(
@@ -61,6 +63,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
             .setFieldName(phoneQuestion.getPhoneNumberPath().toString())
             .setValue(phoneQuestion.getPhoneNumberValue().orElse(""))
             .setLabelText(messages.at(MessageKey.PHONE_LABEL_PHONE_NUMBER.getKeyName()))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 messages,
                 validationErrors.getOrDefault(

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -36,7 +36,8 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
   @Override
   protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
-      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
+      boolean isOptional) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
     boolean hasErrors = !validationErrors.isEmpty();
 
@@ -51,13 +52,18 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
                                 singleOptionQuestion.getSelectionPath().toString(),
                                 option,
                                 singleOptionQuestion.optionIsSelected(option),
-                                hasErrors)));
+                                hasErrors,
+                                isOptional)));
 
     return radioQuestionFormContent;
   }
 
   private DivTag renderRadioOption(
-      String selectionPath, LocalizedQuestionOption option, boolean checked, boolean hasErrors) {
+      String selectionPath,
+      LocalizedQuestionOption option,
+      boolean checked,
+      boolean hasErrors,
+      boolean isOptional) {
     String id = RandomStringUtils.randomAlphabetic(8);
 
     LabelTag labelTag =
@@ -72,6 +78,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
             .withValue(String.valueOf(option.id()))
             .withCondChecked(checked)
             .condAttr(hasErrors, "aria-invalid", "true")
+            .condAttr(!isOptional, "aria-required", "true")
             .withClasses(StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO));
 
     return div()

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -26,13 +26,15 @@ public class TextQuestionRenderer extends ApplicantSingleQuestionRenderer {
   protected DivTag renderInputTag(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds) {
+      ImmutableList<String> ariaDescribedByIds,
+      boolean isOptional) {
     TextQuestion textQuestion = question.createTextQuestion();
 
     FieldWithLabel textField =
         FieldWithLabel.input()
             .setFieldName(textQuestion.getTextPath().toString())
             .setValue(textQuestion.getTextValue().orElse(""))
+            .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),
                 validationErrors.getOrDefault(textQuestion.getTextPath(), ImmutableSet.of()))


### PR DESCRIPTION
### Description

Set aria-required for required questions to help screen reader users be able to tell which questions are required. The file upload question type is an exception since it doesn't have any non-hidden input tags to be able to set the aria-required attribute.

The html required attribute was proposed as another solution here, but that causes the browser to show a built-in "Please fill out this field" tooltip on form submit. We already do our own validation, so I'm using aria-required to avoid side effects on the UI.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #3955 
