### PR TITLE
Ignore net::ERR_ABORTED in browser tests

### DIFF
--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -61,6 +61,10 @@ export class BrowserErrorWatcher {
   failIfContainsErrors() {
     const errorsToReport = this.errors
       .filter((error) => !this.downloadUrls.has(error.url))
+      // Console errors with the message net::ERR_ABORTED have been a source of test
+      // flakiness. We were unable to find any cases of these errors indicating actual
+      // problems with the app or test system so ignore them here.
+      .filter((error) => !error.message.includes("net::ERR_ABORTED"))
       .filter((error) => {
         return !this.urlsToIgnore.some((regexp) => regexp.test(error.url))
       })


### PR DESCRIPTION
### Description

Console errors with the message net::ERR_ABORTED have been a source of test flakiness. We were unable to find any cases of these errors indicating actual problems with the app or test system.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/4217