### PR TITLE
Fix login in tests on AWS staging

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -374,7 +374,8 @@ async function loginAsTestUserAwsStaging(page: Page, loginButton: string) {
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await Promise.all([
     page.waitForURL('**/applicants/**', {waitUntil: 'networkidle'}),
-    page.click('button:has-text("Continue")'),
+    // Auth0 has an additional hidden "Continue" button that does nothing for some reason
+    page.click('button:visible:has-text("Continue")'),
   ])
 }
 


### PR DESCRIPTION
Auth0 added a hidden Continue button in addition to the actual, visible Continue button for some reason. This changes the selector to only click the visible button.