### PR TITLE
Update OpenTelemetry setup

### DIFF
--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -30,11 +30,10 @@ processors:
           - ecs.task.storage.write_bytes
 
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: '${PROMETHEUS_WRITE_ENDPOINT}'
-    aws_auth:
-      region: '${AWS_REGION}'
-      service: aps
+    auth:
+      authenticator: sigv4auth
   logging:
     loglevel: info
 
@@ -44,14 +43,17 @@ extensions:
     endpoint: :1888
   zpages:
     endpoint: :55679
+  sigv4auth:
+    region: '${AWS_REGION}'
+    service: aps
 
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: [pprof, zpages, health_check, sigv4auth]
   pipelines:
     metrics:
       receivers: [prometheus]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]
     metrics/ecs:
       receivers: [awsecscontainermetrics]
       processors: [filter]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]


### PR DESCRIPTION
### Description

We're noticing issues with the metrics writer when using non-default aws region (us-east-2)

Saw that some configuration has changed with OpenTelemetry (see https://aws-otel.github.io/docs/sigv4), so I'm thinking maybe that could be it.

## Release notes

Update OpenTelemetry config

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

#4789
