### PR TITLE
Updating errorprone to 2.19.1 and fixing new errors

### DIFF
--- a/server/app/auth/ProfileUtils.java
+++ b/server/app/auth/ProfileUtils.java
@@ -1,6 +1,7 @@
 package auth;
 
 import com.google.common.base.Preconditions;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
@@ -63,10 +64,10 @@ public class ProfileUtils {
 
   // A temporary placeholder email value, used while the user needs to verify their account.
   private static final String IDCS_PLACEHOLDER_EMAIL_LOWERCASE =
-      "ITD_UCSS_UAT@seattle.gov".toLowerCase();
+      "ITD_UCSS_UAT@seattle.gov".toLowerCase(Locale.ROOT);
   // Testing account to allow for manual verification of the check.
   private static final String IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE =
-      "CiviFormStagingTest@gmail.com".toLowerCase();
+      "CiviFormStagingTest@gmail.com".toLowerCase(Locale.ROOT);
 
   /** Return true if the account is not a fully usable account to the City of Seattle. */
   public boolean accountIsIdcsPlaceholder(CiviFormProfile profile) {
@@ -76,7 +77,7 @@ public class ProfileUtils {
       return false;
     }
 
-    String userEmailLowercase = userEmail.get().toLowerCase();
+    String userEmailLowercase = userEmail.get().toLowerCase(Locale.ROOT);
 
     return IDCS_PLACEHOLDER_EMAIL_LOWERCASE.equals(userEmailLowercase)
         || IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE.equals(userEmailLowercase);

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -13,6 +13,7 @@ import forms.MultiOptionQuestionForm;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -420,7 +421,7 @@ public final class AdminQuestionController extends CiviFormController {
   private String invalidQuestionTypeMessage(String questionType) {
     return String.format(
         "unrecognized question type: '%s', accepted values include: %s",
-        questionType.toUpperCase(), Arrays.toString(QuestionType.values()));
+        questionType.toUpperCase(Locale.ROOT), Arrays.toString(QuestionType.values()));
   }
 
   /**

--- a/server/app/controllers/admin/AdminReportingController.java
+++ b/server/app/controllers/admin/AdminReportingController.java
@@ -6,6 +6,7 @@ import auth.ProfileUtils;
 import com.google.common.base.Preconditions;
 import controllers.BadRequestException;
 import controllers.CiviFormController;
+import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import org.pac4j.play.java.Secure;
@@ -124,6 +125,6 @@ public final class AdminReportingController extends CiviFormController {
             "Content-Disposition",
             String.format(
                 "attachment; filename=\"%s\"",
-                String.format("CiviForm_%s.csv", dataSetName.toLowerCase())));
+                String.format("CiviForm_%s.csv", dataSetName.toLowerCase(Locale.ROOT))));
   }
 }

--- a/server/app/featureflags/FeatureFlag.java
+++ b/server/app/featureflags/FeatureFlag.java
@@ -1,5 +1,7 @@
 package featureflags;
 
+import java.util.Locale;
+
 /**
  * An enum to represent feature flags used in CiviForm.
  *
@@ -57,6 +59,6 @@ public enum FeatureFlag {
   /** Returns a configuration-friendly version of the flag value in lower_camel_case. */
   @Override
   public String toString() {
-    return name().toLowerCase();
+    return name().toLowerCase(Locale.ROOT);
   }
 }

--- a/server/app/filters/DisableCachingFilter.java
+++ b/server/app/filters/DisableCachingFilter.java
@@ -3,6 +3,7 @@ package filters;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
 import play.mvc.EssentialAction;
@@ -33,7 +34,7 @@ public class DisableCachingFilter extends EssentialFilter {
                 .map(
                     result -> {
                       final Integer status = result.status();
-                      final String path = request.uri().toLowerCase();
+                      final String path = request.uri().toLowerCase(Locale.ROOT);
 
                       if (ASSET_PATH_PREFIXES.stream().anyMatch(path::startsWith)
                           && OK_STATUS_CODES.contains(status)) {

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -81,7 +81,7 @@ public class SecurityModule extends AbstractModule {
     logoutController.setDefaultUrl(baseUrl + routes.HomeController.index().url());
     logoutController.setLocalLogout(true);
     logoutController.setDestroySession(true);
-    /**
+    /*
      * This mitigates a vulnerability in the logout process described here:
      * https://groups.google.com/g/pac4j-security/c/poWGfZKo-ww/m/S-h4ggaSAgAJ
      *

--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -509,7 +509,7 @@ public class CfJsonDocumentContext {
   public boolean deleteRepeatedEntities(Path path, ImmutableList<Integer> indices) {
     checkLocked();
 
-    /** Early return if there's nothing to delete */
+    //Early return if there's nothing to delete
     if (indices.isEmpty()) {
       return false;
     }

--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -509,7 +509,7 @@ public class CfJsonDocumentContext {
   public boolean deleteRepeatedEntities(Path path, ImmutableList<Integer> indices) {
     checkLocked();
 
-    //Early return if there's nothing to delete
+    // Early return if there's nothing to delete
     if (indices.isEmpty()) {
       return false;
     }

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -6,6 +6,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import java.util.Optional;
 import services.DateConverter;
 import services.Path;
@@ -64,7 +65,7 @@ public final class JsonPathPredicateGenerator {
         String.format(
             "%s[?(@.%s %s %s)]",
             getPath(node).predicateFormat(),
-            node.scalar().name().toLowerCase(),
+            node.scalar().name().toLowerCase(Locale.ROOT),
             node.operator().toJsonPathOperator(),
             node.comparedValue().value()));
   }
@@ -91,7 +92,7 @@ public final class JsonPathPredicateGenerator {
         String.format(
             "%s[?(@.%s %s %s)]",
             getPath(node).predicateFormat(),
-            Scalar.SERVICE_AREA.name().toLowerCase(),
+            Scalar.SERVICE_AREA.name().toLowerCase(Locale.ROOT),
             Operator.IN_SERVICE_AREA.toJsonPathOperator(),
             String.format(
                 "/([a-zA-Z\\-]+_[a-zA-Z]+_\\d+,)*%1$s_(%2$s|%3$s)_\\d+(,[a-zA-Z\\-]+_[a-zA-Z]+_\\d+)*/",
@@ -136,7 +137,7 @@ public final class JsonPathPredicateGenerator {
                 getPath(node).predicateFormat(),
                 dateConverter.getDateTimestampFromAge(ageRange.get(0)),
                 dateConverter.getDateTimestampFromAge(ageRange.get(1)),
-                node.scalar().name().toLowerCase()));
+                node.scalar().name().toLowerCase(Locale.ROOT)));
       case AGE_OLDER_THAN:
       case AGE_YOUNGER_THAN:
         return JsonPathPredicate.create(
@@ -145,7 +146,7 @@ public final class JsonPathPredicateGenerator {
                 getPath(node).predicateFormat(),
                 dateConverter.getDateTimestampFromAge(Long.parseLong(node.comparedValue().value())),
                 node.operator().toJsonPathOperator(),
-                node.scalar().name().toLowerCase()));
+                node.scalar().name().toLowerCase(Locale.ROOT)));
       default:
         throw new InvalidPredicateException(
             String.format("Expecting an age predicate but instead received %s", node.operator()));

--- a/server/app/services/application/ApplicationEventDetails.java
+++ b/server/app/services/application/ApplicationEventDetails.java
@@ -31,9 +31,9 @@ public abstract class ApplicationEventDetails {
   @JsonProperty("status_event")
   public abstract Optional<StatusEvent> statusEvent();
 
+  /** Type NOTE_EVENT representing a note associated with the Application. */
   @JsonInclude(Include.NON_EMPTY)
   @JsonProperty("note_event")
-  /** Type NOTE_EVENT representing a note associated with the Application. */
   public abstract Optional<NoteEvent> noteEvent();
 
   public static Builder builder() {

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -62,7 +63,7 @@ public final class CsvExporterService {
   private static final String HEADER_SPACER_SCALAR = " ";
 
   private static final String CURRENCY_CENTS_TYPE_STRING =
-      ScalarType.CURRENCY_CENTS.toString().toLowerCase();
+      ScalarType.CURRENCY_CENTS.toString().toLowerCase(Locale.ROOT);
 
   public static final ImmutableSet<QuestionType> NON_EXPORTED_QUESTION_TYPES =
       ImmutableSet.of(QuestionType.ENUMERATOR, QuestionType.STATIC);

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,5 +1,6 @@
 package services.question.types;
 
+import java.util.Locale;
 import services.question.exceptions.InvalidQuestionTypeException;
 
 /** Defines types of questions supported. */
@@ -37,7 +38,7 @@ public enum QuestionType {
   }
 
   public static QuestionType of(String name) throws InvalidQuestionTypeException {
-    String upperName = name.toUpperCase();
+    String upperName = name.toUpperCase(Locale.ROOT);
     try {
       return valueOf(upperName);
     } catch (IllegalArgumentException e) {

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -32,6 +32,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -522,7 +523,7 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
                           .withValue(scalar.name())
                           // Add the scalar type as data so we can determine which operators to
                           // allow.
-                          .withData("type", scalar.toScalarType().name().toLowerCase());
+                          .withData("type", scalar.toScalarType().name().toLowerCase(Locale.ROOT));
 
                   if (maybeSelectedScalar.isPresent()
                       && maybeSelectedScalar.get().name().equals(scalar.name())) {
@@ -614,7 +615,8 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
                       option(operator.toDisplayString()).withValue(operator.name());
                   operator
                       .getOperableTypes()
-                      .forEach(type -> optionTag.withData(type.name().toLowerCase(), ""));
+                      .forEach(
+                          type -> optionTag.withData(type.name().toLowerCase(Locale.ROOT), ""));
 
                   if (maybeSelectedOperator.isPresent()
                       && operator.name().equals(maybeSelectedOperator.get().name())) {

--- a/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
@@ -19,6 +19,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.LabelTag;
+import java.util.Locale;
 import java.util.UUID;
 import javax.inject.Inject;
 import play.mvc.Http;
@@ -174,7 +175,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                 submitButton(
                         String.format(
                             "Remove existing %s condition",
-                            predicateTypeNameTitleCase.toLowerCase()))
+                            predicateTypeNameTitleCase.toLowerCase(Locale.ROOT)))
                     .withClasses(ButtonStyles.SOLID_BLUE)
                     .withForm(removePredicateFormId)
                     .withCondDisabled(!hasExistingPredicate));
@@ -209,7 +210,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                             "edit-condition-button",
                             String.format(
                                 "Edit existing %s condition",
-                                predicateTypeNameTitleCase.toLowerCase()),
+                                predicateTypeNameTitleCase.toLowerCase(Locale.ROOT)),
                             configureExistingPredicateUrl)
                         .withCondDisabled(!hasExistingPredicate)
                         .withClasses(ButtonStyles.SOLID_BLUE)))

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -19,6 +19,7 @@ import forms.QuestionFormBuilder;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
+import java.util.Locale;
 import java.util.Optional;
 import models.QuestionTag;
 import play.i18n.Lang;
@@ -98,7 +99,8 @@ public final class QuestionEditView extends BaseHtmlView {
       ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions,
       Optional<ToastMessage> message) {
     QuestionType questionType = questionForm.getQuestionType();
-    String title = String.format("New %s question", questionType.getLabel().toLowerCase());
+    String title =
+        String.format("New %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
         buildQuestionContainer(title, questionForm)
@@ -148,7 +150,8 @@ public final class QuestionEditView extends BaseHtmlView {
       Optional<ToastMessage> message) {
 
     QuestionType questionType = questionForm.getQuestionType();
-    String title = String.format("Edit %s question", questionType.getLabel().toLowerCase());
+    String title =
+        String.format("Edit %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
         buildQuestionContainer(title, questionForm)
@@ -171,7 +174,8 @@ public final class QuestionEditView extends BaseHtmlView {
       throws InvalidQuestionTypeException {
     QuestionForm questionForm = QuestionFormBuilder.create(questionDefinition);
     QuestionType questionType = questionForm.getQuestionType();
-    String title = String.format("View %s question", questionType.toString().toLowerCase());
+    String title =
+        String.format("View %s question", questionType.toString().toLowerCase(Locale.ROOT));
 
     SelectWithLabel enumeratorOption =
         enumeratorOptionsFromMaybeEnumerationQuestionDefinition(maybeEnumerationQuestionDefinition);

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -28,6 +28,7 @@ import j2html.tags.specialized.PTag;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -192,7 +193,10 @@ public final class QuestionsListView extends BaseHtmlView {
                     .reversed()
                     .thenComparing(
                         card ->
-                            getDisplayQuestion(card).getQuestionText().getDefault().toLowerCase()))
+                            getDisplayQuestion(card)
+                                .getQuestionText()
+                                .getDefault()
+                                .toLowerCase(Locale.ROOT)))
             .collect(ImmutableList.toImmutableList());
 
     for (QuestionCardData card : cards) {

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -8,6 +8,7 @@ import controllers.applicant.routes;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.UlTag;
+import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
@@ -53,14 +54,15 @@ public final class IneligibleBlockView extends ApplicationBaseView {
     ATag infoLink =
         new LinkElement()
             .setStyles("mb-4", "underline")
-            .setText(messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase())
+            .setText(
+                messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase(Locale.ROOT))
             .setHref(programDetailsLink)
             .opensInNewTab()
             .setIcon(Icons.OPEN_IN_NEW, LinkElement.IconPosition.END)
             .asAnchorText()
             .attr(
                 "aria-label",
-                messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase());
+                messages.at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase(Locale.ROOT));
     UlTag listTag = ul().withClasses("list-disc", "mx-8");
     roApplicantProgramService
         .getIneligibleQuestions()

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -8,6 +8,7 @@ import static j2html.TagCreator.p;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
+import java.util.Locale;
 import services.question.types.QuestionType;
 import views.style.StyleUtils;
 
@@ -49,7 +50,7 @@ public final class CreateQuestionButton {
       if (!phoneQuestionTypeEnabled && QuestionType.PHONE.equals(type)) {
         continue;
       }
-      String typeString = type.toString().toLowerCase();
+      String typeString = type.toString().toLowerCase(Locale.ROOT);
       String link =
           controllers.admin.routes.AdminQuestionController.newOne(
                   typeString, questionCreateRedirectUrl)

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -7,6 +7,7 @@ import com.google.auto.value.AutoValue;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import views.style.BaseStyles;
@@ -149,7 +150,8 @@ public abstract class Modal {
     }
     divTag.withClasses(modalStyles);
     if (repeatOpenBehavior().showOnlyOnce()) {
-      divTag.attr("only-show-once-group", repeatOpenBehavior().group().name().toLowerCase());
+      divTag.attr(
+          "only-show-once-group", repeatOpenBehavior().group().name().toLowerCase(Locale.ROOT));
       if (repeatOpenBehavior().bypassUrl().isPresent()) {
         divTag.attr("bypass-url", repeatOpenBehavior().bypassUrl().get());
       }

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -14,6 +14,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.PTag;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.mvc.Http.Request;
@@ -194,7 +195,8 @@ public final class ProgramCardFactory {
             cardData -> getDisplayProgram(cardData).lastModifiedTime().orElse(Instant.EPOCH),
             Comparator.reverseOrder())
         .thenComparing(
-            cardData -> getDisplayProgram(cardData).localizedName().getDefault().toLowerCase());
+            cardData ->
+                getDisplayProgram(cardData).localizedName().getDefault().toLowerCase(Locale.ROOT));
   }
 
   @AutoValue

--- a/server/app/views/components/QuestionBank.java
+++ b/server/app/views/components/QuestionBank.java
@@ -22,6 +22,7 @@ import j2html.tags.specialized.PTag;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.stream.Stream;
 import org.apache.http.client.utils.URIBuilder;
 import play.mvc.Http;
@@ -167,7 +168,7 @@ public final class QuestionBank {
                 Comparator.<QuestionDefinition, Instant>comparing(
                         qdef -> qdef.getLastModifiedTime().orElse(Instant.EPOCH))
                     .reversed()
-                    .thenComparing(qdef -> qdef.getName().toLowerCase()))
+                    .thenComparing(qdef -> qdef.getName().toLowerCase(Locale.ROOT)))
             .collect(ImmutableList.toImmutableList());
 
     contentDiv.with(

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -127,11 +127,11 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
     DivTag addressQuestionFormContent =
         div()
             .with(
-                /** First line of address entry: Address line 1 AKA street address */
+                // First line of address entry: Address line 1 AKA street address
                 streetAddressField.getInputTag(),
-                /** Second line of address entry: Address line 2 AKA apartment, unit, etc. */
+                // Second line of address entry: Address line 2 AKA apartment, unit, etc.
                 addressOptionalField.getInputTag(),
-                /** Third line of address entry: City, State, Zip */
+                // Third line of address entry: City, State, Zip
                 div()
                     .withClasses("grid", "grid-cols-3", "gap-3")
                     .with(

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -83,7 +83,7 @@ lazy val root = (project in file("."))
       "com.google.auto.value" % "auto-value-parent" % "1.10.1" pomOnly (),
 
       // Errorprone
-      "com.google.errorprone" % "error_prone_core" % "2.18.0",
+      "com.google.errorprone" % "error_prone_core" % "2.19.1",
 
       // Apache libraries for export
       "org.apache.commons" % "commons-csv" % "1.10.0",


### PR DESCRIPTION
### Description

Updating errorprone to 2.19.1 and fixing new errors. 

Errors were javadocs comments used in invalid locations and use of tolowercase/touppercase without a locale.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4842
