### PR TITLE
Enable non-gating eligibility feature by default.

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -45,7 +45,7 @@ esri_address_service_area_validation_ids = ["Seattle"]
 esri_address_service_area_validation_attributes = ["CITYNAME"]
 
 intake_form_enabled = false
-nongated_eligibility_enabled = false
+nongated_eligibility_enabled = true
 
 phone_question_type_enabled = false
 

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -33,7 +33,7 @@ feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}
 # Common Intake Form flags
 intake_form_enabled = false
 intake_form_enabled = ${?INTAKE_FORM_ENABLED}
-nongated_eligibility_enabled = false
+nongated_eligibility_enabled = true
 nongated_eligibility_enabled = ${?NONGATED_ELIGIBILITY_ENABLED}
 
 #Phone question type enabling flag


### PR DESCRIPTION
### Description

Enable the non-gating eligibility feature flag by default. This does not set eligibility to non-gating, it just gives admins the ability to choose whether eligibility is gating or non-gating.

## Release notes

This feature gives admins the ability to choose whether eligibility is gating or non-gating. If eligibility is set to gating for a program, applicants will not be able to submit applications to that program unless they meet the eligibility requirements. If it's set to non-gating, applicants will not be blocked from submission, but their eligibility status will be visible to program admins when reviewing applications.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Part of #5036
