### PR TITLE
Rename `ApplicantInformationController` methods

### DIFF
--- a/server/app/controllers/HomeController.java
+++ b/server/app/controllers/HomeController.java
@@ -86,8 +86,8 @@ public class HomeController extends Controller {
                       .withLang(data.preferredLocale(), messagesApi);
                 } else {
                   return redirect(
-                      controllers.applicant.routes.ApplicantInformationController.edit(
-                          applicant.id));
+                      controllers.applicant.routes.ApplicantInformationController
+                          .setLangFromBrowser(applicant.id));
                 }
               },
               httpExecutionContext.current());

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -65,7 +65,7 @@ public final class ApplicantInformationController extends CiviFormController {
    * accordingly.
    */
   @Secure
-  public CompletionStage<Result> edit(Http.Request request, long applicantId) {
+  public CompletionStage<Result> setLangFromBrowser(Http.Request request, long applicantId) {
 
     CompletionStage<Optional<String>> applicantStage = this.applicantService.getName(applicantId);
 
@@ -120,8 +120,12 @@ public final class ApplicantInformationController extends CiviFormController {
             });
   }
 
+  /**
+   * Sets the applicant's preferred language based on their language form selection, then redirects
+   * them.
+   */
   @Secure
-  public CompletionStage<Result> update(Http.Request request, long applicantId) {
+  public CompletionStage<Result> setLangFromSwitcher(Http.Request request, long applicantId) {
     Form<ApplicantInformationForm> form = formFactory.form(ApplicantInformationForm.class);
 
     if (form.hasErrors()) {

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -93,8 +93,8 @@ public final class RedirectController extends CiviFormController {
               if (!applicant.getApplicantData().hasPreferredLocale()) {
                 return CompletableFuture.completedFuture(
                     redirect(
-                            controllers.applicant.routes.ApplicantInformationController.edit(
-                                applicantId))
+                            controllers.applicant.routes.ApplicantInformationController
+                                .setLangFromBrowser(applicantId))
                         .withSession(
                             request.session().adding(REDIRECT_TO_SESSION_KEY, request.uri())));
               }

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -225,7 +225,8 @@ public class ApplicantLayout extends BaseHtmlLayout {
       long userId = profile.get().getApplicant().join().id;
 
       String updateLanguageAction =
-          controllers.applicant.routes.ApplicantInformationController.update(userId).url();
+          controllers.applicant.routes.ApplicantInformationController.setLangFromSwitcher(userId)
+              .url();
 
       String csrfToken = CSRF.getToken(request.asScala()).value();
       InputTag csrfInput = input().isHidden().withValue(csrfToken).withName("csrfToken");

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -131,8 +131,8 @@ GET     /applicants/:applicantId/files/:fileKey     controllers.FileController.s
 GET     /assets/*file               controllers.Assets.versioned(file)
 
 # Methods for applicants
-GET     /applicants/:applicantId/edit                                       controllers.applicant.ApplicantInformationController.edit(request: Request, applicantId: Long)
-POST    /applicants/:applicantId                                            controllers.applicant.ApplicantInformationController.update(request: Request, applicantId: Long)
+GET     /applicants/:applicantId/edit                                       controllers.applicant.ApplicantInformationController.setLangFromBrowser(request: Request, applicantId: Long)
+POST    /applicants/:applicantId                                            controllers.applicant.ApplicantInformationController.setLangFromSwitcher(request: Request, applicantId: Long)
 
 # Program methods for applicants
 GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.index(request: Request, applicantId: Long)

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -32,7 +32,9 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
     Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantInformationController.edit(applicant.id).url());
+            controllers.applicant.routes.ApplicantInformationController.setLangFromBrowser(
+                    applicant.id)
+                .url());
   }
 
   @Test

--- a/server/test/controllers/RedirectControllerTest.java
+++ b/server/test/controllers/RedirectControllerTest.java
@@ -117,7 +117,9 @@ public class RedirectControllerTest extends WithMockedProfiles {
 
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantInformationController.edit(applicant.id).url());
+            controllers.applicant.routes.ApplicantInformationController.setLangFromBrowser(
+                    applicant.id)
+                .url());
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -32,24 +32,27 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void edit_differentApplicant_returnsUnauthorizedResult() {
+  public void setLangFromBrowser_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .edit(fakeRequest().build(), currentApplicant.id + 1)
+            .setLangFromBrowser(fakeRequest().build(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
-  public void edit_updatesLanguageCode_usingRequestHeaders() {
+  public void setLangFromBrowser_updatesLanguageCode_usingRequestHeaders() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(routes.ApplicantInformationController.edit(currentApplicant.id))
+                fakeRequest(
+                        routes.ApplicantInformationController.setLangFromBrowser(
+                            currentApplicant.id))
                     .header("Accept-Language", "es-US"))
             .build();
 
-    Result result = controller.edit(request, currentApplicant.id).toCompletableFuture().join();
+    Result result =
+        controller.setLangFromBrowser(request, currentApplicant.id).toCompletableFuture().join();
 
     currentApplicant =
         userRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();
@@ -60,24 +63,27 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void update_differentApplicant_returnsUnauthorizedResult() {
+  public void setLangFromSwitcher_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .update(fakeRequest().build(), currentApplicant.id + 1)
+            .setLangFromSwitcher(fakeRequest().build(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
-  public void update_redirectsToProgramIndex_withNonEnglishLocale() {
+  public void setLangFromSwitcher_redirectsToProgramIndex_withNonEnglishLocale() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(routes.ApplicantInformationController.update(currentApplicant.id))
+                fakeRequest(
+                        routes.ApplicantInformationController.setLangFromSwitcher(
+                            currentApplicant.id))
                     .bodyForm(ImmutableMap.of("locale", "es-US")))
             .build();
 
-    Result result = controller.update(request, currentApplicant.id).toCompletableFuture().join();
+    Result result =
+        controller.setLangFromSwitcher(request, currentApplicant.id).toCompletableFuture().join();
 
     currentApplicant =
         userRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();
@@ -88,15 +94,18 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void update_ignoresExistingLangCookie() {
+  public void setLangFromSwitcher_ignoresExistingLangCookie() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(routes.ApplicantInformationController.update(currentApplicant.id))
+                fakeRequest(
+                        routes.ApplicantInformationController.setLangFromSwitcher(
+                            currentApplicant.id))
                     .bodyForm(ImmutableMap.of("locale", "es-US")))
             .langCookie(Locale.US, stubMessagesApi())
             .build();
 
-    Result result = controller.update(request, currentApplicant.id).toCompletableFuture().join();
+    Result result =
+        controller.setLangFromSwitcher(request, currentApplicant.id).toCompletableFuture().join();
 
     currentApplicant =
         userRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();


### PR DESCRIPTION
### Description

Renames some `ApplicantInformationController` methods to make them be more in line with what they are doing. Reflects some changes in the Login/Languages project.

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not necessary
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4705