### PR TITLE
Use GITHUB_TOKEN to run add to project Github Action

### DIFF
--- a/.github/workflows/assign_issues_to_project.yaml
+++ b/.github/workflows/assign_issues_to_project.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/civiform/projects/1
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Use [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) instead of an individual's personal access token to run the Github Action. 

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4110
