### PR TITLE
Add support for mode prop to env variables

### DIFF
--- a/env-var-docs/check_vars_documented_test.py
+++ b/env-var-docs/check_vars_documented_test.py
@@ -161,14 +161,16 @@ class TestVarsFromDocs(unittest.TestCase):
     {
         "MY_VAR": {
             "description": "A var",
-            "type": "string"
+            "type": "string",
+            "mode": "HIDDEN"
         },
         "A group": {
             "group_description": "Some group",
             "members": {
                 "MY_OTHER_VAR": {
                     "description": "Another var",
-                    "type": "string"
+                    "type": "string",
+                    "mode": "HIDDEN"
                 }
             }
         }
@@ -200,7 +202,8 @@ class TestMain(unittest.TestCase):
     {
         "MY_VAR": {
             "description": "A var",
-            "type": "string"
+            "type": "string",
+            "mode": "HIDDEN"
         }
     }
     """
@@ -208,7 +211,8 @@ class TestMain(unittest.TestCase):
     {
         "MY_VAR": {
           "description": "A var",
-          "type": "not my type"
+          "type": "not my type",
+          "mode": "BUMMER"
         }
     }
     """

--- a/env-var-docs/generate_markdown_test.py
+++ b/env-var-docs/generate_markdown_test.py
@@ -111,7 +111,8 @@ class TestGenerateMarkdown(unittest.TestCase):
         {
             "MY_VAR": {
                 "description": "A var.",
-                "type": "string"
+                "type": "string",
+                "mode": "HIDDEN"
             }
         }
         """
@@ -134,7 +135,8 @@ class TestGenerateMarkdown(unittest.TestCase):
             "MY_VAR": {
                 "description": "A var.",
                 "type": "string",
-                "required": true
+                "required": true,
+                "mode": "HIDDEN"
             }
         }
         """
@@ -157,7 +159,8 @@ class TestGenerateMarkdown(unittest.TestCase):
             "MY_VAR": {
                 "description": "A var.",
                 "type": "string",
-                "values": ["one", "two"]
+                "values": ["one", "two"],
+                "mode": "HIDDEN"
             }
         }
         """
@@ -187,7 +190,8 @@ class TestGenerateMarkdown(unittest.TestCase):
                 "regex_tests": [
                     { "val": "must_match", "should_match": true },
                     { "val": "can_match", "should_match": false }
-                ]
+                ],
+                "mode": "HIDDEN"
             }
         }
         """
@@ -265,7 +269,8 @@ class TestGenerateMarkdown(unittest.TestCase):
                 "members": {
                     "MY_VAR": {
                         "description": "A var.",
-                        "type": "string"
+                        "type": "string",
+                        "mode": "HIDDEN"
                     }
                 }
             }

--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -93,7 +93,7 @@ Here is an example environment variable documentation file (validated in
             "TITLE": {
                 "description": "Sets the CiviForm title.",
                 "type": "string",
-                "mode": "ADMIN_WRITEABLE"
+                "mode": "ADMIN_READABLE"
             },
             "LOGO_URL": {
                 "description": "URL of the logo.",

--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -92,7 +92,8 @@ Here is an example environment variable documentation file (validated in
         "members": {
             "TITLE": {
                 "description": "Sets the CiviForm title.",
-                "type": "string"
+                "type": "string",
+                "mode": "ADMIN_WRITEABLE"
             },
             "LOGO_URL": {
                 "description": "URL of the logo.",
@@ -102,23 +103,27 @@ Here is an example environment variable documentation file (validated in
                     { "val": "http://mylogo.png", "should_match": true },
                     { "val": "https://my-secure-logo.png", "should_match": true },
                     { "val": "props-not-a-valid-URL", "should_match": false }
-                ]
+                ],
+                "mode": "ADMIN_READABLE"
             }
         }
     },
     "SOME_NUMBER": {
         "description": "Sets a very important number.",
         "type": "int",
-        "required": true
+        "required": true,
+        "mode": "HIDDEN"
     },
     "CLOUD_PROVIDER": {
         "description": "What cloud services to connect to.",
         "type": "string",
-        "values": ["aws", "azure", "gcp"]
+        "values": ["aws", "azure", "gcp"],
+        "mode": "HIDDEN"
     },
     "LANGUAGES": {
         "description": "Supported languages.",
-        "type": "index-list"
+        "type": "index-list",
+        "mode": "ADMIN_READABLE"
     }
 }
 ```

--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -47,6 +47,9 @@ Variables have the following fields:
   configures.
 - `type`: The value type expected. Can be 'string', 'int', 'bool', or
   '[index-list(#index-lists)'.
+- `mode`: Determines where the variable is set and displayed. `HIDDEN` vars are
+set in the environment and not visible to admins, `ADMIN_READABLE` vars are set
+in the environment and displayed to the admin in the Settings UI.
 - `required`: If the environment variable is required to be set. If the
   `required` field is not set, the environment variable is not required.
 - `values`: If `type` is string, a list of valid strings can be provided. If
@@ -66,7 +69,7 @@ Variables have the following fields:
   complexity of `regex`, many more tests should be specified that test the
   corner-cases.
 
-The `description` and `type` fields must be defined for each variable.
+The `description`, `type`, and `mode` fields must be defined for each variable.
 
 ### Index lists
 

--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -48,8 +48,8 @@ Variables have the following fields:
 - `type`: The value type expected. Can be 'string', 'int', 'bool', or
   '[index-list(#index-lists)'.
 - `mode`: Determines where the variable is set and displayed. `HIDDEN` vars are
-set in the environment and not visible to admins, `ADMIN_READABLE` vars are set
-in the environment and displayed to the admin in the Settings UI.
+  set in the environment and not visible to admins, `ADMIN_READABLE` vars are set
+  in the environment and displayed to the admin in the Settings UI.
 - `required`: If the environment variable is required to be set. If the
   `required` field is not set, the environment variable is not required.
 - `values`: If `type` is string, a list of valid strings can be provided. If

--- a/env-var-docs/parser-package/src/env_var_docs/parser.py
+++ b/env-var-docs/parser-package/src/env_var_docs/parser.py
@@ -368,6 +368,7 @@ def _try_parse_variable(
         assert description is not None
         assert type is not None
         assert required is not None
+        assert mode is not None
         return Variable(
             description, type, required, values, regex, regex_tests, mode), []
 

--- a/env-var-docs/parser-package/src/env_var_docs/parser.py
+++ b/env-var-docs/parser-package/src/env_var_docs/parser.py
@@ -7,10 +7,13 @@ See parser-package/README.md for a description of the expected structure.
 """
 
 import dataclasses
+from enum import Enum
 import typing
 import json
 
 UnparsedJSON = dict[str, typing.Any]
+
+Mode = Enum('Mode', ['HIDDEN', 'ADMIN_READABLE'])
 
 
 @dataclasses.dataclass
@@ -49,6 +52,7 @@ class Variable:
     values: list[str] | None
     regex: str | None
     regex_tests: list[RegexTest] | None
+    mode: Mode
 
 
 @dataclasses.dataclass
@@ -283,6 +287,21 @@ def _try_parse_variable(
         default=False)
     errors.extend(errs)
 
+    # Parse the 'mode' field.
+    def extract_mode(obj: UnparsedJSON) -> Mode:
+        return Mode[obj["mode"]]
+
+    mode, errs = _parse_field(
+        parent_path=parent_path,
+        key="mode",
+        json_type=str,
+        required=True,
+        return_type=Mode,
+        extract_fn=extract_mode,
+        obj=obj,
+        checks=[_variable_check_mode_is_valid])
+    errors.extend(errs)
+
     # Parse the 'values' field. Get out a list[str] instead of a JSON list.
     def convert_values(obj: UnparsedJSON) -> list[str]:
         out = []
@@ -339,7 +358,7 @@ def _try_parse_variable(
         _ensure_no_extra_fields(
             parent_path, obj, [
                 "description", "type", "required", "values", "regex",
-                "regex_tests"
+                "regex_tests", "mode"
             ]))
 
     if len(errors) != 0:
@@ -350,7 +369,7 @@ def _try_parse_variable(
         assert type is not None
         assert required is not None
         return Variable(
-            description, type, required, values, regex, regex_tests), []
+            description, type, required, values, regex, regex_tests, mode), []
 
 
 CheckFn = typing.Callable[[str, UnparsedJSON], ParseErrors]
@@ -435,9 +454,7 @@ def _parse_field(
             for check in checks:
                 errors.extend(check(parent_path, obj))
             if len(errors) == 0:
-                value = obj[key]
-                if extract_fn is not None:
-                    value = extract_fn(obj)
+                value = obj[key] if extract_fn is None else extract_fn(obj)
 
     return value, errors
 
@@ -482,6 +499,22 @@ def _variable_check_type_is_valid(
             ParseError(
                 _path(parent_path, "type"),
                 f"'{t}' is an invalid value, valid values are {valid}"))
+    return errors
+
+
+def _variable_check_mode_is_valid(
+        parent_path: str, obj: UnparsedJSON) -> ParseErrors:
+    errors = []
+
+    raw_mode = obj["mode"]
+    try:
+        Mode[raw_mode]
+    except (KeyError) as e:
+        valid = [m.value for m in Mode]
+        errors.append(
+            ParseError(
+                _path(parent_path, "mode"),
+                f"'{raw_mode}' is an invalid mode, valid modes are {valid}"))
     return errors
 
 

--- a/env-var-docs/parser-package/tests/parser_test.py
+++ b/env-var-docs/parser-package/tests/parser_test.py
@@ -1,4 +1,4 @@
-from env_var_docs.parser import Group, Variable, RegexTest, ParseError, NodeParseError, Node, visit, _path, _ensure_no_extra_fields, _parse_field, _try_parse_group, _try_parse_variable
+from env_var_docs.parser import Mode, Group, Variable, RegexTest, ParseError, NodeParseError, Node, visit, _path, _ensure_no_extra_fields, _parse_field, _try_parse_group, _try_parse_variable
 import unittest
 import io
 
@@ -27,7 +27,7 @@ class TestVisit(unittest.TestCase):
 
     def test_file_has_duplicate_keys(self):
         f = io.StringIO(
-            '{ "MY_VAR": { "description": "A var", "type": "string", "type": "bool"} }'
+            '{ "MY_VAR": { "description": "A var", "type": "string", "type": "bool", "mode": "HIDDEN"} }'
         )
         got = visit(f, donothing)
         self.assertEqual(
@@ -83,19 +83,20 @@ class TestVisit(unittest.TestCase):
                 "Group A": {
                     "group_description": "Description A",
                     "members": {
-                        "A_VAR": { "description": "Var A", "type": "string" },
+                        "A_VAR": { "description": "Var A", "type": "string", "mode": "HIDDEN" },
                         "Group B": {
                             "group_description": "Description B",
                             "members": {
-                                "B_VAR": { "description": "Var B", "type": "string" }
+                                "B_VAR": { "description": "Var B", "type": "string", "mode": "HIDDEN" }
                             }
                         },
-                        "C_VAR": { "description": "Var C", "type": "string" }
+                        "C_VAR": { "description": "Var C", "type": "string", "mode": "HIDDEN" }
                     }
                 },
                 "MY_VAR": {
                     "description": "A new cool var",
-                    "type": "bool"
+                    "type": "bool",
+                    "mode": "HIDDEN"
                 }
             }""")
         got = visit(f, visit_fn)
@@ -117,7 +118,8 @@ class TestVisit(unittest.TestCase):
                     required=False,
                     values=None,
                     regex=None,
-                    regex_tests=None)),
+                    regex_tests=None,
+                    mode=Mode.HIDDEN)),
             Node(
                 level=2,
                 json_path="file.Group A",
@@ -133,7 +135,8 @@ class TestVisit(unittest.TestCase):
                     required=False,
                     values=None,
                     regex=None,
-                    regex_tests=None)),
+                    regex_tests=None,
+                    mode=Mode.HIDDEN)),
             Node(
                 level=2,
                 json_path="file.Group A",
@@ -144,7 +147,8 @@ class TestVisit(unittest.TestCase):
                     required=False,
                     values=None,
                     regex=None,
-                    regex_tests=None)),
+                    regex_tests=None,
+                    mode=Mode.HIDDEN)),
             Node(
                 level=1,
                 json_path="file",
@@ -155,7 +159,8 @@ class TestVisit(unittest.TestCase):
                     required=False,
                     values=None,
                     regex=None,
-                    regex_tests=None)),
+                    regex_tests=None,
+                    mode=Mode.HIDDEN)),
         ]
 
         # Using self.assertEqual would require filling in 'members' details for
@@ -276,7 +281,7 @@ class TestParseGroup(unittest.TestCase):
 
 
 class TestParseVariable(unittest.TestCase):
-    basevar = {"description": "Var", "type": "string"}
+    basevar = {"description": "Var", "type": "string", "mode": "HIDDEN"}
     basetests = [
         {
             "val": "hiya",
@@ -293,12 +298,17 @@ class TestParseVariable(unittest.TestCase):
         self.assertEqual(
             gotErrors, [
                 ParseError("root", "'description' is a required field"),
-                ParseError("root", "'type' is a required field")
+                ParseError("root", "'type' is a required field"),
+                ParseError("root", "'mode' is a required field")
             ])
         self.assertEqual(got, None)
 
     def test_no_description(self):
-        got, gotErrors = _try_parse_variable("root", {"type": "string"})
+        got, gotErrors = _try_parse_variable(
+            "root", {
+                "type": "string",
+                "mode": "HIDDEN"
+            })
         self.assertEqual(
             gotErrors, [
                 ParseError("root", "'description' is a required field"),
@@ -309,7 +319,8 @@ class TestParseVariable(unittest.TestCase):
         got, gotErrors = _try_parse_variable(
             "root", {
                 "description": {},
-                "type": "string"
+                "type": "string",
+                "mode": "HIDDEN"
             })
         self.assertEqual(
             gotErrors, [
@@ -318,16 +329,31 @@ class TestParseVariable(unittest.TestCase):
         self.assertEqual(got, None)
 
     def test_no_type(self):
-        got, gotErrors = _try_parse_variable("root", {"description": "A var"})
+        got, gotErrors = _try_parse_variable(
+            "root", {
+                "description": "A var",
+                "mode": "HIDDEN"
+            })
         self.assertEqual(
             gotErrors, [ParseError("root", "'type' is a required field")])
+        self.assertEqual(got, None)
+
+    def test_no_mode(self):
+        got, gotErrors = _try_parse_variable(
+            "root", {
+                "description": "A var",
+                "type": "string"
+            })
+        self.assertEqual(
+            gotErrors, [ParseError("root", "'mode' is a required field")])
         self.assertEqual(got, None)
 
     def test_type_wrong_type(self):
         got, gotErrors = _try_parse_variable(
             "root", {
                 "description": "A var",
-                "type": True
+                "type": True,
+                "mode": "HIDDEN"
             })
         self.assertEqual(
             gotErrors, [ParseError("root.type", "must be a string")])
@@ -337,7 +363,8 @@ class TestParseVariable(unittest.TestCase):
         got, gotErrors = _try_parse_variable(
             "root", {
                 "description": "A var",
-                "type": "cooleo"
+                "type": "cooleo",
+                "mode": "HIDDEN"
             })
         self.assertEqual(
             gotErrors, [
@@ -354,7 +381,8 @@ class TestParseVariable(unittest.TestCase):
                 got, gotErrors = _try_parse_variable(
                     "root", {
                         "description": "A var",
-                        "type": v
+                        "type": v,
+                        "mode": "HIDDEN"
                     })
                 self.assertEqual(gotErrors, [])
                 self.assertEqual(
@@ -365,7 +393,8 @@ class TestParseVariable(unittest.TestCase):
                         required=False,
                         values=None,
                         regex=None,
-                        regex_tests=None))
+                        regex_tests=None,
+                        mode=Mode.HIDDEN))
 
     def test_unrequired_fields_not_set(self):
         got, gotErrors = _try_parse_variable("root", self.basevar)
@@ -378,7 +407,8 @@ class TestParseVariable(unittest.TestCase):
                 required=False,
                 values=None,
                 regex=None,
-                regex_tests=None))
+                regex_tests=None,
+                mode=Mode.HIDDEN))
 
     def test_required_wrong_type(self):
         v = dict(self.basevar, **{"required": 42})
@@ -399,7 +429,8 @@ class TestParseVariable(unittest.TestCase):
                 required=False,
                 values=None,
                 regex=None,
-                regex_tests=None))
+                regex_tests=None,
+                mode=Mode.HIDDEN))
 
     def test_required_true(self):
         v = dict(self.basevar, **{"required": True})
@@ -413,7 +444,8 @@ class TestParseVariable(unittest.TestCase):
                 required=True,
                 values=None,
                 regex=None,
-                regex_tests=None))
+                regex_tests=None,
+                mode=Mode.HIDDEN))
 
     def test_values_wrong_type(self):
         v = dict(self.basevar, **{"values": "only one"})
@@ -448,7 +480,8 @@ class TestParseVariable(unittest.TestCase):
                 required=False,
                 values=["one", "two"],
                 regex=None,
-                regex_tests=None))
+                regex_tests=None,
+                mode=Mode.HIDDEN))
 
     def test_regex_wrong_type(self):
         v = dict(self.basevar, **{"regex": []})
@@ -587,7 +620,8 @@ class TestParseVariable(unittest.TestCase):
                 required=False,
                 values=None,
                 regex=".*",
-                regex_tests=self.basetests_parsed))
+                regex_tests=self.basetests_parsed,
+                mode=Mode.HIDDEN))
 
     def test_has_only_extra_fields(self):
         got, gotErrors = _try_parse_variable(
@@ -599,13 +633,14 @@ class TestParseVariable(unittest.TestCase):
             gotErrors, [
                 ParseError("root", "'description' is a required field"),
                 ParseError("root", "'type' is a required field"),
+                ParseError("root", "'mode' is a required field"),
                 ParseError(
                     "root",
-                    "'extra' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests']"
+                    "'extra' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'mode']"
                 ),
                 ParseError(
                     "root",
-                    "'field' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests']"
+                    "'field' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'mode']"
                 )
             ])
         self.assertEqual(got, None)

--- a/env-var-docs/run_regex_tests_test.py
+++ b/env-var-docs/run_regex_tests_test.py
@@ -109,7 +109,8 @@ class TestMain(unittest.TestCase):
                 "regex": ".*",
                 "regex_tests": [
                     { "val": "will you be my match?", "should_match": false }
-                ]
+                ],
+                "mode": "HIDDEN"
             }
         }
         """
@@ -134,7 +135,8 @@ class TestMain(unittest.TestCase):
                 "regex": ".*",
                 "regex_tests": [
                     { "val": "will you be my match?", "should_match": true }
-                ]
+                ],
+                "mode": "HIDDEN"
             }
         }
         """
@@ -159,7 +161,8 @@ class TestMain(unittest.TestCase):
                         "regex": ".*",
                         "regex_tests": [
                             { "val": "will you be my match?", "should_match": true }
-                        ]
+                        ],
+                        "mode": "HIDDEN"
                     }
                 }
             }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -3,22 +3,27 @@
     "group_description": "Configuration options for CiviForm branding.",
     "members": {
       "WHITELABEL_SMALL_LOGO_URL": {
+        "mode": "ADMIN_READABLE",
         "description": "Small logo for the civic entity used on the login page.",
         "type": "string"
       },
       "WHITELABEL_LOGO_WITH_NAME_URL": {
+        "mode": "ADMIN_READABLE",
         "description": "Logo with civic entity name used on the applicant-facing program index page.",
         "type": "string"
       },
       "WHITELABEL_CIVIC_ENTITY_SHORT_NAME": {
+        "mode": "ADMIN_READABLE",
         "description": "The short display name of the civic entity, will use 'TestCity' if not set.",
         "type": "string"
       },
       "WHITELABEL_CIVIC_ENTITY_FULL_NAME": {
+        "mode": "ADMIN_READABLE",
         "description": "The full display name of the civic entity, will use 'City of TestCity' if not set.",
         "type": "string"
       },
       "FAVICON_URL": {
+        "mode": "ADMIN_READABLE",
         "description": "The URL of a 32x32 or 16x16 pixel [favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon) image, in GIF, PNG, or ICO format.",
         "type": "string"
       }
@@ -31,6 +36,7 @@
         "group_description": "Configuration options for the [applicant identity provider](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#applicant-authentication).",
         "members": {
           "CIVIFORM_APPLICANT_IDP": {
+            "mode": "ADMIN_READABLE",
             "description": "What identity provider to use for applicants.",
             "type": "string",
             "values": [
@@ -43,10 +49,12 @@
             ]
           },
           "APPLICANT_REGISTER_URI": {
+            "mode": "ADMIN_READABLE",
             "description": "URI to create a new account in the applicant identity provider.",
             "type": "string"
           },
           "APPLICANT_PORTAL_NAME": {
+            "mode": "ADMIN_READABLE",
             "description": "The name of the portal that applicants log into, used in sentences like 'Log into your APPLICANT_PORTAL_NAME account.'",
             "type": "string"
           },
@@ -54,14 +62,17 @@
             "group_description": "Configuration options for the [idcs](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#oracle-idcs) provider.",
             "members": {
               "IDCS_CLIENT_ID": {
+                "mode": "HIDDEN",
                 "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with IDCS. A Civiform instance is always the client.",
                 "type": "string"
               },
               "IDCS_SECRET": {
+                "mode": "HIDDEN",
                 "description": "A secret known only to the client (Civiform) and authorization server, specifically for IDCS OIDC systems. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
                 "type": "string"
               },
               "IDCS_DISCOVERY_URI": {
+                "mode": "HIDDEN",
                 "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with the IDCS auth provider.",
                 "type": "string"
               }
@@ -71,26 +82,32 @@
             "group_description": "Configuration options for the [login-radius](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#loginradius-saml) provider",
             "members": {
               "LOGIN_RADIUS_API_KEY": {
+                "mode": "HIDDEN",
                 "description": "The API key used to interact with LoginRadius.",
                 "type": "string"
               },
               "LOGIN_RADIUS_METADATA_URI": {
+                "mode": "HIDDEN",
                 "description": "The base URL to construct SAML endpoints, based on the SAML2 spec.",
                 "type": "string"
               },
               "LOGIN_RADIUS_SAML_APP_NAME": {
+                "mode": "HIDDEN",
                 "description": "The name for the app, based on the SAML2 spec.",
                 "type": "string"
               },
               "LOGIN_RADIUS_KEYSTORE_NAME": {
+                "mode": "HIDDEN",
                 "description": "Name of the SAML2 keystore, used to store digital certificates and private keys for SAML auth.",
                 "type": "string"
               },
               "LOGIN_RADIUS_KEYSTORE_PASS": {
+                "mode": "HIDDEN",
                 "description": "The password used the protect the integrity of the SAML keystore file.",
                 "type": "string"
               },
               "LOGIN_RADIUS_PRIVATE_KEY_PASS": {
+                "mode": "HIDDEN",
                 "description": "The password used to protect the private key of the SAML digital certificate.",
                 "type": "string"
               }
@@ -100,62 +117,77 @@
             "group_description": "Configuration options for the [generic-oidc](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#generic-oidc-oidc) provider.",
             "members": {
               "APPLICANT_OIDC_PROVIDER_LOGOUT": {
+                "mode": "HIDDEN",
                 "description": "Enables [central logout](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#logout).",
                 "type": "bool"
               },
               "APPLICANT_OIDC_OVERRIDE_LOGOUT_URL": {
+                "mode": "HIDDEN",
                 "description": "By default the 'end_session_endpoint' from the auth provider discovery metadata file is used as the logout endpoint. However for some integrations that standard flow might not work and we need to override logout URL.",
                 "type": "string"
               },
               "APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM": {
+                "mode": "HIDDEN",
                 "description": "URL param used to pass the post logout redirect url in the logout request to the auth provider. It defaults to 'post_logout_redirect_uri' if this variable is unset. If this variable is set to the empty string, the post logout redirect url is not passed at all and instead it needs to be hardcoded on the the auth provider (otherwise the user won't be redirected back to civiform after logout).",
                 "type": "string"
               },
               "APPLICANT_OIDC_PROVIDER_NAME": {
+                "mode": "HIDDEN",
                 "description": "The name of the OIDC (OpenID Connect) auth provider (server), such as “Auth0” or “LoginRadius”.",
                 "type": "string"
               },
               "APPLICANT_OIDC_CLIENT_ID": {
+                "mode": "HIDDEN",
                 "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers. A Civiform instance is always the client.",
                 "type": "string"
               },
               "APPLICANT_OIDC_CLIENT_SECRET": {
+                "mode": "HIDDEN",
                 "description": "A secret known only to the client (Civiform) and authorization server. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
                 "type": "string"
               },
               "APPLICANT_OIDC_DISCOVERY_URI": {
+                "mode": "HIDDEN",
                 "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with a given auth provider.",
                 "type": "string"
               },
               "APPLICANT_OIDC_RESPONSE_MODE": {
+                "mode": "HIDDEN",
                 "description": "Informs the auth server of the desired auth processing flow, based on the OpenID Connect spec.",
                 "type": "string"
               },
               "APPLICANT_OIDC_RESPONSE_TYPE": {
+                "mode": "HIDDEN",
                 "description": "Informs the auth server of the mechanism to be used for returning response params from the auth endpoint, based on the OpenID Connect spec.",
                 "type": "string"
               },
               "APPLICANT_OIDC_ADDITIONAL_SCOPES": {
+                "mode": "HIDDEN",
                 "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides.",
                 "type": "string"
               },
               "APPLICANT_OIDC_LOCALE_ATTRIBUTE": {
+                "mode": "HIDDEN",
                 "description": "The locale of the user, such as “en-US”.",
                 "type": "string"
               },
               "APPLICANT_OIDC_EMAIL_ATTRIBUTE": {
+                "mode": "HIDDEN",
                 "description": "The OIDC attribute name for the user’s email address.",
                 "type": "string"
               },
               "APPLICANT_OIDC_FIRST_NAME_ATTRIBUTE": {
+                "mode": "HIDDEN",
                 "description": "The OIDC attribute name for the user’s first name.",
                 "type": "string"
               },
               "APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE": {
+                "mode": "HIDDEN",
                 "description": "The OIDC attribute name for the user’s middle name.",
                 "type": "string"
               },
               "APPLICANT_OIDC_LAST_NAME_ATTRIBUTE": {
+                "mode": "HIDDEN",
                 "description": "The OIDC attribute name for the user’s last name.",
                 "type": "string"
               }
@@ -165,18 +197,22 @@
             "group_description": "Configuration options for the [login-gov](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#login.gov-oidc) provider",
             "members": {
               "LOGIN_GOV_CLIENT_ID": {
+                "mode": "HIDDEN",
                 "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with Login.gov. A Civiform instance is always the client.",
                 "type": "string"
               },
               "LOGIN_GOV_DISCOVERY_URI": {
+                "mode": "HIDDEN",
                 "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with a given auth provider, specifically for Login.gov.",
                 "type": "string"
               },
               "LOGIN_GOV_ADDITIONAL_SCOPES": {
+                "mode": "HIDDEN",
                 "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides. Scopes should be separated by a space.",
                 "type": "string"
               },
               "LOGIN_GOV_ACR_VALUE": {
+                "mode": "HIDDEN",
                 "description": "[Authentication Context Class Reference requests](https://developers.login.gov/oidc/#request-parameters). ial/1 is for open registration, email only. ial/2 is for requiring identity verification.",
                 "type": "string",
                 "values": [
@@ -192,26 +228,32 @@
         "group_description": "Configuration options for the [administrator identity provider](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#admin-authentication).",
         "members": {
           "ADFS_CLIENT_ID": {
+            "mode": "HIDDEN",
             "description": "An opaque public identifier for apps that use OIDC (OpenID Connect) to request data from authorization servers, specifically communicating with ADFS. A Civiform instance is always the client.",
             "type": "string"
           },
           "ADFS_SECRET": {
+            "mode": "HIDDEN",
             "description": "A secret known only to the client (Civiform) and authorization server. This secret essentially acts as the client’s “password” for accessing data from the auth server.",
             "type": "string"
           },
           "ADFS_DISCOVERY_URI": {
+            "mode": "HIDDEN",
             "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with the IDCS auth provider.",
             "type": "string"
           },
           "ADFS_GLOBAL_ADMIN_GROUP": {
+            "mode": "HIDDEN",
             "description": "The name of the admin group in Active Directory, typically used to tell if a user is a global admin.",
             "type": "string"
           },
           "ADFS_ADDITIONAL_SCOPES": {
+            "mode": "HIDDEN",
             "description": "Scopes the client (CiviForm) is requesting in addition to the standard scopes the OpenID Connect spec provides. Scopes should be separated by a space.",
             "type": "string"
           },
           "AD_GROUPS_ATTRIBUTE_NAME": {
+            "mode": "HIDDEN",
             "description": "The attribute name for looking up the groups associated with a particular user.",
             "type": "string"
           }
@@ -221,32 +263,39 @@
         "group_description": "Configures the connection to the PostgreSQL database.",
         "members": {
           "DATABASE_APPLY_DESTRUCTIVE_CHANGES": {
+            "mode": "HIDDEN",
             "description": "If enabled, [playframework down evolutions](https://www.playframework.com/documentation/2.8.x/Evolutions#Evolutions-scripts) are automatically applied on server start if needed.",
             "type": "bool"
           },
           "DATABASE_CONNECTION_POOL_SIZE": {
+            "mode": "HIDDEN",
             "description": "Sets how many connections to the database are maintained.",
             "type": "int"
           },
           "DB_JDBC_STRING": {
+            "mode": "HIDDEN",
             "description": "The database URL.",
             "type": "string"
           },
           "DB_USERNAME": {
+            "mode": "HIDDEN",
             "description": "The username used to connect to the database.",
             "type": "string"
           },
           "DB_PASSWORD": {
+            "mode": "HIDDEN",
             "description": "The password used to connect to the database.",
             "type": "string"
           }
         }
       },
       "AWS_REGION": {
+        "mode": "HIDDEN",
         "description": "Region where the AWS SES service exists. If STORAGE_SERVICE_NAME is set to 'aws', it is also the region where the AWS s3 service exists.",
         "type": "string"
       },
       "AWS_SES_SENDER": {
+        "mode": "HIDDEN",
         "description": "The email address used for the 'from' email header for emails sent by CiviForm.",
         "type": "string"
       },
@@ -254,27 +303,33 @@
         "group_description": "Configuration options for the application file upload storage provider",
         "members": {
           "STORAGE_SERVICE_NAME": {
+            "mode": "HIDDEN",
             "description": "What static file storage provider to use.",
             "type": "string",
             "values": ["s3", "azure-blob"]
           },
           "AWS_S3_BUCKET_NAME": {
+            "mode": "HIDDEN",
             "description": "s3 bucket to store files in.",
             "type": "string"
           },
           "AWS_S3_FILE_LIMIT_MB": {
+            "mode": "HIDDEN",
             "description": "The max size (in Mb) of files uploaded to s3.",
             "type": "string"
           },
           "AZURE_STORAGE_ACCOUNT_NAME": {
+            "mode": "HIDDEN",
             "description": "The azure account name where the blob storage service exists.",
             "type": "string"
           },
           "AZURE_STORAGE_ACCOUNT_CONTAINER": {
+            "mode": "HIDDEN",
             "description": "Azure blob storage container name to store files in.",
             "type": "string"
           },
           "AZURE_LOCAL_CONNECTION_STRING": {
+            "mode": "HIDDEN",
             "description": "Allows local [Azurite emulator](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) to be used for developer deployments.",
             "type": "string"
           }
@@ -284,34 +339,42 @@
         "group_description": "Configuration options for the ESRI GIS client and address validation/correction feature.",
         "members": {
           "ESRI_ADDRESS_CORRECTION_ENABLED": {
+            "mode": "ADMIN_READABLE",
             "description": "Enables the feature that allows address correction for address questions.",
             "type": "bool"
           },
           "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
+            "mode": "ADMIN_READABLE",
             "description": "The URL CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
             "type": "string"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED": {
+            "mode": "ADMIN_READABLE",
             "description": "Enables the feature that allows for service area validation of a corrected address. ESRI_ADDRESS_CORRECTION_ENABLED needs to be enabled.",
             "type": "bool"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {
+            "mode": "ADMIN_READABLE",
             "description": "Human readable labels used to present the service area validation options in CiviForm’s admin UI.",
             "type": "index-list"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS": {
+            "mode": "ADMIN_READABLE",
             "description": "The value CiviForm uses to validate if an address is in a service area.",
             "type": "index-list"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_URLS": {
+            "mode": "ADMIN_READABLE",
             "description": "The URL CiviForm will use to call Esri’s [map query service](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm) for service area validation.",
             "type": "index-list"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES": {
+            "mode": "ADMIN_READABLE",
             "description": "The attribute CiviForm checks from the service area validation response to get the service area validation ID.",
             "type": "index-list"
           },
           "ESRI_EXTERNAL_CALL_TRIES": {
+            "mode": "ADMIN_READABLE",
             "description": "The number of tries CiviForm will attempt requests to external Esri services.",
             "type": "int"
           }
@@ -323,22 +386,27 @@
     "group_description": "Configuration options for [CiviForm email usage](https://docs.civiform.us/it-manual/sre-playbook/email-configuration).",
     "members": {
       "SUPPORT_EMAIL_ADDRESS": {
+        "mode": "ADMIN_READABLE",
         "description": "This email address is listed in the footer for applicants to contact support.",
         "type": "string"
       },
       "IT_EMAIL_ADDRESS": {
+        "mode": "ADMIN_READABLE",
         "description": "This email address receives error notifications from CiviForm when things break.",
         "type": "string"
       },
       "STAGING_ADMIN_LIST": {
+        "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the program administrator's email address.",
         "type": "string"
       },
       "STAGING_TI_LIST": {
+        "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the trusted intermediary's email address.",
         "type": "string"
       },
       "STAGING_APPLICANT_LIST": {
+        "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the applicant's email address.",
         "type": "string"
       }
@@ -348,20 +416,24 @@
     "group_description": "Text specific to a civic entity.",
     "members": {
       "COMMON_INTAKE_MORE_RESOURCES_LINK_TEXT": {
+        "mode": "ADMIN_READABLE",
         "description": "The text for a link on the Common Intake confirmation page that links to more resources. Shown when the applicant is not eligible for any programs in CiviForm.",
         "type": "string"
       },
       "COMMON_INTAKE_MORE_RESOURCES_LINK_HREF": {
+        "mode": "ADMIN_READABLE",
         "description": "The HREF for a link on the Common Intake confirmation page that links to more resources. Shown when the applicant is not eligible for any programs in CiviForm.",
         "type": "string"
       }
     }
   },
   "SECRET_KEY": {
+    "mode": "HIDDEN",
     "description": "The [secret key](http://www.playframework.com/documentation/latest/ApplicationSecret) is used to sign Play's session cookie. This must be changed for production.",
     "type": "string"
   },
   "BASE_URL": {
+    "mode": "ADMIN_READABLE",
     "description": "The URL of the CiviForm deployment.  Must start with 'https://' or 'http://'.",
     "type": "string",
     "regex": "^(http://|https://)",
@@ -372,6 +444,7 @@
     ]
   },
   "STAGING_HOSTNAME": {
+    "mode": "HIDDEN",
     "description": "DNS name of the staging deployment.  Must not start with 'https://' or 'http://'.",
     "type": "string",
     "regex": "^(?!http://|https://)",
@@ -382,22 +455,27 @@
     ]
   },
   "CIVIFORM_SUPPORTED_LANGUAGES": {
+    "mode": "ADMIN_READABLE",
     "description": "The languages that applicants can choose from when specifying their language preference and that admins can choose from when adding translations for programs and applications.",
     "type": "index-list"
   },
   "CIVIFORM_TIME_ZONE_ID": {
+    "mode": "ADMIN_READABLE",
     "description": "A Java [time zone ID](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html) indicating the time zone for this CiviForm deployment. All times in the system will be calculated in this zone. Default value is 'America/Los_Angeles'",
     "type": "string"
   },
   "CIVIFORM_IMAGE_TAG": {
+    "mode": "ADMIN_READABLE",
     "description": "The tag of the docker image this server is running inside. Is added as a HTML meta tag with name 'civiform-build-tag'. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if CIVIFORM_VERSION is the empty string or set to 'latest'.",
     "type": "string"
   },
   "CIVIFORM_VERSION": {
+    "mode": "ADMIN_READABLE",
     "description": "The release version of CiviForm. For example: v1.18.0. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if it a value other than the empty string or 'latest'.",
     "type": "string"
   },
   "CLIENT_IP_TYPE": {
+    "mode": "HIDDEN",
     "description": "Where to find the IP address for incoming requests. Default is \"DIRECT\" where the IP address of the request is the originating IP address. If \"FORWARDED\" then request has been reverse proxied and the originating IP address is stored in the X-Forwarded-For header.",
     "type": "string",
     "values": ["DIRECT", "FORWARDED"]
@@ -406,10 +484,12 @@
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {
       "CIVIFORM_SERVER_METRICS_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If disabled, '/metrics' returns a 404.",
         "type": "bool"
       },
       "MEASUREMENT_ID": {
+        "mode": "ADMIN_READABLE",
         "description": "The Google Analytics tracking ID.  If set, Google Analytics JavaScript scripts are added to the CiviForm pages.",
         "type": "string"
       }
@@ -419,14 +499,17 @@
     "group_description": "Configuration options for the [CiviForm API](https://docs.civiform.us/it-manual/api).",
     "members": {
       "CIVIFORM_API_SECRET_SALT": {
+        "mode": "HIDDEN",
         "description": "A cryptographic [secret salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) used for salting API keys before storing their hash values in the database. This value should be kept strictly secret. If one suspects the secret has been leaked or otherwise comprised it should be changed and all active API keys should be retired and reissued. Default value is 'changeme'.",
         "type": "string"
       },
       "CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET": {
+        "mode": "HIDDEN",
         "description": "When true prevents the CiviForm admin from issuing API keys that allow callers from all IP addresses (i.e. a CIDR mask of /0).",
         "type": "bool"
       },
       "CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE_SIZE": {
+        "mode": "ADMIN_READABLE",
         "description": "An integer specifying the maximum number of entries returned in a page of results for the applications export API.",
         "type": "int"
       }
@@ -436,14 +519,17 @@
     "group_description": "Configuration options for the CiviForm Job Runner.",
     "members": {
       "DURABLE_JOBS_POLL_INTERVAL_SECONDS": {
+        "mode": "HIDDEN",
         "description": "An integer specifying the polling interval in seconds for the durable job system. A smaller number here increases the polling frequency, which results in jobs running sooner when they are scheduled to be run immediately, at the cost of more pressure on the database. Default value is 5.",
         "type": "int"
       },
       "DURABLE_JOBS_JOB_TIMEOUT_MINUTES": {
+        "mode": "HIDDEN",
         "description": "An integer specifying the timeout in minutes for durable jobs i.e. how long a single job is allowed to run before the system attempts to interrupt it. Default value is 30.",
         "type": "int"
       },
       "DURABLE_JOBS_THREAD_POOL_SIZE": {
+        "mode": "HIDDEN",
         "description": "The number of server threads available for the durable job runner. More than a single thread will the server execute multiple jobs in parallel. Default value is 1.",
         "type": "int"
       }
@@ -453,43 +539,53 @@
     "group_description": "Configuration options to enable or disable optional or in-development features.",
     "members": {
       "CF_OPTIONAL_QUESTIONS": {
+        "mode": "ADMIN_READABLE",
         "description": "If enabled, allows questions to be optional in programs. Is enabled by default.",
         "type": "bool"
       },
       "ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS": {
+        "mode": "ADMIN_READABLE",
         "description": "If enabled, CiviForm Admins are able to see all applications for all programs. Is disabled by default.",
         "type": "bool"
       },
       "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE": {
+        "mode": "ADMIN_READABLE",
         "description": "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login screen. Is disabled by default.",
         "type": "bool"
       },
       "FEATURE_FLAG_OVERRIDES_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "Allows feature flags to be overridden via request cookies. Is used by browswer tests. Should only be enabled in test and staging deployments.",
         "type": "bool"
       },
       "INTAKE_FORM_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "Enables the Common Intake Form feature.",
         "type": "bool"
       },
       "NONGATED_ELIGIBILITY_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "Enables the feature that allows setting eligibility criteria to non-gating.",
         "type": "bool"
       },
 
       "STAGING_ADD_NOINDEX_META_TAG": {
+        "mode": "ADMIN_READABLE",
         "description": "If this is a staging deployment and this variable is set to true, a [robots noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) metadata tag is added to the CiviForm pages. This causes the staging site to not be listed on search engines.",
         "type": "bool"
       },
       "STAGING_DISABLE_DEMO_MODE_LOGINS": {
+        "mode": "ADMIN_READABLE",
         "description": "If this is a staging deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page.",
         "type": "bool"
       },
       "PHONE_QUESTION_TYPE_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "Enables the phone number question type.",
         "type": "bool"
       },
       "PUBLISH_SINGLE_PROGRAM_ENABLED": {
+        "mode": "ADMIN_READABLE",
         "description": "Enables the feature that allows publishing a single program on its own.",
         "type": "bool"
       }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -568,14 +568,13 @@
         "description": "Enables the feature that allows setting eligibility criteria to non-gating.",
         "type": "bool"
       },
-
       "STAGING_ADD_NOINDEX_META_TAG": {
-        "mode": "ADMIN_READABLE",
+        "mode": "HIDDEN",
         "description": "If this is a staging deployment and this variable is set to true, a [robots noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) metadata tag is added to the CiviForm pages. This causes the staging site to not be listed on search engines.",
         "type": "bool"
       },
       "STAGING_DISABLE_DEMO_MODE_LOGINS": {
-        "mode": "ADMIN_READABLE",
+        "mode": "HIDDEN",
         "description": "If this is a staging deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page.",
         "type": "bool"
       },


### PR DESCRIPTION
### Description

Per [Admin Settings Panel TDD](https://docs.google.com/document/d/1FK5YLJd6jVu1O1uuu2OOR2mXTs3yVEXkzyfjVwnkz8s/edit), this PR adds a `mode` attribute to the `Variable` type in the env var docs system.

For now it only supports `HIDDEN` and `ADMIN_READABLE` modes, since the first phase of this feature is read-only.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Contributes to https://github.com/civiform/civiform/issues/4948