### PR TITLE
Re-updating localstack to version 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ version: '3.4'
 
 services:
   localstack:
-    image: localstack/localstack:1.4.0
+    image: localstack/localstack:2.0.2
     profiles: ['aws', 'emulator']
     expose:
       - '4566'
     environment:
       - SERVICES=s3,ses
+      - PROVIDER_OVERRIDE_S3=legacy
     networks:
       default:
         aliases:

--- a/localstack/localstack.Dockerfile
+++ b/localstack/localstack.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM localstack/localstack:1.4.0
+FROM localstack/localstack:2.0.2
 
 # Localstack tries to connect to the host specified
 # by success_redirect_url upon successful upload of


### PR DESCRIPTION
### Description

I set the environment variable `PROVIDER_OVERRIDE_S3=legacy` to fix.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4502