### PR TITLE
Add `transifex.yml`

### DIFF
--- a/server/conf/i18n/transifex.yml
+++ b/server/conf/i18n/transifex.yml
@@ -1,0 +1,18 @@
+filters:
+  - filter_type: file
+    # UNICODEPROPERTIES represents a Java Properties file (which is what Play uses for i18n),
+    # in Unicode format. https://help.transifex.com/en/articles/6220741-java-properties
+    file_format: UNICODEPROPERTIES
+    # The source file with English messages.
+    source_file: server/conf/i18n/messages
+    source_language: en_US
+    # The target files where translated messages will be stored.
+    translation_files_expression: server/conf/i18n/messages.<lang>
+settings:
+  language_mapping:
+    # Play requires that we use a dash between the language code and region subtag.
+    # Tell Transifex to look for files with a dash for a given region subtag, instead of
+    # the default underscore. For example, the region subtag es_US will have Transifex
+    # search for a file named server/conf/i18n/messages.es-US
+    es_US: es-US
+    zh_TW: zh-TW


### PR DESCRIPTION
### Description

Adds `transifex.yml`, which configures how Transifex will recognize our `messages` files. See [Transifex's help article](https://help.transifex.com/en/articles/6265125-github-via-transifex-ui#h_b827747da8) on GitHub.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not necessary
   - Tested manually on Transifex UI:
   - <img width="662" alt="image" src="https://github.com/civiform/civiform/assets/30369272/8f475a6b-8556-4d9c-87bd-f1213d31af99">

- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891.