### PR TITLE
Revert action

### DIFF
--- a/.github/workflows/scorecards.yaml
+++ b/.github/workflows/scorecards.yaml
@@ -52,6 +52,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: 'Upload to code-scanning'
-        uses: github/codeql-action/upload-sarif@v2.3.4
+        uses: github/codeql-action/upload-sarif@v2.3.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### Description

There is a bug v2.3.4 of github/codql-action/upload-sarif that doesn't allow it to upload. They are aware of the issue and recommend using the previous version for now. This affects the uploading of the OSSF Score Card only.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
