### PR TITLE
Call out database changes in release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+# Used by the labeler.yaml github action to automatically apply
+# labels based on rules
+
+# Label PRs with database if it contains evolution file(s)
+database:
+  - 'server/conf/evolutions/default/*.sql'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,10 @@ changelog:
       - infrastructure
 
   categories:
+    - title: Database
+      labels:
+        - database
+
     - title: Features
       labels:
         - feature

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,7 +6,7 @@ changelog:
       - infrastructure
 
   categories:
-    - title: Database
+    - title: Database Changes
       labels:
         - database
 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,20 @@
+name: Labeler
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### Description

- Adds a new Github Action to automatically tag sql files in the evolutions folder with the `database` label.
- Adds a category in the release notes generator config for database.
  - If PR has multiple labels the release notes get put in the first matching category. 

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
