### PR TITLE
Make bin/pull-image better handle USE_LOCAL_CIVIFORM

### DIFF
--- a/bin/pull-image
+++ b/bin/pull-image
@@ -8,7 +8,7 @@
 
 source bin/lib.sh
 
-if [[ "${USE_LOCAL_CIVIFORM}" == 1 ]]; then
+if [[ "${USE_LOCAL_CIVIFORM}" == 1 || "${USE_LOCAL_CIVIFORM}" == "true" ]]; then
   echo "Using local civiform and dependency docker images"
   exit 0
 fi

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -8,7 +8,7 @@
 
 source bin/lib.sh
 
-if [[ -n "${USE_LOCAL_CIVIFORM}" ]]; then
+if [[ "${USE_LOCAL_CIVIFORM}" == 1 ]]; then
   echo "Using local civiform and dependency docker images"
   exit 0
 fi


### PR DESCRIPTION
### Description

This was skipping if you had USE_LOCAL_CIVIFORM set at all making overriding back to 0 impossible. Now it will only skip if the env variable is set to 1.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
