### PR TITLE
Retry DurableJobRunnerTest up to 5x on failure

### DIFF
--- a/server/test/durablejobs/DurableJobRunnerTest.java
+++ b/server/test/durablejobs/DurableJobRunnerTest.java
@@ -13,14 +13,18 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import models.PersistedDurableJob;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import play.api.inject.BindingKey;
 import repository.PersistedDurableJobRepository;
 import repository.ResetPostgres;
 import services.cloud.aws.SimpleEmail;
+import support.TestRetry;
 
 public class DurableJobRunnerTest extends ResetPostgres {
+
+  @Rule public TestRetry testRetry = new TestRetry(5);
 
   private SimpleEmail simpleEmailMock;
   private DurableJobRunner durableJobRunner;
@@ -120,9 +124,9 @@ public class DurableJobRunnerTest extends ResetPostgres {
     jobB.refresh();
     jobC.refresh();
 
-    // TODO(bion): investigate why runCount is non-deterministic and sometimes
-    // fails GitHub CI checks.
-    // assertThat(runCount).hasValue(2);
+    // This assertion fails occasionally. I've been unable to figure out why
+    // so added RetryTest rule - bionj@google.com 5/18/2023.
+    assertThat(runCount).hasValue(2);
 
     assertThat(jobA.getRemainingAttempts()).isEqualTo(2);
     assertThat(jobB.getRemainingAttempts()).isEqualTo(2);

--- a/server/test/support/TestRetry.java
+++ b/server/test/support/TestRetry.java
@@ -1,0 +1,47 @@
+package support;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Retries a test a given number of times before allowing it to fail. Useful for tests that flap
+ * occasionally for baffling reasons.
+ */
+public final class TestRetry implements TestRule {
+  private int retryCount;
+
+  public TestRetry(int retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  @Override
+  public Statement apply(Statement statement, Description description) {
+    return new Statement() {
+
+      @Override
+      public void evaluate() throws Throwable {
+        Throwable failureCause = null;
+
+        for (int i = 0; i < retryCount; i++) {
+          try {
+            statement.evaluate();
+            return;
+          } catch (Throwable throwable) {
+            failureCause = throwable;
+            System.err.println(
+                description.getDisplayName()
+                    + ": attempt "
+                    + (i + 1)
+                    + "/"
+                    + retryCount
+                    + " failed.");
+          }
+        }
+
+        System.err.println(description.getDisplayName() + ": failed " + retryCount + " times.");
+        throw failureCause;
+      }
+    };
+  }
+}


### PR DESCRIPTION
### Description

DurableJobRunnerTest fails occasionally, probably due to a threading issue. I've been unable to figure out why exactly as I've been unable to reproduce the failure on my local machine. It does not take long to run and it's somewhat rare for it to fail so I propose re-running automatically to prevent the annoyance of re-running the entire JUnit suite in github when it flaps.