### PR TITLE
Fix visibility predicates questions bug.

### DIFF
--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -11,7 +11,6 @@ import com.google.common.collect.Sets;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Locale;

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -654,7 +654,6 @@ public abstract class ProgramDefinition {
 
     // Only include block definitions up through the specified block.
     for (BlockDefinition siblingBlockDefinition : siblingBlockDefinitions) {
-      System.out.println("in getavail " + siblingBlockDefinition.name());
       builder.add(siblingBlockDefinition);
       // Stop adding block definitions once we reach this block.
       if (siblingBlockDefinition.id() == blockDefinition.id()) break;

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Sets;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Locale;
@@ -553,7 +554,14 @@ public abstract class ProgramDefinition {
       long blockId) throws ProgramBlockDefinitionNotFoundException {
     // Questions through the block before this one are available for this block's visibility
     // conditions.
-    return getAvailablePredicateQuestionDefinitions(blockId - 1);
+    long previousBlockId = -1;
+    for (int i = 1; i < blockDefinitions().size(); i++) {
+      if (blockDefinitions().get(i).id() == blockId) {
+        previousBlockId = blockDefinitions().get(i - 1).id();
+        break;
+      }
+    }
+    return getAvailablePredicateQuestionDefinitions(previousBlockId);
   }
 
   /**
@@ -646,6 +654,7 @@ public abstract class ProgramDefinition {
 
     // Only include block definitions up through the specified block.
     for (BlockDefinition siblingBlockDefinition : siblingBlockDefinitions) {
+      System.out.println("in getavail " + siblingBlockDefinition.name());
       builder.add(siblingBlockDefinition);
       // Stop adding block definitions once we reach this block.
       if (siblingBlockDefinition.id() == blockDefinition.id()) break;

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -449,7 +449,8 @@ public class ProgramDefinitionTest extends ResetPostgres {
     QuestionDefinition questionD = testQuestionBank.applicantSeason().getQuestionDefinition();
 
     long programDefinitionId = 123L;
-    // The blocks have their IDs set to non-consecutive numbers. This mimics blocks being re-ordered and deleted.
+    // The blocks have their IDs set to non-consecutive numbers. This mimics blocks being re-ordered
+    // and deleted.
     BlockDefinition block1QAQB =
         BlockDefinition.builder()
             .setId(2L)


### PR DESCRIPTION
### Description

Before this change, there was a bug in which the list of questions eligible for a block's visibility predicates would be incorrect after blocks had been reordered. The `getAvailableVisibilityPredicateQuestionDefinitions()` was assuming that the block IDs were in order, but after blocks are reordered or removed the IDs no longer correspond to the block indices.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

