### PR TITLE
Activate python venv when running settings manifest generator

### DIFF
--- a/bin/generate-settings-manifest
+++ b/bin/generate-settings-manifest
@@ -4,6 +4,16 @@
 
 source bin/lib.sh
 
+if ! python::env_var_docs_venv_is_installed; then
+  echo "env var docs venv not found, creating..."
+  bin/env-var-docs-create-venv
+fi
+
+if ! python::env_var_docs_venv_is_active; then
+  echo "env var docs venv not activated, activating (this command only)..."
+  source env-var-docs/venv/bin/activate
+fi
+
 ENV_VAR_DOCS_PATH=server/conf/env-var-docs.json \
   python3 env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
 

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -21,6 +21,7 @@ if [[ "${SOURCED_LIB}" != "true" ]]; then
   source "${LIB_DIR}/truth.sh"
   source "${LIB_DIR}/docker.sh"
   source "${LIB_DIR}/emulators.sh"
+  source "${LIB_DIR}/python.sh"
 
   SOURCED_LIB="true"
 fi

--- a/bin/lib/python.sh
+++ b/bin/lib/python.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+#######################################
+# Checks if the var-env-docs venv is active
+#######################################
+function python::env_var_docs_venv_is_active() {
+  [[ "$(which python3)" =~ "env-var-docs/venv/bin/python3" ]]
+}
+
+#######################################
+# Checks if the var-env-docs venv exists
+#######################################
+function python::env_var_docs_venv_is_installed() {
+  [[ -d env-var-docs/venv ]]
+}


### PR DESCRIPTION
### Description

This reduces developer toil by creating and activating the var-env-docs [python venv](https://docs.python.org/3/library/venv.html) when `bin/generate-settings-manifest` is invoked so that developers don't have to manually run the creation and activation scripts when they use `bin/fmt`.