### PR TITLE
Making TI_ONLY display mode visible to TI Members not TI clients

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -66,7 +66,8 @@ public final class ApplicantProgramsController extends CiviFormController {
     return applicantStage
         .thenComposeAsync(v -> checkApplicantAuthorization(profileUtils, request, applicantId))
         .thenComposeAsync(
-            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile), httpContext.current())
+            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile),
+            httpContext.current())
         .thenApplyAsync(
             applicationPrograms -> {
               return ok(
@@ -98,7 +99,8 @@ public final class ApplicantProgramsController extends CiviFormController {
     return applicantStage
         .thenComposeAsync(v -> checkApplicantAuthorization(profileUtils, request, applicantId))
         .thenComposeAsync(
-            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile), httpContext.current())
+            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile),
+            httpContext.current())
         .thenApplyAsync(
             relevantPrograms -> {
               Optional<ProgramDefinition> programDefinition =

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static views.components.ToastMessage.ToastType.ALERT;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import controllers.CiviFormController;
 import java.util.Optional;
@@ -61,10 +62,11 @@ public final class ApplicantProgramsController extends CiviFormController {
     CompletionStage<Optional<String>> applicantStage =
         this.applicantService.getNameOrEmail(applicantId);
 
+    CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request).orElseThrow();
     return applicantStage
         .thenComposeAsync(v -> checkApplicantAuthorization(profileUtils, request, applicantId))
         .thenComposeAsync(
-            v -> applicantService.relevantProgramsForApplicant(applicantId), httpContext.current())
+            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile), httpContext.current())
         .thenApplyAsync(
             applicationPrograms -> {
               return ok(
@@ -92,10 +94,11 @@ public final class ApplicantProgramsController extends CiviFormController {
   public CompletionStage<Result> view(Request request, long applicantId, long programId) {
     CompletionStage<Optional<String>> applicantStage = this.applicantService.getName(applicantId);
 
+    CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request).orElseThrow();
     return applicantStage
         .thenComposeAsync(v -> checkApplicantAuthorization(profileUtils, request, applicantId))
         .thenComposeAsync(
-            v -> applicantService.relevantProgramsForApplicant(applicantId), httpContext.current())
+            v -> applicantService.relevantProgramsForApplicant(applicantId, requesterProfile), httpContext.current())
         .thenApplyAsync(
             relevantPrograms -> {
               Optional<ProgramDefinition> programDefinition =

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -109,7 +109,7 @@ public final class RedirectController extends CiviFormController {
                             request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri())));
               }
 
-              return getProgramVersionForApplicant(applicantId, programSlug,request)
+              return getProgramVersionForApplicant(applicantId, programSlug, request)
                   .thenComposeAsync(
                       (Optional<ProgramDefinition> programForExistingApplication) -> {
                         // Check to see if the applicant already has an application
@@ -145,7 +145,7 @@ public final class RedirectController extends CiviFormController {
   }
 
   private CompletionStage<Optional<ProgramDefinition>> getProgramVersionForApplicant(
-    long applicantId, String programSlug, Http.Request request) {
+      long applicantId, String programSlug, Http.Request request) {
     // Find all applicant's DRAFT applications for programs of the same slug
     // redirect to the newest program version with a DRAFT application.
     CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request).orElseThrow();
@@ -210,8 +210,10 @@ public final class RedirectController extends CiviFormController {
                   .thenComposeAsync(
                       v -> checkApplicantAuthorization(profileUtils, request, applicantId))
                   .thenComposeAsync(
-                     //we are already checking if profile is empty
-                      v -> applicantService.maybeEligibleProgramsForApplicant(applicantId,profile.get()),
+                      // we are already checking if profile is empty
+                      v ->
+                          applicantService.maybeEligibleProgramsForApplicant(
+                              applicantId, profile.get()),
                       httpContext.current())
                   .thenApplyAsync(Optional::of);
             })

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -109,7 +109,7 @@ public final class RedirectController extends CiviFormController {
                             request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri())));
               }
 
-              return getProgramVersionForApplicant(applicantId, programSlug)
+              return getProgramVersionForApplicant(applicantId, programSlug,request)
                   .thenComposeAsync(
                       (Optional<ProgramDefinition> programForExistingApplication) -> {
                         // Check to see if the applicant already has an application
@@ -145,11 +145,12 @@ public final class RedirectController extends CiviFormController {
   }
 
   private CompletionStage<Optional<ProgramDefinition>> getProgramVersionForApplicant(
-      long applicantId, String programSlug) {
+    long applicantId, String programSlug, Http.Request request) {
     // Find all applicant's DRAFT applications for programs of the same slug
     // redirect to the newest program version with a DRAFT application.
+    CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request).orElseThrow();
     return applicantService
-        .relevantProgramsForApplicant(applicantId)
+        .relevantProgramsForApplicant(applicantId, requesterProfile)
         .thenApplyAsync(
             (ApplicationPrograms relevantPrograms) ->
                 relevantPrograms.inProgress().stream()
@@ -209,7 +210,8 @@ public final class RedirectController extends CiviFormController {
                   .thenComposeAsync(
                       v -> checkApplicantAuthorization(profileUtils, request, applicantId))
                   .thenComposeAsync(
-                      v -> applicantService.maybeEligibleProgramsForApplicant(applicantId),
+                     //we are already checking if profile is empty
+                      v -> applicantService.maybeEligibleProgramsForApplicant(applicantId,profile.get()),
                       httpContext.current())
                   .thenApplyAsync(Optional::of);
             })

--- a/server/app/repository/UserRepository.java
+++ b/server/app/repository/UserRepository.java
@@ -300,12 +300,10 @@ public final class UserRepository {
         database.find(Account.class).where().eq("global_admin", true).findList());
   }
   /**
-   * Checks if the account belongs to a TI
-   * In the past we have had difficulties in identifying which is a TI account
-   * and which is a TIClient account. This method help clarify it.
+   * Checks if the account belongs to a TI In the past we have had difficulties in identifying which
+   * is a TI account and which is a TIClient account. This method help clarify it.
    */
-  public boolean isTi(Account account)
-  {
+  public boolean isTi(Account account) {
     return account.getMemberOfGroup().isPresent();
   }
 }

--- a/server/app/repository/UserRepository.java
+++ b/server/app/repository/UserRepository.java
@@ -299,5 +299,4 @@ public final class UserRepository {
     return ImmutableSet.copyOf(
         database.find(Account.class).where().eq("global_admin", true).findList());
   }
-
 }

--- a/server/app/repository/UserRepository.java
+++ b/server/app/repository/UserRepository.java
@@ -299,11 +299,5 @@ public final class UserRepository {
     return ImmutableSet.copyOf(
         database.find(Account.class).where().eq("global_admin", true).findList());
   }
-  /**
-   * Checks if the account belongs to a TI In the past we have had difficulties in identifying which
-   * is a TI account and which is a TIClient account. This method help clarify it.
-   */
-  public boolean isTi(Account account) {
-    return account.getMemberOfGroup().isPresent();
-  }
+
 }

--- a/server/app/repository/UserRepository.java
+++ b/server/app/repository/UserRepository.java
@@ -299,4 +299,13 @@ public final class UserRepository {
     return ImmutableSet.copyOf(
         database.find(Account.class).where().eq("global_admin", true).findList());
   }
+  /**
+   * Checks if the account belongs to a TI
+   * In the past we have had difficulties in identifying which is a TI account
+   * and which is a TIClient account. This method help clarify it.
+   */
+  public boolean isTi(Account account)
+  {
+    return account.getMemberOfGroup().isPresent();
+  }
 }

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -42,7 +42,6 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
-import play.mvc.Http;
 import repository.ApplicationEventRepository;
 import repository.ApplicationRepository;
 import repository.StoredFileRepository;
@@ -839,7 +838,8 @@ public final class ApplicantService {
    *   <li>Any other programs that are public
    * </ul>
    */
-  public CompletionStage<ApplicationPrograms> relevantProgramsForApplicant(long applicantId, CiviFormProfile requesterProfile) {
+  public CompletionStage<ApplicationPrograms> relevantProgramsForApplicant(
+      long applicantId, CiviFormProfile requesterProfile) {
     // Note: The Program model associated with the application is eagerly loaded.
     CompletableFuture<ImmutableSet<Application>> applicationsFuture =
         applicationRepository
@@ -847,14 +847,14 @@ public final class ApplicantService {
                 applicantId, ImmutableSet.of(LifecycleStage.DRAFT, LifecycleStage.ACTIVE))
             .toCompletableFuture();
     ImmutableList<ProgramDefinition> activeProgramDefinitionsFuture =
-                     versionRepository.getActiveVersion().getPrograms().stream()
-                        .map(Program::getProgramDefinition)
-                        .filter(
-                            pdef ->
-                                pdef.displayMode().equals(DisplayMode.PUBLIC)
-                                    || (requesterProfile.isTrustedIntermediary()
-                                  && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
-                        .collect(ImmutableList.toImmutableList());
+        versionRepository.getActiveVersion().getPrograms().stream()
+            .map(Program::getProgramDefinition)
+            .filter(
+                pdef ->
+                    pdef.displayMode().equals(DisplayMode.PUBLIC)
+                        || (requesterProfile.isTrustedIntermediary()
+                            && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
+            .collect(ImmutableList.toImmutableList());
 
     return CompletableFuture.allOf(applicationsFuture)
         .thenComposeAsync(
@@ -888,10 +888,11 @@ public final class ApplicantService {
    *     may be eligible for. Includes programs with matching eligibility criteria or no eligibility
    *     criteria.
    *     <p>Does not include the Common Intake Form.
-   *     <p>"Appropriate programs" those returned by {@link #relevantProgramsForApplicant(long, play.mvc.Http.Request)}.
+   *     <p>"Appropriate programs" those returned by {@link #relevantProgramsForApplicant(long,
+   *     play.mvc.Http.Request)}.
    */
   public CompletionStage<ImmutableList<ApplicantProgramData>> maybeEligibleProgramsForApplicant(
-    long applicantId, CiviFormProfile requesterProfile) {
+      long applicantId, CiviFormProfile requesterProfile) {
     return relevantProgramsForApplicant(applicantId, requesterProfile)
         .thenApplyAsync(
             relevantPrograms ->

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -846,15 +846,15 @@ public final class ApplicantService {
         userRepository
             .lookupApplicant(applicantId)
             .thenApplyAsync(
-                applicant -> applicant.orElseThrow().getAccount().getManagedByGroup().isPresent())
+                applicant -> applicant.orElseThrow().getAccount())
             .thenApplyAsync(
-                isTi ->
+                account ->
                     versionRepository.getActiveVersion().getPrograms().stream()
                         .map(Program::getProgramDefinition)
                         .filter(
                             pdef ->
                                 pdef.displayMode().equals(DisplayMode.PUBLIC)
-                                    || (isTi && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
+                                    || (userRepository.isTi(account) && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
                         .collect(ImmutableList.toImmutableList()))
             .toCompletableFuture();
 

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -845,8 +845,7 @@ public final class ApplicantService {
     CompletableFuture<ImmutableList<ProgramDefinition>> activeProgramDefinitionsFuture =
         userRepository
             .lookupApplicant(applicantId)
-            .thenApplyAsync(
-                applicant -> applicant.orElseThrow().getAccount())
+            .thenApplyAsync(applicant -> applicant.orElseThrow().getAccount())
             .thenApplyAsync(
                 account ->
                     versionRepository.getActiveVersion().getPrograms().stream()
@@ -854,7 +853,8 @@ public final class ApplicantService {
                         .filter(
                             pdef ->
                                 pdef.displayMode().equals(DisplayMode.PUBLIC)
-                                    || (userRepository.isTi(account) && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
+                                    || (userRepository.isTi(account)
+                                        && pdef.displayMode().equals(DisplayMode.TI_ONLY)))
                         .collect(ImmutableList.toImmutableList()))
             .toCompletableFuture();
 

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -890,7 +890,7 @@ public final class ApplicantService {
    *     criteria.
    *     <p>Does not include the Common Intake Form.
    *     <p>"Appropriate programs" those returned by {@link #relevantProgramsForApplicant(long,
-   *     play.mvc.Http.Request)}.
+   *     auth.CiviFormProfile)}.
    */
   public CompletionStage<ImmutableList<ApplicantProgramData>> maybeEligibleProgramsForApplicant(
       long applicantId, CiviFormProfile requesterProfile) {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -3,7 +3,6 @@ package services.applicant;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
-import auth.ProfileUtils;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -107,7 +106,6 @@ public final class ApplicantService {
   private final ServiceAreaUpdateResolver serviceAreaUpdateResolver;
   private final EsriClient esriClient;
   private final MessagesApi messagesApi;
-  ProfileUtils profileUtils;
 
   @Inject
   public ApplicantService(
@@ -125,8 +123,7 @@ public final class ApplicantService {
       DeploymentType deploymentType,
       ServiceAreaUpdateResolver serviceAreaUpdateResolver,
       EsriClient esriClient,
-      MessagesApi messagesApi,
-      ProfileUtils profileUtils) {
+      MessagesApi messagesApi) {
     this.applicationEventRepository = checkNotNull(applicationEventRepository);
     this.applicationRepository = checkNotNull(applicationRepository);
     this.userRepository = checkNotNull(userRepository);
@@ -149,7 +146,6 @@ public final class ApplicantService {
     this.stagingApplicantNotificationMailingList =
         checkNotNull(configuration).getString("staging_applicant_notification_mailing_list");
     this.esriClient = checkNotNull(esriClient);
-    this.profileUtils = checkNotNull(profileUtils);
   }
 
   /** Create a new {@link Applicant}. */

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mockito;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
-import play.mvc.Http;
 import repository.ApplicationRepository;
 import repository.ResetPostgres;
 import repository.UserRepository;
@@ -126,9 +125,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     Mockito.when(applicantProfile.isTrustedIntermediary()).thenReturn(false);
     Account applicantAccount = new Account();
     applicantAccount.setEmailAddress("applicant@example.com");
-    Mockito.when(applicantProfile.getAccount()).thenReturn(CompletableFuture.completedFuture(applicantAccount));
+    Mockito.when(applicantProfile.getAccount())
+        .thenReturn(CompletableFuture.completedFuture(applicantAccount));
     Mockito.when(applicantProfile.getEmailAddress())
-      .thenReturn(CompletableFuture.completedFuture("applicant@example.com"));
+        .thenReturn(CompletableFuture.completedFuture("applicant@example.com"));
 
     programService = instanceOf(ProgramServiceImpl.class);
 
@@ -1710,7 +1710,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(programForDraft.id);
@@ -1764,7 +1767,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(programForDraft.id);
@@ -1799,7 +1805,10 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     // No CIF application started.
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied()).isEmpty();
@@ -1813,7 +1822,11 @@ public class ApplicantServiceTest extends ResetPostgres {
         .createOrUpdateDraft(applicant.id, commonIntakeForm.id)
         .toCompletableFuture()
         .join();
-    result = subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+    result =
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied()).isEmpty();
@@ -1829,7 +1842,11 @@ public class ApplicantServiceTest extends ResetPostgres {
         .submitApplication(applicant.id, commonIntakeForm.id, Optional.empty())
         .toCompletableFuture()
         .join();
-    result = subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+    result =
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied()).isEmpty();
@@ -1869,7 +1886,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(programForDraft.id);
@@ -1931,7 +1951,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(programForDraft.id);
@@ -1984,7 +2007,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(otherApplicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(otherApplicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
@@ -2035,7 +2061,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     versionRepository.publishNewSynchronizedVersion();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     // Drafts always use the version of the program they were
     // started on.
@@ -2103,7 +2132,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     versionRepository.publishNewSynchronizedVersion();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(originalProgramForDraftApp.id);
@@ -2173,9 +2205,15 @@ public class ApplicantServiceTest extends ResetPostgres {
     versionRepository.publishNewSynchronizedVersion();
 
     ApplicantService.ApplicationPrograms applicantResult =
-        subject.relevantProgramsForApplicant(applicant.id, applicantProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, applicantProfile)
+            .toCompletableFuture()
+            .join();
     ApplicantService.ApplicationPrograms tiResult =
-        subject.relevantProgramsForApplicant(ti.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(ti.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(applicantResult.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(originalProgramForDraftApp.id);
@@ -2231,7 +2269,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     Instant secondAppSubmitTime = secondApp.orElseThrow().getSubmitTime();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(programForDraftApp.id);
@@ -2309,7 +2350,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     firstDraft.setLifecycleStage(LifecycleStage.DRAFT).setCreateTimeForTest(draftLater).save();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.submitted().stream().map(p -> p.program().id()))
         .containsExactly(programForSubmitted.id);
@@ -2345,7 +2389,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     addStatusEvent(submittedApplication, APPROVED_STATUS, adminAccount);
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted().stream().map(p -> p.program().id())).containsExactly(program.id);
@@ -2395,7 +2442,10 @@ public class ApplicantServiceTest extends ResetPostgres {
             .build();
 
     ApplicantService.ApplicationPrograms result =
-        subject.relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted().stream().map(p -> p.program().id()))
@@ -2485,7 +2535,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     // Asset results contained expected program IDs
     var matchingProgramIds =
@@ -2558,7 +2611,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());
@@ -2636,7 +2692,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());
@@ -2687,7 +2746,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());
@@ -2732,7 +2794,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());
@@ -2767,7 +2832,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
     var result =
-        subject.maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile).toCompletableFuture().join();
+        subject
+            .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
+            .toCompletableFuture()
+            .join();
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2115,7 +2115,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     TrustedIntermediaryGroup tiGroup =
         new TrustedIntermediaryGroup("Super Cool CBO", "Description");
     tiGroup.save();
-    tiAccount.setManagedByGroup(tiGroup);
+    tiAccount.setMemberOfGroup(tiGroup);
     tiAccount.save();
     ti.setAccount(tiAccount);
     ti.save();


### PR DESCRIPTION
### Description

The TI_ONLY program visibility condition displayed the program to TI Clients who could create an account with the email address shared with the TI. This PR fixes the bug. 

## Release notes
Applicants who are managed by a TI cannot see TI_ONLY programs

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #4857
