### PR TITLE
add label to EMAIL_SEND_COUNT inc

### DIFF
--- a/server/app/services/cloud/aws/SimpleEmail.java
+++ b/server/app/services/cloud/aws/SimpleEmail.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Environment;
 import play.inject.ApplicationLifecycle;
+import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.Body;
 import software.amazon.awssdk.services.ses.model.Content;
@@ -103,12 +104,12 @@ public final class SimpleEmail {
       e.printStackTrace();
       if (metricsEnabled) {
         EMAIL_FAIL_COUNT.inc();
-        EMAIL_SEND_COUNT.labels(String.valueOf(e.statusCode()));
+        EMAIL_SEND_COUNT.labels(String.valueOf(e.statusCode())).inc();
       }
     } finally {
       if (metricsEnabled) {
         // Increase the count of emails sent.
-        EMAIL_SEND_COUNT.inc();
+        EMAIL_SEND_COUNT.labels(String.valueOf(HttpStatusCode.OK)).inc();
         // Record the execution time of the email sending process.
         timer.observeDuration();
       }


### PR DESCRIPTION
### Description

Application submissions on staging are failing with a null pointer exception pointing to the `noLabelsChild.inc(amt);` line in
```
  /**
   * Increment the counter with no labels by the given amount.
   * @throws IllegalArgumentException If amt is negative.
   */
  public void inc(double amt) {
    noLabelsChild.inc(amt);
  }
```

 in `io.prometheus.client.Counter`.

I think this is because we're calling `inc()` [here](https://github.com/civiform/civiform/blob/aaec4b78138b0b74aaebc7238f7760d64d93e8d9/server/app/services/cloud/aws/SimpleEmail.java#L111) without adding a label to it ([docs](https://prometheus.github.io/client_java/io/prometheus/client/Counter.html)).

This pr adds a label to the counter and also calls `inc()` on errors so we will count those according to their statuses.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Issue(s) this completes

Fixes #4768;
