### PR TITLE
Fix redirects when users go to program slugs

### DIFF
--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -122,4 +122,28 @@ describe('navigating to a deep link', () => {
 
     await logout(page)
   })
+
+  it('Logging in to an existing account after opening a deep link in a new browser session', async () => {
+    await resetContext(ctx)
+    const {page, browserContext} = ctx
+
+    await selectApplicantLanguage(page, 'English')
+
+    // Log in and log out to establish the test user in the database.
+    await loginAsTestUser(page)
+    await logout(page)
+    await browserContext.clearCookies()
+
+    // Go to deep link as a guest
+    await gotoEndpoint(page, '/programs/test-deep-link')
+    // Log in as the same test user
+    await loginAsTestUser(page, 'button:has-text("Log in")')
+
+    await page.click('#continue-application-button')
+    expect(await page.innerText('.cf-applicant-question-text')).toContain(
+      questionText,
+    )
+
+    await logout(page)
+  })
 })

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static featureflags.FeatureFlag.NONGATED_ELIGIBILITY_ENABLED;
 import static featureflags.FeatureFlag.PROGRAM_ELIGIBILITY_CONDITIONS_ENABLED;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
+import static views.components.Modal.RepeatOpenBehavior;
+import static views.components.Modal.RepeatOpenBehavior.Group.PROGRAM_SLUG_LOGIN_PROMPT;
 import static views.components.ToastMessage.ToastType.ALERT;
 import static views.components.ToastMessage.ToastType.SUCCESS;
 
@@ -136,6 +138,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                             MessageKey.INITIAL_LOGIN_MODAL_PROMPT,
                             MessageKey.BUTTON_CONTINUE_TO_APPLICATION)
                         .setDisplayOnLoad(true)
+                        .setRepeatOpenBehavior(
+                            RepeatOpenBehavior.showOnlyOnce(PROGRAM_SLUG_LOGIN_PROMPT))
                         .build();
                 params.setLoginPromptModal(loginPromptModal);
               }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -129,7 +129,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 Modal loginPromptModal =
                     createLoginPromptModal(
                             messages,
-                            request.uri(),
+                            /*postLoginRedirectTo=*/ controllers.applicant.routes.RedirectController
+                                .programBySlug(
+                                    request.flash().get("redirected-from-program-slug").get())
+                                .url(),
                             MessageKey.INITIAL_LOGIN_MODAL_PROMPT,
                             MessageKey.BUTTON_CONTINUE_TO_APPLICATION)
                         .setDisplayOnLoad(true)

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -122,7 +122,7 @@ public final class RedirectController extends CiviFormController {
                                           .review(
                                               applicantId,
                                               programForExistingApplication.get().id()))
-                                  .flashing("redirected-from-program-slug", "true"));
+                                  .flashing("redirected-from-program-slug", programSlug));
                         }
 
                         return redirectToActiveProgram(applicantId, programSlug);
@@ -140,7 +140,7 @@ public final class RedirectController extends CiviFormController {
                 redirect(
                         controllers.applicant.routes.ApplicantProgramReviewController.review(
                             applicantId, activeProgramDefinition.id()))
-                    .flashing("redirected-from-program-slug", "true"),
+                    .flashing("redirected-from-program-slug", programSlug),
             httpContext.current());
   }
 

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -121,7 +121,8 @@ public abstract class Modal {
 
     public enum Group {
       NONE,
-      PROGRAMS_INDEX_LOGIN_PROMPT;
+      PROGRAMS_INDEX_LOGIN_PROMPT,
+      PROGRAM_SLUG_LOGIN_PROMPT;
     }
 
     public static RepeatOpenBehavior alwaysShow() {


### PR DESCRIPTION
### Description

In #4859, we introduce an issue where logging in to an existing account after going to a program slug breaks CiviForm because the redirect link is in the form `BASE_URL/applicants/123/programs/456`. Now, we redirect the user to the original program slug itself so there is no coupling with the applicant ID.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
   - Validated the test fails when the source code changes are reverted.
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
   - Not necessary
- [ ] Manually tested at 200% size
   - Not necessary
- [ ] Manually evaluated tab order
   - Not necessary

#### New Features

None.

### Issue(s) this completes

Fixes #4856
