### PR TITLE
Fix guest merge logic

### DIFF
--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -37,9 +37,10 @@ public final class CiviFormProfileMerger {
       BiFunction<Optional<CiviFormProfile>, T, UserProfile> mergeFunction) {
 
     if (applicantInDatabase.isPresent()) {
-      if (guestProfile.isEmpty()) {
-        // Easy merge case - we have an existing applicant, but no guest profile.
-        // This will be the most common.
+      if (guestProfile.isEmpty()
+          || guestProfile.get().getApplicant().join().getApplications().isEmpty()) {
+        // Easy merge case - we have an existing applicant, but no guest profile (or a guest profile
+        // with no applications). This will be the most common.
         guestProfile = Optional.of(profileFactory.wrap(applicantInDatabase.get()));
       } else {
         // Merge the two applicants and prefer the newer one.


### PR DESCRIPTION
### Description

This PR avoids merging a guest with a user logging in if the guest has no submitted applications. This resolves a bug where if `BYPASS_LOGIN_LANGUAGE_SCREENS` is set, a TI creates an applicant, and the applicant later logs in to CiviForm with the same email, then a duplicate applicant will be created.

Before the login changes, this wasn't a possibility because users would see the login screen first, and directly log in with their email that matches the one the TI used. Now, since they start as a guest upon loading CiviForm, this issue in the merging logic is manifesting.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
   - `CiviFormProfileMergerTest.java` is updated to account for that fact that we should not merge guests with no applications. 
   - There are browser tests are in [mzetune/duplicant-applicant-test](https://github.com/civiform/civiform/commit/2cf5040636971b6185892f8304a3aae1da8e575f). I've asserted that they fail before this change and pass afterwards, Unfortunately I don't think it's feasible to include these tests in the PR because they will rely on the name of the test user the TI creates exactly matching the name of the test user that the user logs in with, which couples this test with the test environment.
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

None.
