### PR TITLE
Display API username/password along with key

### DIFF
--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -91,7 +91,12 @@ public class AdminApiKeysController extends CiviFormController {
     ApiKeyCreationResult result = apiKeyService.createApiKey(form, profile.get());
 
     if (result.isSuccessful()) {
-      return created(apiKeyCredentialsView.render(result.getApiKey(), result.getCredentials()));
+      return created(
+          apiKeyCredentialsView.render(
+              result.getApiKey(),
+              result.getEncodedCredentials(),
+              result.getKeyId(),
+              result.getKeySecret()));
     }
 
     return badRequest(

--- a/server/app/services/apikey/ApiKeyCreationResult.java
+++ b/server/app/services/apikey/ApiKeyCreationResult.java
@@ -1,5 +1,7 @@
 package services.apikey;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Optional;
 import models.ApiKey;
 import play.data.DynamicForm;
@@ -17,31 +19,42 @@ import play.data.DynamicForm;
  */
 public final class ApiKeyCreationResult {
   private final Optional<ApiKey> apiKey;
-  private final Optional<String> credentials;
+  private final Optional<String> keyId;
+  private final Optional<String> keySecret;
   private final Optional<DynamicForm> form;
 
   /** Constructs an instance in the case of success. */
-  public static ApiKeyCreationResult success(ApiKey apiKey, String credentials) {
+  public static ApiKeyCreationResult success(ApiKey apiKey, String keyId, String keySecret) {
     return new ApiKeyCreationResult(
-        Optional.of(apiKey), Optional.of(credentials), /* form= */ Optional.empty());
+        Optional.of(apiKey),
+        Optional.of(keyId),
+        Optional.of(keySecret),
+        /* form= */ Optional.empty());
   }
 
   /** Constructs an instance in the case of failure. */
   public static ApiKeyCreationResult failure(DynamicForm form) {
     return new ApiKeyCreationResult(
-        /* apiKey= */ Optional.empty(), /* credentials= */ Optional.empty(), Optional.of(form));
+        /* apiKey= */ Optional.empty(),
+        /* keyId= */ Optional.empty(),
+        /* keySecret= */ Optional.empty(),
+        Optional.of(form));
   }
 
   private ApiKeyCreationResult(
-      Optional<ApiKey> apiKey, Optional<String> credentials, Optional<DynamicForm> form) {
+      Optional<ApiKey> apiKey,
+      Optional<String> keyId,
+      Optional<String> keySecret,
+      Optional<DynamicForm> form) {
     this.apiKey = apiKey;
-    this.credentials = credentials;
+    this.keyId = keyId;
+    this.keySecret = keySecret;
     this.form = form;
   }
 
   /** Returns true if the key was created. */
   public boolean isSuccessful() {
-    return credentials.isPresent();
+    return keySecret.isPresent() && keyId.isPresent();
   }
 
   /** Returns the API key if creation was successful. */
@@ -55,7 +68,19 @@ public final class ApiKeyCreationResult {
   }
 
   /** Returns the base64 encoded credentials string if creation was successful. */
-  public String getCredentials() {
-    return credentials.get();
+  public String getEncodedCredentials() {
+    return Base64.getEncoder()
+        .encodeToString(
+            String.format("%s:%s", keyId.get(), keySecret.get()).getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Returns the keyId string if creation was successful. */
+  public String getKeyId() {
+    return keyId.get();
+  }
+
+  /** Returns the keySecret string if creation was successful. */
+  public String getKeySecret() {
+    return keySecret.get();
   }
 }

--- a/server/app/services/apikey/ApiKeyService.java
+++ b/server/app/services/apikey/ApiKeyService.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import controllers.admin.NotChangeableException;
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -180,9 +179,6 @@ public final class ApiKeyService {
     String keyId = generateSecret(KEY_ID_LENGTH);
     String keySecret = generateSecret(KEY_SECRET_LENGTH);
     String saltedSecret = salt(keySecret);
-    String rawCredentials = keyId + ":" + keySecret;
-    String credentials =
-        Base64.getEncoder().encodeToString(rawCredentials.getBytes(StandardCharsets.UTF_8));
 
     apiKey.setKeyId(keyId);
     apiKey.setSaltedKeySecret(saltedSecret);
@@ -190,7 +186,7 @@ public final class ApiKeyService {
 
     apiKey = repository.insert(apiKey).toCompletableFuture().join();
 
-    return ApiKeyCreationResult.success(apiKey, credentials);
+    return ApiKeyCreationResult.success(apiKey, keyId, keySecret);
   }
 
   // {@code apiKey} is mutable and modified here, {@code form} is immutable so a new instance is

--- a/server/app/views/admin/apikeys/ApiKeyCredentialsView.java
+++ b/server/app/views/admin/apikeys/ApiKeyCredentialsView.java
@@ -9,6 +9,7 @@ import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 
 import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.PTag;
 import javax.inject.Inject;
 import models.ApiKey;
 import play.twirl.api.Content;
@@ -17,23 +18,39 @@ import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
+import views.components.Icons;
+import views.components.LinkElement;
 
-/** Renders a page that displays an API key's crentials after it's created. */
+/** Renders a page that displays an API key's credentials after it's created. */
 public final class ApiKeyCredentialsView extends BaseHtmlView {
   private final AdminLayout layout;
 
   private static final String CREDENTIALS_DESCRIPTION =
-      "Please copy your API key and it store it somewhere secure. This is your only"
+      "Please copy your API credentials and store them somewhere secure. This is your only"
           + " opportunity to copy the secret from CiviForm, if you"
           + " refresh the page or navigate away you will not be able to recover the"
           + " secret value and will need to create a new key instead.";
+
+  private static final PTag CREDENTIALS_USERNAME_PASSWORD_EXPLANATION =
+      p(
+          text(
+              "The API credentials are available as both a single token (the \"API Secret Token\")"
+                  + " or a username/password combination, depending on the needs of your API"
+                  + " client. See the "),
+          new LinkElement()
+              .setHref("https://docs.civiform.us/it-manual/api/authentication")
+              .setIcon(Icons.OPEN_IN_NEW, LinkElement.IconPosition.END)
+              .setText("API Documentation")
+              .opensInNewTab()
+              .asAnchorText(),
+          text("for details."));
 
   @Inject
   public ApiKeyCredentialsView(AdminLayoutFactory layoutFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.API_KEYS);
   }
 
-  public Content render(ApiKey apiKey, String credentials) {
+  public Content render(ApiKey apiKey, String encodedCredentials, String keyId, String keySecret) {
     String title = "Created API key: " + apiKey.getName();
 
     DivTag contentDiv =
@@ -42,9 +59,16 @@ public final class ApiKeyCredentialsView extends BaseHtmlView {
             .with(
                 h1(title).withClasses("my-4"),
                 h2("Credentials"),
-                p(CREDENTIALS_DESCRIPTION),
-                p(text("API key: "), span(credentials).withId("api-key-credentials"))
-                    .withClasses("mt-4"));
+                p(CREDENTIALS_DESCRIPTION).withClasses("my-4"),
+                CREDENTIALS_USERNAME_PASSWORD_EXPLANATION.withClasses("my-4"),
+                p(
+                        text("API Secret Token: "),
+                        span(encodedCredentials)
+                            .withId("api-key-credentials")
+                            .withClasses("font-mono"))
+                    .withClasses("my-4"),
+                p(text("API Username: "), span(keyId).withClasses("font-mono")),
+                p(text("API Password: "), span(keySecret).withClasses("font-mono")));
 
     HtmlBundle htmlBundle = layout.getBundle().setTitle(title).addMainContent(contentDiv);
 

--- a/server/test/services/apikey/ApiKeyServiceTest.java
+++ b/server/test/services/apikey/ApiKeyServiceTest.java
@@ -138,7 +138,7 @@ public class ApiKeyServiceTest extends ResetPostgres {
 
     assertThat(apiKeyCreationResult.isSuccessful()).isTrue();
 
-    String credentialString = apiKeyCreationResult.getCredentials();
+    String credentialString = apiKeyCreationResult.getEncodedCredentials();
     byte[] keyIdBytes = Base64.getDecoder().decode(credentialString);
     String keyId =
         Iterables.get(Splitter.on(':').split(new String(keyIdBytes, StandardCharsets.UTF_8)), 0);


### PR DESCRIPTION
### Description

Adds API key username and password to API key confirmation screen, to enable clients that require a username/password for Basic Auth, instead of a single token.

## Release notes

Adds API key's username and password to the API key confirmation screen. This enables support for API clients that require a username and password for Basic Auth.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] (n/a) Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary. (civiform/docs#324)

#### User visible changes

- [ ] (n/a) Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] (n/a) Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] (n/a) Manually tested at 200% size
- [ ] (n/a) Manually evaluated tab order

#### New Features

- [ ] (n/a) Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] (n/a) Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] (n/a) Wrote browser tests with the feature flag off and on, etc.

Partially completes #4861
