### PR TITLE
Update bellsoft/liberica-openjdk-alpine to 11.0.19-7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:11.0.19_7-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.18-10 as arm64
+FROM bellsoft/liberica-openjdk-alpine:11.0.19-7 as arm64
 
 FROM ${TARGETARCH}
 

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -4,7 +4,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:11.0.19_7-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.18-10 as arm64
+FROM bellsoft/liberica-openjdk-alpine:11.0.19-7 as arm64
 
 FROM ${TARGETARCH}
 


### PR DESCRIPTION
One-time update to this image. Should be taken care of renovatebot from now on.