### PR TITLE
Correct single/multi select `QuestionType`s

### DIFF
--- a/server/app/services/applicant/question/MultiSelectQuestion.java
+++ b/server/app/services/applicant/question/MultiSelectQuestion.java
@@ -33,7 +33,7 @@ public final class MultiSelectQuestion extends Question {
 
   @Override
   protected ImmutableSet<QuestionType> validQuestionTypes() {
-    return ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+    return ImmutableSet.of(QuestionType.CHECKBOX);
   }
 
   @Override

--- a/server/app/services/applicant/question/SingleSelectQuestion.java
+++ b/server/app/services/applicant/question/SingleSelectQuestion.java
@@ -30,7 +30,7 @@ public final class SingleSelectQuestion extends Question {
 
   @Override
   protected ImmutableSet<QuestionType> validQuestionTypes() {
-    return ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+    return ImmutableSet.of(QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
   }
 
   @Override


### PR DESCRIPTION
### Description

The only MultiSelectQuestion type is a checkbox, and the SingleSelectQuestion types are radio button and dropdown. However, these aren't currently reflected in the `ImmutableSet<QuestionType> validQuestionTypes()` implementations of `Question`:

https://github.com/civiform/civiform/blob/7ce5f689d8f1f1b9d99717c9d448750dfa4b38b8/server/app/services/applicant/question/MultiSelectQuestion.java#L34-L37

https://github.com/civiform/civiform/blob/7ce5f689d8f1f1b9d99717c9d448750dfa4b38b8/server/app/services/applicant/question/SingleSelectQuestion.java#L31-L34

This PR fixes that. Notably the only use of `validQuestionTypes()` is here:

https://github.com/civiform/civiform/blob/7ce5f689d8f1f1b9d99717c9d448750dfa4b38b8/server/app/services/applicant/question/Question.java#L27-L40

## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created tests which fail without the change (if possible)
   - No, but tested creation of checkbox, radio, and dropdown questions in local dev environment
- [ ] Extended the README / documentation, if necessary
   - Not necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

None.