### PR TITLE
[Experimental] Switch to using only Eclipse-Temurin for Java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM eclipse-temurin:11.0.19_7-jdk-jammy
+FROM alpine:3.18.0
 
 ENV SBT_VERSION "${SBT_VERSION:-1.8.2}"
 ENV INSTALL_DIR /usr/local
@@ -18,20 +18,18 @@ ENV PROJECT_LOC "${PROJECT_HOME}/${PROJECT_NAME}"
 ########################################################
 
 # Update and add system dependancies
-
-RUN apt update && \
-  apt upgrade -y && \
-  apt install -y openjdk-11-jdk bash curl wget git openssh-server ncurses-bin
-
-# Install nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-RUN apt install -y nodejs
+RUN set -o pipefail && \
+  apk update && \
+  apk add --upgrade apk-tools && \
+  apk upgrade --available && \
+  apk add --no-cache --update openjdk11 bash wget npm git openssh ncurses
 
 # Install npm (node)
-#RUN npm install -g npm@8.5.1
+RUN npm install -g npm@8.5.1
 
 # Download sbt
-RUN mkdir -p "${SBT_HOME}" && \
+RUN set -o pipefail && \
+  mkdir -p "${SBT_HOME}" && \
   wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
   echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built
 

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -14,19 +14,6 @@ readonly LOCATION="."
 readonly DOCKERFILE="prod.Dockerfile"
 readonly HOST_CPU_ARCH="$(docker info --format='{{.Architecture}}')"
 
-if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
-  echo "----------------------------------------------------------------"
-  echo " WARNING"
-  echo "----------------------------------------------------------------"
-  echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
-  echo " Currently only x86_64 is supported by our prod.Dockerfile."
-  echo ""
-  echo " For more info: https://github.com/civiform/civiform/issues/4785"
-  echo "----------------------------------------------------------------"
-  echo ""
-  exit 1
-fi
-
 echo "Building ${SNAPSHOT_TAG}..."
 
 BUILD_ARGS="-f ${DOCKERFILE}

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -1,16 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM eclipse-temurin:11.0.19_7-jdk-jammy
+FROM alpine:3.18.0
 
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
 
-RUN apt update && apt install -y \
-  openjdk-11-jdk bash curl wget shfmt git python3-pip
-
-# Install nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-RUN apt install -y nodejs
+RUN apk update && apk add --no-cache --update \
+  openjdk11 bash wget npm shfmt git py3-pip
 
 # Install python formatter
 RUN pip install yapf

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -1,19 +1,18 @@
 # syntax=docker/dockerfile:1
-# The eclipse-temurin image and the standard openJDK11 fails to run on M1 Macs because it is incompatible with ARM architecture. This
-# workaround uses an aarch64 (arm64) image instead when an optional platform argument is set to arm64.
-# Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
-FROM eclipse-temurin:11.0.19_7-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.19-7 as arm64
-
-FROM ${TARGETARCH}
+FROM eclipse-temurin:11.0.19_7-jdk-jammy
 
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
 
-RUN apk update && apk add --no-cache --update \
-  openjdk11 bash wget npm shfmt git py3-pip terraform
+RUN apt update && apt install -y \
+  openjdk-11-jdk bash curl wget shfmt git python3-pip
 
+# Install nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+RUN apt install -y nodejs
+
+# Install python formatter
 RUN pip install yapf
 
 COPY .prettier* /

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -15,9 +15,9 @@ RUN apt update && \
     wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
 
-# Install nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-RUN apt install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
+    apt install -y nodejs
+
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME server
@@ -34,12 +34,12 @@ RUN cd "${PROJECT_LOC}" && \
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
 FROM eclipse-temurin:11.0.19_7-jre-jammy AS stage2
-COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.
 RUN apt update && \
     apt upgrade -y && \
-    apt install -y bash openssh-server
+    apt install -y bash openssh-server && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG image_tag
 ENV CIVIFORM_IMAGE_TAG=$image_tag
@@ -47,4 +47,5 @@ ENV CIVIFORM_IMAGE_TAG=$image_tag
 ARG git_commit_sha
 LABEL civiform.git.commit_sha=$git_commit_sha
 
+COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 CMD ["/civiform-server-0.0.1/bin/civiform-server", "-Dconfig.file=/civiform-server-0.0.1/conf/application.conf"]

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # For production images, use the adoptium.net official JRE & JDK docker images.
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.19_7-jdk-alpine AS stage1
+FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.19_7-jdk-jammy AS stage1
 
 ENV SBT_VERSION "${SBT_VERSION:-1.8.2}"
 ENV INSTALL_DIR /usr/local
@@ -8,14 +8,16 @@ ENV SBT_HOME /usr/local/sbt
 ENV PATH "${PATH}:${SBT_HOME}/bin"
 ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz"
 
-RUN set -o pipefail && \
-    apk update && \
-    apk add --upgrade apk-tools && \
-    apk upgrade --available && \
-    apk add --no-cache --update bash wget npm git openssh && \
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y bash wget curl git openssh-server unzip && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
+
+# Install nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+RUN apt install -y nodejs
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME server
@@ -23,7 +25,6 @@ ENV PROJECT_LOC "${PROJECT_HOME}/${PROJECT_NAME}"
 
 COPY "${PROJECT_NAME}" "${PROJECT_LOC}"
 RUN cd "${PROJECT_LOC}" && \
-    npm install -g npm@8.5.1 && \
     npm install && \
     sbt update && \
     sbt dist && \
@@ -32,15 +33,13 @@ RUN cd "${PROJECT_LOC}" && \
 
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
-FROM eclipse-temurin:11.0.19_7-jre-alpine AS stage2
+FROM eclipse-temurin:11.0.19_7-jre-jammy AS stage2
 COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.
-RUN set -o pipefail && \
-    apk update && \
-    apk add --upgrade apk-tools && \
-    apk upgrade --available && \
-    apk add --no-cache --update bash openssh
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y bash openssh-server
 
 ARG image_tag
 ENV CIVIFORM_IMAGE_TAG=$image_tag


### PR DESCRIPTION
### Description

Removing Bellsoft JDK and Eclipse-Temurin JDK/JRE images. Switching to use Alpine Linux as the base image and installing the JDK/JRE directly.

This now has a prod image for arm64.


## Release notes


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Fixes #4785, #4014
