### PR TITLE
Make Modal title required at compile-time

### DIFF
--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -44,13 +44,15 @@ public abstract class Modal {
   }
 
   public interface RequiredContent {
-    Builder setContent(ContainerTag<?> content);
+    RequiredTitle setContent(ContainerTag<?> content);
+  }
+
+  public interface RequiredTitle {
+    Builder setModalTitle(String modalTitle);
   }
 
   @AutoValue.Builder
-  public abstract static class Builder implements RequiredModalId, RequiredContent {
-    public abstract Builder setModalTitle(String modalTitle);
-
+  public abstract static class Builder implements RequiredModalId, RequiredTitle, RequiredContent {
     public abstract Builder setTriggerButtonContent(ButtonTag triggerButtonContent);
 
     public abstract Builder setWidth(Width width);


### PR DESCRIPTION
### Description

In `Modal.java`, we use `AutoValue` [stepped builders](https://github.com/google/auto/blob/main/value/userguide/builders-howto.md#-create-a-step-builder) to enforce inclusion of required properties at compile-time. I originally forgot to include the title, even though AutoValue is enforcing them at runtime anyways.