### PR TITLE
Disable request session logging on dev/test/browser tests as default

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -1,7 +1,7 @@
 # Configuration for the dev CiviForm server.
 include "application.conf"
 
-filters.LoggingFilter.enable_request_session_logging = true
+filters.LoggingFilter.enable_request_session_logging = false
 
 play.i18n {
   langCookieSecure = false


### PR DESCRIPTION
### Description

The output is encrypted json so it's not really useful to have on all the time.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
