### PR TITLE
Fix API client IP logging

### DIFF
--- a/server/test/auth/ApiAuthenticatorTest.java
+++ b/server/test/auth/ApiAuthenticatorTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.test.Helpers.fakeRequest;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -23,6 +27,7 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.exception.BadCredentialsException;
 import org.pac4j.play.PlayWebContext;
+import org.slf4j.LoggerFactory;
 import play.Application;
 import play.ApplicationLoader;
 import play.Environment;
@@ -97,22 +102,76 @@ public class ApiAuthenticatorTest {
   }
 
   @Test
+  public void resolveClientIp_direct() {
+    var authenticator =
+        new ApiAuthenticator(
+            injector.getProvider(ApiKeyService.class),
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "DIRECT")));
+
+    var request =
+        new FakeRequestBuilder()
+            .withRemoteAddress("4.4.4.4")
+            .withXForwadedFor("3.3.3.3, 2.2.2.2")
+            .build();
+
+    assertThat(authenticator.resolveClientIp(new PlayWebContext(request))).isEqualTo("4.4.4.4");
+  }
+
+  @Test
   public void resolveClientIp_forwarded() {
     var authenticator =
         new ApiAuthenticator(
             injector.getProvider(ApiKeyService.class),
             ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
 
-    var request = fakeRequest().header("X-Forwarded-For", "1.1.1.1, 2.2.2.2").build();
+    var request = new FakeRequestBuilder().withXForwadedFor("3.3.3.3, 2.2.2.2").build();
 
     assertThat(authenticator.resolveClientIp(new PlayWebContext(request))).isEqualTo("2.2.2.2");
   }
 
   @Test
-  public void validate_success() {
+  public void resolveClientIp_forwarded_no_header() {
+    var authenticator =
+        new ApiAuthenticator(
+            injector.getProvider(ApiKeyService.class),
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    var request = new FakeRequestBuilder().withRemoteAddress("3.3.3.3").build();
+
+    assertThatThrownBy(() -> authenticator.resolveClientIp(new PlayWebContext(request)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("CLIENT_IP_TYPE is FORWARDED but no value found for X-Forwarded-For header!");
+  }
+
+  @Test
+  public void validate_success_direct() {
     apiAuthenticator.validate(
         new UsernamePasswordCredentials(keyId, secret),
-        new PlayWebContext(buildFakeRequest(validRawCredentials)),
+        new PlayWebContext(
+            new FakeRequestBuilder().withRawCredentials(validRawCredentials).build()),
+        MOCK_SESSION_STORE);
+
+    Optional<Optional<ApiKey>> cacheEntry = cacheApi.get(keyId);
+    Optional<ApiKey> cachedMaybeKey = cacheEntry.get();
+    assertThat(cachedMaybeKey.get().id).isEqualTo(apiKey.id);
+  }
+
+  @Test
+  public void validate_success_forwarded() {
+    var authenticator =
+        new ApiAuthenticator(
+            injector.getProvider(ApiKeyService.class),
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+    apiKey.setSubnet("3.3.3.3/32");
+    apiKey.save();
+
+    authenticator.validate(
+        new UsernamePasswordCredentials(keyId, secret),
+        new PlayWebContext(
+            new FakeRequestBuilder()
+                .withRawCredentials(validRawCredentials)
+                .withXForwadedFor("2.2.2.2, 3.3.3.3")
+                .build()),
         MOCK_SESSION_STORE);
 
     Optional<Optional<ApiKey>> cacheEntry = cacheApi.get(keyId);
@@ -125,7 +184,7 @@ public class ApiAuthenticatorTest {
     String rawCredentials = "wrong" + ":" + secret;
 
     assertBadCredentialsException(
-        buildFakeRequest(rawCredentials),
+        new FakeRequestBuilder().withRawCredentials(rawCredentials).build(),
         new UsernamePasswordCredentials("wrong", secret),
         "API key does not exist: wrong");
   }
@@ -136,7 +195,8 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        buildFakeRequest(validRawCredentials), "API key is retired: " + keyId);
+        new FakeRequestBuilder().withRawCredentials(validRawCredentials).build(),
+        "API key is retired: " + keyId);
   }
 
   @Test
@@ -146,7 +206,8 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        buildFakeRequest(validRawCredentials), "API key is expired: " + keyId);
+        new FakeRequestBuilder().withRawCredentials(validRawCredentials).build(),
+        "API key is expired: " + keyId);
   }
 
   @Test
@@ -155,8 +216,71 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        buildFakeRequest(validRawCredentials),
-        "IP 1.1.1.1 not in allowed range for key ID: " + keyId);
+        new FakeRequestBuilder()
+            .withRemoteAddress("4.4.4.4")
+            .withRawCredentials(validRawCredentials)
+            .build(),
+        String.format(
+            "Resolved IP 4.4.4.4 is not in allowed range for key ID: %s, which is \"%s\"",
+            keyId, "2.2.2.2/30,3.3.3.3/32"));
+  }
+
+  @Test
+  public void validate_ipNotInSubnet_forwarded() {
+    var authenticator =
+        new ApiAuthenticator(
+            injector.getProvider(ApiKeyService.class),
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    apiKey.setSubnet("2.2.2.2/30,3.3.3.3/32");
+    apiKey.save();
+
+    assertBadCredentialsException(
+        authenticator,
+        new FakeRequestBuilder()
+            .withXForwadedFor("5.5.5.5, 6.6.6.6")
+            .withRawCredentials(validRawCredentials)
+            .build(),
+        String.format(
+            "Resolved IP 6.6.6.6 is not in allowed range for key ID: %s, which is \"%s\"",
+            keyId, "2.2.2.2/30,3.3.3.3/32"));
+  }
+
+  @Test
+  public void validate_logsDetailedError() {
+    Logger logger = (Logger) LoggerFactory.getLogger(ApiAuthenticator.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    var authenticator =
+        new ApiAuthenticator(
+            injector.getProvider(ApiKeyService.class),
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    apiKey.setSubnet("2.2.2.2/30,3.3.3.3/32");
+    apiKey.save();
+
+    assertThatThrownBy(
+            () ->
+                authenticator.validate(
+                    new UsernamePasswordCredentials(keyId, secret),
+                    new PlayWebContext(
+                        new FakeRequestBuilder()
+                            .withRemoteAddress("7.7.7.7")
+                            .withXForwadedFor("5.5.5.5, 6.6.6.6")
+                            .withRawCredentials(validRawCredentials)
+                            .build()),
+                    MOCK_SESSION_STORE))
+        .isInstanceOf(BadCredentialsException.class);
+
+    ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
+    assertThat(logsList.get(0).getMessage())
+        .isEqualTo(
+            "UnauthorizedApiRequest(resource: \"/\", Remote Address: \"7.7.7.7\","
+                + " X-Forwarded-For: \"5.5.5.5, 6.6.6.6\", CLIENT_IP_TYPE: \"FORWARDED\", cause:"
+                + " \"Resolved IP 6.6.6.6 is not in allowed range for key ID: keyId, which is"
+                + " \"2.2.2.2/30,3.3.3.3/32\"\")");
   }
 
   @Test
@@ -164,7 +288,7 @@ public class ApiAuthenticatorTest {
     var rawCredentials = keyId + ":" + "notthesecret";
 
     assertBadCredentialsException(
-        buildFakeRequest(rawCredentials),
+        new FakeRequestBuilder().withRawCredentials(rawCredentials).build(),
         new UsernamePasswordCredentials(keyId, "notthesecret"),
         "Invalid secret for key ID: " + keyId);
   }
@@ -175,7 +299,21 @@ public class ApiAuthenticatorTest {
   }
 
   private void assertBadCredentialsException(
+      ApiAuthenticator apiAuthenticator, Http.Request request, String expectedMessage) {
+    assertBadCredentialsException(
+        apiAuthenticator, request, new UsernamePasswordCredentials(keyId, secret), expectedMessage);
+  }
+
+  private void assertBadCredentialsException(
       Http.Request request, UsernamePasswordCredentials credentials, String expectedMessage) {
+    assertBadCredentialsException(apiAuthenticator, request, credentials, expectedMessage);
+  }
+
+  private void assertBadCredentialsException(
+      ApiAuthenticator apiAuthenticator,
+      Http.Request request,
+      UsernamePasswordCredentials credentials,
+      String expectedMessage) {
     assertThatThrownBy(
             () ->
                 apiAuthenticator.validate(
@@ -184,9 +322,38 @@ public class ApiAuthenticatorTest {
         .hasMessage(expectedMessage);
   }
 
-  private static Http.Request buildFakeRequest(String rawCredentials) {
-    String creds =
-        Base64.getEncoder().encodeToString(rawCredentials.getBytes(StandardCharsets.UTF_8));
-    return fakeRequest().remoteAddress("1.1.1.1").header("Authorization", "Basic " + creds).build();
+  private static class FakeRequestBuilder {
+    String remoteAddress = "1.1.1.1";
+    Optional<String> xForwardedFor = Optional.empty();
+    Optional<String> rawCredentials = Optional.empty();
+
+    public FakeRequestBuilder() {}
+
+    public FakeRequestBuilder withRemoteAddress(String remoteAddress) {
+      this.remoteAddress = remoteAddress;
+      return this;
+    }
+
+    public FakeRequestBuilder withXForwadedFor(String xForwadedFor) {
+      this.xForwardedFor = Optional.of(xForwadedFor);
+      return this;
+    }
+
+    public FakeRequestBuilder withRawCredentials(String rawCredentials) {
+      this.rawCredentials = Optional.of(rawCredentials);
+      return this;
+    }
+
+    public Http.Request build() {
+      Http.RequestBuilder fakeRequest = fakeRequest().remoteAddress(this.remoteAddress);
+      xForwardedFor.ifPresent(
+          xForwardedFor -> fakeRequest.header("X-Forwarded-For", xForwardedFor));
+      rawCredentials
+          .map(
+              rawCreds ->
+                  Base64.getEncoder().encodeToString(rawCreds.getBytes(StandardCharsets.UTF_8)))
+          .ifPresent(creds -> fakeRequest.header("Authorization", "Basic " + creds));
+      return fakeRequest.build();
+    }
   }
 }

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -34,7 +34,8 @@ public class ResourceCreator {
   }
 
   /**
-   * Create an API key with subnet of "1.1.1.1/32" and an expiration date one year in the future.
+   * Create an API key with subnet of "8.8.8.8/32,1.1.1.1/32" and an expiration date one year in the
+   * future.
    */
   public ApiKey createActiveApiKey(String name, String keyId, String keySecret) {
     ApiKey apiKey =


### PR DESCRIPTION
### Description

Updates API logging to log the correct client IP address, and adds additional details to error logs.

Additional details that are now logged for 401 errors are:
- The `CLIENT_IP_TYPE`
- The value of the `X-Forwarded-For` header
- The allowed subnet set for the key.

Also adds additional tests for the logs, and requests with the `X-Forwarded-For` header set.

## Release notes

Updates API logging to log the correct client IP address, as well as additional debugging information.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

n/a

#### New Features

n/a

### Issue(s) this completes

Fixes #4998
