### PR TITLE
Store language code instead of language on initial page load

### DIFF
--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -94,7 +94,7 @@ public final class ApplicantInformationController extends CiviFormController {
                     maybeApplicant,
                     applicantId,
                     Locale.forLanguageTag(
-                        layout.languageSelector.getPreferredLangage(request).language())),
+                        layout.languageSelector.getPreferredLangage(request).code())),
             httpExecutionContext.current())
         .thenApplyAsync(
             applicant -> {

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -42,6 +42,24 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void edit_updatesLanguageCode_usingRequestHeaders() {
+    Http.Request request =
+        addCSRFToken(
+                fakeRequest(routes.ApplicantInformationController.edit(currentApplicant.id))
+                    .header("Accept-Language", "es-US"))
+            .build();
+
+    Result result = controller.edit(request, currentApplicant.id).toCompletableFuture().join();
+
+    currentApplicant =
+        userRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();
+    assertThat(currentApplicant.getApplicantData().preferredLocale())
+        .isEqualTo(Locale.forLanguageTag("es-US"));
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.cookie("PLAY_LANG").get().value()).isEqualTo("es-US");
+  }
+
+  @Test
   public void update_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller


### PR DESCRIPTION
### Description

**Apparently**, there is a difference between a language code and short language string itself. We've been retrieving the language string (like `es`) instead of the language code (like `es-US`).


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

None.