### PR TITLE
Use minimatch glob pattern for renovate matchPaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,10 @@
     },
     {
       "matchPaths": [
-        ".github/workflows/",
-        "browser-test/",
-        "env-var-docs/",
-        "formatter/"
+        ".github/workflows/**",
+        "browser-test/**",
+        "env-var-docs/**",
+        "formatter/**"
       ],
       "labels": ["dependencies", "ignore-for-release"]
     },


### PR DESCRIPTION
### Description

Partial matches with matchPaths is deprecated. Switching to their minimatch glob pattern.

https://docs.renovatebot.com/configuration-options/#matchpaths


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

