### PR TITLE
Take TIs directly to their dashboard instead of the programs index page

### DIFF
--- a/server/app/controllers/HomeController.java
+++ b/server/app/controllers/HomeController.java
@@ -78,6 +78,13 @@ public class HomeController extends Controller {
     } else if (profile.isProgramAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.ProgramAdminController.index()));
+    } else if (profile.isTrustedIntermediary()) {
+      return CompletableFuture.completedFuture(
+          redirect(
+              controllers.ti.routes.TrustedIntermediaryController.dashboard(
+                  /* nameQuery= */ Optional.empty(),
+                  /* dateQuery= */ Optional.empty(),
+                  /* page= */ Optional.empty())));
     } else {
       return profile
           .getApplicant()


### PR DESCRIPTION
## Description

Takes TIs directly to their dashboard instead of the programs index page. Previously, we would take TIs to the programs index page, and this causes confusion as they often apply for programs under their own account instead of their managed users. See #4816

## Release notes

Takes TIs directly to their dashboard instead of the programs index page.

## Test strategy

1. Create a new user `myuser` in the test environment.
2. Set `member_of_group_id` with `UPDATE accounts SET member_of_group_id = 1 WHERE id = 123;`
3. Log in as `myuser` and expect to be taken directly to TI dashboard.

## Checklist

### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not possible to unit test this behavior directly, as our test helper `loginAsTrustedIntermediary` uses the fake admin login, which is not the same as a true TI. The other conditional routes in `HomeController.index()` aren't unit tested for this same reason.
- [ ] Extended the README / documentation, if necessary
   - Not necessary

### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
   - Same issue as earlier, `loginAsTrustedIntermediary` depends on fake admin so hard to test this directly.
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### New Features

No new feature flags

### Issue(s) this completes

Fixes #4816
