### PR TITLE
Enable individual program publishing by default.

### DIFF
--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -48,5 +48,5 @@ phone_question_type_enabled = ${?PHONE_QUESTION_TYPE_ENABLED}
 bypass_login_language_screens = false
 bypass_login_language_screens = ${?BYPASS_LOGIN_LANGUAGE_SCREENS}
 
-publish_single_program_enabled = false
+publish_single_program_enabled = true
 publish_single_program_enabled = ${?PUBLISH_SINGLE_PROGRAM_ENABLED}


### PR DESCRIPTION
### Description

Sets the flag that enables the feature to allow publishing a single program at a time to true by default. Will wait for #4882 to be merged before merging this.

## Release notes

After this change, you will be able to publish a single program's draft instead of only being able to publish all programs and questions at the same time. If the program has any draft questions, those questions will also be published. If the draft questions are also used by other programs, however, the program will not be able to be published individually.

You can find this feature by clicking on the dropdown menu for a draft program to see the new "Publish program" button.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #1589
