### PR TITLE
Create `enforce-labels.yml`

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,27 @@
+name: Label Checker
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - labeled
+    - unlabeled
+
+jobs:
+
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Check for label
+      run: |
+        if [ ${{ github.event.pull_request.labels[@] }} -eq 0 ]; then
+          echo "PR has at least one label. Success."
+        else
+          echo "PR does not have any labels."
+          exit 1
+        fi


### PR DESCRIPTION
### Description

Enforces we don't forget to add labels to PRs. Adds https://github.com/marketplace/actions/enforce-pr-labels to the CIviForm repository to ensure that all PRs have any label.

Here's what the error looks like when we forget:

<img width="1690" alt="image" src="https://user-images.githubusercontent.com/30369272/234071121-883ee6f5-3c8e-41f9-8318-a2bf33b353be.png">

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

#### User visible changes

None.

#### New Features

- [x] Enforce adding labels to GitHub PRs as required by project policy

### Issue(s) this completes

None.