### PR TITLE
Display correct client IP in API key view

### DIFF
--- a/server/app/auth/ApiAuthenticator.java
+++ b/server/app/auth/ApiAuthenticator.java
@@ -2,10 +2,6 @@ package auth;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
-import com.typesafe.config.Config;
 import java.time.Instant;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -53,12 +49,13 @@ public class ApiAuthenticator implements Authenticator {
 
   private static final Logger logger = LoggerFactory.getLogger(ApiAuthenticator.class);
   private final Provider<ApiKeyService> apiKeyService;
-  private final ClientIpType clientIpType;
+  private final ClientIpResolver clientIpResolver;
 
   @Inject
-  public ApiAuthenticator(Provider<ApiKeyService> apiKeyService, Config config) {
+  public ApiAuthenticator(
+      Provider<ApiKeyService> apiKeyService, ClientIpResolver clientIpResolver) {
     this.apiKeyService = checkNotNull(apiKeyService);
-    this.clientIpType = checkNotNull(config).getEnum(ClientIpType.class, "client_ip_type");
+    this.clientIpResolver = clientIpResolver;
   }
 
   /**
@@ -100,7 +97,7 @@ public class ApiAuthenticator implements Authenticator {
       throwUnauthorized(context, "API key is expired: " + keyId);
     }
 
-    String resolvedIp = resolveClientIp(context);
+    String resolvedIp = clientIpResolver.resolveClientIp(context);
     if (!isAllowedIp(apiKey, resolvedIp)) {
       throwUnauthorized(
           context,
@@ -125,31 +122,6 @@ public class ApiAuthenticator implements Authenticator {
         .anyMatch(allowedSubnet -> allowedSubnet.getInfo().isInRange(clientIp));
   }
 
-  @VisibleForTesting
-  String resolveClientIp(WebContext context) {
-    switch (clientIpType) {
-      case DIRECT:
-        return context.getRemoteAddr();
-      case FORWARDED:
-        String forwardedFor =
-            context
-                .getRequestHeader("X-Forwarded-For")
-                .orElseThrow(
-                    () ->
-                        new RuntimeException(
-                            "CLIENT_IP_TYPE is FORWARDED but no value found for X-Forwarded-For"
-                                + " header!"));
-        // AWS appends the original client IP to the end of the X-Forwarded-For
-        // header if it is present in the original request.
-        // See
-        // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
-        return Iterables.getLast(Splitter.on(",").split(forwardedFor)).strip();
-      default:
-        throw new IllegalStateException(
-            String.format("Unrecognized ClientIpType: %s", clientIpType));
-    }
-  }
-
   private void throwUnauthorized(WebContext context, String cause) {
     logger.warn(
         String.format(
@@ -158,7 +130,7 @@ public class ApiAuthenticator implements Authenticator {
             context.getPath(),
             context.getRemoteAddr(),
             context.getRequestHeader("X-Forwarded-For").orElse(""),
-            clientIpType.toString(),
+            clientIpResolver.getClientIpType().toString(),
             cause));
 
     throw new BadCredentialsException(cause);

--- a/server/app/auth/ClientIpResolver.java
+++ b/server/app/auth/ClientIpResolver.java
@@ -1,0 +1,83 @@
+package auth;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.typesafe.config.Config;
+import javax.inject.Inject;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.play.PlayWebContext;
+import play.mvc.Http;
+
+/**
+ * Resolves the client IP address from the provided request.
+ *
+ * <p>The value of the {@link ClientIpType} config variable is used to determine where to look for
+ * the client's IP address.
+ *
+ * <p>When CiviForm is behind a load balancer the client's IP address is not in the remoteAddress
+ * field of the request. To find the actual client IP we need to inspect the {@code X-Forwarded-For}
+ * header that's added by the load balancer. See MDN's <a
+ * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address">X-Forwarded-For
+ * docs</a> for more.
+ */
+public final class ClientIpResolver {
+  private final ClientIpType clientIpType;
+
+  @Inject
+  public ClientIpResolver(Config config) {
+    this.clientIpType = checkNotNull(config).getEnum(ClientIpType.class, "client_ip_type");
+  }
+
+  /**
+   * Gets the current {@link ClientIpType}
+   *
+   * @return the value of the {@link ClientIpType} config variable
+   */
+  public ClientIpType getClientIpType() {
+    return this.clientIpType;
+  }
+
+  /**
+   * Resolve the client's IP, using {@code X-Forwarded-For} if the {@link ClientIpType} is set to
+   * {@code FORWARDED}.
+   *
+   * @param request - the request to parse for the client IP address
+   * @see #resolveClientIp(WebContext)
+   */
+  public String resolveClientIp(Http.RequestHeader request) {
+    return resolveClientIp(new PlayWebContext(request));
+  }
+
+  /**
+   * Resolve the client's IP, using {@code X-Forwarded-For} if the {@link ClientIpType} is set to
+   * {@code FORWARDED}.
+   *
+   * @param context the WebContext for the request
+   * @return the resolved IP address for the client
+   */
+  public String resolveClientIp(WebContext context) {
+    switch (clientIpType) {
+      case DIRECT:
+        return context.getRemoteAddr();
+      case FORWARDED:
+        String forwardedFor =
+            context
+                .getRequestHeader("X-Forwarded-For")
+                .orElseThrow(
+                    () ->
+                        new RuntimeException(
+                            "CLIENT_IP_TYPE is FORWARDED but no value found for X-Forwarded-For"
+                                + " header!"));
+        // AWS appends the original client IP to the end of the X-Forwarded-For
+        // header if it is present in the original request.
+        // See
+        // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
+        return Iterables.getLast(Splitter.on(",").split(forwardedFor)).strip();
+      default:
+        throw new IllegalStateException(
+            String.format("Unrecognized ClientIpType: %s", clientIpType));
+    }
+  }
+}

--- a/server/app/filters/ApiKeyUsageFilter.java
+++ b/server/app/filters/ApiKeyUsageFilter.java
@@ -2,6 +2,7 @@ package filters;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.ClientIpResolver;
 import auth.ProfileUtils;
 import java.time.Duration;
 import java.util.Optional;
@@ -31,6 +32,7 @@ public class ApiKeyUsageFilter extends EssentialFilter {
   private final Provider<ApiKeyService> apiKeyServiceProvider;
   private final Executor exec;
   private final Provider<ProfileUtils> profileUtilsProvider;
+  private final ClientIpResolver clientIpResolver;
   private static final Logger LOGGER = LoggerFactory.getLogger(ApiKeyUsageFilter.class);
 
   @Inject
@@ -38,11 +40,13 @@ public class ApiKeyUsageFilter extends EssentialFilter {
       AkkaSchedulerProvider akkaSchedulerProvider,
       Provider<ApiKeyService> apiKeyServiceProvider,
       Executor exec,
-      Provider<ProfileUtils> profileUtilsProvider) {
+      Provider<ProfileUtils> profileUtilsProvider,
+      ClientIpResolver clientIpResolver) {
     this.akkaSchedulerProvider = checkNotNull(akkaSchedulerProvider);
     this.apiKeyServiceProvider = checkNotNull(apiKeyServiceProvider);
     this.exec = checkNotNull(exec);
     this.profileUtilsProvider = checkNotNull(profileUtilsProvider);
+    this.clientIpResolver = checkNotNull(clientIpResolver);
   }
 
   @Override
@@ -60,7 +64,7 @@ public class ApiKeyUsageFilter extends EssentialFilter {
                           // If the key ID is not present then the request was not
                           // authenticated and does not need to be recorded.
                           if (maybeApiKeyId.isPresent()) {
-                            String remoteAddress = request.remoteAddress();
+                            String remoteAddress = clientIpResolver.resolveClientIp(request);
 
                             akkaSchedulerProvider
                                 .get()

--- a/server/test/auth/ClientIpResolverTest.java
+++ b/server/test/auth/ClientIpResolverTest.java
@@ -1,0 +1,77 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+import org.pac4j.play.PlayWebContext;
+
+public class ClientIpResolverTest {
+  @Test
+  public void resolveClientIp_direct() {
+    var clientIpResolver =
+        new ClientIpResolver(ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "DIRECT")));
+
+    var request =
+        new FakeRequestBuilder()
+            .withRemoteAddress("4.4.4.4")
+            .withXForwardedFor("3.3.3.3, 2.2.2.2")
+            .build();
+
+    assertThat(clientIpResolver.resolveClientIp(new PlayWebContext(request))).isEqualTo("4.4.4.4");
+  }
+
+  @Test
+  public void resolveClientIp_forwarded() {
+    var clientIpResolver =
+        new ClientIpResolver(
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    var request = new FakeRequestBuilder().withXForwardedFor("3.3.3.3, 2.2.2.2").build();
+
+    assertThat(clientIpResolver.resolveClientIp(new PlayWebContext(request))).isEqualTo("2.2.2.2");
+  }
+
+  @Test
+  public void resolveClientIp_forwarded_no_header() {
+    var clientIpResolver =
+        new ClientIpResolver(
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    var request = new FakeRequestBuilder().withRemoteAddress("3.3.3.3").build();
+
+    assertThatThrownBy(() -> clientIpResolver.resolveClientIp(new PlayWebContext(request)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("CLIENT_IP_TYPE is FORWARDED but no value found for X-Forwarded-For header!");
+  }
+
+  @Test
+  public void resolveClientIp_overload() {
+    var clientIpResolver =
+        new ClientIpResolver(
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    var request = new FakeRequestBuilder().withXForwardedFor("3.3.3.3, 2.2.2.2").build();
+
+    assertThat(clientIpResolver.resolveClientIp(request)).isEqualTo("2.2.2.2");
+  }
+
+  @Test
+  public void getClientIpType_forwarded() {
+    var clientIpResolver =
+        new ClientIpResolver(
+            ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "FORWARDED")));
+
+    assertThat(clientIpResolver.getClientIpType()).isEqualTo(ClientIpType.FORWARDED);
+  }
+
+  @Test
+  public void getClientIpType_direct() {
+    var clientIpResolver =
+        new ClientIpResolver(ConfigFactory.parseMap(ImmutableMap.of("client_ip_type", "DIRECT")));
+
+    assertThat(clientIpResolver.getClientIpType()).isEqualTo(ClientIpType.DIRECT);
+  }
+}

--- a/server/test/auth/FakeRequestBuilder.java
+++ b/server/test/auth/FakeRequestBuilder.java
@@ -1,0 +1,42 @@
+package auth;
+
+import static play.test.Helpers.fakeRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import play.mvc.Http;
+
+public final class FakeRequestBuilder {
+  String remoteAddress = "1.1.1.1";
+  Optional<String> xForwardedFor = Optional.empty();
+  Optional<String> rawCredentials = Optional.empty();
+
+  public FakeRequestBuilder() {}
+
+  public FakeRequestBuilder withRemoteAddress(String remoteAddress) {
+    this.remoteAddress = remoteAddress;
+    return this;
+  }
+
+  public FakeRequestBuilder withXForwardedFor(String xForwardedFor) {
+    this.xForwardedFor = Optional.of(xForwardedFor);
+    return this;
+  }
+
+  public FakeRequestBuilder withRawCredentials(String rawCredentials) {
+    this.rawCredentials = Optional.of(rawCredentials);
+    return this;
+  }
+
+  public Http.Request build() {
+    Http.RequestBuilder fakeRequest = fakeRequest().remoteAddress(this.remoteAddress);
+    xForwardedFor.ifPresent(xForwardedFor -> fakeRequest.header("X-Forwarded-For", xForwardedFor));
+    rawCredentials
+        .map(
+            rawCreds ->
+                Base64.getEncoder().encodeToString(rawCreds.getBytes(StandardCharsets.UTF_8)))
+        .ifPresent(creds -> fakeRequest.header("Authorization", "Basic " + creds));
+    return fakeRequest.build();
+  }
+}

--- a/server/test/auth/FakeRequestBuilderTest.java
+++ b/server/test/auth/FakeRequestBuilderTest.java
@@ -1,0 +1,36 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.itextpdf.xmp.impl.Base64;
+import org.junit.Test;
+import play.mvc.Http;
+
+public class FakeRequestBuilderTest {
+  @Test
+  public void createsFakeRequest() {
+    String rawCreds = "raw creds";
+    String encodedCreds = Base64.encode(rawCreds);
+
+    Http.Request fakeRequest =
+        new FakeRequestBuilder()
+            .withRawCredentials(rawCreds)
+            .withRemoteAddress("3.3.3.3")
+            .withXForwardedFor("4.4.4.4, 5.5.5.5")
+            .build();
+
+    assertThat(fakeRequest.header("Authorization").get()).isEqualTo("Basic " + encodedCreds);
+    assertThat(fakeRequest.remoteAddress()).isEqualTo("3.3.3.3");
+    assertThat(fakeRequest.header("X-Forwarded-For").get()).isEqualTo("4.4.4.4, 5.5.5.5");
+  }
+
+  @Test
+  public void hasUsableDefaults() {
+    Http.Request fakeRequest = new FakeRequestBuilder().build();
+
+    assertThat(fakeRequest.header("Authorization")).isEmpty();
+    // Tests that don't care about the IP address assume a remote address of 1.1.1.1
+    assertThat(fakeRequest.remoteAddress()).isEqualTo("1.1.1.1");
+    assertThat(fakeRequest.header("X-Forwarded-For")).isEmpty();
+  }
+}


### PR DESCRIPTION
### Description

Displays correct client IP in admin API key view, based on setting for CLIENT_IP_TYPE

Also
- Refactors IP resolution logic into a `ClientIpResolver`
- Refactors FakeRequestBuilder into a separate class and adds tests for it

## Release notes

Use the CLIENT_IP_TYPE setting to decide which IP address to show in the "Last used by" line of the admin API key list view.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
- [x] Created tests which fail without the change (if possible)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #4794 
