### PR TITLE
Fix hover shape for some buttons.

### DIFF
--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -439,7 +439,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     return toLinkButtonForPost(
             makeSvgTextButton("Publish ", Icons.PUBLISH)
                 .withId("publish-program-button")
-                .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN),
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON),
             linkDestination,
             request)
         .attr(

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -685,7 +685,8 @@ public final class QuestionsListView extends BaseHtmlView {
             .withClasses("p-6", "flex-row", "space-y-6");
 
     ButtonTag discardMenuButton =
-        makeSvgTextButton("Discard Draft", Icons.DELETE).withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
+        makeSvgTextButton("Discard Draft", Icons.DELETE)
+            .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
 
     Modal modal =
         Modal.builder()

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -593,7 +593,7 @@ public final class QuestionsListView extends BaseHtmlView {
     ButtonTag button =
         asRedirectElement(
             makeSvgTextButton("Manage Translations", Icons.TRANSLATE)
-                .withClasses(ButtonStyles.CLEAR_WITH_ICON),
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN),
             link);
     return Optional.of(button);
   }
@@ -685,7 +685,7 @@ public final class QuestionsListView extends BaseHtmlView {
             .withClasses("p-6", "flex-row", "space-y-6");
 
     ButtonTag discardMenuButton =
-        makeSvgTextButton("Discard Draft", Icons.DELETE).withClasses(ButtonStyles.CLEAR_WITH_ICON);
+        makeSvgTextButton("Discard Draft", Icons.DELETE).withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
 
     Modal modal =
         Modal.builder()
@@ -710,7 +710,7 @@ public final class QuestionsListView extends BaseHtmlView {
         ButtonTag unarchiveButton =
             toLinkButtonForPost(
                 makeSvgTextButton("Restore Archived", Icons.UNARCHIVE)
-                    .withClasses(ButtonStyles.CLEAR_WITH_ICON),
+                    .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN),
                 restoreLink,
                 request);
         return Pair.of(unarchiveButton, Optional.empty());
@@ -720,7 +720,7 @@ public final class QuestionsListView extends BaseHtmlView {
         ButtonTag archiveButton =
             toLinkButtonForPost(
                 makeSvgTextButton("Archive", Icons.ARCHIVE)
-                    .withClasses(ButtonStyles.CLEAR_WITH_ICON),
+                    .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN),
                 archiveLink,
                 request);
         return Pair.of(archiveButton, Optional.empty());
@@ -743,7 +743,7 @@ public final class QuestionsListView extends BaseHtmlView {
                 definition.getName(), referencingPrograms, Optional.of(modalHeader));
         ButtonTag cantArchiveButton =
             makeSvgTextButton("Archive", Icons.ARCHIVE)
-                .withClasses(ButtonStyles.CLEAR_WITH_ICON)
+                .withClasses(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN)
                 .withId(maybeModal.get().getTriggerButtonId());
 
         return Pair.of(cantArchiveButton, maybeModal);


### PR DESCRIPTION
### Description

Fix the shape of the gray background when hovering over some buttons
- The shape on hover for the publish button should be an oval like the edit button.
- The shape on hover for the dropdown buttons in the Questions page should be a rectangle.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

### Issue(s) this completes

Fixes #4881
