### PR TITLE
Test for equivalent keys between `MessageKey` and `messages` files.

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -79,6 +79,8 @@ public enum MessageKey {
   ERROR_NOT_FOUND_TITLE("error.notFoundTitle"),
   ERROR_NOT_FOUND_DESCRIPTION("error.notFoundDescription"),
   ERROR_NOT_FOUND_DESCRIPTION_LINK("error.notFoundDescriptionLink"),
+  ERROR_INTERNAL_SERVER_TITLE("error.internalServerTitle"),
+  ERROR_INTERNAL_SERVER_DESCRIPTION("error.internalServerDescription"),
   DATE_VALIDATION_MISFORMATTED("validation.dateMisformatted"),
   DROPDOWN_PLACEHOLDER("placeholder.noDropdownSelection"),
   END_SESSION("header.endSession"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -227,9 +227,6 @@ button.continue=Continue
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=Not Eligible
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Does not qualify
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=Previously answered on {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Answer {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=Start here. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=You may not qualify
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Your client may not qualify
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=At this time, we are unable to check your eligibility for the {0}.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=At this time, we are unable to check your client''s eligibility for the {0}.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=We're working to fix this issue quickly. Try again at a later time.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=View all programs
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
@@ -393,20 +374,11 @@ content.foundSimilarAddress=We could not verify the address that you provided, b
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Address entered:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName={0} entered:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Suggested address:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Suggested addresses:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=Edit address
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=Save and confirm
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=No valid address found

--- a/server/conf/i18n/messages.am
+++ b/server/conf/i18n/messages.am
@@ -227,9 +227,6 @@ button.continue=ቀጥል
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=በመተግበሪያው ላይ ዝማኔ ተደርጓል፣ ለመቀጠል እባክዎ ይገምግሙ እና ጥያቄዎችን ይመልሱ
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=ብቁ አይደለም
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=ብቁ አይደለም
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=ቀደም ሲል በ{0} ላይ መልስ ተሰጥ�
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=መልስ {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=እዚህ ይጀምሩ። {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=ብቁ ላይሆኑ ይችላሉ
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=ደንበኛዎ ብቁ ላይሆኑ ይችላሉ
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=በዚህ ጊዜ ለ{0} የእርስዎን ብቁነት ማረጋገጥ አንችልም።
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=በዚህ ጊዜ ለ{0} የደንበኛዎን ብቁነት ማረጋገጥ አንችልም።
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=ይህን ችግር በፍጥነት ለማስተካከል እየሰራን ነው። በኋላ ላይ እንደገና ይሞክሩ።
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=ሁሉንም ፕሮግራሞች ይመልከቱ
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=በምላሾችዎ መሰረት ለ{0} ብቁ ላይሆኑ ይችላሉ። መረጃዎ ከተለወጠ መልሶችዎን አርትዕ ማድረግ እና ማመልከት መቀጠል ይችላሉ።
@@ -393,20 +374,11 @@ content.foundSimilarAddress=የሰጡትን አድራሻ ማረጋገጥ አል�
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=የገባ አድራሻ፦
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName={0} ገብቷል፦
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=የተጠቆመው አድራሻ፦
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=የተጠቆሙ አድራሻዎች፦
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=አድራሻን አርትዕ ያድርጉ
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=ያስቀምጡ እና ያረጋግጡ
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=ምንም የሚሠሩ አድራሻዎች አልተገኙም

--- a/server/conf/i18n/messages.es-US
+++ b/server/conf/i18n/messages.es-US
@@ -227,9 +227,6 @@ button.continue=Continuar
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Se actualizó la aplicación; revisa y responde las preguntas para proceder
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=No apto
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=No califica
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=Ya se respondió el {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Responder {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=Comienza aquí. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=Es posible que no califiques
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Es posible que tu cliente no califique
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=Por el momento, no podemos revisar tu elegibilidad para {0}.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=Por el momento, no podemos revisar la elegibilidad de tu cliente para {0}.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=Estamos trabajando para resolver este problema lo más rápido posible. Vuelve a intentarlo más tarde.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=Ver todos los programas
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Según tus respuestas, es posible que no califiques para {0}. Si cambió la información, puedes editar tus respuestas y continuar con la inscripción.
@@ -393,20 +374,11 @@ content.foundSimilarAddress=No pudimos verificar la dirección que proporcionast
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Dirección ingresada:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName=Se ingresó {0}:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Dirección sugerida:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Direcciones sugeridas:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=Editar dirección
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=Guardar y confirmar
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=No se encontró ninguna dirección válida

--- a/server/conf/i18n/messages.ko
+++ b/server/conf/i18n/messages.ko
@@ -227,9 +227,6 @@ button.continue=계속
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=신청서가 업데이트되었습니다. 계속하려면 질문을 검토하고 답변해 주세요.
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=제출을 위해 확인 필요
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=자격요건을 충족하지 않음
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn={0}에 답변됨
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer={0}에 답변
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=여기서 시작합니다. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=자격요건을 충족하지 않을 수 있음
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=클라이언트가 자격요건을 충족하지 않을 수 있음
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=현재 {0}에 대한 귀하의 자격을 확인할 수 없습니다.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=현재 {0}에 대한 클라이언트의 자격을 확인할 수 없습니다.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=이 문제를 신속히 해결하기 위해 노력하는 중입니다. 잠시 후 다시 시도해 주세요.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=모든 프로그램 보기
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=응답을 토대로 귀하는 {0}의 자격요건을 충족하지 않을 수도 있습니다. 정보가 변경된 경우 응답을 수정한 후 계속 신청서를 작성할 수 있습니다.
@@ -393,20 +374,11 @@ content.foundSimilarAddress=제공된 주소를 확인할 수 없지만 비슷�
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=입력된 주소:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName=입력된 {0}:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=추천 주소:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=추천 주소:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=주소 수정
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=저장 및 확인
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=유효한 주소를 찾을 수 없습니다

--- a/server/conf/i18n/messages.so
+++ b/server/conf/i18n/messages.so
@@ -227,9 +227,6 @@ button.continue=Sii wad
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Waxaa jirtay cusboonaysiin lagu sameeyay app-ka, fadlan dib u eeg oo ka jawaab su'aalaha si aad horay ugu sii socoto
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=Uma Qalmo
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Uma qalmo
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=Hore loogaga jawaabay {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Jawaab {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=Halkan ka bilow. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=Waxa dhici karta inaanad u qalmin
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Macmiilkaaga waxa dhici karta inuusan u qalmin
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=Wakhtigan, ma awoodno hubinta u qalmidaada {0}.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=Wakhtigan, ma awoodno hubinta u qalmida macmiilkaaga {0}.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=Waxaanu ka shaqaynaynaa hagaajinta dhibkan si degdeg ah. Isku day mar kale wakhti dambe.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=Arag barnaamijyada oo dhan
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Iyaddoo ku salaysan jawaabahaaga, waxa dhici karta inaanad u qalmin {0}. Haddi imacluumaadkaagu uu is beddelay waxaad wax ka beddeli kartaa jawaabahaaga oo ka dib sii wad codsiga.
@@ -393,20 +374,11 @@ content.foundSimilarAddress=Waanu xaqiijin kari waynay cinwaanka aad bixisay, la
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Cinwaanka waa la geliyay:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName={0} la geliyay:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Cinwaanka la soo jeediyay:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Cinwaanada la soo jeediyay:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=Wax ka beddel cinwaanka
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=Kaydi oo xaqiiji
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=Lama helin cinwaan ansax ah

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -227,9 +227,6 @@ button.continue=Magsimula dito
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Nagkaroon ng update sa application, pakisuri at sagutan ang mga sagot para magpatuloy
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=Hindi Kwalipikado
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Hindi kwalipikado
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=Sinagutan noong {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Sagot {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=Magsimula rito. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=Posibleng hindi ka kwalipikado
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Posibleng hindi kwalipikado ang iyong kliyente
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=Sa ngayon, hindi namin masuri ang pagiging kwalipikado mo para sa {0}.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=Sa ngayon, hindi namin masuri ang pagiging kwalipikado ng iyong kliyente para sa {0}.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=Nagsisikap kami para mabilis na maayos ang isyung ito. Subukan ulit sa ibang pagkakataon.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=Tingnan ang lahat ng programa
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Batay sa iyong mga tugon, posibleng hindi ka kwalipikado para sa {0}. Kung nagbago ang iyong impormasyon, puwede mong i-edit ang iyong mga sagot at pagkatapos ay magpatuloy sa application.
@@ -393,20 +374,11 @@ content.foundSimilarAddress=Hindi namin ma-verify ang ibinigay mong address, per
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Inilagay na address:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName=Inilagay na {0}:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Iminumungkahing address:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Mga iminumungkahing address:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=I-edit ang address
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=I-save at kumpirmahin
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=Walang nakitang valid na address

--- a/server/conf/i18n/messages.vi
+++ b/server/conf/i18n/messages.vi
@@ -227,9 +227,6 @@ button.continue=Tiếp tục
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=Ứng dụng này đã có bản cập nhật. Vui lòng xem và trả lời các câu hỏi để tiếp tục
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=Không đủ điều kiện
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Không đủ tiêu chuẩn
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=Trước đây đã trả lời vào {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Câu trả lời {0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=Bắt đầu tại đây. {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -294,17 +287,6 @@ tag.mayNotQualify=Bạn có thể không đủ tiêu chuẩn
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Khách hàng của bạn có thể không đủ tiêu chuẩn
 
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=Hiện tại, chúng tôi không thể kiểm tra xem bạn có đủ điều kiện tham gia {0} hay không.
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=Hiện tại, chúng tôi không thể kiểm tra xem khách hàng của bạn có đủ điều kiện tham gia {0} hay không.
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=Chúng tôi đang nỗ lực để nhanh chóng khắc phục sự cố này. Hãy thử lại sau.
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=Xem tất cả chương trình
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Dựa trên câu trả lời của bạn, bạn có thể không đủ tiêu chuẩn tham gia {0}. Nếu thông tin của bạn đã thay đổi, bạn có thể chỉnh sửa câu trả lời rồi sau đó tiếp tục điền vào đơn đăng ký.
@@ -393,20 +375,11 @@ content.foundSimilarAddress=Chúng tôi không thể xác minh địa chỉ do b
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Địa chỉ đã nhập:
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName={0} đã nhập:
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Địa chỉ được đề xuất:
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Các địa chỉ được đề xuất:
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=Chỉnh sửa địa chỉ
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=Lưu và xác nhận
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=Không tìm thấy địa chỉ hợp lệ

--- a/server/conf/i18n/messages.zh-TW
+++ b/server/conf/i18n/messages.zh-TW
@@ -227,9 +227,6 @@ button.continue=繼續
 # A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=申請內容有所更新，如要繼續操作，請查看並回答問題
 
-# Text shown next to a question indicating that due to it, the application is not eligible to be submitted.
-content.notEligible=不符合資格
-
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=不符合資格
 
@@ -243,10 +240,6 @@ content.previouslyAnsweredOn=已於 {0}回答
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=回答以下問題：{0}
-
-# An aria-label for screen readers that helps provide context for the associated "start here" link. The link is for a specific
-# question, so this might say "Start here. What is your name?". The {0} variable is the question text.
-ariaLabel.begin=從這裡開始作答。{0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
@@ -293,18 +286,6 @@ tag.mayNotQualify=您可能不符合資格
 
 # Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=您的客戶可能不符合資格
-
-# Title of page when there is a system outage and eligibility can't be determined for the applicant.
-title.cannotCheckEligibility=我們目前無法判斷您是否符合「{0}」的資格。
-
-# Title of page when there is a system outage and eligibility can't be determined for the client, when someone is filling out an application on a client''s behalf.
-title.cannotCheckEligibilityTi=我們目前無法判斷您的客戶是否符合「{0}」的資格。
-
-# Content of page when there is a system outage and eligibility can't be determined for the applicant.
-content.cannotCheckEligibility=我們會盡力在短時間內修正這個問題，請稍後再試。
-
-# Button that allows an applicant to view all programs.
-button.viewAllPrograms=查看所有計畫
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=根據您的回覆，您可能不符合「{0}」的資格。如果您的資訊有所變更，可以編輯回答並繼續進行申請流程。
@@ -393,20 +374,11 @@ content.foundSimilarAddress=我們無法驗證您提供的地址，但找到了�
 # Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=您輸入的地址：
 
-# Text on address correction dialog that shows what address the user had entered, with the address question name.
-content.addressEnteredWithQuestionName=您輸入的{0}：
-
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=建議的地址：
 
 # Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=建議的地址：
-
-# Button to close the address correction dialog and allow applicant to edit address manually.
-button.editAddress=編輯地址
-
-# Button for applicant to save and confirm the address suggested in the dialog.
-button.saveAndConfirm=儲存並確認
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=找不到有效的網址

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -1,22 +1,22 @@
 package conf;
 
+import static com.google.auto.common.MoreStreams.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import services.MessageKey;
 
 /**
  * Tests that the messages files are in sync. Reads in the keys from the primary language file,
@@ -92,6 +92,16 @@ public class MessagesTest {
               assertThat(key).doesNotContain(PROHIBITED_CHARACTERS);
               assertThat(value).doesNotContain(PROHIBITED_CHARACTERS);
             });
+  }
+
+  @Test
+  public void messageKeyValuesAndMessagesFileKeysAreIdentical() throws Exception {
+    TreeSet<String> keysInPrimaryFile = keysInFile(PRIMARY_LANGUAGE_FILE_PATH);
+
+    ImmutableList<String> messageKeys =
+        Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
+
+    assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
   }
 
   private static TreeSet<String> keysInFile(String filePath) throws Exception {


### PR DESCRIPTION
### Description

This PR adds a test to `MessagesTest` to ensure that key values in `MessageKey` and the keys in `messages` are identical.

We also remove unused keys in `messages` to clean it up and get the test to pass. Alternatively, we could have added unused values to `MessageKey` for the unused translations, but it seems better to clean this up.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
   - Not neccessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891