### PR TITLE
Send status email to TI on status change

### DIFF
--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -134,7 +134,7 @@ public final class ProgramAdminApplicationService {
       Optional<String> adminSubmitterEmail = application.getSubmitterEmail();
       if (adminSubmitterEmail.isPresent()) {
         sendAdminSubmitterEmail(
-            program.getProgramDefinition(), applicant, newStatusText, adminSubmitterEmail);
+            program.getProgramDefinition(), applicant, statusDef, adminSubmitterEmail);
       }
       // Notify the applicant.
       Optional<String> applicantEmail =
@@ -174,7 +174,7 @@ public final class ProgramAdminApplicationService {
   private void sendAdminSubmitterEmail(
       ProgramDefinition programDef,
       Applicant applicant,
-      String newStatusText,
+      Status statusDef,
       Optional<String> adminSubmitterEmail) {
     String programName = programDef.localizedName().getDefault();
     String tiDashLink =
@@ -203,11 +203,7 @@ public final class ProgramAdminApplicationService {
     String body =
         String.format(
             "%s\n%s",
-            messages.at(
-                MessageKey.EMAIL_TI_APPLICATION_UPDATE_BODY.getKeyName(),
-                applicant.id,
-                programName,
-                newStatusText),
+            statusDef.localizedEmailBodyText().get().getOrDefault(locale),
             messages.at(MessageKey.EMAIL_TI_MANAGE_YOUR_CLIENTS.getKeyName(), tiDashLink));
 
     emailClient.send(

--- a/server/test/services/applications/ProgramAdminApplicationServiceTest.java
+++ b/server/test/services/applications/ProgramAdminApplicationServiceTest.java
@@ -333,11 +333,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
                     programDisplayName,
                     applicant.id)),
             Mockito.contains(
-                messages.at(
-                    MessageKey.EMAIL_TI_APPLICATION_UPDATE_BODY.getKeyName(),
-                    applicant.id,
-                    programDisplayName,
-                    STATUS_WITH_ONLY_ENGLISH_EMAIL.statusText())));
+                STATUS_WITH_ONLY_ENGLISH_EMAIL.localizedEmailBodyText().get().getDefault()));
     verify(simpleEmail, times(1))
         .send(
             eq(userEmail),
@@ -402,11 +398,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
                     programDisplayName,
                     applicant.id)),
             Mockito.contains(
-                koMessages.at(
-                    MessageKey.EMAIL_TI_APPLICATION_UPDATE_BODY.getKeyName(),
-                    applicant.id,
-                    programDisplayName,
-                    STATUS_WITH_ONLY_ENGLISH_EMAIL.statusText())));
+                STATUS_WITH_ONLY_ENGLISH_EMAIL.localizedEmailBodyText().get().getDefault()));
     verify(simpleEmail, times(1))
         .send(
             eq(userEmail),


### PR DESCRIPTION
### Description

Previously, a boilerplate email was sent to a TI when one of the applications the TI submitted had the status changed. Now, the TI will receive the email body defined by the status, if it exists, like the applicant currently does.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/4734
