### PR TITLE
Revert "Fix issue that allowed applicants to access draft programs."

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -153,20 +153,6 @@ public final class ProgramRepository {
     }
   }
 
-  /** Get the current active program with the provided id. */
-  public CompletableFuture<Program> getActiveProgram(Long id) {
-    return supplyAsync(
-        () -> {
-          ImmutableList<Program> activePrograms =
-              versionRepository.get().getActiveVersion().getPrograms();
-          return activePrograms.stream()
-              .filter(p -> p.id.equals(id))
-              .findFirst()
-              .orElseThrow(() -> new RuntimeException(new ProgramNotFoundException(id)));
-        },
-        executionContext.current());
-  }
-
   /** Get the current active program with the provided slug. */
   public CompletableFuture<Program> getForSlug(String slug) {
     return supplyAsync(

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -1,14 +1,12 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.*;
 import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
-import java.util.concurrent.CompletionException;
 import models.Applicant;
 import models.Program;
 import org.junit.Before;
@@ -17,14 +15,13 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.Path;
 import services.applicant.question.Scalar;
-import services.program.ProgramNotFoundException;
 import support.ProgramBuilder;
 
 public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
   private ApplicantProgramReviewController subject;
   private ApplicantProgramBlocksController blockController;
-  private Program activeProgram;
+  private Program draftProgram;
   public Applicant applicant;
 
   @Before
@@ -33,8 +30,8 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
     subject = instanceOf(ApplicantProgramReviewController.class);
     blockController = instanceOf(ApplicantProgramBlocksController.class);
-    activeProgram =
-        ProgramBuilder.newActiveProgram()
+    draftProgram =
+        ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
@@ -44,29 +41,27 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   @Test
   public void review_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
-    Result result = this.review(badApplicantId, activeProgram.id);
+    Result result = this.review(badApplicantId, draftProgram.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void review_toAProgramThatDoesNotExist_returns404() {
-    long badProgramId = activeProgram.id + 1000;
-    assertThatThrownBy(() -> this.review(applicant.id, badProgramId))
-        .isInstanceOf(CompletionException.class)
-        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
-        .hasMessageContaining("Program not found for ID");
+    long badProgramId = draftProgram.id + 1000;
+    Result result = this.review(applicant.id, badProgramId);
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test
   public void review_rendersSummaryView() {
-    Result result = this.review(applicant.id, activeProgram.id);
+    Result result = this.review(applicant.id, draftProgram.id);
     assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test
   public void submit_invalid_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
-    Result result = this.submit(badApplicantId, activeProgram.id);
+    Result result = this.submit(badApplicantId, draftProgram.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -1,7 +1,6 @@
 package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -10,7 +9,6 @@ import io.ebean.DB;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -148,25 +146,6 @@ public class ProgramRepositoryTest extends ResetPostgres {
     Program found = repo.getForSlug("something-with-a-name").toCompletableFuture().join();
 
     assertThat(found).isEqualTo(program);
-  }
-
-  @Test
-  public void getActiveProgram_findsCorrectProgram() {
-    Program program = resourceCreator.insertActiveProgram("Something With A Name");
-
-    Program found = repo.getActiveProgram(program.id).toCompletableFuture().join();
-
-    assertThat(found).isEqualTo(program);
-  }
-
-  @Test
-  public void getActiveProgram_doesNotFindDraftProgram() {
-    Program program = resourceCreator.insertDraftProgram("Something With A Name");
-
-    assertThatThrownBy(() -> repo.getActiveProgram(program.id).toCompletableFuture().join())
-        .isInstanceOf(CompletionException.class)
-        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
-        .hasMessageContaining("Program not found for ID");
   }
 
   @Test

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -394,7 +394,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_forEnumeratorBlock_withEmptyUpdates_doesNotDeleteRealData() {
     programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc")
+        ProgramBuilder.newDraftProgram("test program", "desc")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
             .buildDefinition();
@@ -660,7 +660,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     .join());
 
     assertThat(thrown).isInstanceOf(CompletionException.class);
-    assertThat(thrown).hasRootCauseInstanceOf(ProgramNotFoundException.class);
+    assertThat(thrown).hasCauseInstanceOf(ProgramNotFoundException.class);
   }
 
   @Test
@@ -829,14 +829,14 @@ public class ApplicantServiceTest extends ResetPostgres {
             .getResult();
 
     Program firstProgram =
-        ProgramBuilder.newActiveProgram("first test program", "desc")
+        ProgramBuilder.newDraftProgram("first test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(fileUploadQuestion))
             .build();
     firstProgram.save();
 
     Program secondProgram =
-        ProgramBuilder.newActiveProgram("second test program", "desc")
+        ProgramBuilder.newDraftProgram("second test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(fileUploadQuestion))
             .build();
@@ -1397,7 +1397,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc")
+        ProgramBuilder.newDraftProgram("test program", "desc")
             .withBlock()
             .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
             .withEligibilityDefinition(eligibilityDef)
@@ -1453,7 +1453,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc")
+        ProgramBuilder.newDraftProgram("test program", "desc")
             .withBlock()
             .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
             .withEligibilityDefinition(eligibilityDef)
@@ -1669,12 +1669,11 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
-    // programDefinition is the program created during test set up.
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
+        .containsExactly(programForUnapplied.id);
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.allPrograms())
@@ -1682,8 +1681,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.commonIntakeForm().get(),
             result.inProgress().get(0),
             result.submitted().get(0),
-            result.unapplied().get(0),
-            result.unapplied().get(1));
+            result.unapplied().get(0));
   }
 
   @Test
@@ -1729,17 +1727,14 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
+        .containsExactly(programForUnapplied.id);
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty());
     assertThat(result.commonIntakeForm().isPresent()).isFalse();
     assertThat(result.allPrograms())
         .containsExactlyInAnyOrder(
-            result.inProgress().get(0),
-            result.submitted().get(0),
-            result.unapplied().get(0),
-            result.unapplied().get(1));
+            result.inProgress().get(0), result.submitted().get(0), result.unapplied().get(0));
   }
 
   @Test
@@ -1759,8 +1754,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1778,8 +1772,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1799,8 +1792,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted()).isEmpty();
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
     assertThat(result.commonIntakeForm().isPresent()).isTrue();
     assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
@@ -1820,13 +1812,12 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withEligibilityDefinition(eligibilityDef)
             .build();
     Program programForSubmitted =
-        ProgramBuilder.newDraftProgram("program_for_submitted")
+        ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
     Program programForUnapplied =
-        ProgramBuilder.newDraftProgram("program_for_unapplied").withBlock().build();
-    versionRepository.publishNewSynchronizedVersion();
+        ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
 
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraft.id)
@@ -1859,12 +1850,12 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
+        .containsExactly(programForUnapplied.id);
     assertThat(result.unapplied().stream().map(ApplicantProgramData::isProgramMaybeEligible))
-        .containsExactly(Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty());
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty());
   }
 
   @Test
@@ -1878,17 +1869,20 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withEligibilityDefinition(eligibilityDef)
             .build();
     Program programForSubmitted =
-        ProgramBuilder.newDraftProgram("program_for_submitted")
+        ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
     Program programForUnapplied =
-        ProgramBuilder.newDraftProgram("program_for_unapplied")
+        ProgramBuilder.newActiveProgram("program_for_unapplied")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(questionDefinition))
             .withEligibilityDefinition(eligibilityDef)
             .build();
-    versionRepository.publishNewSynchronizedVersion();
+
+    Question q = new Question(questionDefinition);
+    q.refresh();
+    versionRepository.getActiveVersion().addQuestion(q).save();
 
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraft.id)
@@ -1921,12 +1915,12 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty());
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(programForUnapplied.id, programDefinition.id());
+        .containsExactly(programForUnapplied.id);
     assertThat(result.unapplied().stream().map(ApplicantProgramData::isProgramMaybeEligible))
-        .containsExactlyInAnyOrder(Optional.of(true), Optional.empty());
+        .containsExactly(Optional.of(true));
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty());
   }
 
   @Test
@@ -1965,13 +1959,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(
-            programForDraft.id,
-            programForUnapplied.id,
-            programForSubmitted.id,
-            programDefinition.id());
+            programForDraft.id, programForUnapplied.id, programForSubmitted.id);
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
-        .containsExactly(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        .containsExactly(Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   @Test
@@ -2182,6 +2173,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(tiResult.unapplied().stream().map(p -> p.program().id()))
         .containsExactly(
             programDefinition.id(), updatedProgramForDraftApp.id, updatedProgramForSubmittedApp.id);
+    // assertThat(tiResult.submitted()).
   }
 
   @Test
@@ -2315,8 +2307,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationTime))
         .containsExactly(Optional.of(secondAppSubmitTime));
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
   }
 
   @Test
@@ -2395,6 +2386,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.inProgress().stream().map(p -> p.program().id()))
         .containsExactly(firstDraft.getProgram().id);
     // As part of test setup, a "test program" is initialized.
+    // When calling publish, this will become active. This provides
+    // confidence that the draft version created above is actually published.
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactly(programDefinition.id());
   }
@@ -2429,8 +2422,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.of(APPROVED_STATUS));
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
   }
 
   @Test
@@ -2484,8 +2476,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.submitted().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.of(APPROVED_STATUS));
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programDefinition.id());
+    assertThat(result.unapplied()).isEmpty();
   }
 
   @Test
@@ -2510,43 +2501,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(eligibleQuestion)
             .build();
-
-    // Set up program for draft application.
-    Program programForDraftApp =
-        ProgramBuilder.newDraftProgram("program_for_draft_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
-
-    // Set up program for submitted application.
-    Program programForSubmittedApp =
-        ProgramBuilder.newDraftProgram("program_for_submitted_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
-
-    // Set up unapplied program.
-    Program programForUnappliedApp =
-        ProgramBuilder.newDraftProgram("program_for_unapplied_app")
-            .withBlock()
-            .withRequiredQuestionDefinition(eligibleQuestion)
-            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
-            .withBlock()
-            .withRequiredQuestionDefinition(unansweredQuestion)
-            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
-            .build();
-
-    versionRepository.publishNewSynchronizedVersion();
-
-    // Answer questions.
     answerNameQuestion(
         eligibleQuestion,
         "Taylor",
@@ -2560,18 +2514,49 @@ public class ApplicantServiceTest extends ResetPostgres {
         applicant.id,
         programForAnsweringQuestions.id);
 
-    // Start a draft application.
+    // Set up draft program and answer question
+    Program programForDraftApp =
+        ProgramBuilder.newDraftProgram("program_for_draft_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, programForDraftApp.id)
         .toCompletableFuture()
         .join();
 
-    // Submit an application.
+    // Set up submitted program
+    Program programForSubmittedApp =
+        ProgramBuilder.newDraftProgram("program_for_submitted_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
     applicationRepository
         .submitApplication(applicant.id, programForSubmittedApp.id, Optional.empty())
         .toCompletableFuture()
         .join();
 
+    // Set up unapplied program
+    Program programForUnappliedApp =
+        ProgramBuilder.newDraftProgram("program_for_unapplied_app")
+            .withBlock()
+            .withRequiredQuestionDefinition(eligibleQuestion)
+            .withEligibilityDefinition(eligibleQuestionEligibilityDefinition)
+            .withBlock()
+            .withRequiredQuestionDefinition(unansweredQuestion)
+            .withEligibilityDefinition(unansweredQuestionEligibilityDefinition)
+            .build();
+
+    // Publish version and fetch results
+    versionRepository.publishNewSynchronizedVersion();
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2612,7 +2597,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinition(ineligibleQuestion)
             .withEligibilityDefinition(ineligibleQuestionEligibilityDefinition)
             .build();
-    versionRepository.publishNewSynchronizedVersion();
 
     // Fill out application
     answerNameQuestion(
@@ -2643,7 +2627,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2667,7 +2651,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
-    System.out.println("reemax setting up pqs");
     // Set up program and questions
     NameQuestionDefinition eligibleQuestion =
         createNameQuestion("question_with_matching_eligibility");
@@ -2697,9 +2680,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinition(ineligibleQuestion)
             .withEligibilityDefinition(ineligibleQuestionEligibilityDefinition)
             .build();
-    programWithEligibleAndIneligibleAnswers.save();
-    versionRepository.publishNewSynchronizedVersion();
-    System.out.println("published 1");
 
     // Fill out application
     answerNameQuestion(
@@ -2714,7 +2694,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .id(),
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
-    System.out.println("answered 1");
     answerNameQuestion(
         ineligibleQuestion,
         "Solána",
@@ -2728,18 +2707,14 @@ public class ApplicantServiceTest extends ResetPostgres {
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
 
-    System.out.println("answered 2");
-
     applicationRepository
         .submitApplication(
             applicant.id, programWithEligibleAndIneligibleAnswers.id, Optional.empty())
         .toCompletableFuture()
         .join();
-    System.out.println("submitted ");
 
     // Publish version and fetch results
     versionRepository.publishNewSynchronizedVersion();
-    System.out.println("publish2");
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2776,7 +2751,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .build();
-    versionRepository.publishNewSynchronizedVersion();
 
     answerNameQuestion(
         question,
@@ -2790,7 +2764,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2821,7 +2795,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .build();
-    versionRepository.publishNewSynchronizedVersion();
 
     answerNameQuestion(
         question,
@@ -2839,7 +2812,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2877,7 +2850,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, ProgramBuilder.newActiveProgram("throwaway").build().id)
+        .createOrUpdateDraft(applicant.id, ProgramBuilder.newDraftProgram("throwaway").build().id)
         .toCompletableFuture()
         .join();
 
@@ -2959,7 +2932,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.copyOf(questions))
             .buildDefinition();
-    versionRepository.publishNewSynchronizedVersion();
   }
 
   private void createProgramWithStatusDefinitions(StatusDefinitions statuses) {
@@ -2969,7 +2941,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(questionDefinition))
             .buildDefinition();
-    versionRepository.publishNewSynchronizedVersion();
   }
 
   private void createProgramWithOptionalQuestion(QuestionDefinition question) {
@@ -2978,7 +2949,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withBlock()
             .withOptionalQuestion(question)
             .buildDefinition();
-    versionRepository.publishNewSynchronizedVersion();
   }
 
   /**
@@ -3029,7 +2999,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc")
+        ProgramBuilder.newDraftProgram("test program", "desc")
             .withBlock()
             .withRequiredQuestionDefinitions(ImmutableList.of(question))
             .withEligibilityDefinition(eligibilityDef)
@@ -3066,7 +3036,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .withRequiredQuestionDefinitions(ImmutableList.of(question))
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
-    versionRepository.publishNewSynchronizedVersion();
   }
 
   private Messages getMessages(Locale locale) {

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -993,8 +993,8 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getActiveProgramDefinitionAsync_getsRequestedProgram() {
-    ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
+  public void getProgramDefinitionAsync_getsRequestedProgram() {
+    ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
         ps.getActiveProgramDefinitionAsync(programDefinition.id());
@@ -1004,36 +1004,23 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getActiveProgramDefinitionAsync_doesNotGetDraftProgram() {
+  public void getProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
-
-    CompletionStage<ProgramDefinition> found =
-        ps.getActiveProgramDefinitionAsync(programDefinition.id());
-
-    assertThatThrownBy(() -> found.toCompletableFuture().join())
-        .isInstanceOf(CompletionException.class)
-        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
-        .hasMessageContaining("Program not found for ID");
-  }
-
-  @Test
-  public void getActiveProgramDefinitionAsync_cannotFindRequestedProgram_throwsException() {
-    ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
         ps.getActiveProgramDefinitionAsync(programDefinition.id() + 1);
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
-        .hasRootCauseInstanceOf(ProgramNotFoundException.class)
+        .hasCauseInstanceOf(ProgramNotFoundException.class)
         .hasMessageContaining("Program not found for ID");
   }
 
   @Test
-  public void getActiveProgramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
+  public void getProgramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
     QuestionDefinition question = nameQuestion;
     ProgramDefinition program =
-        ProgramBuilder.newActiveProgram()
+        ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .buildDefinition();


### PR DESCRIPTION
Reverts civiform/civiform#5007. I realized that this breaks the case where an applicant has an in-progress application, a new version is published, and then the applicant tries to continue their application which is tied to the now-obsolete program. Reverting before the next release to avoid breaking applicant flows while I work on a fix.