### PR TITLE
Resolve HTTP client IP addresses by CLIENT_IP_TYPE

### DIFF
--- a/server/app/auth/ClientIpType.java
+++ b/server/app/auth/ClientIpType.java
@@ -1,0 +1,10 @@
+package auth;
+
+/** Where to find the IP address for incoming requests. */
+public enum ClientIpType {
+  // The IP address of the HTTP client is the originating IP address.
+  DIRECT,
+  // Incoming requests are reverse proxied and the originating IP address is stored in the
+  // X-Forwarded-For header.
+  FORWARDED;
+}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -507,6 +507,12 @@ civiform_version = ${?CIVIFORM_VERSION}
 api_secret_salt = "changeme"
 api_secret_salt = ${?CIVIFORM_API_SECRET_SALT}
 
+# Where to find the IP address for incoming requests. Options are:
+#   DIRECT - the IP address of the request is the originating IP address
+#   FORWARDED - the request has been reverse proxied and the originating IP address is stored in the X-Forwarded-For header
+client_ip_type = "DIRECT"
+client_ip_type = ${?CLIENT_IP_TYPE}
+
 api_keys_ban_global_subnet = true
 api_keys_ban_global_subnet = ${?CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET}
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -397,6 +397,11 @@
     "description": "The release version of CiviForm. For example: v1.18.0. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if it a value other than the empty string or 'latest'.",
     "type": "string"
   },
+  "CLIENT_IP_TYPE": {
+    "description": "Where to find the IP address for incoming requests. Default is \"DIRECT\" where the IP address of the request is the originating IP address. If \"FORWARDED\" then request has been reverse proxied and the originating IP address is stored in the X-Forwarded-For header.",
+    "type": "string",
+    "values": ["DIRECT", "FORWARDED"]
+  },
   "Observability": {
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {


### PR DESCRIPTION
### Description

We currently use [WebContext.getRemoteAddr](https://github.com/civiform/civiform/blob/main/server/app/auth/ApiAuthenticator.java#L117) to determine the remote IP address when authenticating API requests. When CiviForm is deployed on AWS, this value will refer to internal AWS resources (such as load balancers) rather than the actual API client IP address.

When CiviForm is deployed in AWS it should instead refer to the [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header for retrieving the client's IP address.

Deploy system PR for setting the value in AWS: https://github.com/civiform/cloud-deploy-infra/pull/165

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4775