### PR TITLE
Store updated snapshots from running screenshot tests.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,6 +97,12 @@ jobs:
           name: image diff output directory
           path: browser-test/diff_output
         if: failure()
+      - name: Upload updated snapshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: updated snapshots output directory
+          path: browser-test/updated_snapshots
+        if: failure()
       - name: Upload test videos on failure
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 *.swp
 diff_output/
+updated_snapshots/
 
 # Test artifacts
 .log

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -531,6 +531,8 @@ export const validateScreenshot = async (
     failureThresholdType: 'percent',
     customSnapshotsDir: 'image_snapshots',
     customDiffDir: 'diff_output',
+    storeReceivedOnFailure: true,
+    customReceivedDir: 'updated_snapshots',
     customSnapshotIdentifier: ({testPath}) => {
       const dir = path.basename(testPath).replace('.test.ts', '_test')
       return `${dir}/${screenshotFileName}`


### PR DESCRIPTION
### Description

Currently if you run screenshot tests and there are failures, we store the diffs but not the new screenshot. The only way to update the accepted screenshots is to run the browser test again with "-u". Sometimes it would be useful to just be able to grab the updated screenshots directly rather than having to run the tests a second time. For example, if you see a test failing in CI and want to accept the screenshot without running the browser test environment and running the test locally.

Unfortunately the library names the updated screenshot with a "-received" suffix and doesn't allow you to change this, so you'll have to rename the screenshots manually. I'm going to look into ways to make this easier in a follow up.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
