### PR TITLE
Removing Hard-coded Seattle Discovery URIs

### DIFF
--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -30,6 +30,7 @@ auth {
 # IDCS secrets must be provided by environment variables - we cannot check them in.
 idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?IDCS_SECRET}
+idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
 idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration

--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -30,7 +30,6 @@ auth {
 # IDCS secrets must be provided by environment variables - we cannot check them in.
 idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?IDCS_SECRET}
-idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
 idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration
@@ -97,7 +96,6 @@ login_gov.acr_value=${?LOGIN_GOV_ACR_VALUE}
 # ADFS secrets must be provided by environment variables - we cannot check them in.
 adfs.client_id = ${?ADFS_CLIENT_ID}
 adfs.secret = ${?ADFS_SECRET}
-adfs.discovery_uri = "https://sts.seattle.gov/adfs/.well-known/openid-configuration"
 adfs.discovery_uri = ${?ADFS_DISCOVERY_URI}
 adfs.admin_group = "ad\\ITD_CiviForm_Admins_Test"
 adfs.admin_group = ${?ADFS_GLOBAL_ADMIN_GROUP}


### PR DESCRIPTION
### Description

The ADFS discovery URIs were hard-coded to default to Seattle. I've updated Seattle's deployment to pass in the values now so we can remove these.

The app still loads on localhost after removing them. Any deployment other than Seattle should have already been setting these as environment variables otherwise those auth options shouldn't be working.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4683
