### PR TITLE
Stop non-CiviForm Admin users from applying to draft programs.

### DIFF
--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -6,6 +6,7 @@ import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import play.mvc.Controller;
 import play.mvc.Http;
+import repository.VersionRepository;
 import services.CiviFormError;
 
 /**
@@ -38,5 +39,20 @@ public class CiviFormController extends Controller {
         .currentUserProfile(request)
         .orElseThrow()
         .checkProgramAuthorization(programName, request);
+  }
+
+  /** Checks that the profile is authorized to access draft programs. */
+  protected CompletableFuture<Void> checkProgramAuthorization(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
+      Http.Request request,
+      Long programId) {
+    return CompletableFuture.runAsync(
+        () -> {
+          if (versionRepository.isDraftProgram(programId)
+              && !profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+            throw new SecurityException();
+          }
+        });
   }
 }

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -41,7 +41,7 @@ public class CiviFormController extends Controller {
         .checkProgramAuthorization(programName, request);
   }
 
-  /** Checks that the profile is authorized to access draft programs. */
+  /** Checks that the profile is authorized to access the specified program. */
   protected CompletableFuture<Void> checkProgramAuthorization(
       ProfileUtils profileUtils,
       VersionRepository versionRepository,

--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -17,6 +17,7 @@ import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.StoredFileRepository;
+import repository.VersionRepository;
 import services.cloud.StorageClient;
 
 /** Controller for handling methods for admins and applicants accessing uploaded files. */
@@ -24,23 +25,23 @@ public class FileController extends CiviFormController {
   private final HttpExecutionContext httpExecutionContext;
   private final StorageClient storageClient;
   private final StoredFileRepository storedFileRepository;
-  private final ProfileUtils profileUtils;
 
   @Inject
   public FileController(
       HttpExecutionContext httpExecutionContext,
       StoredFileRepository storedFileRepository,
       StorageClient storageClient,
-      ProfileUtils profileUtils) {
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
     this.storageClient = checkNotNull(storageClient);
     this.storedFileRepository = checkNotNull(storedFileRepository);
-    this.profileUtils = checkNotNull(profileUtils);
   }
 
   @Secure
   public CompletionStage<Result> show(Request request, long applicantId, String fileKey) {
-    return checkApplicantAuthorization(profileUtils, request, applicantId)
+    return checkApplicantAuthorization(request, applicantId)
         .thenApplyAsync(
             v -> {
               // Ensure the file being accessed indeed belongs to the applicant.

--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -13,6 +13,7 @@ import play.data.DynamicForm;
 import play.data.FormFactory;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.PageNumberBasedPaginationSpec;
 import services.apikey.ApiKeyCreationResult;
 import services.apikey.ApiKeyService;
@@ -30,7 +31,6 @@ public class AdminApiKeysController extends CiviFormController {
   private final ApiKeyCredentialsView apiKeyCredentialsView;
   private final ProgramService programService;
   private final FormFactory formFactory;
-  private final ProfileUtils profileUtils;
 
   @Inject
   public AdminApiKeysController(
@@ -40,14 +40,15 @@ public class AdminApiKeysController extends CiviFormController {
       ApiKeyCredentialsView apiKeyCredentialsView,
       ProgramService programService,
       FormFactory formFactory,
-      ProfileUtils profileUtils) {
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.apiKeyService = checkNotNull(apiKeyService);
     this.indexView = checkNotNull(indexView);
     this.newOneView = checkNotNull(newOneView);
     this.apiKeyCredentialsView = checkNotNull(apiKeyCredentialsView);
     this.programService = checkNotNull(programService);
     this.formFactory = checkNotNull(formFactory);
-    this.profileUtils = checkNotNull(profileUtils);
   }
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -34,6 +34,7 @@ import play.mvc.Http;
 import play.mvc.Result;
 import repository.SubmittedApplicationFilter;
 import repository.TimeFilter;
+import repository.VersionRepository;
 import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
 import services.PageNumberBasedPaginationSpec;
@@ -75,7 +76,6 @@ public final class AdminApplicationController extends CiviFormController {
   private final FormFactory formFactory;
   private final JsonExporter jsonExporter;
   private final PdfExporter pdfExporter;
-  private final ProfileUtils profileUtils;
   private final Provider<LocalDateTime> nowProvider;
   private final MessagesApi messagesApi;
   private final DateConverter dateConverter;
@@ -94,11 +94,12 @@ public final class AdminApplicationController extends CiviFormController {
       ProfileUtils profileUtils,
       MessagesApi messagesApi,
       DateConverter dateConverter,
-      @Now Provider<LocalDateTime> nowProvider) {
+      @Now Provider<LocalDateTime> nowProvider,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
     this.applicantService = checkNotNull(applicantService);
     this.applicationListView = checkNotNull(applicationListView);
-    this.profileUtils = checkNotNull(profileUtils);
     this.applicationView = checkNotNull(applicationView);
     this.programAdminApplicationService = checkNotNull(programAdminApplicationService);
     this.nowProvider = checkNotNull(nowProvider);
@@ -125,7 +126,7 @@ public final class AdminApplicationController extends CiviFormController {
 
     try {
       program = programService.getProgramDefinition(programId);
-      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
@@ -183,7 +184,7 @@ public final class AdminApplicationController extends CiviFormController {
                 .build();
       }
       ProgramDefinition program = programService.getProgramDefinition(programId);
-      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      checkProgramAdminAuthorization(request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
       String csv = exporterService.getProgramAllVersionsCsv(programId, filters);
       return ok(csv)
@@ -204,7 +205,7 @@ public final class AdminApplicationController extends CiviFormController {
       throws ProgramNotFoundException {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
-      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      checkProgramAdminAuthorization(request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
       String csv = exporterService.getProgramCsv(programId);
       return ok(csv)
@@ -260,7 +261,7 @@ public final class AdminApplicationController extends CiviFormController {
       throws ProgramNotFoundException {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     try {
-      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
@@ -292,7 +293,7 @@ public final class AdminApplicationController extends CiviFormController {
     String programName = program.adminName();
 
     try {
-      checkProgramAdminAuthorization(profileUtils, request, programName).join();
+      checkProgramAdminAuthorization(request, programName).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
@@ -347,7 +348,7 @@ public final class AdminApplicationController extends CiviFormController {
     String programName = program.adminName();
 
     try {
-      checkProgramAdminAuthorization(profileUtils, request, programName).join();
+      checkProgramAdminAuthorization(request, programName).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
@@ -425,7 +426,7 @@ public final class AdminApplicationController extends CiviFormController {
     String programName = program.adminName();
 
     try {
-      checkProgramAdminAuthorization(profileUtils, request, programName).join();
+      checkProgramAdminAuthorization(request, programName).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }
@@ -496,7 +497,7 @@ public final class AdminApplicationController extends CiviFormController {
     final ProgramDefinition program;
     try {
       program = programService.getProgramDefinition(programId);
-      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
     }

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -3,6 +3,7 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -13,6 +14,7 @@ import play.data.DynamicForm;
 import play.data.FormFactory;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.EligibilityNotValidForProgramTypeException;
@@ -52,7 +54,10 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       ProgramPredicatesEditViewV2 predicatesEditViewV2,
       ProgramPredicateConfigureView predicatesConfigureView,
       FormFactory formFactory,
-      RequestChecker requestChecker) {
+      RequestChecker requestChecker,
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.predicateGenerator = checkNotNull(predicateGenerator);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);

--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -6,6 +6,7 @@ import static views.ViewUtils.ProgramDisplayType.DRAFT;
 import static views.components.ToastMessage.ToastType.ERROR;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import controllers.CiviFormController;
 import forms.BlockForm;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.program.BlockDefinition;
@@ -48,7 +50,10 @@ public final class AdminProgramBlocksController extends CiviFormController {
       QuestionService questionService,
       ProgramBlocksView.Factory programBlockViewFactory,
       FormFactory formFactory,
-      RequestChecker requestChecker) {
+      RequestChecker requestChecker,
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
     this.editView = checkNotNull(programBlockViewFactory.create(DRAFT));

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -46,8 +46,6 @@ public final class AdminProgramController extends CiviFormController {
   private final ProgramMetaDataEditView editView;
   private final ProgramSettingsEditView programSettingsEditView;
   private final FormFactory formFactory;
-  private final VersionRepository versionRepository;
-  private final ProfileUtils profileUtils;
   private final RequestChecker requestChecker;
   private final SettingsManifest settingsManifest;
 
@@ -64,14 +62,13 @@ public final class AdminProgramController extends CiviFormController {
       FormFactory formFactory,
       RequestChecker requestChecker,
       SettingsManifest settingsManifest) {
+    super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
     this.listView = checkNotNull(listView);
     this.newOneView = checkNotNull(newOneView);
     this.editView = checkNotNull(editView);
     this.programSettingsEditView = checkNotNull(programSettingsEditView);
-    this.versionRepository = checkNotNull(versionRepository);
-    this.profileUtils = checkNotNull(profileUtils);
     this.formFactory = checkNotNull(formFactory);
     this.requestChecker = checkNotNull(requestChecker);
     this.settingsManifest = settingsManifest;

--- a/server/app/controllers/admin/AdminProgramStatusesController.java
+++ b/server/app/controllers/admin/AdminProgramStatusesController.java
@@ -3,6 +3,7 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import com.google.inject.Inject;
 import controllers.CiviFormController;
 import forms.admin.ProgramStatusesForm;
@@ -13,6 +14,7 @@ import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
@@ -39,7 +41,10 @@ public final class AdminProgramStatusesController extends CiviFormController {
       ProgramService service,
       ProgramStatusesView statusesView,
       RequestChecker requestChecker,
-      FormFactory formFactory) {
+      FormFactory formFactory,
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.service = checkNotNull(service);
     this.statusesView = checkNotNull(statusesView);
     this.requestChecker = checkNotNull(requestChecker);

--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static views.components.ToastMessage.ToastType.ERROR;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import controllers.CiviFormController;
 import forms.translation.ProgramTranslationForm;
 import java.util.Locale;
@@ -13,6 +14,7 @@ import org.pac4j.play.java.Secure;
 import play.data.FormFactory;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
@@ -35,10 +37,13 @@ public class AdminProgramTranslationsController extends CiviFormController {
 
   @Inject
   public AdminProgramTranslationsController(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
       ProgramService service,
       ProgramTranslationView translationView,
       FormFactory formFactory,
       TranslationLocales translationLocales) {
+    super(profileUtils, versionRepository);
     this.service = checkNotNull(service);
     this.translationView = checkNotNull(translationView);
     this.formFactory = checkNotNull(formFactory);

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static views.components.ToastMessage.ToastType.ERROR;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
@@ -22,6 +23,7 @@ import play.data.FormFactory;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
@@ -51,11 +53,14 @@ public final class AdminQuestionController extends CiviFormController {
 
   @Inject
   public AdminQuestionController(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
       QuestionService service,
       QuestionsListView listView,
       QuestionEditView editView,
       FormFactory formFactory,
       HttpExecutionContext httpExecutionContext) {
+    super(profileUtils, versionRepository);
     this.service = checkNotNull(service);
     this.listView = checkNotNull(listView);
     this.editView = checkNotNull(editView);

--- a/server/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/server/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static views.components.ToastMessage.ToastType.ERROR;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import controllers.CiviFormController;
 import forms.translation.EnumeratorQuestionTranslationForm;
 import forms.translation.MultiOptionQuestionTranslationForm;
@@ -18,6 +19,7 @@ import play.data.FormFactory;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.TranslationLocales;
@@ -42,11 +44,14 @@ public class AdminQuestionTranslationsController extends CiviFormController {
 
   @Inject
   public AdminQuestionTranslationsController(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
       HttpExecutionContext httpExecutionContext,
       QuestionService questionService,
       QuestionTranslationView translationView,
       FormFactory formFactory,
       TranslationLocales translationLocales) {
+    super(profileUtils, versionRepository);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
     this.questionService = checkNotNull(questionService);
     this.translationView = checkNotNull(translationView);

--- a/server/app/controllers/admin/AdminReportingController.java
+++ b/server/app/controllers/admin/AdminReportingController.java
@@ -12,6 +12,7 @@ import javax.inject.Provider;
 import org.pac4j.play.java.Secure;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.program.ProgramService;
 import services.reporting.ReportingService;
 import views.admin.reporting.AdminReportingIndexView;
@@ -22,7 +23,6 @@ public final class AdminReportingController extends CiviFormController {
 
   private final Provider<AdminReportingIndexView> adminReportingIndexView;
   private final Provider<AdminReportingShowView> adminReportingShowView;
-  private final ProfileUtils profileUtils;
   private final ProgramService programService;
   private final ReportingService reportingService;
 
@@ -32,10 +32,11 @@ public final class AdminReportingController extends CiviFormController {
       Provider<AdminReportingShowView> adminReportingShowView,
       ProfileUtils profileUtils,
       ProgramService programService,
+      VersionRepository versionRepository,
       ReportingService reportingService) {
+    super(profileUtils, versionRepository);
     this.adminReportingIndexView = Preconditions.checkNotNull(adminReportingIndexView);
     this.adminReportingShowView = Preconditions.checkNotNull(adminReportingShowView);
-    this.profileUtils = Preconditions.checkNotNull(profileUtils);
     this.programService = Preconditions.checkNotNull(programService);
     this.reportingService = Preconditions.checkNotNull(reportingService);
   }

--- a/server/app/controllers/admin/AdminSettingsController.java
+++ b/server/app/controllers/admin/AdminSettingsController.java
@@ -3,10 +3,12 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import controllers.CiviFormController;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.mvc.Result;
+import repository.VersionRepository;
 import views.admin.settings.AdminSettingsIndexView;
 
 /** Provides access to application settings to the CiviForm Admin role. */
@@ -15,7 +17,11 @@ public class AdminSettingsController extends CiviFormController {
   private final AdminSettingsIndexView indexView;
 
   @Inject
-  public AdminSettingsController(AdminSettingsIndexView indexView) {
+  public AdminSettingsController(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
+      AdminSettingsIndexView indexView) {
+    super(profileUtils, versionRepository);
     this.indexView = checkNotNull(indexView);
   }
 

--- a/server/app/controllers/admin/ProgramAdminController.java
+++ b/server/app/controllers/admin/ProgramAdminController.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramService;
 import views.admin.programs.ProgramAdministratorProgramListView;
@@ -19,16 +20,16 @@ import views.admin.programs.ProgramAdministratorProgramListView;
 public class ProgramAdminController extends CiviFormController {
   private final ProgramAdministratorProgramListView listView;
   private final ProgramService programService;
-  private final ProfileUtils profileUtils;
 
   @Inject
   public ProgramAdminController(
       ProgramAdministratorProgramListView listView,
       ProgramService programService,
-      ProfileUtils profileUtils) {
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.listView = Preconditions.checkNotNull(listView);
     this.programService = Preconditions.checkNotNull(programService);
-    this.profileUtils = Preconditions.checkNotNull(profileUtils);
   }
 
   /** Return a HTML page showing all programs the program admin administers. */

--- a/server/app/controllers/api/CiviFormApiController.java
+++ b/server/app/controllers/api/CiviFormApiController.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 import models.ApiKey;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 
 /**
  * Base class for controllers that handle API requests. Requests that reach an API controller have
@@ -24,13 +25,14 @@ import play.mvc.Result;
 public class CiviFormApiController extends CiviFormController {
 
   protected final ApiPaginationTokenSerializer apiPaginationTokenSerializer;
-  protected final ProfileUtils profileUtils;
 
   @Inject
   public CiviFormApiController(
-      ApiPaginationTokenSerializer apiPaginationTokenSerializer, ProfileUtils profileUtils) {
+      ApiPaginationTokenSerializer apiPaginationTokenSerializer,
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.apiPaginationTokenSerializer = checkNotNull(apiPaginationTokenSerializer);
-    this.profileUtils = checkNotNull(profileUtils);
   }
 
   /**

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -21,6 +21,7 @@ import play.mvc.Http;
 import play.mvc.Result;
 import repository.SubmittedApplicationFilter;
 import repository.TimeFilter;
+import repository.VersionRepository;
 import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
 import services.PaginationResult;
@@ -48,8 +49,9 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
       JsonExporter jsonExporter,
       HttpExecutionContext httpContext,
       ProgramService programService,
+      VersionRepository versionRepository,
       Config config) {
-    super(apiPaginationTokenSerializer, profileUtils);
+    super(apiPaginationTokenSerializer, profileUtils, versionRepository);
     this.dateConverter = checkNotNull(dateConverter);
     this.httpContext = checkNotNull(httpContext);
     this.jsonExporter = checkNotNull(jsonExporter);

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -23,6 +23,7 @@ import play.mvc.Http.Session;
 import play.mvc.Result;
 import play.mvc.Results;
 import repository.UserRepository;
+import repository.VersionRepository;
 import services.applicant.ApplicantData;
 import services.applicant.exception.ApplicantNotFoundException;
 import views.applicant.ApplicantLayout;
@@ -37,7 +38,6 @@ public final class ApplicantInformationController extends CiviFormController {
   private final MessagesApi messagesApi;
   private final UserRepository repository;
   private final FormFactory formFactory;
-  private final ProfileUtils profileUtils;
   private final ApplicantLayout layout;
 
   @Inject
@@ -47,12 +47,13 @@ public final class ApplicantInformationController extends CiviFormController {
       UserRepository repository,
       FormFactory formFactory,
       ProfileUtils profileUtils,
-      ApplicantLayout layout) {
+      ApplicantLayout layout,
+      VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.httpExecutionContext = httpExecutionContext;
     this.messagesApi = messagesApi;
     this.repository = repository;
     this.formFactory = formFactory;
-    this.profileUtils = profileUtils;
     this.layout = layout;
   }
 
@@ -63,7 +64,7 @@ public final class ApplicantInformationController extends CiviFormController {
   @Secure
   public CompletionStage<Result> setLangFromBrowser(Http.Request request, long applicantId) {
 
-    return checkApplicantAuthorization(profileUtils, request, applicantId)
+    return checkApplicantAuthorization(request, applicantId)
         .thenComposeAsync(
             v -> repository.lookupApplicant(applicantId), httpExecutionContext.current())
         .thenComposeAsync(
@@ -137,7 +138,7 @@ public final class ApplicantInformationController extends CiviFormController {
       session = request.session().removing(REDIRECT_TO_SESSION_KEY);
     }
 
-    return checkApplicantAuthorization(profileUtils, request, applicantId)
+    return checkApplicantAuthorization(request, applicantId)
         .thenComposeAsync(
             v -> repository.lookupApplicant(applicantId), httpExecutionContext.current())
         .thenComposeAsync(

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -16,6 +16,7 @@ import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.applicant.ApplicantPersonalInfo;
 import services.applicant.ApplicantService;
 import services.applicant.ApplicantService.ApplicantProgramData;
@@ -39,6 +40,7 @@ public final class ApplicantProgramsController extends CiviFormController {
   private final ProgramIndexView programIndexView;
   private final ApplicantProgramInfoView programInfoView;
   private final ProfileUtils profileUtils;
+  private final VersionRepository versionRepository;
 
   @Inject
   public ApplicantProgramsController(
@@ -47,13 +49,15 @@ public final class ApplicantProgramsController extends CiviFormController {
       MessagesApi messagesApi,
       ProgramIndexView programIndexView,
       ApplicantProgramInfoView programInfoView,
-      ProfileUtils profileUtils) {
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository) {
     this.httpContext = checkNotNull(httpContext);
     this.applicantService = checkNotNull(applicantService);
     this.messagesApi = checkNotNull(messagesApi);
     this.programIndexView = checkNotNull(programIndexView);
     this.programInfoView = checkNotNull(programInfoView);
     this.profileUtils = checkNotNull(profileUtils);
+    this.versionRepository = checkNotNull(versionRepository);
   }
 
   @Secure
@@ -139,6 +143,8 @@ public final class ApplicantProgramsController extends CiviFormController {
 
     // Determine first incomplete block, then redirect to other edit.
     return checkApplicantAuthorization(profileUtils, request, applicantId)
+        .thenComposeAsync(
+            v -> checkProgramAuthorization(profileUtils, versionRepository, request, programId))
         .thenComposeAsync(
             v -> applicantService.getReadOnlyApplicantProgramService(applicantId, programId))
         .thenApplyAsync(

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -24,6 +24,7 @@ import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.applicant.ApplicantPersonalInfo;
 import services.applicant.ApplicantService;
 import services.applicant.ApplicantService.ApplicantProgramData;
@@ -44,7 +45,6 @@ public final class RedirectController extends CiviFormController {
 
   private final HttpExecutionContext httpContext;
   private final ApplicantService applicantService;
-  private final ProfileUtils profileUtils;
   private final ProgramService programService;
   private final ApplicantUpsellCreateAccountView upsellView;
   private final ApplicantCommonIntakeUpsellCreateAccountView cifUpsellView;
@@ -60,10 +60,11 @@ public final class RedirectController extends CiviFormController {
       ApplicantUpsellCreateAccountView upsellView,
       ApplicantCommonIntakeUpsellCreateAccountView cifUpsellView,
       MessagesApi messagesApi,
+      VersionRepository versionRepository,
       LanguageUtils languageUtils) {
+    super(profileUtils, versionRepository);
     this.httpContext = checkNotNull(httpContext);
     this.applicantService = checkNotNull(applicantService);
-    this.profileUtils = checkNotNull(profileUtils);
     this.programService = checkNotNull(programService);
     this.upsellView = checkNotNull(upsellView);
     this.cifUpsellView = checkNotNull(cifUpsellView);
@@ -177,8 +178,7 @@ public final class RedirectController extends CiviFormController {
     CompletableFuture<Account> account =
         applicantPersonalInfo
             .thenComposeAsync(
-                v -> checkApplicantAuthorization(profileUtils, request, applicantId),
-                httpContext.current())
+                v -> checkApplicantAuthorization(request, applicantId), httpContext.current())
             .thenComposeAsync(v -> profile.get().getAccount(), httpContext.current())
             .toCompletableFuture();
 
@@ -198,8 +198,7 @@ public final class RedirectController extends CiviFormController {
               }
 
               return applicantPersonalInfo
-                  .thenComposeAsync(
-                      v -> checkApplicantAuthorization(profileUtils, request, applicantId))
+                  .thenComposeAsync(v -> checkApplicantAuthorization(request, applicantId))
                   .thenComposeAsync(
                       // we are already checking if profile is empty
                       v ->

--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -2,6 +2,7 @@ package controllers.monitoring;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.ProfileUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
 import controllers.CiviFormController;
@@ -15,6 +16,7 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import javax.inject.Inject;
 import play.mvc.Result;
+import repository.VersionRepository;
 
 /**
  * Controller for exporting Prometheus server metrics via HTTP. Based on the implementation found in
@@ -40,7 +42,9 @@ public final class MetricsController extends CiviFormController {
   private static final int SUBSTRING_INDEX = 4;
 
   @Inject
-  public MetricsController(Config config) {
+  public MetricsController(
+      Config config, ProfileUtils profileUtils, VersionRepository versionRepository) {
+    super(profileUtils, versionRepository);
     this.collectorRegistry = checkNotNull(CollectorRegistry.defaultRegistry);
     this.metricsEnabled = checkNotNull(config).getBoolean("civiform_server_metrics_enabled");
     this.database = DB.getDefault();

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -2,7 +2,6 @@ package repository;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.function.Predicate.not;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -22,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.persistence.NonUniqueResultException;

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -403,10 +403,6 @@ public final class VersionRepository {
         .anyMatch(draftProgram -> draftProgram.id.equals(programId));
   }
 
-  public CompletionStage<Boolean> isDraftProgramAsync(Long programId) {
-    return supplyAsync(() -> isDraftProgram(programId));
-  }
-
   /** Returns true if the program with the provided id is a member of the current active version. */
   public boolean isActiveProgram(Long programId) {
     return getActiveVersion().getPrograms().stream()

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -2,6 +2,7 @@ package repository;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.function.Predicate.not;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.persistence.NonUniqueResultException;
@@ -399,6 +401,10 @@ public final class VersionRepository {
   public boolean isDraftProgram(Long programId) {
     return getDraftVersion().getPrograms().stream()
         .anyMatch(draftProgram -> draftProgram.id.equals(programId));
+  }
+
+  public CompletionStage<Boolean> isDraftProgramAsync(Long programId) {
+    return supplyAsync(() -> isDraftProgram(programId));
   }
 
   /** Returns true if the program with the provided id is a member of the current active version. */

--- a/server/test/controllers/RedirectControllerTest.java
+++ b/server/test/controllers/RedirectControllerTest.java
@@ -140,6 +140,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             instanceOf(ApplicantUpsellCreateAccountView.class),
             instanceOf(ApplicantCommonIntakeUpsellCreateAccountView.class),
             instanceOf(MessagesApi.class),
+            instanceOf(VersionRepository.class),
             languageUtils);
     Result result =
         controller
@@ -171,6 +172,7 @@ public class RedirectControllerTest extends WithMockedProfiles {
             instanceOf(ApplicantUpsellCreateAccountView.class),
             instanceOf(ApplicantCommonIntakeUpsellCreateAccountView.class),
             instanceOf(MessagesApi.class),
+            instanceOf(VersionRepository.class),
             languageUtils);
     Result result =
         controller

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -120,14 +120,16 @@ public class WithMockedProfiles {
   }
 
   protected Account createGlobalAdminWithMockedProfile() {
-    Account globalAdmin = resourceCreator.insertAccount();
-
-    globalAdmin.setGlobalAdmin(true);
-    globalAdmin.save();
-
-    CiviFormProfile profile = profileFactory.wrap(globalAdmin);
+    CiviFormProfile profile = profileFactory.wrapProfileData(profileFactory.createNewAdmin());
     mockProfile(profile);
-    return globalAdmin;
+
+    Account adminAccount = profile.getAccount().join();
+
+    Applicant applicant = resourceCreator.insertApplicant();
+    applicant.setAccount(adminAccount);
+    applicant.save();
+
+    return adminAccount;
   }
 
   private void mockProfile(CiviFormProfile profile) {

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -43,6 +43,7 @@ import play.mvc.Result;
 import play.test.Helpers;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.VersionRepository;
 import services.DateConverter;
 import services.LocalizedStrings;
 import services.applicant.ApplicantService;
@@ -602,7 +603,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         profileUtilsNoOpTester,
         instanceOf(MessagesApi.class),
         instanceOf(DateConverter.class),
-        Providers.of(LocalDateTime.now(ZoneId.systemDefault())));
+        Providers.of(LocalDateTime.now(ZoneId.systemDefault())),
+        instanceOf(VersionRepository.class));
   }
 
   // A test version of ProfileUtils that disable functionality that is hard

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import models.Account;
 import models.Applicant;
 import models.Program;
 import models.StoredFile;
@@ -61,6 +62,61 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         subject.edit(request, badApplicantId, program.id, "1").toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void edit_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.edit(applicant.id, program.id, "1")))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void edit_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    applicant = adminAccount.newestApplicant().orElseThrow();
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.edit(applicant.id, program.id, "1")))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void edit_obsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.edit(applicant.id, program.id, "1")))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, obsoleteProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test
@@ -136,6 +192,64 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void previous_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.previous(
+                        applicant.id, program.id, 0, true)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void previous_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    applicant = adminAccount.newestApplicant().orElseThrow();
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.previous(
+                        applicant.id, program.id, 0, true)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void previous_obsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.previous(
+                        applicant.id, program.id, 0, true)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, obsoleteProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
   public void update_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
     Request request =
@@ -152,6 +266,64 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .join();
 
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void update_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.update(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void update_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    applicant = adminAccount.newestApplicant().orElseThrow();
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.update(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void update_obsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.update(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, obsoleteProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test
@@ -398,6 +570,64 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .join();
 
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void updateFile_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.updateFile(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void updateFile_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    applicant = adminAccount.newestApplicant().orElseThrow();
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.updateFile(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, draftProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void updateFile_obsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
+
+    Request request =
+        addCSRFToken(
+                fakeRequest(
+                    routes.ApplicantProgramBlocksController.updateFile(
+                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+            .build();
+    Result result =
+        subject.edit(request, applicant.id, obsoleteProgram.id, "1").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -113,7 +113,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   @Test
   public void submit_civiformAdminAccessToDraftProgram_isOk() {
     Account adminAccount = createGlobalAdminWithMockedProfile();
-    long adminApplicantId = adminAccount.newestApplicant().orElseThrow().id;
+    applicant = adminAccount.newestApplicant().orElseThrow();
 
     ProgramBuilder.newActiveProgram("test program", "desc")
         .withBlock()
@@ -126,7 +126,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .buildDefinition();
     answer(draftProgramDefinition.id());
 
-    Result result = this.submit(adminApplicantId, draftProgramDefinition.id());
+    Result result = this.submit(applicant.id, draftProgramDefinition.id());
     assertThat(result.status()).isEqualTo(FOUND);
   }
 

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -7,14 +7,17 @@ import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
+import models.Account;
 import models.Applicant;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import repository.VersionRepository;
 import services.Path;
 import services.applicant.question.Scalar;
+import services.program.ProgramDefinition;
 import support.ProgramBuilder;
 
 public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
@@ -46,6 +49,37 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void review_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+    Result result = this.review(applicant.id, draftProgram.id);
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void review_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    applicant = adminAccount.newestApplicant().orElseThrow();
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+    Result result = this.review(applicant.id, draftProgram.id);
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void review_obsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
+    Result result = this.review(applicant.id, obsoleteProgram.id);
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
   public void review_toAProgramThatDoesNotExist_returns404() {
     long badProgramId = activeProgram.id + 1000;
     Result result = this.review(applicant.id, badProgramId);
@@ -63,6 +97,54 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     long badApplicantId = applicant.id + 1000;
     Result result = this.submit(badApplicantId, activeProgram.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void submit_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+    Result result = this.submit(applicant.id, draftProgram.id);
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void submit_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    long adminApplicantId = adminAccount.newestApplicant().orElseThrow().id;
+
+    ProgramBuilder.newActiveProgram("test program", "desc")
+        .withBlock()
+        .withRequiredQuestion(testQuestionBank().applicantName())
+        .buildDefinition();
+    ProgramDefinition draftProgramDefinition =
+        ProgramBuilder.newDraftProgram("test program")
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .buildDefinition();
+    answer(draftProgramDefinition.id());
+
+    Result result = this.submit(adminApplicantId, draftProgramDefinition.id());
+    assertThat(result.status()).isEqualTo(FOUND);
+  }
+
+  @Test
+  public void submit_obsoleteProgram_isOk() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test program", "desc")
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .buildDefinition();
+    resourceCreator().insertDraftProgram(programDefinition.adminName());
+    VersionRepository versionRepository = instanceOf(VersionRepository.class);
+    versionRepository.publishNewSynchronizedVersion();
+
+    answer(programDefinition.id());
+
+    Result result = this.submit(applicant.id, programDefinition.id());
+    assertThat(result.status()).isEqualTo(FOUND);
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -5,6 +5,7 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.OK;
+import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
@@ -14,6 +15,7 @@ import controllers.WithMockedProfiles;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import models.Account;
 import models.Applicant;
 import models.Application;
 import models.LifecycleStage;
@@ -200,6 +202,28 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void edit_applicantAccessToDraftProgram_returnsUnauthorized() {
+    Program draftProgram = ProgramBuilder.newDraftProgram().build();
+    Request request = addCSRFToken(fakeRequest()).build();
+    Result result =
+        controller.edit(request, currentApplicant.id, draftProgram.id).toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void edit_civiformAdminAccessToDraftProgram_isOk() {
+    Account adminAccount = createGlobalAdminWithMockedProfile();
+    long adminApplicantId = adminAccount.newestApplicant().orElseThrow().id;
+    Program draftProgram = ProgramBuilder.newDraftProgram().build();
+    Request request = addCSRFToken(fakeRequest()).build();
+    Result result =
+        controller.edit(request, adminApplicantId, draftProgram.id).toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+  }
+
+  @Test
   public void edit_invalidProgram_returnsBadRequest() {
     Result result =
         controller
@@ -208,6 +232,19 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             .join();
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
+  }
+
+  @Test
+  public void edit_applicantAccessToObsoleteProgram_isOk() {
+    Program obsoleteProgram = ProgramBuilder.newObsoleteProgram("name").build();
+    Request request = addCSRFToken(fakeRequest()).build();
+    Result result =
+        controller
+            .edit(request, currentApplicant.id, obsoleteProgram.id)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test

--- a/server/test/controllers/monitoring/MetricsControllerTest.java
+++ b/server/test/controllers/monitoring/MetricsControllerTest.java
@@ -3,6 +3,7 @@ package controllers.monitoring;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.contentAsString;
 
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -34,7 +35,9 @@ public class MetricsControllerTest extends WithMockedProfiles {
             ImmutableMap.<String, String>builder()
                 .put("civiform_server_metrics_enabled", "true")
                 .build());
-    MetricsController controllerWithMetricsEnabled = new MetricsController(config);
+    MetricsController controllerWithMetricsEnabled =
+        new MetricsController(
+            config, instanceOf(ProfileUtils.class), instanceOf(VersionRepository.class));
 
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
@@ -68,7 +71,9 @@ public class MetricsControllerTest extends WithMockedProfiles {
             ImmutableMap.<String, String>builder()
                 .put("civiform_server_metrics_enabled", "false")
                 .build());
-    MetricsController controllerWithoutMetricsEnabled = new MetricsController(config);
+    MetricsController controllerWithoutMetricsEnabled =
+        new MetricsController(
+            config, instanceOf(ProfileUtils.class), instanceOf(VersionRepository.class));
     assertThat(controllerWithoutMetricsEnabled.getMetrics().status()).isEqualTo(404);
   }
 


### PR DESCRIPTION
### Description

Check that the user is a CiviForm Admin before allowing access to a draft program's application pages.

This is a bug fix but is also set-up work for #240.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created tests which fail without the change (if possible)