### PR TITLE
Adding additional environment variable checks for idcs client_id/secret

### DIFF
--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -33,7 +33,9 @@ applicant_portal_name = ${?APPLICANT_PORTAL_NAME}
 
 ## IDCS integration
 # IDCS secrets must be provided by environment variables - we cannot check them in.
+idcs.client_id = ${?APPLICANT_OIDC_CLIENT_ID}
 idcs.client_id = ${?IDCS_CLIENT_ID}
+idcs.secret = ${?APPLICANT_OIDC_CLIENT_SECRET}
 idcs.secret = ${?IDCS_SECRET}
 idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
 idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}


### PR DESCRIPTION
### Description
Adding additional environment variable checks for idcs client_id/secret using the common ones we use elsewhere. If empty it will fall back to the existing environment variable.


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

