### PR TITLE
Fix issue that allowed applicants to access draft programs.

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -153,6 +153,20 @@ public final class ProgramRepository {
     }
   }
 
+  /** Get the current active program with the provided id. */
+  public CompletableFuture<Program> getActiveProgram(Long id) {
+    return supplyAsync(
+        () -> {
+          ImmutableList<Program> activePrograms =
+              versionRepository.get().getActiveVersion().getPrograms();
+          return activePrograms.stream()
+              .filter(p -> p.id.equals(id))
+              .findFirst()
+              .orElseThrow(() -> new RuntimeException(new ProgramNotFoundException(id)));
+        },
+        executionContext.current());
+  }
+
   /** Get the current active program with the provided slug. */
   public CompletableFuture<Program> getForSlug(String slug) {
     return supplyAsync(

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -108,16 +108,8 @@ public final class ProgramServiceImpl implements ProgramService {
   @Override
   public CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(long id) {
     return programRepository
-        .lookupProgram(id)
-        .thenComposeAsync(
-            programMaybe -> {
-              if (programMaybe.isEmpty()) {
-                return CompletableFuture.failedFuture(new ProgramNotFoundException(id));
-              }
-
-              return syncProgramAssociations(programMaybe.get());
-            },
-            httpExecutionContext.current());
+        .getActiveProgram(id)
+        .thenComposeAsync(this::syncProgramAssociations, httpExecutionContext.current());
   }
 
   @Override

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -86,13 +86,27 @@ public final class ProgramServiceImpl implements ProgramService {
   @Override
   public ProgramDefinition getProgramDefinition(long id) throws ProgramNotFoundException {
     try {
-      return getActiveProgramDefinitionAsync(id).toCompletableFuture().join();
+      return getProgramDefinitionAsync(id).toCompletableFuture().join();
     } catch (CompletionException e) {
       if (e.getCause() instanceof ProgramNotFoundException) {
         throw new ProgramNotFoundException(id);
       }
       throw new RuntimeException(e);
     }
+  }
+
+  private CompletionStage<ProgramDefinition> getProgramDefinitionAsync(long id) {
+    return programRepository
+    .lookupProgram(id)
+    .thenComposeAsync(
+        programMaybe -> {
+          if (programMaybe.isEmpty()) {
+            return CompletableFuture.failedFuture(new ProgramNotFoundException(id));
+          }
+
+          return syncProgramAssociations(programMaybe.get());
+        },
+        httpExecutionContext.current());
   }
 
   @Override

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -97,16 +97,16 @@ public final class ProgramServiceImpl implements ProgramService {
 
   private CompletionStage<ProgramDefinition> getProgramDefinitionAsync(long id) {
     return programRepository
-    .lookupProgram(id)
-    .thenComposeAsync(
-        programMaybe -> {
-          if (programMaybe.isEmpty()) {
-            return CompletableFuture.failedFuture(new ProgramNotFoundException(id));
-          }
+        .lookupProgram(id)
+        .thenComposeAsync(
+            programMaybe -> {
+              if (programMaybe.isEmpty()) {
+                return CompletableFuture.failedFuture(new ProgramNotFoundException(id));
+              }
 
-          return syncProgramAssociations(programMaybe.get());
-        },
-        httpExecutionContext.current());
+              return syncProgramAssociations(programMaybe.get());
+            },
+            httpExecutionContext.current());
   }
 
   @Override

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -42,7 +42,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     subject = instanceOf(ApplicantProgramBlocksController.class);
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .withBlock()
@@ -262,7 +262,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_withNextBlock_redirectsToEdit() {
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredQuestion(testQuestionBank().applicantName())
             .withBlock("block 2")
@@ -296,7 +296,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_savesCorrectedAddressWhenValidAddressIsEntered() {
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
             .build();
@@ -347,7 +347,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_completedProgram_redirectsToReviewPage() {
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
@@ -486,7 +486,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void updateFile_withNextBlock_redirectsToEdit() {
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .withBlock("block 2")
@@ -519,7 +519,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void updateFile_completedProgram_redirectsToReviewPage() {
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .build();
@@ -558,7 +558,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     var storedFileRepo = instanceOf(StoredFileRepository.class);
 
     program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .build();

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -2,6 +2,7 @@ package controllers.applicant;
 
 import static featureflags.FeatureFlag.ESRI_ADDRESS_CORRECTION_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
@@ -16,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
 import java.util.Locale;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import models.Applicant;
 import models.Program;
@@ -28,6 +30,7 @@ import play.mvc.Result;
 import repository.StoredFileRepository;
 import services.Path;
 import services.applicant.question.Scalar;
+import services.program.ProgramNotFoundException;
 import support.ProgramBuilder;
 
 public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
@@ -73,10 +76,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                         applicant.id, program.id + 1000, "1")))
             .build();
 
-    Result result =
-        subject.edit(request, applicant.id, program.id + 1000, "1").toCompletableFuture().join();
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThatThrownBy(
+            () ->
+                subject
+                    .edit(request, applicant.id, program.id + 1000, "1")
+                    .toCompletableFuture()
+                    .join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
   }
 
   @Test
@@ -156,7 +164,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void update_invalidProgram_returnsBadRequest() {
+  public void update_invalidProgram_returnsNotFound() {
     long badProgramId = program.id + 1000;
     Request request =
         fakeRequest(
@@ -164,14 +172,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     applicant.id, badProgramId, /* blockId = */ "1", /* inReview = */ false))
             .build();
 
-    Result result =
-        subject
-            .update(
-                request, applicant.id, badProgramId, /* blockId = */ "1", /* inReview = */ false)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(BAD_REQUEST);
+    assertThatThrownBy(
+            () ->
+                subject
+                    .update(
+                        request,
+                        applicant.id,
+                        badProgramId,
+                        /* blockId = */ "1",
+                        /* inReview = */ false)
+                    .toCompletableFuture()
+                    .join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
   }
 
   @Test
@@ -402,7 +416,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void updateFile_invalidProgram_returnsBadRequest() {
+  public void updateFile_invalidProgram_returnsNotFound() {
     long badProgramId = program.id + 1000;
     RequestBuilder request =
         fakeRequest(
@@ -410,18 +424,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 applicant.id, badProgramId, /* blockId = */ "2", /* inReview = */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
-    Result result =
-        subject
-            .updateFile(
-                request.build(),
-                applicant.id,
-                badProgramId,
-                /* blockId = */ "2",
-                /* inReview = */ false)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(BAD_REQUEST);
+    assertThatThrownBy(
+            () ->
+                subject
+                    .updateFile(
+                        request.build(),
+                        applicant.id,
+                        badProgramId,
+                        /* blockId = */ "2",
+                        /* inReview = */ false)
+                    .toCompletableFuture()
+                    .join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -187,7 +187,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void view_invalidProgram_returnsNotFound() {
+  public void view_invalidProgram_returnsBadRequest() {
     Result result =
         controller
             .view(fakeRequest().build(), currentApplicant.id, 9999L)

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -187,16 +187,14 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void view_invalidProgram_returnsBadRequest() {
-    assertThatThrownBy(
-            () ->
-                controller
-                    .view(fakeRequest().build(), currentApplicant.id, 9999L)
-                    .toCompletableFuture()
-                    .join())
-        .isInstanceOf(CompletionException.class)
-        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
-        .hasMessageContaining("Program not found for ID");
+  public void view_invalidProgram_returnsNotFound() {
+    Result result =
+        controller
+            .view(fakeRequest().build(), currentApplicant.id, 9999L)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
@@ -208,14 +206,16 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void edit_invalidProgram_returnsBadRequest() {
-    Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id, 9999L)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(BAD_REQUEST);
+  public void edit_invalidProgram_returnsNotFound() {
+    assertThatThrownBy(
+            () ->
+                controller
+                    .edit(fakeRequest().build(), currentApplicant.id, 9999L)
+                    .toCompletableFuture()
+                    .join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -217,7 +217,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_withNewProgram_redirectsToFirstBlock() {
     Program program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
@@ -238,7 +238,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     QuestionDefinition colorQuestion =
         testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
     Program program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock()
             .withRequiredQuestionDefinition(colorQuestion)
             .withBlock()

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -67,7 +67,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void index_withPrograms_returnsOnlyRelevantPrograms() {
     resourceCreator().insertActiveProgram("one");
     resourceCreator().insertActiveProgram("two");
-    resourceCreator().insertDraftProgram("three");
+    resourceCreator().insertActiveProgram("three");
 
     Request request = addCSRFToken(fakeRequest()).build();
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
@@ -87,7 +87,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     Application app = new Application(currentApplicant, program, LifecycleStage.DRAFT);
     app.save();
 
-    resourceCreator().insertDraftProgram(programName);
+    resourceCreator().insertActiveProgram(programName);
 
     this.versionRepository.publishNewSynchronizedVersion();
 

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -1,6 +1,7 @@
 package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -145,6 +146,25 @@ public class ProgramRepositoryTest extends ResetPostgres {
     Program found = repo.getForSlug("something-with-a-name").toCompletableFuture().join();
 
     assertThat(found).isEqualTo(program);
+  }
+
+  @Test
+  public void getActiveProgram_findsCorrectProgram() {
+    Program program = resourceCreator.insertActiveProgram("Something With A Name");
+
+    Program found = repo.getActiveProgram(program.id).toCompletableFuture().join();
+
+    assertThat(found).isEqualTo(program);
+  }
+
+  @Test
+  public void getActiveProgram_doesNotFindDraftProgram() {
+    Program program = resourceCreator.insertDraftProgram("Something With A Name");
+
+    assertThatThrownBy(() -> repo.getActiveProgram(program.id).toCompletableFuture().join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
   }
 
   @Test

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -9,6 +9,7 @@ import io.ebean.DB;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -164,7 +164,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
     assertThatThrownBy(() -> repo.getActiveProgram(program.id).toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
-        .hasCauseInstanceOf(ProgramNotFoundException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
         .hasMessageContaining("Program not found for ID");
   }
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -388,7 +388,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_forEnumeratorBlock_withEmptyUpdates_doesNotDeleteRealData() {
     programDefinition =
-        ProgramBuilder.newDraftProgram("test program", "desc")
+        ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
             .buildDefinition();
@@ -654,7 +654,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     .join());
 
     assertThat(thrown).isInstanceOf(CompletionException.class);
-    assertThat(thrown).hasCauseInstanceOf(ProgramNotFoundException.class);
+    assertThat(thrown).hasRootCauseInstanceOf(ProgramNotFoundException.class);
   }
 
   @Test
@@ -823,14 +823,14 @@ public class ApplicantServiceTest extends ResetPostgres {
             .getResult();
 
     Program firstProgram =
-        ProgramBuilder.newDraftProgram("first test program", "desc")
+        ProgramBuilder.newActiveProgram("first test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(fileUploadQuestion))
             .build();
     firstProgram.save();
 
     Program secondProgram =
-        ProgramBuilder.newDraftProgram("second test program", "desc")
+        ProgramBuilder.newActiveProgram("second test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(fileUploadQuestion))
             .build();
@@ -1391,7 +1391,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
-        ProgramBuilder.newDraftProgram("test program", "desc")
+        ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
             .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
             .withEligibilityDefinition(eligibilityDef)
@@ -1447,7 +1447,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
-        ProgramBuilder.newDraftProgram("test program", "desc")
+        ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
             .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
             .withEligibilityDefinition(eligibilityDef)
@@ -1672,11 +1672,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
+    // programDefinition is the program created during test set up.
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programForUnapplied.id);
+        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.allPrograms())
@@ -1684,7 +1685,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.commonIntakeForm().get(),
             result.inProgress().get(0),
             result.submitted().get(0),
-            result.unapplied().get(0));
+            result.unapplied().get(0),
+            result.unapplied().get(1));
   }
 
   @Test
@@ -1730,14 +1732,17 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programForUnapplied.id);
+        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isFalse();
     assertThat(result.allPrograms())
         .containsExactlyInAnyOrder(
-            result.inProgress().get(0), result.submitted().get(0), result.unapplied().get(0));
+            result.inProgress().get(0),
+            result.submitted().get(0),
+            result.unapplied().get(0),
+            result.unapplied().get(1));
   }
 
   @Test
@@ -1757,7 +1762,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactlyInAnyOrder(programDefinition.id());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1775,7 +1781,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactlyInAnyOrder(programDefinition.id());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1795,7 +1802,8 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactlyInAnyOrder(programDefinition.id());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1815,12 +1823,13 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withEligibilityDefinition(eligibilityDef)
             .build();
     Program programForSubmitted =
-        ProgramBuilder.newActiveProgram("program_for_submitted")
+        ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
     Program programForUnapplied =
-        ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
+        ProgramBuilder.newDraftProgram("program_for_unapplied").withBlock().build();
+    versionRepository.publishNewSynchronizedVersion();
 
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraft.id)
@@ -1853,12 +1862,12 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programForUnapplied.id);
+        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
     assertThat(result.unapplied().stream().map(ApplicantProgramData::isProgramMaybeEligible))
-        .containsExactly(Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty());
   }
 
   @Test
@@ -1872,20 +1881,17 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withEligibilityDefinition(eligibilityDef)
             .build();
     Program programForSubmitted =
-        ProgramBuilder.newActiveProgram("program_for_submitted")
+        ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
     Program programForUnapplied =
-        ProgramBuilder.newActiveProgram("program_for_unapplied")
+        ProgramBuilder.newDraftProgram("program_for_unapplied")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(questionDefinition))
             .withEligibilityDefinition(eligibilityDef)
             .build();
-
-    Question q = new Question(questionDefinition);
-    q.refresh();
-    versionRepository.getActiveVersion().addQuestion(q).save();
+    versionRepository.publishNewSynchronizedVersion();
 
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraft.id)
@@ -1918,12 +1924,12 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programForUnapplied.id);
+        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
     assertThat(result.unapplied().stream().map(ApplicantProgramData::isProgramMaybeEligible))
-        .containsExactly(Optional.of(true));
+        .containsExactlyInAnyOrder(Optional.of(true), Optional.empty());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty());
   }
 
   @Test
@@ -1962,10 +1968,13 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(
-            programForDraft.id, programForUnapplied.id, programForSubmitted.id);
+            programForDraft.id,
+            programForUnapplied.id,
+            programForSubmitted.id,
+            programDefinition.id());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   @Test
@@ -2176,7 +2185,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(tiResult.unapplied().stream().map(p -> p.program().id()))
         .containsExactly(
             programDefinition.id(), updatedProgramForDraftApp.id, updatedProgramForSubmittedApp.id);
-    // assertThat(tiResult.submitted()).
   }
 
   @Test
@@ -2230,7 +2238,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationTime))
         .containsExactly(Optional.of(secondAppSubmitTime));
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactly(programDefinition.id());
   }
 
   @Test
@@ -2309,8 +2318,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(firstDraft.getProgram().id);
     // As part of test setup, a "test program" is initialized.
-    // When calling publish, this will become active. This provides
-    // confidence that the draft version created above is actually published.
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactly(programDefinition.id());
   }
@@ -2345,7 +2352,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.of(APPROVED_STATUS));
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactly(programDefinition.id());
   }
 
   @Test
@@ -2399,7 +2407,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.of(APPROVED_STATUS));
-    assertThat(result.unapplied()).isEmpty();
+    assertThat(result.unapplied().stream().map(p -> p.program().id()))
+        .containsExactly(programDefinition.id());
   }
 
   @Test
@@ -2424,6 +2433,43 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(eligibleQuestion)
             .build();
+
+    // Set up program for draft application.
+    Program programForDraftApp =
+        ProgramBuilder.newDraftProgram("program_for_draft_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
+
+    // Set up program for submitted application.
+    Program programForSubmittedApp =
+        ProgramBuilder.newDraftProgram("program_for_submitted_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
+
+    // Set up unapplied program.
+    Program programForUnappliedApp =
+        ProgramBuilder.newDraftProgram("program_for_unapplied_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
+
+    versionRepository.publishNewSynchronizedVersion();
+
+    // Answer questions.
     answerNameQuestion(
         eligibleQuestion,
         "Taylor",
@@ -2437,49 +2483,18 @@ public class ApplicantServiceTest extends ResetPostgres {
         applicant.id,
         programForAnsweringQuestions.id);
 
-    // Set up draft program and answer question
-    Program programForDraftApp =
-        ProgramBuilder.newDraftProgram("program_for_draft_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
+    // Start a draft application.
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraftApp.id)
         .toCompletableFuture()
         .join();
 
-    // Set up submitted program
-    Program programForSubmittedApp =
-        ProgramBuilder.newDraftProgram("program_for_submitted_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
+    // Submit an application.
     applicationRepository
         .submitApplication(applicant.id, programForSubmittedApp.id, Optional.empty())
         .toCompletableFuture()
         .join();
 
-    // Set up unapplied program
-    Program programForUnappliedApp =
-        ProgramBuilder.newDraftProgram("program_for_unapplied_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
-
-    // Publish version and fetch results
-    versionRepository.publishNewSynchronizedVersion();
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2520,6 +2535,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinition(ineligibleQuestion)
             .withEligibilityDefinition(ineligibleQuestionEligibilityDefinition)
             .build();
+    versionRepository.publishNewSynchronizedVersion();
 
     // Fill out application
     answerNameQuestion(
@@ -2550,7 +2566,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2574,6 +2590,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
+    System.out.println("reemax setting up pqs");
     // Set up program and questions
     NameQuestionDefinition eligibleQuestion =
         createNameQuestion("question_with_matching_eligibility");
@@ -2602,6 +2619,9 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinition(ineligibleQuestion)
             .withEligibilityDefinition(ineligibleQuestionEligibilityDefinition)
             .build();
+    programWithEligibleAndIneligibleAnswers.save();
+    versionRepository.publishNewSynchronizedVersion();
+    System.out.println("published 1");
 
     // Fill out application
     answerNameQuestion(
@@ -2616,6 +2636,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .id(),
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
+    System.out.println("answered 1");
     answerNameQuestion(
         ineligibleQuestion,
         "Solána",
@@ -2629,14 +2650,18 @@ public class ApplicantServiceTest extends ResetPostgres {
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
 
+    System.out.println("answered 2");
+
     applicationRepository
         .submitApplication(
             applicant.id, programWithEligibleAndIneligibleAnswers.id, Optional.empty())
         .toCompletableFuture()
         .join();
+    System.out.println("submitted ");
 
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
+    System.out.println("publish2");
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2672,6 +2697,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .build();
+    versionRepository.publishNewSynchronizedVersion();
 
     answerNameQuestion(
         question,
@@ -2685,7 +2711,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2716,6 +2742,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .build();
+    versionRepository.publishNewSynchronizedVersion();
 
     answerNameQuestion(
         question,
@@ -2733,7 +2760,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2771,7 +2798,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2853,6 +2880,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.copyOf(questions))
             .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
   }
 
   private void createProgramWithStatusDefinitions(StatusDefinitions statuses) {
@@ -2862,6 +2890,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(questionDefinition))
             .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
   }
 
   private void createProgramWithOptionalQuestion(QuestionDefinition question) {
@@ -2870,6 +2899,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withOptionalQuestion(question)
             .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
   }
 
   /**
@@ -2920,7 +2950,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     programDefinition =
-        ProgramBuilder.newDraftProgram("test program", "desc")
+        ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(question))
             .withEligibilityDefinition(eligibilityDef)
@@ -2956,6 +2986,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinitions(ImmutableList.of(question))
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
   }
 
   private Messages getMessages(Locale locale) {

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -892,7 +892,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
   @Test
   public void getProgramDefinitionAsync_getsRequestedProgram() {
-    ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
+    ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
         ps.getActiveProgramDefinitionAsync(programDefinition.id());
@@ -902,8 +902,21 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
+  public void getProgramDefinitionAsync_doesNotGetDraftProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
+
+    CompletionStage<ProgramDefinition> found =
+        ps.getActiveProgramDefinitionAsync(programDefinition.id());
+
+    assertThatThrownBy(() -> found.toCompletableFuture().join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("Program not found for ID");
+  }
+
+  @Test
+  public void getProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
+    ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
         ps.getActiveProgramDefinitionAsync(programDefinition.id() + 1);

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -928,7 +928,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getActiverogramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
+  public void getActiveProgramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
     QuestionDefinition question = nameQuestion;
     ProgramDefinition program =
         ProgramBuilder.newActiveProgram()

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -891,7 +891,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getProgramDefinitionAsync_getsRequestedProgram() {
+  public void getActiveProgramDefinitionAsync_getsRequestedProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
@@ -902,7 +902,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getProgramDefinitionAsync_doesNotGetDraftProgram() {
+  public void getActiveProgramDefinitionAsync_doesNotGetDraftProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
@@ -910,12 +910,12 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
-        .hasCauseInstanceOf(ProgramNotFoundException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
         .hasMessageContaining("Program not found for ID");
   }
 
   @Test
-  public void getProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
+  public void getActiveProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
     ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
@@ -923,15 +923,15 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
-        .hasCauseInstanceOf(ProgramNotFoundException.class)
+        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
         .hasMessageContaining("Program not found for ID");
   }
 
   @Test
-  public void getProgramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
+  public void getActiverogramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
     QuestionDefinition question = nameQuestion;
     ProgramDefinition program =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newActiveProgram()
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .buildDefinition();


### PR DESCRIPTION
### Description

If you knew the id of the draft program, you were able to access it by putting its ID into the URL. The method to get the active program was not actually checking if the program was active.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
