### PR TITLE
Fix Renovate Config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
     },
     {
       "matchPackageNames": ["postgres"],
-      "allowedVersion": "<13.0.0"
+      "allowedVersions": "<13.0.0"
     }
   ]
 }


### PR DESCRIPTION
### Description

Fix renovate config. Misspelled element name.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

Fixes #2210
