### PR TITLE
Making sure to correctly tag mock-web-service in docker

### DIFF
--- a/bin/pull-image
+++ b/bin/pull-image
@@ -39,6 +39,7 @@ function pull_all() {
 
   docker tag civiform/civiform-dev:latest civiform-dev
   docker tag civiform/civiform-localstack:latest civiform-localstack
+  docker tag docker.io/civiform/mock-web-services:latest civiform-mock-web-services
 }
 
 if [[ $# -eq 0 ]]; then
@@ -88,6 +89,7 @@ while [ "${1:-}" != "" ]; do
     "--mock-web-services")
       echo "Pull mock-web-services docker image"
       docker pull docker.io/civiform/mock-web-services:latest
+      docker tag docker.io/civiform/mock-web-services:latest civiform-mock-web-services
       ;;
 
     *)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,7 +45,7 @@ services:
       - 10000:10000
 
   mock-web-services:
-    image: civiform/mock-web-services
+    image: civiform-mock-web-services
 
   db:
     image: postgres:12.14


### PR DESCRIPTION
### Description

Making sure to correctly tag mock-web-service in docker

The main problem was that I forgot to tag the image after pulling it. I'm making a switch to the docker-compose.dev.yml back to it's prior value. The reason I'm doing so is because the rest of the dev compose file looks for the dash tagged version whereas the docker-compose.yml version runs the one directly from docker hub.

It's a nuance I'm not 100% certain I understand other than for overriding, but seems important to maintain without knowing if there would be side effects.

If anyone wants to try it before merge you'll want to remove any running containers and images based on the mock web services. Then run `USE_LOCAL_CIVIFORM=0 bin/run-dev`. I've tried different combos of having and not having the image already and no longer get the error.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
