### PR TITLE
Allow publishing draft questions when there are no draft programs.

### DIFF
--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -200,8 +200,8 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   private Optional<Modal> maybeRenderPublishAllModal(
       ActiveAndDraftPrograms programs, ActiveAndDraftQuestions questions, Http.Request request) {
-    // We should only render the publish modal / button if there is at least one draft program.
-    if (!programs.anyDraft()) {
+    // We should only render the publish modal / button if there is at least one draft.
+    if (!programs.anyDraft() && !questions.draftVersionHasAnyEdits()) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
### Description

Previously, the publish button was only shown if there was at least one draft program. This meant that questions could not be published unless you first created a draft of a program. The main case where this is a problem is when archiving questions that are no longer used in programs. You'd have to edit a program if you were trying to archive questions just so that you could publish the change.

The functionality to publish questions already existed on the backend, the button was just hidden. I added a test for that anyway to validate the behavior since it's being exposed now.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4868
