### PR TITLE
Parameterize `createXQuestion()`

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -43,6 +43,7 @@ import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.exception.ApplicantNotFoundException;
 import services.applicant.exception.ProgramBlockNotFoundException;
 import services.applicant.question.AddressQuestion;
+import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
 import services.cloud.StorageClient;
 import services.geo.AddressSuggestion;
@@ -394,7 +395,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                       .filter(question -> question.getType().equals(QuestionType.FILEUPLOAD))
                       .findAny()
                       .get()
-                      .createFileUploadQuestion();
+                      .createQuestion(FileUploadQuestion.class);
 
               ImmutableMap.Builder<String, String> fileUploadQuestionFormData =
                   new ImmutableMap.Builder<>();
@@ -519,10 +520,9 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     if (featureFlags.getFlagEnabled(request, ESRI_ADDRESS_CORRECTION_ENABLED)
         && thisBlockUpdated.hasAddressWithCorrectionEnabled()) {
 
-      AddressQuestion addressQuestion =
-          applicantService
-              .getFirstAddressCorrectionEnabledApplicantQuestion(thisBlockUpdated)
-              .createAddressQuestion();
+      ApplicantQuestion applicantQuestion =
+          applicantService.getFirstAddressCorrectionEnabledApplicantQuestion(thisBlockUpdated);
+      AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
       if (addressQuestion.needsAddressCorrection()) {
 

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1477,7 +1477,8 @@ public final class ApplicantService {
 
               ApplicantQuestion applicantQuestion =
                   getFirstAddressCorrectionEnabledApplicantQuestion(blockMaybe.get());
-              AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+              AddressQuestion addressQuestion =
+                  applicantQuestion.createQuestion(AddressQuestion.class);
 
               Optional<AddressSuggestion> suggestionMaybe =
                   addressSuggestions.stream()
@@ -1571,7 +1572,7 @@ public final class ApplicantService {
   /** Gets address suggestions */
   public CompletionStage<AddressSuggestionGroup> getAddressSuggestionGroup(Block block) {
     ApplicantQuestion applicantQuestion = getFirstAddressCorrectionEnabledApplicantQuestion(block);
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
     return esriClient.getAddressSuggestions(addressQuestion.getAddress());
   }
 
@@ -1603,7 +1604,8 @@ public final class ApplicantService {
                 return CompletableFuture.completedFuture(formData);
               }
 
-              AddressQuestion addressQuestion = addressQuestionMaybe.get().createAddressQuestion();
+              AddressQuestion addressQuestion =
+                  addressQuestionMaybe.get().createQuestion(AddressQuestion.class);
 
               if (addressQuestion.hasChanges(formData)) {
                 return CompletableFuture.completedFuture(

--- a/server/app/services/applicant/question/ApplicantQuestion.java
+++ b/server/app/services/applicant/question/ApplicantQuestion.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -211,101 +213,59 @@ public final class ApplicantQuestion {
     return getContextualizedPath().join(metadataScalar);
   }
 
-  public AddressQuestion createAddressQuestion() {
-    return new AddressQuestion(this);
+  public <T extends Question> T createQuestion(Class<T> questionClass) {
+    try {
+      // Get the constructor for T that has a single parameter of type ApplicantQuestion.
+      Constructor<T> constructor = questionClass.getDeclaredConstructor(this.getClass());
+      return constructor.newInstance(this);
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
+      throw new RuntimeException(
+          "Could not find appropriate constructor for " + questionClass.getName(), e);
+    }
   }
 
   public boolean isAddressCorrectionEnabled() {
     return programQuestionDefinition.addressCorrectionEnabled();
   }
 
-  public CurrencyQuestion createCurrencyQuestion() {
-    return new CurrencyQuestion(this);
-  }
-
-  public DateQuestion createDateQuestion() {
-    return new DateQuestion(this);
-  }
-
-  public EmailQuestion createEmailQuestion() {
-    return new EmailQuestion(this);
-  }
-
-  public FileUploadQuestion createFileUploadQuestion() {
-    return new FileUploadQuestion(this);
-  }
-
   public boolean isFileUploadQuestion() {
     return getType().equals(QuestionType.FILEUPLOAD);
-  }
-
-  public IdQuestion createIdQuestion() {
-    return new IdQuestion(this);
-  }
-
-  public MultiSelectQuestion createMultiSelectQuestion() {
-    return new MultiSelectQuestion(this);
-  }
-
-  public NameQuestion createNameQuestion() {
-    return new NameQuestion(this);
-  }
-
-  public NumberQuestion createNumberQuestion() {
-    return new NumberQuestion(this);
-  }
-
-  public EnumeratorQuestion createEnumeratorQuestion() {
-    return new EnumeratorQuestion(this);
-  }
-
-  public SingleSelectQuestion createSingleSelectQuestion() {
-    return new SingleSelectQuestion(this);
-  }
-
-  public PhoneQuestion createPhoneQuestion() {
-    return new PhoneQuestion(this);
-  }
-
-  public StaticContentQuestion createStaticContentQuestion() {
-    return new StaticContentQuestion(this);
-  }
-
-  public TextQuestion createTextQuestion() {
-    return new TextQuestion(this);
   }
 
   public Question errorsPresenter() {
     switch (getType()) {
       case ADDRESS:
-        return createAddressQuestion();
+        return createQuestion(AddressQuestion.class);
       case CHECKBOX:
-        return createMultiSelectQuestion();
+        return createQuestion(MultiSelectQuestion.class);
       case CURRENCY:
-        return createCurrencyQuestion();
+        return createQuestion(CurrencyQuestion.class);
       case DATE:
-        return createDateQuestion();
+        return createQuestion(DateQuestion.class);
       case EMAIL:
-        return createEmailQuestion();
+        return createQuestion(EmailQuestion.class);
       case FILEUPLOAD:
-        return createFileUploadQuestion();
+        return createQuestion(FileUploadQuestion.class);
       case ID:
-        return createIdQuestion();
+        return createQuestion(IdQuestion.class);
       case NAME:
-        return createNameQuestion();
+        return createQuestion(NameQuestion.class);
       case NUMBER:
-        return createNumberQuestion();
+        return createQuestion(NumberQuestion.class);
       case DROPDOWN: // fallthrough to RADIO_BUTTON
       case RADIO_BUTTON:
-        return createSingleSelectQuestion();
+        return createQuestion(SingleSelectQuestion.class);
       case ENUMERATOR:
-        return createEnumeratorQuestion();
+        return createQuestion(EnumeratorQuestion.class);
       case TEXT:
-        return createTextQuestion();
+        return createQuestion(TextQuestion.class);
       case STATIC:
-        return createStaticContentQuestion();
+        return createQuestion(StaticContentQuestion.class);
       case PHONE:
-        return createPhoneQuestion();
+        return createQuestion(PhoneQuestion.class);
       default:
         throw new RuntimeException("Unrecognized question type: " + getType());
     }

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -25,6 +25,7 @@ import services.applicant.AnswerData;
 import services.applicant.ApplicantService;
 import services.applicant.JsonPathProvider;
 import services.applicant.ReadOnlyApplicantProgramService;
+import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
 import services.applicant.question.MultiSelectQuestion;
@@ -130,8 +131,9 @@ public final class JsonExporter {
       switch (answerData.questionDefinition().getQuestionType()) {
         case CHECKBOX:
           {
+            ApplicantQuestion applicantQuestion = answerData.applicantQuestion();
             MultiSelectQuestion multiSelectQuestion =
-                answerData.applicantQuestion().createMultiSelectQuestion();
+                applicantQuestion.createQuestion(MultiSelectQuestion.class);
             Path path = multiSelectQuestion.getSelectionPath().asApplicationPath();
 
             if (multiSelectQuestion.getSelectedOptionsValue().isPresent()) {
@@ -146,8 +148,9 @@ public final class JsonExporter {
           }
         case CURRENCY:
           {
+            ApplicantQuestion applicantQuestion = answerData.applicantQuestion();
             CurrencyQuestion currencyQuestion =
-                answerData.applicantQuestion().createCurrencyQuestion();
+                applicantQuestion.createQuestion(CurrencyQuestion.class);
             Path path =
                 currencyQuestion
                     .getCurrencyPath()
@@ -166,7 +169,8 @@ public final class JsonExporter {
           }
         case NUMBER:
           {
-            NumberQuestion numberQuestion = answerData.applicantQuestion().createNumberQuestion();
+            NumberQuestion numberQuestion =
+                answerData.applicantQuestion().createQuestion(NumberQuestion.class);
             Path path = numberQuestion.getNumberPath().asApplicationPath();
 
             if (numberQuestion.getNumberValue().isPresent()) {
@@ -179,7 +183,8 @@ public final class JsonExporter {
           }
         case DATE:
           {
-            DateQuestion dateQuestion = answerData.applicantQuestion().createDateQuestion();
+            DateQuestion dateQuestion =
+                answerData.applicantQuestion().createQuestion(DateQuestion.class);
             Path path = dateQuestion.getDatePath().asApplicationPath();
 
             if (dateQuestion.getDateValue().isPresent()) {
@@ -193,7 +198,8 @@ public final class JsonExporter {
           }
         case PHONE:
           {
-            PhoneQuestion phoneQuestion = answerData.applicantQuestion().createPhoneQuestion();
+            PhoneQuestion phoneQuestion =
+                answerData.applicantQuestion().createQuestion(PhoneQuestion.class);
             Path path = phoneQuestion.getPhoneNumberPath().asApplicationPath();
 
             if (phoneQuestion.getPhoneNumberValue().isPresent()

--- a/server/app/views/FileUploadViewStrategy.java
+++ b/server/app/views/FileUploadViewStrategy.java
@@ -271,7 +271,7 @@ public abstract class FileUploadViewStrategy extends ApplicationBaseView {
 
   private boolean hasUploadedFile(Params params) {
     return params.block().getQuestions().stream()
-        .map(ApplicantQuestion::createFileUploadQuestion)
+        .map(applicantQuestion -> applicantQuestion.createQuestion(FileUploadQuestion.class))
         .map(FileUploadQuestion::getFileKeyValue)
         .anyMatch(Optional::isPresent);
   }

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -45,7 +45,7 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    AddressQuestion addressQuestion = question.createAddressQuestion();
+    AddressQuestion addressQuestion = question.createQuestion(AddressQuestion.class);
 
     FieldWithLabel streetAddressField =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -38,7 +38,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
       boolean isOptional) {
 
     boolean hasErrors = !validationErrors.isEmpty();
-    MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
+    MultiSelectQuestion multiOptionQuestion = question.createQuestion(MultiSelectQuestion.class);
 
     DivTag checkboxQuestionFormContent =
         div()

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -30,7 +30,7 @@ public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
+    CurrencyQuestion currencyQuestion = question.createQuestion(CurrencyQuestion.class);
 
     FieldWithLabel currencyField =
         FieldWithLabel.currency()

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -31,7 +31,7 @@ public class DateQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    DateQuestion dateQuestion = question.createDateQuestion();
+    DateQuestion dateQuestion = question.createQuestion(DateQuestion.class);
 
     FieldWithLabel dateField =
         FieldWithLabel.date()

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -35,7 +35,7 @@ public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
     Messages messages = params.messages();
-    SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
+    SingleSelectQuestion singleSelectQuestion = question.createQuestion(SingleSelectQuestion.class);
 
     SelectWithLabel select =
         new SelectWithLabel()

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -30,7 +30,7 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    EmailQuestion emailQuestion = question.createEmailQuestion();
+    EmailQuestion emailQuestion = question.createQuestion(EmailQuestion.class);
 
     FieldWithLabel emailField =
         FieldWithLabel.email()

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -55,7 +55,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
+    EnumeratorQuestion enumeratorQuestion = question.createQuestion(EnumeratorQuestion.class);
     String localizedEntityType = enumeratorQuestion.getEntityType();
     ImmutableList<String> entityNames = enumeratorQuestion.getEntityNames();
     boolean hasErrors = !validationErrors.isEmpty();

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -33,7 +33,7 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
 
   public static DivTag renderFileKeyField(
       ApplicantQuestion question, ApplicantQuestionRendererParams params, boolean clearData) {
-    FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
+    FileUploadQuestion fileUploadQuestion = question.createQuestion(FileUploadQuestion.class);
     String value = fileUploadQuestion.getFileKeyValue().orElse("");
     if (clearData) {
       value = "";
@@ -47,7 +47,7 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
   public FileUploadQuestionRenderer(
       ApplicantQuestion question, FileUploadViewStrategy fileUploadViewStrategy) {
     super(question);
-    this.fileUploadQuestion = question.createFileUploadQuestion();
+    this.fileUploadQuestion = question.createQuestion(FileUploadQuestion.class);
     this.fileUploadViewStrategy = fileUploadViewStrategy;
     this.fileInputId = RandomStringUtils.randomAlphabetic(8);
   }

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -28,7 +28,7 @@ public class IdQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    IdQuestion idQuestion = question.createIdQuestion();
+    IdQuestion idQuestion = question.createQuestion(IdQuestion.class);
 
     FieldWithLabel idField =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -33,7 +33,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    NameQuestion nameQuestion = question.createNameQuestion();
+    NameQuestion nameQuestion = question.createQuestion(NameQuestion.class);
 
     FieldWithLabel firstNameField =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -31,7 +31,7 @@ public class NumberQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    NumberQuestion numberQuestion = question.createNumberQuestion();
+    NumberQuestion numberQuestion = question.createQuestion(NumberQuestion.class);
 
     FieldWithLabel numberField =
         FieldWithLabel.number()

--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -32,7 +32,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    PhoneQuestion phoneQuestion = question.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = question.createQuestion(PhoneQuestion.class);
 
     Messages messages = params.messages();
 

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -38,7 +38,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
-    SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
+    SingleSelectQuestion singleOptionQuestion = question.createQuestion(SingleSelectQuestion.class);
     boolean hasErrors = !validationErrors.isEmpty();
 
     DivTag radioQuestionFormContent =

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -28,7 +28,7 @@ public class TextQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    TextQuestion textQuestion = question.createTextQuestion();
+    TextQuestion textQuestion = question.createQuestion(TextQuestion.class);
 
     FieldWithLabel textField =
         FieldWithLabel.input()

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2989,7 +2989,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(questionDefinition, applicantData, Optional.empty());
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     AddressSuggestion addressSuggestion1 =
         AddressSuggestion.builder()
@@ -3096,7 +3096,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(questionDefinition, applicantData, Optional.empty());
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     AddressSuggestion addressSuggestion1 =
         AddressSuggestion.builder()
@@ -3185,7 +3185,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(questionDefinition, applicantData, Optional.empty());
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     AddressSuggestion addressSuggestion1 =
         AddressSuggestion.builder()

--- a/server/test/services/applicant/predicate/PredicateEvaluatorTest.java
+++ b/server/test/services/applicant/predicate/PredicateEvaluatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import services.DateConverter;
 import services.applicant.ApplicantData;
+import services.applicant.question.AddressQuestion;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
 import services.program.predicate.AndNode;
@@ -52,10 +53,11 @@ public class PredicateEvaluatorTest {
     PredicateExpressionNode node = PredicateExpressionNode.create(leafNode);
 
     applicantData.putString(
-        applicantQuestion.createAddressQuestion().getStreetPath(), "123 Rhode St.");
+        applicantQuestion.createQuestion(AddressQuestion.class).getStreetPath(), "123 Rhode St.");
     assertThat(evaluator.evaluate(node)).isTrue();
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStreetPath(), "different");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStreetPath(), "different");
     assertThat(evaluator.evaluate(node)).isFalse();
   }
 
@@ -70,7 +72,7 @@ public class PredicateEvaluatorTest {
     PredicateExpressionNode node = PredicateExpressionNode.create(leafNode);
 
     applicantData.putString(
-        applicantQuestion.createAddressQuestion().getStreetPath(), "123 Rhode St.");
+        applicantQuestion.createQuestion(AddressQuestion.class).getStreetPath(), "123 Rhode St.");
 
     assertThat(evaluator.evaluate(node)).isFalse();
   }
@@ -84,8 +86,10 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.STATE, Operator.EQUAL_TO, PredicateValue.of("WA"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Seattle");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Seattle");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "WA");
 
     AndNode andNode =
         AndNode.create(
@@ -104,8 +108,10 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.STATE, Operator.EQUAL_TO, PredicateValue.of("WA"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Spokane");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Spokane");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "WA");
 
     AndNode andNode =
         AndNode.create(
@@ -124,8 +130,10 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.STATE, Operator.EQUAL_TO, PredicateValue.of("WA"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Spokane");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Spokane");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "WA");
 
     OrNode orNode =
         OrNode.create(
@@ -144,8 +152,10 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.STATE, Operator.EQUAL_TO, PredicateValue.of("WA"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Minneapolis");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "MN");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Minneapolis");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "MN");
 
     OrNode orNode =
         OrNode.create(
@@ -167,9 +177,12 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.ZIP, Operator.EQUAL_TO, PredicateValue.of("55555"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Spokane");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "WA");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getZipPath(), "55555");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Spokane");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getZipPath(), "55555");
 
     OrNode orNode =
         OrNode.create(
@@ -195,10 +208,13 @@ public class PredicateEvaluatorTest {
         LeafOperationExpressionNode.create(
             addressQuestion.getId(), Scalar.ZIP, Operator.EQUAL_TO, PredicateValue.of("55555"));
 
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "Spokane");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "Spokane");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "WA");
     // Mismatched AND data.
-    applicantData.putString(applicantQuestion.createAddressQuestion().getZipPath(), "NOT 55555");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getZipPath(), "NOT 55555");
 
     OrNode orNode =
         OrNode.create(
@@ -225,9 +241,12 @@ public class PredicateEvaluatorTest {
             addressQuestion.getId(), Scalar.ZIP, Operator.EQUAL_TO, PredicateValue.of("55555"));
 
     // Mismatched Or data.
-    applicantData.putString(applicantQuestion.createAddressQuestion().getCityPath(), "NOT Spokane");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getStatePath(), "NOT WA");
-    applicantData.putString(applicantQuestion.createAddressQuestion().getZipPath(), "55555");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getCityPath(), "NOT Spokane");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getStatePath(), "NOT WA");
+    applicantData.putString(
+        applicantQuestion.createQuestion(AddressQuestion.class).getZipPath(), "55555");
 
     OrNode orNode =
         OrNode.create(

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -84,7 +84,7 @@ public class AddressQuestionTest {
         "WA",
         "98101");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(addressQuestion.getStreetValue().get()).isEqualTo("PO Box 123");
@@ -112,7 +112,7 @@ public class AddressQuestionTest {
         1000L,
         "Seattle_InArea_1234");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(addressQuestion.getStreetValue().get()).isEqualTo("PO Box 123");
@@ -137,7 +137,7 @@ public class AddressQuestionTest {
         new ApplicantQuestion(noPoBoxAddressQuestionDefinition, applicantData, Optional.empty());
     QuestionAnswerer.answerAddressQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "", "", "", "", "");
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getValidationErrors())
         .isEqualTo(
@@ -173,7 +173,7 @@ public class AddressQuestionTest {
         "WA",
         zipValue);
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getValidationErrors())
         .isEqualTo(
@@ -197,7 +197,7 @@ public class AddressQuestionTest {
         "WA",
         "98107");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getValidationErrors().isEmpty()).isTrue();
   }
@@ -227,7 +227,7 @@ public class AddressQuestionTest {
         "WA",
         "98107");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
         addressQuestion.getValidationErrors();
@@ -258,7 +258,7 @@ public class AddressQuestionTest {
         stateValue,
         zipValue);
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     assertThat(addressQuestion.getAnswerString()).isEqualTo(expected);
   }
@@ -293,7 +293,7 @@ public class AddressQuestionTest {
         1000L,
         "Seattle_InArea_1234");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     ImmutableMap<String, String> formData =
         new ImmutableMap.Builder<String, String>()
@@ -325,7 +325,7 @@ public class AddressQuestionTest {
         1000L,
         "Seattle_InArea_1234");
 
-    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createQuestion(AddressQuestion.class);
 
     ImmutableMap<String, String> formData =
         new ImmutableMap.Builder<String, String>()

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -83,7 +83,7 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantAddress().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(addressApplicantQuestion.createAddressQuestion())
+    assertThat(addressApplicantQuestion.createQuestion(AddressQuestion.class))
         .isInstanceOf(AddressQuestion.class);
 
     ApplicantQuestion checkboxApplicantQuestion =
@@ -91,7 +91,7 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantKitchenTools().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(checkboxApplicantQuestion.createMultiSelectQuestion())
+    assertThat(checkboxApplicantQuestion.createQuestion(MultiSelectQuestion.class))
         .isInstanceOf(MultiSelectQuestion.class);
 
     ApplicantQuestion dropdownApplicantQuestion =
@@ -99,7 +99,7 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantIceCream().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(dropdownApplicantQuestion.createSingleSelectQuestion())
+    assertThat(dropdownApplicantQuestion.createQuestion(SingleSelectQuestion.class))
         .isInstanceOf(SingleSelectQuestion.class);
 
     ApplicantQuestion enumeratorApplicantQuestion =
@@ -107,7 +107,7 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(enumeratorApplicantQuestion.createEnumeratorQuestion())
+    assertThat(enumeratorApplicantQuestion.createQuestion(EnumeratorQuestion.class))
         .isInstanceOf(EnumeratorQuestion.class);
 
     ApplicantQuestion nameApplicantQuestion =
@@ -115,21 +115,23 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantName().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(nameApplicantQuestion.createNameQuestion()).isInstanceOf(NameQuestion.class);
+    assertThat(nameApplicantQuestion.createQuestion(NameQuestion.class))
+        .isInstanceOf(NameQuestion.class);
 
     ApplicantQuestion numberApplicantQuestion =
         new ApplicantQuestion(
             testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(numberApplicantQuestion.createNumberQuestion()).isInstanceOf(NumberQuestion.class);
+    assertThat(numberApplicantQuestion.createQuestion(NumberQuestion.class))
+        .isInstanceOf(NumberQuestion.class);
 
     ApplicantQuestion radioApplicantQuestion =
         new ApplicantQuestion(
             testQuestionBank.applicantSeason().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(radioApplicantQuestion.createSingleSelectQuestion())
+    assertThat(radioApplicantQuestion.createQuestion(SingleSelectQuestion.class))
         .isInstanceOf(SingleSelectQuestion.class);
 
     ApplicantQuestion textApplicantQuestion =
@@ -137,14 +139,15 @@ public class ApplicantQuestionTest {
             testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(textApplicantQuestion.createTextQuestion()).isInstanceOf(TextQuestion.class);
+    assertThat(textApplicantQuestion.createQuestion(TextQuestion.class))
+        .isInstanceOf(TextQuestion.class);
 
     ApplicantQuestion phoneQuestion =
         new ApplicantQuestion(
             testQuestionBank.applicantPhone().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
-    assertThat(phoneQuestion.createPhoneQuestion()).isInstanceOf(PhoneQuestion.class);
+    assertThat(phoneQuestion.createQuestion(PhoneQuestion.class)).isInstanceOf(PhoneQuestion.class);
   }
 
   @Test

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -74,7 +74,7 @@ public class CurrencyQuestionTest {
     QuestionAnswerer.answerCurrencyQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), dollars);
 
-    CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
+    CurrencyQuestion currencyQuestion = applicantQuestion.createQuestion(CurrencyQuestion.class);
 
     assertThat(currencyQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(currencyQuestion.getCurrencyValue().isPresent()).isTrue();
@@ -91,7 +91,7 @@ public class CurrencyQuestionTest {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(currencyQuestionDefinition, applicantData, Optional.empty());
 
-    CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
+    CurrencyQuestion currencyQuestion = applicantQuestion.createQuestion(CurrencyQuestion.class);
 
     assertThat(currencyQuestion.getValidationErrors())
         .isEqualTo(

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -75,7 +75,7 @@ public class DateQuestionTest extends ResetPostgres {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(dateQuestionDefinition, applicantData, Optional.empty());
 
-    DateQuestion dateQuestion = applicantQuestion.createDateQuestion();
+    DateQuestion dateQuestion = applicantQuestion.createQuestion(DateQuestion.class);
 
     assertThat(dateQuestion.getValidationErrors())
         .isEqualTo(

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -104,7 +104,8 @@ public class MultiSelectQuestionTest {
     QuestionAnswerer.answerMultiSelectQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 0, 0L);
 
-    MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
+    MultiSelectQuestion multiSelectQuestion =
+        applicantQuestion.createQuestion(MultiSelectQuestion.class);
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
         multiSelectQuestion.getValidationErrors();
@@ -129,7 +130,8 @@ public class MultiSelectQuestionTest {
     QuestionAnswerer.answerMultiSelectQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 3, 4L);
 
-    MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
+    MultiSelectQuestion multiSelectQuestion =
+        applicantQuestion.createQuestion(MultiSelectQuestion.class);
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
         multiSelectQuestion.getValidationErrors();
@@ -150,7 +152,8 @@ public class MultiSelectQuestionTest {
     QuestionAnswerer.answerMultiSelectQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 1, 2L);
 
-    MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
+    MultiSelectQuestion multiSelectQuestion =
+        applicantQuestion.createQuestion(MultiSelectQuestion.class);
 
     assertThat(multiSelectQuestion.getValidationErrors().isEmpty()).isTrue();
   }
@@ -161,7 +164,8 @@ public class MultiSelectQuestionTest {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(CHECKBOX_QUESTION, applicantData, Optional.empty());
 
-    MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
+    MultiSelectQuestion multiSelectQuestion =
+        applicantQuestion.createQuestion(MultiSelectQuestion.class);
 
     assertThat(multiSelectQuestion.getOptions()).isNotEmpty();
     assertThat(multiSelectQuestion.getOptions().get(0).locale())

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -65,7 +65,7 @@ public class NameQuestionTest {
     QuestionAnswerer.answerNameQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), firstName, middleName, lastName);
 
-    NameQuestion nameQuestion = applicantQuestion.createNameQuestion();
+    NameQuestion nameQuestion = applicantQuestion.createQuestion(NameQuestion.class);
 
     assertThat(nameQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(nameQuestion.getFirstNameValue().get()).isEqualTo(firstName);
@@ -84,7 +84,7 @@ public class NameQuestionTest {
     QuestionAnswerer.answerNameQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), firstName, middleName, lastName);
 
-    NameQuestion nameQuestion = applicantQuestion.createNameQuestion();
+    NameQuestion nameQuestion = applicantQuestion.createQuestion(NameQuestion.class);
 
     assertThat(nameQuestion.getValidationErrors().isEmpty()).isFalse();
     assertThat(

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -79,7 +79,7 @@ public class NumberQuestionTest extends ResetPostgres {
     QuestionAnswerer.answerNumberQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "");
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     assertThat(numberQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue()).isEmpty();
@@ -92,7 +92,7 @@ public class NumberQuestionTest extends ResetPostgres {
     QuestionAnswerer.answerNumberQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 800);
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     assertThat(numberQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue().get()).isEqualTo(800);
@@ -106,7 +106,7 @@ public class NumberQuestionTest extends ResetPostgres {
     QuestionAnswerer.answerNumberQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), value);
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     assertThat(numberQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue().get()).isEqualTo(value);
@@ -127,7 +127,7 @@ public class NumberQuestionTest extends ResetPostgres {
     QuestionAnswerer.answerNumberQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), value);
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
         numberQuestion.getValidationErrors();
@@ -147,7 +147,7 @@ public class NumberQuestionTest extends ResetPostgres {
     QuestionAnswerer.answerNumberQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "");
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     assertThat(numberQuestion.getValidationErrors().isEmpty()).isTrue();
   }
@@ -162,7 +162,7 @@ public class NumberQuestionTest extends ResetPostgres {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(numberQuestionDefinition, applicantData, Optional.empty());
 
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createQuestion(NumberQuestion.class);
 
     assertThat(numberQuestion.getValidationErrors())
         .isEqualTo(

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -64,7 +64,7 @@ public class PhoneQuestionTest {
         new ApplicantQuestion(phoneQuestionDefinition, applicantData, Optional.empty());
     QuestionAnswerer.answerPhoneQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "US", "(615) 717-1234");
-    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createQuestion(PhoneQuestion.class);
 
     assertThat(phoneQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(phoneQuestion.getPhoneNumberValue().get()).isEqualTo("6157171234");
@@ -77,7 +77,7 @@ public class PhoneQuestionTest {
         new ApplicantQuestion(phoneQuestionDefinition, applicantData, Optional.empty());
     QuestionAnswerer.answerPhoneQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "", "");
-    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createQuestion(PhoneQuestion.class);
     assertThat(phoneQuestion.getValidationErrors())
         .isEqualTo(
             ImmutableMap.of(
@@ -103,7 +103,7 @@ public class PhoneQuestionTest {
     QuestionAnswerer.answerPhoneQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "US", number);
 
-    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createQuestion(PhoneQuestion.class);
 
     assertThat(phoneQuestion.getValidationErrors())
         .isEqualTo(
@@ -123,7 +123,7 @@ public class PhoneQuestionTest {
     QuestionAnswerer.answerPhoneQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "US", number);
 
-    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createQuestion(PhoneQuestion.class);
 
     assertThat(phoneQuestion.getValidationErrors())
         .isEqualTo(
@@ -142,7 +142,7 @@ public class PhoneQuestionTest {
     QuestionAnswerer.answerPhoneQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), "CA", number);
 
-    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createQuestion(PhoneQuestion.class);
 
     assertThat(phoneQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(phoneQuestion.getPhoneNumberValue().get()).isEqualTo("2505550199");

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -63,7 +63,8 @@ public class SingleSelectQuestionTest {
     QuestionAnswerer.answerSingleSelectQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 1L);
 
-    SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
+    SingleSelectQuestion singleSelectQuestion =
+        applicantQuestion.createQuestion(SingleSelectQuestion.class);
 
     assertThat(singleSelectQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue())
@@ -77,7 +78,8 @@ public class SingleSelectQuestionTest {
     QuestionAnswerer.answerSingleSelectQuestion(
         applicantData, applicantQuestion.getContextualizedPath(), 9L);
 
-    SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
+    SingleSelectQuestion singleSelectQuestion =
+        applicantQuestion.createQuestion(SingleSelectQuestion.class);
 
     assertThat(singleSelectQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue()).isEmpty();
@@ -89,7 +91,8 @@ public class SingleSelectQuestionTest {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(dropdownQuestionDefinition, applicantData, Optional.empty());
 
-    SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
+    SingleSelectQuestion singleSelectQuestion =
+        applicantQuestion.createQuestion(SingleSelectQuestion.class);
 
     assertThat(singleSelectQuestion.getOptions()).isNotEmpty();
     assertThat(singleSelectQuestion.getOptions().get(0).locale())

--- a/server/test/services/export/CsvExporterTest.java
+++ b/server/test/services/export/CsvExporterTest.java
@@ -71,7 +71,7 @@ public class CsvExporterTest extends AbstractExporterTest {
 
     NameQuestion nameApplicantQuestion =
         getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
-            .createNameQuestion();
+            .createQuestion(NameQuestion.class);
     String firstNameHeader =
         CsvExporterService.pathToHeader(nameApplicantQuestion.getFirstNamePath());
     String lastNameHeader =
@@ -79,7 +79,8 @@ public class CsvExporterTest extends AbstractExporterTest {
     Question phoneQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.PHONE);
     PhoneQuestion phoneQuestion1 =
-        getApplicantQuestion(phoneQuestion.getQuestionDefinition()).createPhoneQuestion();
+        getApplicantQuestion(phoneQuestion.getQuestionDefinition())
+            .createQuestion(PhoneQuestion.class);
     String phoneHeader = CsvExporterService.pathToHeader(phoneQuestion1.getPhoneNumberPath());
     String countryCodeHeader = CsvExporterService.pathToHeader(phoneQuestion1.getCountryCodePath());
     assertThat(records.get(1).get(phoneHeader)).contains("6157571010");
@@ -94,7 +95,8 @@ public class CsvExporterTest extends AbstractExporterTest {
     Question checkboxQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.CHECKBOX);
     MultiSelectQuestion multiSelectApplicantQuestion =
-        getApplicantQuestion(checkboxQuestion.getQuestionDefinition()).createMultiSelectQuestion();
+        getApplicantQuestion(checkboxQuestion.getQuestionDefinition())
+            .createQuestion(MultiSelectQuestion.class);
     String multiSelectHeader =
         CsvExporterService.pathToHeader(multiSelectApplicantQuestion.getSelectionPath());
     assertThat(records.get(1).get(multiSelectHeader)).isEqualTo("[toaster, pepper grinder]");
@@ -102,7 +104,8 @@ public class CsvExporterTest extends AbstractExporterTest {
     Question fileuploadQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.FILEUPLOAD);
     FileUploadQuestion fileuploadApplicantQuestion =
-        getApplicantQuestion(fileuploadQuestion.getQuestionDefinition()).createFileUploadQuestion();
+        getApplicantQuestion(fileuploadQuestion.getQuestionDefinition())
+            .createQuestion(FileUploadQuestion.class);
     String fileKeyHeader =
         CsvExporterService.pathToHeader(fileuploadApplicantQuestion.getFileKeyPath());
     assertThat(records.get(1).get(fileKeyHeader))
@@ -135,9 +138,9 @@ public class CsvExporterTest extends AbstractExporterTest {
             "applicant name (last_name)",
             "applicant favorite color (text)");
 
-    NameQuestion nameApplicantQuestion =
-        getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
-            .createNameQuestion();
+    ApplicantQuestion applicantQuestion =
+        getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition());
+    NameQuestion nameApplicantQuestion = applicantQuestion.createQuestion(NameQuestion.class);
     String firstNameHeader =
         CsvExporterService.pathToHeader(nameApplicantQuestion.getFirstNamePath());
     // Applications should appear most recent first.


### PR DESCRIPTION
### Description

Quick refactor of `createXQuestion()` with parameterization

Instead of:

https://github.com/civiform/civiform/blob/52b543260f9e0557039e93e4de870a3065cc70f7/server/app/services/applicant/question/ApplicantQuestion.java#L214-L276

We just use:

```java
  public <T extends Question> T createQuestion(Class<T> questionClass) {
    try {
      // Get the constructor for T that has a single parameter of type ApplicantQuestion.
      Constructor<T> constructor = questionClass.getDeclaredConstructor(this.getClass());
      return constructor.newInstance(this);
    } catch (InstantiationException
        | IllegalAccessException
        | NoSuchMethodException
        | InvocationTargetException e) {
      throw new RuntimeException(
          "Could not find appropriate constructor for " + questionClass.getName(), e);
    }
  }
```

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [ ] Created tests which fail without the change (if possible)
   - Not necessary
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

None.