### PR TITLE
Add new `CLEAR_WITH_ICON_FOR_DROPDOWN` button style for dropdowns

### DIFF
--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -388,13 +388,11 @@ public final class ProgramIndexView extends BaseHtmlView {
       editLinkId = "program-new-version-link-" + program.id();
     }
 
-    ButtonTag button =
-        makeSvgTextButton("Edit", Icons.EDIT)
-            .withId(editLinkId)
-            .withClasses(ButtonStyles.CLEAR_WITH_ICON);
+    ButtonTag button = makeSvgTextButton("Edit", Icons.EDIT).withId(editLinkId);
     return isActive
-        ? toLinkButtonForPost(button, editLink, request)
-        : asRedirectElement(button, editLink);
+        ? toLinkButtonForPost(
+            button.withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN), editLink, request)
+        : asRedirectElement(button.withClass(ButtonStyles.CLEAR_WITH_ICON), editLink);
   }
 
   ButtonTag renderViewLink(ProgramDefinition program, Http.Request request) {
@@ -418,7 +416,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withId("program-translations-link-" + program.id())
-            .withClass(ButtonStyles.CLEAR_WITH_ICON);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
     return Optional.of(asRedirectElement(button, linkDestination));
   }
 
@@ -426,7 +424,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     String linkDestination = routes.AdminProgramStatusesController.index(program.id()).url();
     ButtonTag button =
         makeSvgTextButton("Manage application statuses", Icons.FLAKY)
-            .withClass(ButtonStyles.CLEAR_WITH_ICON);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
     return asRedirectElement(button, linkDestination);
   }
 
@@ -476,7 +474,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Manage Program Admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
-            .withClass(ButtonStyles.CLEAR_WITH_ICON);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
     return asRedirectElement(button, adminLink);
   }
 
@@ -493,7 +491,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     ButtonTag button =
         makeSvgTextButton("Settings", Icons.SETTINGS)
             .withId("edit-settings-link-" + program.id())
-            .withClass(ButtonStyles.CLEAR_WITH_ICON);
+            .withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
     return Optional.of(asRedirectElement(button, linkDestination));
   }
 }

--- a/server/app/views/components/ButtonStyles.java
+++ b/server/app/views/components/ButtonStyles.java
@@ -87,4 +87,8 @@ public final class ButtonStyles {
           "bg-transparent",
           BaseStyles.TEXT_SEATTLE_BLUE,
           StyleUtils.hover("bg-gray-200"));
+
+  // Just like CLEAR_WITH_ICON, but in dropdowns we want to remove the rounded corners.
+  public static final String CLEAR_WITH_ICON_FOR_DROPDOWN =
+      StyleUtils.removeStyles(CLEAR_WITH_ICON, "rounded-full");
 }


### PR DESCRIPTION
### Description

Allows dropdown buttons to be non-rounded to stay consistent with the previous style, to address #4688.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
   * Decided this wasn't necessary; feel free to push back.
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features

None.

### Issue(s) this completes

Fixes #4688


## Screenshots

### Before

<img width="1898" alt="image" src="https://user-images.githubusercontent.com/30369272/234401576-5f4a7a84-9f14-4e40-9444-3b7d25a3efef.png">

<img width="1898" alt="image" src="https://user-images.githubusercontent.com/30369272/234401633-84fc3e52-f9fa-40c4-b6a1-d5fd388e77ed.png">


### After

<img width="1898" alt="image" src="https://user-images.githubusercontent.com/30369272/234401803-2f20189f-a5f2-4d15-b121-8c386a427d8e.png">


<img width="1898" alt="image" src="https://user-images.githubusercontent.com/30369272/234401737-258082a9-c115-4759-9b6b-2f9bb95118d2.png">


