### PR TITLE
Fix `reviewers.yml`

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -13,3 +13,4 @@ files:
 options:
   ignore_draft: true
   enable_group_assignment: true
+  number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -12,5 +12,5 @@ files:
 
 options:
   ignore_draft: true
-  enable_group_assignment: true
+  enable_group_assignment: false
   number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -2,7 +2,7 @@ reviewers:
   groups:
     i18n-reviewers:
       # TODO(#4891): remove Michael once i18n process is established
-      - dkatzz
+      - MichaelZetune
       - team:developers # CiviForm Developers GitHub team
 
 files:
@@ -13,4 +13,5 @@ files:
 options:
   ignore_draft: true
   enable_group_assignment: false
+  # TODO(#4891): set to 1 once i18n process is established
   number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -12,4 +12,4 @@ files:
 
 options:
   ignore_draft: true
-  enable_group_assignment: false
+  enable_group_assignment: true

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -5,9 +5,10 @@ reviewers:
       - MichaelZetune
       - team:developers # CiviForm Developers GitHub team
 
-  per_author:
-    transifex-integration: # The Transifex bot's username
-      - i18n-reviewers
+files:
+  # The foreign language files, not including `messages`.
+  'server/conf/i18n/messages.*':
+    - i18n-reviewers
 
 options:
   ignore_draft: true

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -13,6 +13,3 @@ files:
 options:
   ignore_draft: true
   enable_group_assignment: false
-
-  # TODO(#4891): set to 1 once i18n process is established
-  number_of_reviewers: 2

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -2,7 +2,7 @@ reviewers:
   groups:
     i18n-reviewers:
       # TODO(#4891): remove Michael once i18n process is established
-      - MichaelZetune
+      - dkatzz
       - team:developers # CiviForm Developers GitHub team
 
 files:


### PR DESCRIPTION
### Description

`reviewers.yml` isn't recognizing `transifex-integration` as a username. Let's use the glob of `messages.xx` files instead.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Test out manually
- [ ] Extended the README / documentation, if necessary
   - Not neccessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891
