### PR TITLE
Make entity logo not stretch on mobile

### DIFF
--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -274,7 +274,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
         .withClasses("w-16", "py-1");
 
     return a().withHref(routes.HomeController.index().url())
-        .withClasses("flex", "flex-row")
+        .withClasses("flex", "flex-row", "items-center")
         .with(
             cityImage,
             div()


### PR DESCRIPTION
### Description

Previously, the entity logo would be stretched thin on mobile devices. This PR fixes that.

I'm thinking of making some simple mobile tests, just for the landing page and perhaps 1-2 other mission-critical pages, and putting it in a fast follow-up to this PR. I've noticed we (often me) neglect mobile views because of forgetting to check on them when testing so a few screenshots would be a great value add and easy to create.

### Before

<img width="439" alt="image" src="https://github.com/civiform/civiform/assets/30369272/6c704d57-6d0c-4d40-a436-48ba1feab3a6">

### After
<img width="439" alt="image" src="https://github.com/civiform/civiform/assets/30369272/2826a620-c7e6-4513-a7aa-d1af66ed4591">

## Release notes

Fixes logo rendering on mobile

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [n/a] Created tests which fail without the change (if possible)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features

No new features

### Issue(s) this completes

Fixes #4796
