### PR TITLE
Fix for SELECT_TI Visibility Browser tests failures

### DIFF
--- a/browser-test/src/admin_program_visibility.test.ts
+++ b/browser-test/src/admin_program_visibility.test.ts
@@ -125,7 +125,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await adminTiGroups.addGroupMember('groupOne@bar.com')
     await adminTiGroups.gotoAdminTIPage()
     await adminTiGroups.editGroup('groupTwo')
-    // GroupTwo will have the TestUser as the TI, so it will be visible to this TI only
+    // Add the TEST_USER_DISPLAY_NAME user to GroupTwo, which is the user that gets logged into upon calling loginAsTestUser()
     await adminTiGroups.addGroupMember(TEST_USER_DISPLAY_NAME)
     await logout(page)
 
@@ -199,7 +199,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await adminTiGroups.addGroupMember('groupOne@bar.com')
     await adminTiGroups.gotoAdminTIPage()
     await adminTiGroups.editGroup('groupTwo')
-    // GroupTwo will have the TestUser as the TI, so it will be visible to this TI only
+    // Add the TEST_USER_DISPLAY_NAME user to GroupTwo, which is the user that gets logged into upon calling loginAsTestUser()
     await adminTiGroups.addGroupMember(TEST_USER_DISPLAY_NAME)
     await logout(page)
 

--- a/browser-test/src/admin_program_visibility.test.ts
+++ b/browser-test/src/admin_program_visibility.test.ts
@@ -9,6 +9,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from './support'
+import {TEST_USER_DISPLAY_NAME} from './support/config'
 import {ProgramVisibility} from './support/admin_programs'
 
 describe('Validate program visibility is correct for applicants and TIs', () => {
@@ -125,7 +126,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await adminTiGroups.gotoAdminTIPage()
     await adminTiGroups.editGroup('groupTwo')
     // GroupTwo will have the TestUser as the TI, so it will be visible to this TI only
-    await adminTiGroups.addGroupMember('testuser@example.com')
+    await adminTiGroups.addGroupMember(TEST_USER_DISPLAY_NAME)
     await logout(page)
 
     await loginAsAdmin(page)
@@ -199,7 +200,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await adminTiGroups.gotoAdminTIPage()
     await adminTiGroups.editGroup('groupTwo')
     // GroupTwo will have the TestUser as the TI, so it will be visible to this TI only
-    await adminTiGroups.addGroupMember('testuser@example.com')
+    await adminTiGroups.addGroupMember(TEST_USER_DISPLAY_NAME)
     await logout(page)
 
     await loginAsAdmin(page)


### PR DESCRIPTION
### Description

Fix for SELECT_TI Visibility Browser tests failures.

### Bug details
Previously to create a logged in TI experience, the TI Client's email 'testuser@example.com' was hard coded in the browser tests which ended up breaking the test runs in staging environments. Ideally it should be pulled from the environment variables (part of  Github secrets). This fix, instead of having a hard-coded value, will use the export value from config, so that the browser test runs for all environment pass successfully. 


Fixes #5050 
