### PR TITLE
Add "required" field to vars required on startup

### DIFF
--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -5,17 +5,20 @@
       "WHITELABEL_SMALL_LOGO_URL": {
         "mode": "ADMIN_READABLE",
         "description": "Small logo for the civic entity used on the login page.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "WHITELABEL_CIVIC_ENTITY_SHORT_NAME": {
         "mode": "ADMIN_READABLE",
         "description": "The short display name of the civic entity, will use 'TestCity' if not set.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "WHITELABEL_CIVIC_ENTITY_FULL_NAME": {
         "mode": "ADMIN_READABLE",
         "description": "The full display name of the civic entity, will use 'City of TestCity' if not set.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "FAVICON_URL": {
         "mode": "ADMIN_READABLE",
@@ -41,7 +44,8 @@
               "login-gov",
               "auth0",
               "disabled"
-            ]
+            ],
+            "required": true
           },
           "APPLICANT_REGISTER_URI": {
             "mode": "ADMIN_READABLE",
@@ -79,17 +83,20 @@
               "LOGIN_RADIUS_API_KEY": {
                 "mode": "HIDDEN",
                 "description": "The API key used to interact with LoginRadius.",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               "LOGIN_RADIUS_METADATA_URI": {
                 "mode": "HIDDEN",
                 "description": "The base URL to construct SAML endpoints, based on the SAML2 spec.",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               "LOGIN_RADIUS_SAML_APP_NAME": {
                 "mode": "HIDDEN",
                 "description": "The name for the app, based on the SAML2 spec.",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               "LOGIN_RADIUS_KEYSTORE_NAME": {
                 "mode": "HIDDEN",
@@ -144,7 +151,8 @@
               "APPLICANT_OIDC_DISCOVERY_URI": {
                 "mode": "HIDDEN",
                 "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with a given auth provider.",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               "APPLICANT_OIDC_RESPONSE_MODE": {
                 "mode": "HIDDEN",
@@ -235,7 +243,8 @@
           "ADFS_DISCOVERY_URI": {
             "mode": "HIDDEN",
             "description": "A URL that returns a JSON listing of OIDC (OpenID Connect) data associated with the IDCS auth provider.",
-            "type": "string"
+            "type": "string",
+            "required": true
           },
           "ADFS_GLOBAL_ADMIN_GROUP": {
             "mode": "HIDDEN",
@@ -292,7 +301,8 @@
       "AWS_SES_SENDER": {
         "mode": "HIDDEN",
         "description": "The email address used for the 'from' email header for emails sent by CiviForm.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "Application File Upload Storage": {
         "group_description": "Configuration options for the application file upload storage provider",
@@ -383,7 +393,8 @@
       "SUPPORT_EMAIL_ADDRESS": {
         "mode": "ADMIN_READABLE",
         "description": "This email address is listed in the footer for applicants to contact support.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "IT_EMAIL_ADDRESS": {
         "mode": "ADMIN_READABLE",
@@ -393,17 +404,20 @@
       "STAGING_ADMIN_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the program administrator's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "STAGING_TI_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the trusted intermediary's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "STAGING_APPLICANT_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the applicant's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       }
     }
   },
@@ -436,7 +450,8 @@
       {"val": "http://my-civiform.org", "should_match": true},
       {"val": "https://my-civiform.org", "should_match": true},
       {"val": "my-civiform.org", "should_match": false}
-    ]
+    ],
+    "required": true
   },
   "STAGING_HOSTNAME": {
     "mode": "HIDDEN",


### PR DESCRIPTION
### Description

As a part of the validation work required for auto-generating server vars, we need to be able to throw an error if a required var is missing from the config ([code](https://github.com/civiform/cloud-deploy-infra/blob/2284e9b6dd86b09369443216da7be77490f1a466/cloud/shared/bin/lib/config_loader.py#L274)). This PR adds the required field to the appropriate vars in `env-var-docs.json` for use in validation.

I determined which vars are required by looking at the values for "required" in the `variable_definitions` files in our infra repository:
- [shared](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/shared/variable_definitions.json)
- [aws](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/templates/aws_oidc/variable_definitions.json)
- [azure](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/azure/templates/azure_saml_ses/variable_definitions.json)

Related to https://github.com/civiform/civiform/issues/4612

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >