### PR TITLE
Add remaining translations keys from Google Sheet

### DIFF
--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -542,12 +542,18 @@ validation.textTooShort=Must contain at least {0} characters.
 # Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 
-#-------------------------------------------------------#
-# 404 PAGE ERROR - error messages displayed on 404 page #
-#-------------------------------------------------------#
+#----------------------------------#
+# ERRORS - various error messages  #
+#----------------------------------#
 error.notFoundTitle=We were unable to find the page you tried to visit
 error.notFoundDescription=Please go back or return to the {0}
 error.notFoundDescriptionLink=homepage
+
+# This occurs when an unhandled exception happens.
+error.internalServerTitle=An error occurred
+
+# Message to user that an error happened. %s will be replaced with tech support email address. {0} is replaced by the exception id we use to look up the error in the logs.
+error.internalServerDescription=Please contact technical support for assistance at %s and include this error id {0}.
 
 #-------------------------------------------------------------#
 # EMAILS - boilerplate text contained in emails sent to users #


### PR DESCRIPTION
### Description

We are no longer going to use the [Google Sheet](https://docs.google.com/spreadsheets/d/1x9xq-X61Gev2c470dPYe69tzI4azLTerZu-jfzFHmTE/edit?resourcekey=0-6T7y1Mv3Rr_u1rkmhGCeuQ#gid=276759783) for translations. In this PR, we move the last remaining in-progress keys, `error.internalServerTitle` and `error.internalServerDescription`, and deprecate the Google Sheet.

These keys will appear on Transifex as untranslated upon submission of this PR

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not necessary
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891