### PR TITLE
Replace `AdminStyles.SECONDARY_BUTTON_STYLES` with new `ButtonStyles.OUTLINED_WHITE_WITH_ICON`

### DIFF
--- a/server/app/views/components/ButtonStyles.java
+++ b/server/app/views/components/ButtonStyles.java
@@ -15,14 +15,14 @@ public final class ButtonStyles {
    * added by other button style constants that use this as a base.
    */
   private static final String BUTTON_BASE =
-      StyleUtils.joinStyles(
-          "block", "py-2", "text-center", "rounded-full", "border", "border-transparent");
+      StyleUtils.joinStyles("block", "py-2", "text-center", "rounded-full", "border");
 
   /** Base styles for semibold buttons with a solid blue background. */
   private static final String BUTTON_BASE_SOLID_BLUE_SEMIBOLD =
       StyleUtils.joinStyles(
           BUTTON_BASE,
           BaseStyles.BG_SEATTLE_BLUE,
+          "border-transparent",
           "text-white",
           "rounded-full",
           "font-semibold",
@@ -34,8 +34,7 @@ public final class ButtonStyles {
       StyleUtils.joinStyles(
           "font-semibold",
           "px-8",
-          // Remove "border-transparent" so it doesn't conflict with "border-seattle-blue".
-          StyleUtils.removeStyles(BUTTON_BASE, "border-transparent"),
+          BUTTON_BASE,
           "bg-transparent",
           BaseStyles.TEXT_SEATTLE_BLUE,
           BaseStyles.BORDER_SEATTLE_BLUE,
@@ -58,4 +57,14 @@ public final class ButtonStyles {
 
   public static final String OUTLINED_TRANSPARENT =
       StyleUtils.joinStyles(BUTTON_BASE_OUTLINE_SEMIBOLD, "text-base");
+
+  public static final String OUTLINED_WHITE_WITH_ICON =
+      StyleUtils.joinStyles(
+          StyleUtils.removeStyles(BUTTON_BASE_OUTLINE_SEMIBOLD, "px-8", "bg-transparent"),
+          "flex",
+          "items-center",
+          "font-medium",
+          "space-x-2",
+          "bg-white",
+          StyleUtils.hover("bg-gray-200"));
 }

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -71,16 +71,8 @@ public final class AdminStyles {
   // TODO(MichaelZetune): replace instances of this with ButtonStyles directly.
   public static final String PRIMARY_BUTTON_STYLES = ButtonStyles.SOLID_BLUE;
 
-  public static final String SECONDARY_BUTTON_STYLES =
-      StyleUtils.joinStyles(
-          BASE_BUTTON_STYLES,
-          "rounded-full",
-          "space-x-2",
-          "border",
-          BaseStyles.BORDER_SEATTLE_BLUE,
-          "bg-white",
-          BaseStyles.TEXT_SEATTLE_BLUE,
-          StyleUtils.hover("bg-gray-200"));
+  // TODO(MichaelZetune): replace instances of this with ButtonStyles directly.
+  public static final String SECONDARY_BUTTON_STYLES = ButtonStyles.OUTLINED_WHITE_WITH_ICON;
 
   public static final String TERTIARY_BUTTON_STYLES =
       StyleUtils.joinStyles(


### PR DESCRIPTION
### Description

The second step towards removing button styles in `AdminStyles` - we want all button styling for both applicants and admins to be in `ButtonStyles`.

Here, we set `AdminStyles.SECONDARY_BUTTON_STYLES` to a new style, `ButtonStyles.OUTLINED_WHITE_WITH_ICON`. In a future PR we will remove the former variable altogether.

### Checklist

#### General
- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Add `ButtonStyles.OUTLINED_WHITE_WITH_ICON`
- [x] Set `AdminStyles.SECONDARY_BUTTON_STYLES` to `ButtonStyles.OUTLINED_WHITE_WITH_ICON`

#### User visible changes

None.

### Issue(s) this completes

None.