### PR TITLE
Remove comments from `messages` file

### DIFF
--- a/server/conf/i18n/README.md
+++ b/server/conf/i18n/README.md
@@ -12,8 +12,9 @@ Please see the [internationalization docs](https://docs.civiform.us/contributor-
 
 When updating this file:
 
-- Keep in mind that translators do not have all of CiviForm's context in mind. To help them, please include a description that allows someone without knowledge about where this string is being used to understand it fully.
+- Keep in mind that translators do not have all of CiviForm's context in mind. To help them, please include a description **to the [Transifex dashboard](https://app.transifex.com/civiform/civiform/dashboard/)** that allows someone without knowledge about where this string is being used to understand it fully.
   - For example, explain where the string is shown and if strings are deployment-specific, specify what each passed through value represents, such as: "Shown to applicants to encourage login; {0} represents the civic entity's name, in reference to their login portal."
+  - See https://user-images.githubusercontent.com/30369272/239957567-5ddd5c42-4194-488a-9b1e-61cb4ec33c8b.png
 - Apostrophes in translations must be escaped by another apostrophe. See https://www.playframework.com/documentation/2.8.x/JavaI18N#Notes-on-apostrophes
 - Sections correspond to a single view, such as the applicant's home page or a view of an address question.
 - We use the following key format: `${component_type}.${descriptive_name}`

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -4,287 +4,121 @@
 # GENERAL - contains text that corresponds to multiple views. #
 #-------------------------------------------------------------#
 
-# The text on the button an applicant clicks to log out of their session.
 button.logout=Logout
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 label.selectLanguage=Please select your preferred language.
-
-# NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit
-
-# Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=For technical support, contact
-
-# Placeholder message when an applicant clicked the "Continue as Guest".
-# This should be consistent with button.guestLogin.
-# TODO(#1918): Translate.
 guest=Guest
-
-# Label read by screen readers for the language dropdown shown in the page header.
 label.languageSr=Choose a language
-
-# Message for guest users to end their session. Technically this logs out the user from the guest profile, but we use different phrasing in order to not imply that they are currently logged in from a product perspective.
 header.endSession=End session
-
-# Toast message that tells the user their session has ended, to help indicate that they are no longer logged in to an account (but still as a guest).
 toast.sessionEnded=Your session has ended.
-
-# Message for guest users, to avoid showing "Logged in as Guest" when they are really not logged in.
 header.guestIndicator=You''re a guest user.
-
-# Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}
-
-# Error message to answer a required question
 validation.isRequired=This question is required.
-
-# Validation error that is shown when the user input couldn't be converted for any reason.
 validation.invalidInput=Please enter valid input.
-
-# Error message announced to screen reader when there are errors on the current page.
 validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
-
-# Message displayed at the top of a question page denoting fields with a * are required.
 content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
-
-# Message displayed below "Choose File" button to say that on the phone users can use their camera.
 content.mobileFileUploadHelp=On your phone? "Choose File" also allows you to use your phone camera to upload documents.
 
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#
 
-# Title of the login page.
 title.login=Login
-
-# Prompt for applicant to log in, input is the full civic entity name.
 content.loginPrompt=Please log in with your {0} account
-
-# The text on the button an applicant clicks to create an account.
 button.createAnAccount=Create an account
-
-# The text on the button an applicant clicks to log in to their session.
 button.login=Log in
-
-# Prompt for applicant to create a new account or become a guest
 content.alternativeLoginPrompt=Don''t have an account?
-
-# The text between creating a new account, and becoming a guest
 content.or=or
-
-# The text on the button for applicants to create a new account.
 button.createAccount=Create account
-
-# The text on the button for guests to log in to their session.
 button.guestLogin=Continue as guest
-
-# Prompt for whem applicant account login is disabled. Replaces loginPrompt and alternativeLoginPrompt.
 content.loginDisabledPrompt=Account login currently disabled
-
-# The words leading up to the admin login anchor
 content.adminLoginPrompt=Looking for something else?
-
-# The footer of the CiviForm site to prompt admins to login if needed.
 content.adminFooterPrompt=Are you a benefits administrator?
-
-# The text on the anchor for admins to log in to their session.
 link.adminLogin=Admin login
 
 #--------------------------------------------------------------------------#
 # PROGRAM FORM - contains text shown when filling out an application form. #
 #--------------------------------------------------------------------------#
 
-# The text displayed when a file has already been uploaded and the name is being displayed.
 input.fileAlreadyUploaded=File uploaded: {0}
-
-# The text on the button an applicant clicks to delete an uploaded file.
 button.deleteFile=Delete
-
-# The text on the button an applicant clicks to skip uploading a new file while there is already an uploaded file.
 button.keepFile=Continue
-
-# The button text for saving the current applicant-entered data and continuing to the next screen in the form.
 button.nextScreen=Save and next
-
-# The button text for navigating to the previous screen in the form.
 button.previousScreen=Previous
-
-# The text on the button an applicant clicks to jump to the review page.
 button.review=Review
-
-# The text on the button an applicant clicks to skip uploading a file.
 button.skipFileUpload=Skip
-
-# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
-
-# A link that logs out a guest user after they submit an application.
 link.allDone=I''m all done
-
-# A link that appears next to the create account button that offers applicants the option to not create an account right now.
 link.applyToAnotherProgram=Apply to another program
-
-# A link that offers applicants the option to create an account.
 link.createAccountOrSignIn=Create account or sign in
 
 #----------------------------------------------------------------------------#
 # APPLICANT HOME PAGE - contains text specific to the applicant's home page. #
 #----------------------------------------------------------------------------#
 
-# The text on the button an applicant clicks to apply to a specific program.
 button.apply=Apply
-
-# The text read for screen readers.
 button.applySr=Apply to {0}
-
-# The text on the button an applicant clicks to edit the application for a specific program.
 button.edit=Edit
-
-# The screen reader text for a button allowing an applicant to edit a submitted application for a given program.
 button.editSr=Edit submitted application to {0}
-
-# The screen reader text for a button allowing an applicant to continue editing an in-progress application for a given program.
 button.continueSr=Continue application to {0}
-
-# The text on the button an applicant clicks to start filling out a pre-screener form.
 button.startHere=Start here
-
-# The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continue to application
-
-# The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
 button.startHereCommonIntakeSr=Start here by filling out {0}
-
-# The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
 button.editCommonIntakeSr=Edit submitted information for {0}
-
-# The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
 button.continueCommonIntakeSr=Continue filling out {0}
-
-# Text describing the date the application was last submitted.
 content.submittedDate=Submitted {0}
-
-# "Get benefits" floating text
 content.benefits=Get benefits
-
-# Long form description of the CiviForm site shown to the applicant.
 content.description=CiviForm helps you find benefits you may be eligible for in {0}. Get started by choosing an application below.
-
-# Title for programs page when applicant is not logged in
 content.saveTime=Save time when applying for benefits
-
-# Long form description of the site shown to the applicant when they are not logged in.
-# {0} represents the authentication provider's name
 content.guestDescription=Log in to your {0} account or create an account and apply for many benefits without having to enter the same information again. You can also edit applications at any time and check your application statuses.
-
-# Link text to read more about a program.
 link.programDetails=Program details
-
-# The same text, read for screen readers.
 link.programDetailsSr=Program details for {0}
-
-# The title of the page for the list of programs.
 title.programs=Programs & services
-
-# The title for the section in the list of programs that contains the pre-screener form.
 title.findServicesSection=Find services that can help you
-
-# The title for the section in the list of programs that contains all regular, non-pre-screener programs.
 title.allProgramsSection=All programs ({0})
-
-# For the badge on the program list index denoting the current status of an application
 title.status=Status
-
-# Subtitle for the list of programs with draft applications
 title.inProgressProgramsUpdated=In progress
-
-# Subtitle for the list of programs for which the applicant has no draft applications
 title.activeProgramsUpdated=Not started
-
-# Subtitle for the list of programs for which the applicant has already submitted an application
 title.submittedPrograms=Submitted
-
-# Badge on an application that has a status assigned to it
-title.status=Status
-
-# A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: application ID {0}
-
-# A toast message that displays when an applicant tries to apply to a previously completed program.
 toast.programCompleted=Application was already completed.
 
 #------------------------------------------------------------------------#
 # APPLICANT APPLICATION REVIEW PAGE - text when reviewing an application #
 #------------------------------------------------------------------------#
 
-# Submit application button
 button.submit=Submit
-
-# Continue application button
 button.continue=Continue
-
-# A toast message shown after submitting an application when it's been determined the application is incomplete typically due to external changes.
 toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
 
 # Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Does not qualify
-
-# The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Edit
 link.answer=Answer
-
-# The text that appears next to a question that was answered in another program to let the user know the date it was previously answered on.
 content.previouslyAnsweredOn=Previously answered on {0}
-
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Answer What is your name?". The {0} variable is the question text.
 ariaLabel.answer=Answer {0}
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
-
-# Program Summary Title
 title.programSummary=Program application summary
-# Title of the page where applicants can view a summary of the pre-screener form's questions and their answers.
 title.commonIntakeSummary=Benefits pre-screener summary
 
 #------------------------------------------------------------------------#
 # APPLICANT ELIGIBILITY - text related to applicant eligibility #
 #------------------------------------------------------------------------#
 
-# Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
-
-# Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client''s behalf. This text includes the program name.
 title.applicantNotEligibleTi=Based on your responses to the following questions, your client may not qualify for the {0}.
-
-# Text shown that allows the users to click on a program details link to find out more about the eligibility criteria for the program.
 content.eligibilityCriteria=For eligibility criteria please refer to {0}
-
-# Text shown to explain what the user can do since they are not eligible for the program with their current answers.
 content.changeAnswersForEligibility=You can return to the previous page to edit your answers. Or apply to another program.
-
-# Button for the applicant to go back and edit their responses.
 button.goBackAndEdit=Go back and edit
-
-# Toast message that shows that a client is likely eligible for a program, when someone else is filling out the application on a client''s behalf.
 toast.mayQualifyTi=Based on your responses, your client may qualify for the {0}. To proceed, continue filling out the application.
-
-# Toast message that shows that an applicant is likely eligible for a program, based on their responses.
 toast.mayQualify=Based on your responses, you may qualify for the {0}. To proceed, continue filling out the application.
-
-# Tag on the top of a program card, that lets the applicant know they may qualify for the program, based on their responses in other programs.
 tag.mayQualify=You may qualify
-
-# Tag on the top of a program card, that lets the person know their client may qualify for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayQualifyTi=Your client may qualify
-
-# Tag on the top of a program card, that lets the applicant know they are likely not eligible for the program, based on their responses in other programs.
 tag.mayNotQualify=You may not qualify
-
-# Tag on the top of a program card, that lets the person know their client is likely not eligible for the program, based on their responses in other programs. This is in the case when someone is filling out applications on their client''s behalf.
 tag.mayNotQualifyTi=Your client may not qualify
 
 # Toast message that shows that an applicant may not be eligible for a program, based on their responses.
@@ -292,64 +126,32 @@ toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If
 
 # Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client''s behalf.
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
-
-# Error when there was an exception while submitting the application
 banner.errorSavingApplication=Error saving application
 
 #---------------------------------------------------------------------------------------------#
 # APPLICANT APPLICATION CONFIRMATION PAGE - text for a page confirming application submission #
 #---------------------------------------------------------------------------------------------#
 
-# Title on the page after the applicant has successfully submitted an application.
 title.applicationConfirmation=Application confirmation
-
-# A confirmation message that shows after an applicant has submitted their application.
 content.confirmed=Thank you for applying to {0}.  Your application has been received, and your application ID is {1}.
-
-# Title (not a main page title) on section prompting an applicant to create an account or sign in to save their data.
 title.createAnAccount=Create an account or sign in
-
-# Shown to applicants to encourage login; {0} represents the authentication provider's name
 content.pleaseCreateAccount=Log in to your {0} account or create an account to have your information saved. You''ll be able to return at any time to complete future applications. If you do not already have an account, the login page will allow you to sign up and you won''t lose any data you''ve already entered.
-
-# A message to show on the login prompt modal that encourages users to log in before applying to other programs.
 content.generalLoginModalPrompt=You are not logged in to an account. Without an account you will not be able to edit an application, check the status of your application, or apply for other benefits quickly.
-
-# A message to show on the login prompt modal that encourages users to log in before applying to a program from the programs index page.
 content.initialLoginModalPrompt=Before you continue, log in to your City of Seattle account or create an account. You''ll be able to apply for many benefits without having to enter the same information again. You can also edit applications and check your application statuses.
-
-# A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continue without an account
-
-# Title on the page after applicant has successfully filled out the common intake form.
 title.commonIntakeConfirmation=Benefits you may qualify for
-
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
 title.commonIntakeConfirmationTi=Benefits your client may qualify for
-
-# A message explaining that the applicant may be eligible for the preceding list of programs, and that they need to apply to them.
 content.commonIntakeConfirmation=You may be able to get these benefits if you apply through the online application by clicking ''Apply to programs''.
-
-# A message explaining that the trusted intermediary's client may be eligible for the preceding list of programs, and that they need to apply to them.
 content.commonIntakeConfirmationTi=Your client may be able to get these benefits if you apply through the online application by clicking ''Apply to programs''.
-
-# A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
 content.commonIntakeNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for benefits at any time, by clicking ''Apply to programs''.  Or to view additional benefit programs you can visit {0}
-
-# A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
 content.commonIntakeNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for benefits at any time, by clicking ''Apply to programs''.  Or to view additional benefit programs you can visit {0}
-
-# A message explaining a second option when there are no eligible programs, which is to edit your responses.
 content.commonIntakeNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
-
-# A button prompting users to apply to programs.
 button.applyToPrograms=Apply to programs
 
 #----------------------------------------------------------#
 # ADDRESS QUESTION - text when viewing an address question #
 #----------------------------------------------------------#
 
-# Address question labels - these are shown as the field label before an input box.
 label.addressLine2=Apartment, suite, etc. (optional)
 label.city=City
 label.state=State
@@ -357,7 +159,6 @@ label.selectState=Select State
 label.street=Address
 label.zipcode=ZIP Code
 
-# Validation errors that are shown when a user enters an invalid address.
 validation.streetRequired=Please enter valid street name and number.
 validation.cityRequired=Please enter city.
 validation.currencyMisformatted=Currency must be one of the following formats: 1000 1,000 1000.30 1,000.30
@@ -365,37 +166,29 @@ validation.stateRequired=Please enter state.
 validation.invalidZipcode=Please enter valid 5-digit ZIP code.
 validation.noPoBox=Please enter a valid address. We do not accept PO Boxes.
 
-# Title on address correction dialog asking the user to verify their address.
 title.verifyAddress=Verify address
 
-# Content on address correction dialog that asks the user to check a similar address.
 content.foundSimilarAddress=We could not verify the address that you provided, but found something similar.
-
-# Text on address correction dialog that shows what address the user had entered.
 content.addressEntered=Address entered:
 
 # Text on dialog that shows a suggestion for the user's correct address when entered incorrectly.
 content.suggestedAddress=Suggested address:
-
-# Text on dialog that shows a suggestions for the user's correct address when entered incorrectly (and there is more than one).
 content.suggestedAddresses=Suggested addresses:
 
 # Title on address correction dialog when no address is found.
 title.noValidAddress=No valid address found
-
-# Content on address correction dialog when no address is found.
 content.noValidAddress=We could not verify the address that you provided. Please edit your address to continue.
 
 #----------------------------------------------------------------------------------------------------------#
 # DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
 #----------------------------------------------------------------------------------------------------------#
 
-# Placeholder text shown in a dropdown selector before the user has made a selection.
 placeholder.noDropdownSelection=Choose an option:
 
 #------------------------------------------------------------------------------------------------------------------------------#
 # PHONE QUESTION - text shown when answering a question where a user must select an option for country and enter phone number. #
 #------------------------------------------------------------------------------------------------------------------------------#
+
 label.countryCode=Country
 label.phoneNumber=Enter Phone number
 validation.phoneNumberRequired=Phone number is required
@@ -407,45 +200,31 @@ validation.phoneMustBeLocalToCountry=The phone you have provided does not belong
 #----------------------------------------------------------------------------------------------------------#
 # DATE QUESTION - text shown when answering a question where a user must select date. #
 #----------------------------------------------------------------------------------------------------------#
+
 validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
 
 #--------------------------------------------------------------------------------------------------------#
 # ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
 #--------------------------------------------------------------------------------------------------------#
 
-# Text on a button an applicant would click to add another entity
 button.addEntity=Add {0}
-
-# Text on a button an applicant would click to delete an entity
 button.removeEntity=Remove {0}
-
-# The confirmation dialog when an applicant deletes an enumerator entry.
 dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
-
-# Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Please enter a value for each line.
-
-# Validation error that shows when an applicant uses a duplicate entity name
 validation.duplicateEntityName=Please enter a unique value for each line.
-
-# The placeholder text for enumerator fields
 placeholder.entityName={0} name
 
 #---------------------------------------------------------------------------------#
 # FILEUPLOAD QUESTION - text when viewing a question where a user uploads a file. #
 #---------------------------------------------------------------------------------#
 
-# Validation error that shows when an applicant does not select a file to upload
 validation.fileRequired=Please select a file.
-
-# Button text that prompts the user to select a file to upload.
 button.chooseFile=Choose File
 
 #---------------------------------------------------------------------#
 # ID QUESTION - id specific to filling out a question. #
 #---------------------------------------------------------------------#
 
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.idTooLong=Must contain at most {0} characters.
 validation.idTooShort=Must contain at least {0} characters.
 validation.numberRequired=Must contain only numbers.
@@ -454,7 +233,6 @@ validation.numberRequired=Must contain only numbers.
 # MULTI-SELECT QUESTION - text shown when filling out a question with multiple answers, such as a checkbox #
 #----------------------------------------------------------------------------------------------------------#
 
-# Validation errors that are shown if a user selects too many or too few answers.
 validation.tooFewSelections=Please select at least {0}.
 validation.tooManySelections=Please select fewer than {0}.
 
@@ -462,17 +240,14 @@ validation.tooManySelections=Please select fewer than {0}.
 # NAME QUESTION - text when viewing a name question #
 #---------------------------------------------------#
 
-# Name question labels - these are shown as the field label before an input box.
 label.firstName=First name
 label.lastName=Last name
 label.middleName=Middle name
 
-# Placeholder text - this is shown inside the input box, before a user enters an answer.
 placeholder.firstName=First name
 placeholder.lastName=Last name
 placeholder.middleName=Middle name
 
-# Validation errors - these are shown if a user enters an invalid name.
 validation.firstNameRequired=Please enter your first name.
 validation.lastNameRequired=Please enter your last name.
 
@@ -480,7 +255,6 @@ validation.lastNameRequired=Please enter your last name.
 # NUMBER QUESTION - text specific to answering a question with a number. #
 #------------------------------------------------------------------------#
 
-# Validation errors that are shown when a user enters a number that is too big or too small, or a non-integer.
 validation.numberTooBig=Must be at most {0}.
 validation.numberTooSmall=Must be at least {0}.
 validation.numberNonInteger=Number must be a positive whole number and can only contain numeric characters 0-9.
@@ -489,57 +263,35 @@ validation.numberNonInteger=Number must be a positive whole number and can only 
 # TEXT QUESTION - text specific to filling out a question with words. #
 #---------------------------------------------------------------------#
 
-# Validation errors that appear if a user enters an answer that is too long or too short.
 validation.textTooLong=Must contain at most {0} characters.
 validation.textTooShort=Must contain at least {0} characters.
-
 
 #---------------------------------------------------------------------#
 # MULTI OPTION QUESTION ADMIN EDIT - text specific when creating/editing a multi option question. #
 #---------------------------------------------------------------------#
 
-# Validation errors that appear if an admin leaves a multi option question blank.
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 
 #----------------------------------#
 # ERRORS - various error messages  #
 #----------------------------------#
+
 error.notFoundTitle=We were unable to find the page you tried to visit
 error.notFoundDescription=Please go back or return to the {0}
 error.notFoundDescriptionLink=homepage
-
-# This occurs when an unhandled exception happens.
 error.internalServerTitle=An error occurred
-
-# Message to user that an error happened. %s will be replaced with tech support email address. {0} is replaced by the exception id we use to look up the error in the logs.
 error.internalServerDescription=Please contact technical support for assistance at %s and include this error id {0}.
 
 #-------------------------------------------------------------#
 # EMAILS - boilerplate text contained in emails sent to users #
 #-------------------------------------------------------------#
-# Bottom of the body of the email sent automatically on application submission
+
 email.loginToCiviform=Log in to Civiform at {0}
-
-# Subject of the email sent automatically on application submission
 email.applicationReceivedSubject=Your application to program {0} is received
-
-# Body of the email sent automatically on application submission
 email.applicationReceivedBody=Your application to program {0} has been received. Your applicant ID is {1} and the application ID is {2}
-
-# Subject of the email sent to the TI on application submission
 email.tiApplicationSubmittedSubject=You submitted an application for program {0} on behalf of applicant {1}
-
-# Body of the email sent to the TI on application submission
 email.tiApplicationSubmittedBody=The application to program {0} as applicant {1} has been received, and the application ID is {2}.
-
-# Link at the bottom of the email sent to the TI on application submission
 email.tiManageYourClients=Manage your clients at {0}.
-
-# Subject of the email sent to an applicant when the status of their application has changed
 email.applicationUpdateSubject=An update on your application {0}
-
-# Subject of the email sent to a TI when they change the status of an application
 email.tiApplicationUpdateSubject=An update on the application for program {0} on behalf of applicant {1}
-
-# Body of the email sent to a TI when they change the status of an application
 email.tiApplicationUpdateBody=The status for applicant {0} on program {1} has changed to {2}.

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -96,15 +96,12 @@ button.submit=Submit
 button.continue=Continue
 toast.applicationOutOfDate=There''s been an update to the application, please review and answer questions to proceed
 
-# Text shown next to a question indicating that due to it, the application does not qualify or is not eligible.
 content.doesNotQualify=Does not qualify
 link.edit=Edit
 link.answer=Answer
 content.previouslyAnsweredOn=Previously answered on {0}
 ariaLabel.answer=Answer {0}
 
-# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
-# question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
 title.programSummary=Program application summary
 title.commonIntakeSummary=Benefits pre-screener summary
@@ -125,10 +122,8 @@ tag.mayQualifyTi=Your client may qualify
 tag.mayNotQualify=You may not qualify
 tag.mayNotQualifyTi=Your client may not qualify
 
-# Toast message that shows that an applicant may not be eligible for a program, based on their responses.
 toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
 
-# Toast message that shows that a client may not be eligible for a program, when someone else is filling out the application on a client''s behalf.
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
 banner.errorSavingApplication=Error saving application
 

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1,4 +1,8 @@
 # Please see the README.md in the same directory for more information on localization.
+#
+# ALWAYS add context strings to the Transifex dashboard immediately after
+# merging changes to this file. See
+# https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings
 
 #-------------------------------------------------------------#
 # GENERAL - contains text that corresponds to multiple views. #


### PR DESCRIPTION
### Description

Removes the comments from `messages`. These have been moved to Transifex [context strings](https://help.transifex.com/en/articles/6244125-the-complete-guide-to-adding-context-to-strings):

![image](https://github.com/civiform/civiform/assets/30369272/5ddd5c42-4194-488a-9b1e-61cb4ec33c8b)

Also adds a comment to the top of `messages` reminding developers to add a context string to Transifex.


## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - `MessagesTest` already checks this
- [ ] Extended the README / documentation, if necessary


#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4891
