### PR TITLE
Group jdk/jre dependency updates and enforce max version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,14 @@
       "matchPackagePrefixes": ["com.fasterxml.jackson"]
     },
     {
+      "groupName": "jdk and jre",
+      "matchPackagePrefixes": [
+        "bellsoft/liberica-openjdk-alpine",
+        "eclipse-temurin"
+      ],
+      "allowedVersions": "<12.0.0"
+    },
+    {
       "groupName": "jupiter",
       "matchPackagePrefixes": ["org.junit.jupiter:"]
     },


### PR DESCRIPTION
### Description

Have Renovate group updates for the amd64 and ARM releases of the JRE/JDK. The goal is to try to keep them updated together in a single PR if they release at the same time.

This also sets the allowed version to stay below version 12 until we can and are ready to move to a newer major version of Java.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
