### PR TITLE
Fixing code scanning alert on permissions

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,5 +1,7 @@
 name: Auto Request Review
 
+permissions: read-all
+
 on:
   pull_request:
     types: [opened, ready_for_review, reopened, synchronize]
@@ -12,5 +14,9 @@ jobs:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.10.0
         with:
+          # This does not use the built in GITHUB_TOKEN because we are using Github
+          # teams to specify the list of reviewers. Because of that we need to
+          # specify specific permissions within the personal access token
+          # See: https://github.com/marketplace/actions/auto-request-review#optional-github-personal-access-token
           token: ${{ secrets.CIVIFORM_GITHUB_PR_AUTOMATION_PAT }}
           config: .github/reviewers.yml # Config file location


### PR DESCRIPTION
### Description

This fixes a 'high' code scanning alert. Setting default permissions to read. Also adding a comment on the token being used.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

