### PR TITLE
Automatically assign reviewers to Transifex PRs

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,19 +1,17 @@
 reviewers:
   groups:
     i18n-reviewers:
+      # TODO(#4891): remove Michael once i18n process is established
+      - MichaelZetune
       - team:developers # CiviForm Developers GitHub team
 
   per_author:
-    transifex-bot:
-      - transifex-integration # The Transifex bot's username
-
-files:
-  # The foreign language files, not including `messages`.
-  'server/conf/i18n/messages.*':
-    - i18n-reviewers
+    transifex-integration: # The Transifex bot's username
+      - i18n-reviewers
 
 options:
   ignore_draft: true
   enable_group_assignment: false
 
-  number_of_reviewers: 1
+  # TODO(#4891): set to 1 once i18n process is established
+  number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,7 +1,7 @@
 reviewers:
   groups:
     i18n-reviewers:
-      - team:Developers # CiviForm Developers GitHub team
+      - team:developers # CiviForm Developers GitHub team
 
   per_author:
     transifex-bot:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,22 @@
+reviewers:
+  groups:
+    i18n-reviewers:
+      -  # TODO(#4891): remove Michael once i18n process is established
+      - MichaelZetune
+      - team:Developers # CiviForm Developers GitHub team
+
+  per_author:
+    transifex-bot:
+      - transifex-integration # The Transifex bot's username
+
+files:
+  # The foreign language files, not including `messages`.
+  'server/conf/i18n/messages.*':
+    - i18n-reviewers
+
+options:
+  ignore_draft: true
+  enable_group_assignment: false
+
+  # TODO(#4891): set to 1 once i18n process is established
+  number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,8 +1,6 @@
 reviewers:
   groups:
     i18n-reviewers:
-      -  # TODO(#4891): remove Michael once i18n process is established
-      - MichaelZetune
       - team:Developers # CiviForm Developers GitHub team
 
   per_author:
@@ -18,5 +16,4 @@ options:
   ignore_draft: true
   enable_group_assignment: false
 
-  # TODO(#4891): set to 1 once i18n process is established
-  number_of_reviewers: 2
+  number_of_reviewers: 1

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.10.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CIVIFORM_GITHUB_PR_AUTOMATION_PAT }}
           config: .github/reviewers.yml # Config file location

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.10.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -3,7 +3,7 @@
 #-------------------------------------------------------------#
 # GENERAL - contains text that corresponds to multiple views. #
 #-------------------------------------------------------------#
-
+# test change
 # The text on the button an applicant clicks to log out of their session.
 button.logout=Mag-logout
 

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -3,7 +3,7 @@
 #-------------------------------------------------------------#
 # GENERAL - contains text that corresponds to multiple views. #
 #-------------------------------------------------------------#
-# test change
+
 # The text on the button an applicant clicks to log out of their session.
 button.logout=Mag-logout
 


### PR DESCRIPTION
### Description

Creates a [GitHub Action](https://github.com/marketplace/actions/auto-request-review) that automatically requests a review from CiviForm/Developers for any Transifex PRs. Also adds me, for now, so I can monitor this for a bit while we get used to using it.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not necessary
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891