### PR TITLE
Inline `ButtonStyles` from `AdminStyles`

### DIFF
--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -19,6 +19,7 @@ import play.mvc.Http;
 import services.LocalizedStrings;
 import services.TranslationLocales;
 import views.BaseHtmlView;
+import views.components.ButtonStyles;
 import views.components.LinkElement;
 import views.style.AdminStyles;
 
@@ -95,7 +96,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
                             "Save %s updates",
                             locale.getDisplayLanguage(LocalizedStrings.DEFAULT_LOCALE)))
                     .withId("update-localizations-button")
-                    .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES));
+                    .withClasses(ButtonStyles.SOLID_BLUE));
     return form;
   }
 

--- a/server/app/views/admin/apikeys/ApiKeyIndexView.java
+++ b/server/app/views/admin/apikeys/ApiKeyIndexView.java
@@ -33,8 +33,8 @@ import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.Icons;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 
 /** Renders a page that lists the system's {@link models.ApiKey}s. */
@@ -56,7 +56,7 @@ public final class ApiKeyIndexView extends BaseHtmlView {
     ButtonTag newKeyButton =
         ViewUtils.makeSvgTextButton("New API Key", Icons.PLUS)
             .withId("new-api-key-button")
-            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES);
+            .withClasses(ButtonStyles.SOLID_BLUE);
     DivTag headerDiv =
         div()
             .withClasses("flex", "items-center", "place-content-between", "my-8")
@@ -114,7 +114,7 @@ public final class ApiKeyIndexView extends BaseHtmlView {
               .withId(String.format("retire-%s", keyNameSlugified))
               .with(
                   makeSvgTextButton("Retire key", Icons.DELETE)
-                      .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES)));
+                      .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON)));
     }
 
     DivTag topRowDiv =

--- a/server/app/views/admin/apikeys/ApiKeyNewOneView.java
+++ b/server/app/views/admin/apikeys/ApiKeyNewOneView.java
@@ -28,9 +28,9 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.LinkElement;
-import views.style.AdminStyles;
 
 /** Renders a page for adding a new ApiKey. */
 public final class ApiKeyNewOneView extends BaseHtmlView {
@@ -132,7 +132,7 @@ public final class ApiKeyNewOneView extends BaseHtmlView {
                 formTag
                     .with(
                         submitButton("Save")
-                            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES)
+                            .withClasses(ButtonStyles.SOLID_BLUE)
                             .withId("apikey-submit-button"))
                     .withAction(routes.AdminApiKeysController.create().url()));
 

--- a/server/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/server/app/views/admin/programs/ManageProgramAdminsView.java
@@ -21,10 +21,10 @@ import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -87,14 +87,14 @@ public class ManageProgramAdminsView extends BaseHtmlView {
                 ViewUtils.makeSvgTextButton("Add admin", Icons.PLUS)
                     .withType("button")
                     .withId(ADD_BUTTON_ID)
-                    .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "my-2"));
+                    .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2"));
 
     return form()
         .with(makeCsrfTokenInputTag(request))
         .withAction(routes.ProgramAdminManagementController.update(programId).url())
         .withMethod("POST")
         .with(emailFields)
-        .with(submitButton("Save").withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "my-4"));
+        .with(submitButton("Save").withClasses(ButtonStyles.SOLID_BLUE, "my-4"));
   }
 
   private DivTag adminEmailInput(Optional<String> existing) {
@@ -119,7 +119,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
             .withType("button")
             .withClasses(
                 ReferenceClasses.PROGRAM_ADMIN_REMOVE_BUTTON,
-                AdminStyles.SECONDARY_BUTTON_STYLES,
+                ButtonStyles.OUTLINED_WHITE_WITH_ICON,
                 "flex",
                 "m-2");
 

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -25,10 +25,10 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.Icons;
 import views.components.ProgramCardFactory;
 import views.components.ProgramCardFactory.ProgramCardData;
-import views.style.AdminStyles;
 
 /** Renders a page for program admins to view programs they administer. */
 public final class ProgramAdministratorProgramListView extends BaseHtmlView {
@@ -110,8 +110,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
             ? "Forms"
             : "Applications";
     ButtonTag button =
-        makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET)
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+        makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, viewApplicationsLink);
   }
 
@@ -120,7 +119,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
         baseUrl
             + controllers.applicant.routes.RedirectController.programBySlug(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
-        .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
+        .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);
   }
 }

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -44,13 +44,13 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.SelectWithLabel;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -250,7 +250,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                     div().withClass("flex-grow"),
                     downloadButton,
                     makeSvgTextButton("Filter", Icons.FILTER_ALT)
-                        .withClass(AdminStyles.PRIMARY_BUTTON_STYLES)
+                        .withClass(ButtonStyles.SOLID_BLUE)
                         .withType("submit")));
   }
 
@@ -298,7 +298,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                     .withClasses(
                                         ReferenceClasses.DOWNLOAD_ALL_BUTTON,
                                         ReferenceClasses.MODAL_CLOSE,
-                                        AdminStyles.PRIMARY_BUTTON_STYLES)
+                                        ButtonStyles.SOLID_BLUE)
                                     .withFormaction(
                                         controllers.admin.routes.AdminApplicationController
                                             .downloadAll(
@@ -314,7 +314,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                     .withClasses(
                                         ReferenceClasses.DOWNLOAD_ALL_BUTTON,
                                         ReferenceClasses.MODAL_CLOSE,
-                                        AdminStyles.PRIMARY_BUTTON_STYLES)
+                                        ButtonStyles.SOLID_BLUE)
                                     .withFormaction(
                                         controllers.admin.routes.AdminApplicationController
                                             .downloadAllJson(
@@ -332,7 +332,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
         .setModalTitle("Download application data")
         .setTriggerButtonContent(
             makeSvgTextButton("Download", Icons.DOWNLOAD)
-                .withClass(AdminStyles.SECONDARY_BUTTON_STYLES)
+                .withClass(ButtonStyles.OUTLINED_WHITE_WITH_ICON)
                 .withType("button"))
         .build();
   }

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -43,12 +43,12 @@ import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.JsBundle;
 import views.ViewUtils;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.Modal.Width;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -170,7 +170,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .url();
     return asRedirectElement(
         ViewUtils.makeSvgTextButton("Export to PDF", Icons.DOWNLOAD)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES),
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON),
         link);
   }
 
@@ -300,7 +300,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
   private Modal renderUpdateNoteConfirmationModal(
       long programId, Application application, Optional<String> noteMaybe) {
     ButtonTag triggerButton =
-        makeSvgTextButton("Edit note", Icons.EDIT).withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
+        makeSvgTextButton("Edit note", Icons.EDIT).withClasses(ButtonStyles.CLEAR_WITH_ICON);
     String formId = Modal.randomModalId();
     // No form action or content is rendered since admin_application_view.ts extracts the values
     // and calls postMessage rather than attempting a submission. The main frame is responsible for
@@ -320,8 +320,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .with(
                 div().withClass("flex-grow"),
                 button("Cancel")
-                    .withClasses(ReferenceClasses.MODAL_CLOSE, AdminStyles.TERTIARY_BUTTON_STYLES),
-                submitButton("Save").withClass(AdminStyles.TERTIARY_BUTTON_STYLES)));
+                    .withClasses(ReferenceClasses.MODAL_CLOSE, ButtonStyles.CLEAR_WITH_ICON),
+                submitButton("Save").withClass(ButtonStyles.CLEAR_WITH_ICON)));
     return Modal.builder()
         .setModalId(Modal.randomModalId())
         .setContent(modalContent)
@@ -391,8 +391,8 @@ public final class ProgramApplicationView extends BaseHtmlView {
                         div().withClass("flex-grow"),
                         button("Cancel")
                             .withClasses(
-                                ReferenceClasses.MODAL_CLOSE, AdminStyles.TERTIARY_BUTTON_STYLES),
-                        submitButton("Confirm").withClass(AdminStyles.TERTIARY_BUTTON_STYLES)));
+                                ReferenceClasses.MODAL_CLOSE, ButtonStyles.CLEAR_WITH_ICON),
+                        submitButton("Confirm").withClass(ButtonStyles.CLEAR_WITH_ICON)));
     ButtonTag triggerButton =
         button("")
             .withClasses("hidden")

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -17,8 +17,8 @@ import services.question.types.QuestionDefinition;
 import views.BaseHtmlView;
 import views.ViewUtils;
 import views.ViewUtils.ProgramDisplayType;
+import views.components.ButtonStyles;
 import views.components.Icons;
-import views.style.AdminStyles;
 import views.style.StyleUtils;
 
 abstract class ProgramBaseView extends BaseHtmlView {
@@ -106,7 +106,7 @@ abstract class ProgramBaseView extends BaseHtmlView {
    */
   protected ButtonTag getStandardizedEditButton(String buttonText) {
     return ViewUtils.makeSvgTextButton(buttonText, Icons.EDIT)
-        .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "my-5")
+        .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5")
         .withId("header_edit_button");
   }
 

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -52,6 +52,7 @@ import views.ViewUtils.ProgramDisplayType;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
@@ -248,7 +249,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     if (viewAllowsEditingProgram()) {
       ret.with(
           ViewUtils.makeSvgTextButton("Add screen", Icons.ADD)
-              .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "m-4")
+              .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "m-4")
               .withType("submit")
               .withId("add-block-button")
               .withForm(CREATE_BLOCK_FORM_ID));
@@ -465,9 +466,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
       ButtonTag addQuestion =
           makeSvgTextButton("Add a question", Icons.ADD)
               .withClasses(
-                  AdminStyles.PRIMARY_BUTTON_STYLES,
-                  ReferenceClasses.OPEN_QUESTION_BANK_BUTTON,
-                  "my-4");
+                  ButtonStyles.SOLID_BLUE, ReferenceClasses.OPEN_QUESTION_BANK_BUTTON, "my-4");
 
       div.with(blockInfoDisplay, buttons, visibilityPredicateDisplay);
       maybeEligibilityPredicateDisplay.ifPresent(div::with);
@@ -497,7 +496,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
             .withType("submit")
             .withId("create-repeated-block-button")
             .withForm(CREATE_REPEATED_BLOCK_FORM_ID)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES));
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON));
 
     // TODO: Maybe add alpha variants to button color on hover over so we do not have
     //  to hard-code what the color will be when button is in hover state?
@@ -538,7 +537,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     if (viewAllowsEditingProgram()) {
       ButtonTag editScreenButton =
           ViewUtils.makeSvgTextButton("Edit visibility condition", Icons.EDIT)
-              .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "m-2")
+              .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "m-2")
               .withId(ReferenceClasses.EDIT_VISIBILITY_PREDICATE_BUTTON);
       div.with(
           asRedirectElement(
@@ -572,7 +571,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     if (viewAllowsEditingProgram()) {
       ButtonTag editScreenButton =
           ViewUtils.makeSvgTextButton("Edit eligibility condition", Icons.EDIT)
-              .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "m-2")
+              .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "m-2")
               .withId(ReferenceClasses.EDIT_ELIGIBILITY_PREDICATE_BUTTON);
       div.with(
           asRedirectElement(
@@ -985,7 +984,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                     + " repeated screens.")
             .withClasses(
                 ReferenceClasses.REMOVE_QUESTION_BUTTON,
-                AdminStyles.SECONDARY_BUTTON_STYLES,
+                ButtonStyles.OUTLINED_WHITE_WITH_ICON,
                 canRemove ? "" : "opacity-50");
     String deleteQuestionAction =
         controllers.admin.routes.AdminProgramBlockQuestionsController.destroy(
@@ -1094,7 +1093,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
 
     ButtonTag deleteScreenButton =
         ViewUtils.makeSvgTextButton("Delete screen", Icons.DELETE)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES);
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON);
 
     return Modal.builder()
         .setModalId("block-delete-modal")
@@ -1140,7 +1139,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 .isDisabled());
     ButtonTag editScreenButton =
         ViewUtils.makeSvgTextButton("Edit screen name and description", Icons.EDIT)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES);
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON);
     return Modal.builder()
         .setModalId("block-description-modal")
         .setContent(blockDescriptionForm)

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -23,11 +23,11 @@ import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import views.BaseHtmlView;
 import views.ViewUtils;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.Modal.Width;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 
 /**
@@ -193,7 +193,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     formTag.with(
         submitButton("Save")
             .withId("program-update-button")
-            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "mt-6"));
+            .withClasses(ButtonStyles.SOLID_BLUE, "mt-6"));
 
     return formTag;
   }
@@ -241,7 +241,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                         submitButton("Confirm")
                             .withForm("program-details-form")
                             .withId("confirm-common-intake-change-button")
-                            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "cursor-pointer")));
+                            .withClasses(ButtonStyles.SOLID_BLUE, "cursor-pointer")));
     return Modal.builder()
         .setModalId("confirm-common-intake-change")
         .setContent(content)

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -42,13 +42,13 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.ProgramCardFactory;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 
 /** Renders a page so the admin can view all active programs and draft programs. */
@@ -103,7 +103,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                         div().withClass("flex-grow"),
                         demographicsCsvModal
                             .getButton()
-                            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "my-2"),
+                            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2"),
                         renderNewProgramButton(),
                         maybePublishModal.isPresent() ? maybePublishModal.get().getButton() : null),
                 div()
@@ -187,7 +187,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                                     .getDateTag()
                                     .withClasses("ml-3", "inline-flex")),
                         makeSvgTextButton(downloadActionText, Icons.DOWNLOAD)
-                            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "mt-6")
+                            .withClasses(ButtonStyles.SOLID_BLUE, "mt-6")
                             .withType("submit")));
     return Modal.builder()
         .setModalId(modalId)
@@ -250,14 +250,14 @@ public final class ProgramIndexView extends BaseHtmlView {
                         div().withClass("flex-grow"),
                         button("Cancel")
                             .withClasses(
-                                ReferenceClasses.MODAL_CLOSE, AdminStyles.TERTIARY_BUTTON_STYLES),
+                                ReferenceClasses.MODAL_CLOSE, ButtonStyles.CLEAR_WITH_ICON),
                         toLinkButtonForPost(
-                            submitButton("Confirm").withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
+                            submitButton("Confirm").withClasses(ButtonStyles.CLEAR_WITH_ICON),
                             link,
                             request)));
     ButtonTag publishAllButton =
         makeSvgTextButton("Publish all drafts", Icons.PUBLISH)
-            .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "my-2");
+            .withClasses(ButtonStyles.SOLID_BLUE, "my-2");
     Modal publishAllModal =
         Modal.builder()
             .setModalId("publish-all-programs-modal")
@@ -305,7 +305,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Create new program", Icons.ADD)
             .withId("new-program-button")
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "my-2");
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2");
     return asRedirectElement(button, link);
   }
 
@@ -375,7 +375,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         baseUrl
             + controllers.applicant.routes.RedirectController.programBySlug(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
-        .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
+        .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);
   }
 
@@ -391,7 +391,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Edit", Icons.EDIT)
             .withId(editLinkId)
-            .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClasses(ButtonStyles.CLEAR_WITH_ICON);
     return isActive
         ? toLinkButtonForPost(button, editLink, request)
         : asRedirectElement(button, editLink);
@@ -405,7 +405,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("View", Icons.VIEW)
             .withId(viewLinkId)
-            .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClasses(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, viewLink);
   }
 
@@ -418,7 +418,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withId("program-translations-link-" + program.id())
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON);
     return Optional.of(asRedirectElement(button, linkDestination));
   }
 
@@ -426,7 +426,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     String linkDestination = routes.AdminProgramStatusesController.index(program.id()).url();
     ButtonTag button =
         makeSvgTextButton("Manage application statuses", Icons.FLAKY)
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, linkDestination);
   }
 
@@ -465,8 +465,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               ? "Forms"
               : "Applications";
       ButtonTag button =
-          makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET)
-              .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+          makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
       return Optional.of(asRedirectElement(button, editLink));
     }
     return Optional.empty();
@@ -477,7 +476,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage Program Admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, adminLink);
   }
 
@@ -494,7 +493,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Settings", Icons.SETTINGS)
             .withId("edit-settings-link-" + program.id())
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON);
     return Optional.of(asRedirectElement(button, linkDestination));
   }
 }

--- a/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
@@ -32,11 +32,11 @@ import views.ViewUtils.ProgramDisplayType;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.Icons;
 import views.components.LinkElement;
 import views.components.LinkElement.IconPosition;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 
 /** Renders a page for editing predicates of a block in a program. */
@@ -175,7 +175,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                         String.format(
                             "Remove existing %s condition",
                             predicateTypeNameTitleCase.toLowerCase()))
-                    .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES)
+                    .withClasses(ButtonStyles.SOLID_BLUE)
                     .withForm(removePredicateFormId)
                     .withCondDisabled(!hasExistingPredicate));
 
@@ -212,7 +212,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                                 predicateTypeNameTitleCase.toLowerCase()),
                             configureExistingPredicateUrl)
                         .withCondDisabled(!hasExistingPredicate)
-                        .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES)))
+                        .withClasses(ButtonStyles.SOLID_BLUE)))
             // Show the control to remove the current predicate.
             .with(removePredicateForm)
             // Show all available questions that predicates can be made for, for this block.
@@ -232,7 +232,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                                             hasExistingPredicate
                                                 ? "Replace condition"
                                                 : "Add condition")
-                                        .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES))
+                                        .withClasses(ButtonStyles.SOLID_BLUE))
                                 .withAction(configureNewPredicateUrl)
                                 .withMethod(POST)));
 

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -37,12 +37,12 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.Modal.Width;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
@@ -98,7 +98,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
             /* showEmailDeletionWarning= */ false);
     ButtonTag createStatusTriggerButton =
         makeSvgTextButton("Create a new status", Icons.PLUS)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, "my-2")
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2")
             .withId(createStatusModal.getTriggerButtonId());
 
     Pair<DivTag, ImmutableList<Modal>> statusContainerAndModals =
@@ -149,7 +149,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
         routes.AdminProgramTranslationsController.redirectToFirstLocale(program.id()).url();
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
-            .withClass(AdminStyles.SECONDARY_BUTTON_STYLES);
+            .withClass(ButtonStyles.OUTLINED_WHITE_WITH_ICON);
     return Optional.of(asRedirectElement(button, linkDestination));
   }
 
@@ -236,13 +236,13 @@ public final class ProgramStatusesView extends BaseHtmlView {
             /* showEmailDeletionWarning= */ status.localizedEmailBodyText().isPresent());
     ButtonTag editStatusTriggerButton =
         makeSvgTextButton("Edit", Icons.EDIT)
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
+            .withClass(ButtonStyles.CLEAR_WITH_ICON)
             .withId(editStatusModal.getTriggerButtonId());
 
     Modal deleteStatusModal = makeStatusDeleteModal(request, program, status.statusText());
     ButtonTag deleteStatusTriggerButton =
         makeSvgTextButton("Delete", Icons.DELETE)
-            .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
+            .withClass(ButtonStyles.CLEAR_WITH_ICON)
             .withId(deleteStatusModal.getTriggerButtonId());
     return Pair.of(
         div()
@@ -310,7 +310,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
                             .with(
                                 div().withClass("flex-grow"),
                                 submitButton("Delete")
-                                    .withClass(AdminStyles.SECONDARY_BUTTON_STYLES))));
+                                    .withClass(ButtonStyles.OUTLINED_WHITE_WITH_ICON))));
 
     return Modal.builder()
         .setModalId(Modal.randomModalId())
@@ -403,7 +403,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
                     .with(
                         defaultCheckbox,
                         div().withClass("flex-grow"),
-                        submitButton("Confirm").withClass(AdminStyles.TERTIARY_BUTTON_STYLES)));
+                        submitButton("Confirm").withClass(ButtonStyles.CLEAR_WITH_ICON)));
     return Modal.builder()
         .setModalId(Modal.randomModalId())
         .setContent(content)

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -22,9 +22,9 @@ import services.MessageKey;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
 import views.ViewUtils;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -191,7 +191,7 @@ public final class QuestionConfig {
         ViewUtils.makeSvgTextButton("Delete", Icons.DELETE)
             .withType("button")
             .withClasses(
-                AdminStyles.SECONDARY_BUTTON_STYLES,
+                ButtonStyles.OUTLINED_WHITE_WITH_ICON,
                 "ml-4",
                 "multi-option-question-field-remove-button");
 
@@ -243,7 +243,7 @@ public final class QuestionConfig {
             ViewUtils.makeSvgTextButton("Add answer option", Icons.PLUS)
                 .withType("button")
                 .withId("add-new-option")
-                .withClasses("m-2", AdminStyles.SECONDARY_BUTTON_STYLES));
+                .withClasses("m-2", ButtonStyles.OUTLINED_WHITE_WITH_ICON));
     return this;
   }
 

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -39,11 +39,11 @@ import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.LinkElement;
 import views.components.SelectWithLabel;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
@@ -267,10 +267,8 @@ public final class QuestionEditView extends BaseHtmlView {
                 .with(
                     div().withClasses("flex-grow"),
                     asRedirectElement(button("Cancel"), cancelUrl)
-                        .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES),
-                    submitButton("Create")
-                        .withClass("m-4")
-                        .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES)));
+                        .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON),
+                    submitButton("Create").withClass("m-4").withClasses(ButtonStyles.SOLID_BLUE)));
 
     return formTag;
   }
@@ -287,7 +285,7 @@ public final class QuestionEditView extends BaseHtmlView {
             controllers.admin.routes.AdminQuestionController.update(
                     id, questionForm.getQuestionType().toString())
                 .url())
-        .with(submitButton("Update").withClasses("ml-2", AdminStyles.PRIMARY_BUTTON_STYLES));
+        .with(submitButton("Update").withClasses("ml-2", ButtonStyles.SOLID_BLUE));
     return formTag;
   }
 

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -44,13 +44,13 @@ import views.ViewUtils.ProgramDisplayType;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.CreateQuestionButton;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.Modal.Width;
 import views.components.SvgTag;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -544,7 +544,7 @@ public final class QuestionsListView extends BaseHtmlView {
     String link = controllers.admin.routes.AdminQuestionController.edit(definition.getId()).url();
     return asRedirectElement(
         makeSvgTextButton("Edit", Icons.EDIT)
-            .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES, isVisible ? "" : "invisible"),
+            .withClasses(ButtonStyles.CLEAR_WITH_ICON, isVisible ? "" : "invisible"),
         link);
   }
 
@@ -560,7 +560,7 @@ public final class QuestionsListView extends BaseHtmlView {
     ButtonTag button =
         asRedirectElement(
             makeSvgTextButton("Manage Translations", Icons.TRANSLATE)
-                .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON),
             link);
     return Optional.of(button);
   }
@@ -604,7 +604,7 @@ public final class QuestionsListView extends BaseHtmlView {
         makeSvgTextButton("", Icons.MORE_VERT)
             .withId(extraActionsButtonId)
             .withClasses(
-                AdminStyles.TERTIARY_BUTTON_STYLES,
+                ButtonStyles.CLEAR_WITH_ICON,
                 ReferenceClasses.WITH_DROPDOWN,
                 "h-12",
                 extraActions.build().isEmpty() ? "invisible" : "");
@@ -641,8 +641,7 @@ public final class QuestionsListView extends BaseHtmlView {
 
     ButtonTag discardConfirmButton =
         toLinkButtonForPost(
-            makeSvgTextButton("Discard", Icons.DELETE)
-                .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES),
+            makeSvgTextButton("Discard", Icons.DELETE).withClasses(ButtonStyles.SOLID_BLUE),
             link,
             request);
 
@@ -651,8 +650,7 @@ public final class QuestionsListView extends BaseHtmlView {
             .withClasses("p-6", "flex-row", "space-y-6");
 
     ButtonTag discardMenuButton =
-        makeSvgTextButton("Discard Draft", Icons.DELETE)
-            .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
+        makeSvgTextButton("Discard Draft", Icons.DELETE).withClasses(ButtonStyles.CLEAR_WITH_ICON);
 
     Modal modal =
         Modal.builder()
@@ -677,7 +675,7 @@ public final class QuestionsListView extends BaseHtmlView {
         ButtonTag unarchiveButton =
             toLinkButtonForPost(
                 makeSvgTextButton("Restore Archived", Icons.UNARCHIVE)
-                    .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
+                    .withClasses(ButtonStyles.CLEAR_WITH_ICON),
                 restoreLink,
                 request);
         return Pair.of(unarchiveButton, Optional.empty());
@@ -687,7 +685,7 @@ public final class QuestionsListView extends BaseHtmlView {
         ButtonTag archiveButton =
             toLinkButtonForPost(
                 makeSvgTextButton("Archive", Icons.ARCHIVE)
-                    .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES),
+                    .withClasses(ButtonStyles.CLEAR_WITH_ICON),
                 archiveLink,
                 request);
         return Pair.of(archiveButton, Optional.empty());
@@ -710,7 +708,7 @@ public final class QuestionsListView extends BaseHtmlView {
                 definition.getName(), referencingPrograms, Optional.of(modalHeader));
         ButtonTag cantArchiveButton =
             makeSvgTextButton("Archive", Icons.ARCHIVE)
-                .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES)
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON)
                 .withId(maybeModal.get().getTriggerButtonId());
 
         return Pair.of(cantArchiveButton, maybeModal);

--- a/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
+++ b/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
@@ -29,9 +29,9 @@ import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -87,7 +87,7 @@ public class EditTrustedIntermediaryGroupView extends BaseHtmlView {
             formTag.with(
                 emailField.getInputTag(),
                 makeCsrfTokenInputTag(request),
-                submitButton("Add").withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "ml-2", "mb-6")))
+                submitButton("Add").withClasses(ButtonStyles.SOLID_BLUE, "ml-2", "mb-6")))
         .withClasses("border", "border-gray-300", "shadow-md", "mt-6");
   }
 
@@ -135,7 +135,7 @@ public class EditTrustedIntermediaryGroupView extends BaseHtmlView {
         .with(input().isHidden().withName("accountId").withValue(account.id.toString()))
         .with(
             ViewUtils.makeSvgTextButton("Delete", Icons.DELETE)
-                .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES));
+                .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON));
   }
 
   private TheadTag renderGroupTableHeader() {

--- a/server/app/views/admin/ti/TrustedIntermediaryGroupListView.java
+++ b/server/app/views/admin/ti/TrustedIntermediaryGroupListView.java
@@ -30,10 +30,10 @@ import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.ToastMessage;
-import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -103,8 +103,7 @@ public class TrustedIntermediaryGroupListView extends BaseHtmlView {
                 nameField.getInputTag(),
                 descriptionField.getInputTag(),
                 makeCsrfTokenInputTag(request),
-                submitButton("Create")
-                    .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, "ml-2", "mb-6")))
+                submitButton("Create").withClasses(ButtonStyles.SOLID_BLUE, "ml-2", "mb-6")))
         .withClasses("border", "border-gray-300", "shadow-md", "w-1/2", "mt-6");
   }
 
@@ -147,13 +146,13 @@ public class TrustedIntermediaryGroupListView extends BaseHtmlView {
         .with(makeCsrfTokenInputTag(request))
         .with(
             ViewUtils.makeSvgTextButton("Delete", Icons.DELETE)
-                .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES));
+                .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON));
   }
 
   private ButtonTag renderEditButton(TrustedIntermediaryGroup tiGroup) {
     return asRedirectElement(
         ViewUtils.makeSvgTextButton("Edit members", Icons.EDIT)
-            .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES),
+            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON),
         routes.TrustedIntermediaryManagementController.edit(tiGroup.id).url());
   }
 

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -9,7 +9,6 @@ import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import services.question.types.QuestionType;
-import views.style.AdminStyles;
 import views.style.StyleUtils;
 
 /**
@@ -27,9 +26,7 @@ public final class CreateQuestionButton {
             .withId(parentId)
             .withType("button")
             .withClass(
-                isPrimaryButton
-                    ? AdminStyles.PRIMARY_BUTTON_STYLES
-                    : AdminStyles.SECONDARY_BUTTON_STYLES);
+                isPrimaryButton ? ButtonStyles.SOLID_BLUE : ButtonStyles.OUTLINED_WHITE_WITH_ICON);
     DivTag dropdown =
         div()
             .withId(dropdownId)

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -21,7 +21,6 @@ import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import views.ViewUtils;
 import views.ViewUtils.ProgramDisplayType;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -119,7 +118,7 @@ public final class ProgramCardFactory {
         ViewUtils.makeSvgTextButton("", Icons.MORE_VERT)
             .withId(extraActionsButtonId)
             .withClasses(
-                AdminStyles.TERTIARY_BUTTON_STYLES,
+                ButtonStyles.CLEAR_WITH_ICON,
                 ReferenceClasses.WITH_DROPDOWN,
                 "h-12",
                 programRow.extraRowActions().size() == 0 ? "invisible" : "");

--- a/server/app/views/components/QuestionBank.java
+++ b/server/app/views/components/QuestionBank.java
@@ -30,7 +30,6 @@ import services.ProgramBlockValidation;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
-import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -199,7 +198,8 @@ public final class QuestionBank {
             .withId("question-" + definition.getId())
             .withName("question-" + definition.getId())
             .withValue(definition.getId() + "")
-            .withClasses(ReferenceClasses.ADD_QUESTION_BUTTON, AdminStyles.SECONDARY_BUTTON_STYLES);
+            .withClasses(
+                ReferenceClasses.ADD_QUESTION_BUTTON, ButtonStyles.OUTLINED_WHITE_WITH_ICON);
 
     SvgTag icon =
         Icons.questionTypeSvg(definition.getQuestionType()).withClasses("shrink-0", "h-12", "w-6");

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -1,7 +1,5 @@
 package views.style;
 
-import views.components.ButtonStyles;
-
 /** Styles for admin pages. */
 public final class AdminStyles {
 
@@ -64,13 +62,4 @@ public final class AdminStyles {
   public static final String MAIN =
       StyleUtils.joinStyles(
           "bg-white", "border", "border-gray-200", "mt-12", "shadow-lg", "w-screen");
-
-  // TODO(MichaelZetune): replace instances of this with ButtonStyles directly.
-  public static final String PRIMARY_BUTTON_STYLES = ButtonStyles.SOLID_BLUE;
-
-  // TODO(MichaelZetune): replace instances of this with ButtonStyles directly.
-  public static final String SECONDARY_BUTTON_STYLES = ButtonStyles.OUTLINED_WHITE_WITH_ICON;
-
-  // TODO(MichaelZetune): replace instances of this with ButtonStyles directly.
-  public static final String TERTIARY_BUTTON_STYLES = ButtonStyles.CLEAR_WITH_ICON;
 }


### PR DESCRIPTION
### Description

The last change for moving Admin button styles to `ButtonStyles.java`. Inlines the usages of `AdminStyles.x` to the appropriate `ButtonStyles` vars and deletes the `AdminStyles` ones.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

None.