### PR TITLE
Add eligibility status to questions on PDF export

### DIFF
--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -62,7 +62,6 @@ public final class PdfExporter {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", application.getApplicantData().getApplicantName(), application.id);
     String filename = String.format("%s-%s.pdf", applicantNameWithApplicationId, nowProvider.get());
-
     byte[] bytes =
         buildPDF(
             answers,

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -135,15 +135,14 @@ public final class PdfExporter {
           try {
             Optional<EligibilityDefinition> eligibilityDef =
                 programDefinition.getBlockDefinition(answerData.blockId()).eligibilityDefinition();
-            if (eligibilityDef.isPresent()
-                && eligibilityDef
-                    .map(
-                        definition ->
-                            definition
-                                .predicate()
-                                .getQuestions()
-                                .contains(answerData.questionDefinition().getId()))
-                    .orElse(false)) {
+            if (eligibilityDef
+                .map(
+                    definition ->
+                        definition
+                            .predicate()
+                            .getQuestions()
+                            .contains(answerData.questionDefinition().getId()))
+                .orElse(false)) {
 
               String eligibilityText =
                   answerData.isEligible() ? "Meets eligibility" : "Doesn't meet eligibility";

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -104,7 +104,6 @@ public class PdfExporterTest extends AbstractExporterTest {
     String programName = applicationFive.getProgram().getProgramDefinition().adminName();
     assertThat(linesFromPDF.get(0)).isEqualTo(applicantNameWithApplicationId);
     assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
-    System.out.println(linesFromPDF);
     List<String> linesFromStaticString = Splitter.on("\n").splitToList(APPLICATION_FIVE_STRING);
 
     for (int i = 3; i < linesFromPDF.size(); i++) {
@@ -142,6 +141,28 @@ public class PdfExporterTest extends AbstractExporterTest {
     for (int i = 3; i < linesFromPDF.size(); i++) {
       assertThat(linesFromPDF.get(i)).isEqualTo(linesFromStaticString.get(i));
     }
+  }
+
+  @Test
+  public void validatePDFExport_eligibility() throws IOException, DocumentException {
+    createFakeProgramWithEligibilityPredicate();
+
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String applicantNameWithApplicationId =
+        String.format(
+            "%s (%d)", applicationTwo.getApplicantData().getApplicantName(), applicationTwo.id);
+    PdfExporter.InMemoryPdf result = exporter.export(applicationTwo);
+    PdfReader pdfReader = new PdfReader(result.getByteArray());
+    StringBuilder textFromPDF = new StringBuilder();
+    textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
+    pdfReader.close();
+    assertThat(textFromPDF).isNotNull();
+    List<String> linesFromPDF = Splitter.on('\n').splitToList(textFromPDF.toString());
+    String programName = applicationTwo.getProgram().getProgramDefinition().adminName();
+    assertThat(linesFromPDF.get(0)).isEqualTo(applicantNameWithApplicationId);
+    assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
+    assertThat(textFromPDF).contains("Meets eligibility");
   }
 
   public static final String APPLICATION_SIX_STRING =


### PR DESCRIPTION
### Description

Add eligibility status to questions on PDF export when eligibility conditions are applied to the program and question.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #4455
