### PR TITLE
Add a confirmation dialog before publishing a program.

### DIFF
--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -433,11 +433,21 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   private ButtonTag renderPublishProgramLink(ProgramDefinition program, Http.Request request) {
     String linkDestination = routes.AdminProgramController.publishProgram(program.id()).url();
+    String confirmationMessage =
+        String.format(
+            "Are you sure you want to publish %s and all of its draft questions?",
+            program.localizedName().getDefault());
     return toLinkButtonForPost(
-        makeSvgTextButton("Publish program", Icons.PUBLISH)
-            .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN),
-        linkDestination,
-        request);
+            makeSvgTextButton("Publish program", Icons.PUBLISH)
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN, "publish-program-link"),
+            linkDestination,
+            request)
+        .attr(
+            "onclick",
+            String.format(
+                "if(confirm('%s')){ return true; } else { var e = arguments[0] ||"
+                    + " window.event; e.stopImmediatePropagation(); return false; }",
+                confirmationMessage));
   }
 
   private Optional<ButtonTag> maybeRenderViewApplicationsLink(


### PR DESCRIPTION
### Description

Add a confirmation dialog that is displayed when a single program is being published.

Using the Modal class would be a bit complicated in this case because the target of the confirm button is dependent on which program's publish button was clicked. For simplicity, I'm using the browser's built-in confirmation instead.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Part of #1589
