### PR TITLE
Fixing some address bugs

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -126,9 +126,16 @@ public abstract class EsriClient {
                 Address candidateAddress =
                     Address.builder()
                         .setStreet(attributes.get("Address").asText())
-                        .setLine2(attributes.get("SubAddr").asText())
+                        .setLine2(
+                            attributes.get("SubAddr") == null || attributes.get("SubAddr").isEmpty()
+                                ? address.getLine2()
+                                : attributes.get("SubAddr").asText())
                         .setCity(attributes.get("City").asText())
-                        .setState(attributes.get("RegionAbbr").asText())
+                        .setState(
+                            attributes.get("RegionAbbr") == null
+                                    || attributes.get("RegionAbbr").isEmpty()
+                                ? address.getState()
+                                : attributes.get("RegionAbbr").asText())
                         .setZip(attributes.get("Postal").asText())
                         .build();
                 // Suggestion must be a fully formed address.

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -162,6 +162,8 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
     geo += location.getLatitude();
     geo += ",'spatialReference':";
     geo += location.getWellKnownId();
+    geo += "}";
+
     request.addQueryParameter("geometry", geo);
 
     return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)


### PR DESCRIPTION
### Description

- Geometry url parameter is malformed missing the closing "}". ESRI appears to have been handling it, but my mock service broken because of it.

- Seattle's ESRI instance doesn't return the SubAddr (Line2) and is ignored in queries. We can just use the value as entered. Similar with the RegionAbbr. 





### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)


