### PR TITLE
Update fmt prettier check to include Markdown

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -39,11 +39,11 @@ function get_modified_java_files() {
   ) | grep -E ".+\.java$"
 }
 
-function get_modified_ts_and_json_files() {
+function get_modified_ts_json_and_md_files() {
   (
     get_tracked_modified_files
     get_untracked_files
-  ) | grep -E ".+\.(ts|json)$"
+  ) | grep -E ".+\.(ts|json|md)$"
 }
 
 function get_modified_python_files() {
@@ -61,8 +61,9 @@ else
   echo 'Done formatting java'
 fi
 
-if [[ -z $(get_modified_ts_and_json_files) ]]; then
-  echo 'No modified TypeScript or JSON files found'
+modified_ts_json_md=$(get_modified_ts_json_and_md_files)
+if [[ -z $modified_ts_json_md ]]; then
+  echo 'No modified TypeScript, JSON or Markdown files found'
 else
   echo 'Start formatting with prettier'
   # prettier is installed as node module in `formatter` directory
@@ -72,7 +73,7 @@ else
     --config ../.prettierrc.js \
     --ignore-path ../.prettierignore \
     --ignore-unknown \
-    ../
+    $(printf "../%s " ${modified_ts_json_md[@]})
   cd ..
   echo 'Done formatting with prettier'
 

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -63,7 +63,7 @@ fi
 
 modified_ts_json_md="$(get_modified_ts_json_and_md_files)"
 if [[ -z "${modified_ts_json_md}" ]]; then
-  echo 'No modified TypeScript, JSON or Markdown files found'
+  echo 'No modified TypeScript, JSON, or Markdown files found'
 else
   echo 'Start formatting with prettier'
   # prettier is installed as node module in `formatter` directory

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -62,7 +62,7 @@ else
 fi
 
 modified_ts_json_md=$(get_modified_ts_json_and_md_files)
-if [[ -z $modified_ts_json_md ]]; then
+if [[ -z "${modified_ts_json_md}" ]]; then
   echo 'No modified TypeScript, JSON or Markdown files found'
 else
   echo 'Start formatting with prettier'

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -61,7 +61,7 @@ else
   echo 'Done formatting java'
 fi
 
-modified_ts_json_md=$(get_modified_ts_json_and_md_files)
+modified_ts_json_md="$(get_modified_ts_json_and_md_files)"
 if [[ -z "${modified_ts_json_md}" ]]; then
   echo 'No modified TypeScript, JSON or Markdown files found'
 else

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -69,7 +69,7 @@ else
   # prettier is installed as node module in `formatter` directory
   cd formatter
 
-  # Prefix each file with ../ and remove newlines. The newlines prevent printf from 
+  # Prefix each file with ../ and remove newlines. The newlines prevent printf from
   # prefixi each line itself which is why this sed command is needed.
   prettier_file_list="$(printf "%s" "${modified_ts_json_md}" | sed 's/^/ ..\//' | tr -d '\n')"
 

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -58,6 +58,12 @@ if [[ -z $(get_modified_java_files) ]]; then
 else
   echo 'Start format java'
   java -jar /fmt.jar --replace $(get_modified_java_files)
+
+  if [[ $? != 0 ]]; then
+    printf "Java formatter failed. Tried formatting these files: %s" "$(get_modified_java_files)"
+    exit 1
+  fi
+
   echo 'Done formatting java'
 fi
 
@@ -82,6 +88,12 @@ else
     --ignore-path ../.prettierignore \
     --ignore-unknown \
     -- $(printf "%s" "${prettier_file_list[@]}")
+
+  if [[ $? != 0 ]]; then
+    printf "Prettier failed. Tried formatting these files: %s" "${prettier_file_list[@]}"
+    exit 1
+  fi
+
   cd ..
   echo 'Done formatting with prettier'
 

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -75,15 +75,15 @@ else
   # prefix each line itself which is why this sed command is needed.
   prettier_file_list="$(printf "%s" "${modified_ts_json_md}" | sed 's/^/ ..\//' | tr -d '\n')"
 
-  # The subshell printf statement should not be surrounded by quotes, in this case
+  # The prettier_file_list array should not be surrounded by quotes, in this case
   # we want work splitting to occur so prettier will operate in each file. If
-  # quotes it gets treated as a single path.
+  # quoted it gets treated as a single path.
   npx prettier \
     --write \
     --config ../.prettierrc.js \
     --ignore-path ../.prettierignore \
     --ignore-unknown \
-    -- $(printf "%s" "${prettier_file_list[@]}")
+    -- ${prettier_file_list[@]}
 
   cd ..
   echo 'Done formatting with prettier'

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -43,7 +43,7 @@ function get_modified_ts_json_and_md_files() {
   (
     get_tracked_modified_files
     get_untracked_files
-  ) | grep -E ".+\.(ts|json|md)$"
+  ) | grep -E ".+\.(ts|json|md)$" || true
 }
 
 function get_modified_python_files() {
@@ -58,12 +58,6 @@ if [[ -z $(get_modified_java_files) ]]; then
 else
   echo 'Start format java'
   java -jar /fmt.jar --replace $(get_modified_java_files)
-
-  if [[ $? != 0 ]]; then
-    printf "Java formatter failed. Tried formatting these files: %s" "$(get_modified_java_files)"
-    exit 1
-  fi
-
   echo 'Done formatting java'
 fi
 
@@ -88,11 +82,6 @@ else
     --ignore-path ../.prettierignore \
     --ignore-unknown \
     -- $(printf "%s" "${prettier_file_list[@]}")
-
-  if [[ $? != 0 ]]; then
-    printf "Prettier failed. Tried formatting these files: %s" "${prettier_file_list[@]}"
-    exit 1
-  fi
 
   cd ..
   echo 'Done formatting with prettier'

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -72,11 +72,11 @@ else
   cd formatter
 
   # Prefix each file with ../ and remove newlines. The newlines prevent printf from
-  # prefix each line itself which is why this sed command is needed.
+  # prefixing each line itself which is why this sed command is needed.
   prettier_file_list="$(printf "%s" "${modified_ts_json_md}" | sed 's/^/ ..\//' | tr -d '\n')"
 
   # The prettier_file_list array should not be surrounded by quotes, in this case
-  # we want work splitting to occur so prettier will operate in each file. If
+  # we want word splitting to occur so prettier will operate in each file. If
   # quoted it gets treated as a single path.
   npx prettier \
     --write \

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -68,12 +68,20 @@ else
   echo 'Start formatting with prettier'
   # prettier is installed as node module in `formatter` directory
   cd formatter
+
+  # Prefix each file with ../ and remove newlines. The newlines prevent printf from 
+  # prefixi each line itself which is why this sed command is needed.
+  prettier_file_list="$(printf "%s" "${modified_ts_json_md}" | sed 's/^/ ..\//' | tr -d '\n')"
+
+  # The subshell printf statement should not be surrounded by quotes, in this case
+  # we want work splitting to occur so prettier will operate in each file. If
+  # quotes it gets treated as a single path.
   npx prettier \
     --write \
     --config ../.prettierrc.js \
     --ignore-path ../.prettierignore \
     --ignore-unknown \
-    $(printf "../%s " ${modified_ts_json_md[@]})
+    -- $(printf "%s" "${prettier_file_list[@]}")
   cd ..
   echo 'Done formatting with prettier'
 

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -40,6 +40,8 @@ function get_modified_java_files() {
 }
 
 function get_modified_ts_json_and_md_files() {
+  # Zero matches in grep returns a 1, but we want to treat as empty which is
+  # why the `|| true` is there
   (
     get_tracked_modified_files
     get_untracked_files

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -72,7 +72,7 @@ else
   cd formatter
 
   # Prefix each file with ../ and remove newlines. The newlines prevent printf from
-  # prefixi each line itself which is why this sed command is needed.
+  # prefix each line itself which is why this sed command is needed.
   prettier_file_list="$(printf "%s" "${modified_ts_json_md}" | sed 's/^/ ..\//' | tr -d '\n')"
 
   # The subshell printf statement should not be surrounded by quotes, in this case


### PR DESCRIPTION
This updates the prettier check in bin/fmt to include Markdown files in addition to TS and JSON. Additionally, it optimizes the call to prettier to only operate on changed and untracked files, speeding it up a bit.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >