### PR TITLE
Add link to bin/build-prod warning message

### DIFF
--- a/bin/build-prod
+++ b/bin/build-prod
@@ -20,6 +20,8 @@ if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
   echo "----------------------------------------------------------------"
   echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
   echo " Currently only x86_64 is supported by our prod.Dockerfile."
+  echo ""
+  echo " For more info: https://github.com/civiform/civiform/issues/4785"
   echo "----------------------------------------------------------------"
   echo ""
   exit 1


### PR DESCRIPTION
### Description

Includes a link in the bin/build-prod warning message to the issue tracking adding Arm support to the prod image build.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
