### PR TITLE
Introduce `QuestionDefinitionConfig` for `QuestionDefinition` storage

### DIFF
--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -256,11 +256,16 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new EnumeratorQuestionDefinition(
-                "enumerator",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("List all members of your household."),
-                LocalizedStrings.withDefaultValue("help text"),
+                QuestionDefinitionConfig.builder()
+                    .setName("enumerator")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue("List all members of your household."))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                    .build(),
                 LocalizedStrings.withDefaultValue("household member")))
         .getResult();
   }

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -365,11 +365,18 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new TextQuestionDefinition(
-                "text",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("What is your favorite color?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("text")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue("What is your favorite color?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                    .setValidationPredicates(
+                        TextQuestionDefinition.TextValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -33,7 +33,6 @@ import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionOption;
 import services.question.QuestionService;
-import services.question.types.*;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.CurrencyQuestionDefinition;
 import services.question.types.DateQuestionDefinition;
@@ -47,6 +46,7 @@ import services.question.types.MultiOptionQuestionDefinitionConfig.MultiOptionQu
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import services.settings.SettingsService;

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -291,11 +291,14 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new IdQuestionDefinition(
-                "id",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("What is your driver's license ID?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("id")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue("What is your driver's license ID?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -343,16 +343,21 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new StaticContentQuestionDefinition(
-                "static content",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue(
-                    "Hi I'm a block of static text. \n"
-                        + " * Welcome to this test program.\n"
-                        + " * It contains one of every question type. \n\n"
-                        + "### What are the eligibility requirements? \n"
-                        + ">You are 18 years or older."),
-                LocalizedStrings.withDefaultValue("")))
+                QuestionDefinitionConfig.builder()
+                    .setName("static content")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue(
+                            "Hi I'm a block of static text. \n"
+                                + " * Welcome to this test program.\n"
+                                + " * It contains one of every question type. \n\n"
+                                + "### What are the eligibility requirements? \n"
+                                + ">You are 18 years or older."))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
+                    .setValidationPredicates(
+                        StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -372,11 +372,15 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new PhoneQuestionDefinition(
-                "phone",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("what is your phone number"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("phone")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(LocalizedStrings.withDefaultValue("what is your phone number"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -145,7 +145,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         AddressQuestionDefinition.AddressValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -184,7 +183,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -219,7 +217,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         DateQuestionDefinition.DateValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -255,7 +252,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         EmailQuestionDefinition.EmailValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -272,7 +268,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build(),
                 LocalizedStrings.withDefaultValue("household member")))
         .getResult();
@@ -290,7 +285,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -306,7 +300,6 @@ public class DatabaseSeedController extends Controller {
                         LocalizedStrings.withDefaultValue("What is your driver's license ID?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -323,7 +316,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         NumberQuestionDefinition.NumberValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -365,7 +357,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
                     .setValidationPredicates(
                         StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -382,7 +373,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         TextQuestionDefinition.TextValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -398,7 +388,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         PhoneQuestionDefinition.PhoneValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -240,11 +240,15 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new EmailQuestionDefinition(
-                "email",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("What is your email?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("email")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(LocalizedStrings.withDefaultValue("What is your email?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        EmailQuestionDefinition.EmailValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -140,10 +140,12 @@ public class DatabaseSeedController extends Controller {
             new AddressQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("address")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("What is your address?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        AddressQuestionDefinition.AddressValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -175,12 +177,14 @@ public class DatabaseSeedController extends Controller {
             new CurrencyQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("currency")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue(
                             "How much should a scoop of ice cream cost?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -191,11 +195,13 @@ public class DatabaseSeedController extends Controller {
             new DateQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("enumerator date")
-                    .setEnumeratorId(Optional.of(enumeratorId))
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("When is $this's birthday?"))
                     .setQuestionHelpText(
                         LocalizedStrings.withDefaultValue("help text for $this's birthday"))
+                    .setValidationPredicates(
+                        DateQuestionDefinition.DateValidationPredicates.create())
+                    .setEnumeratorId(Optional.of(enumeratorId))
                     .build()))
         .getResult();
   }
@@ -208,10 +214,12 @@ public class DatabaseSeedController extends Controller {
             new DateQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName(name)
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue(questionText))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        DateQuestionDefinition.DateValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -242,12 +250,12 @@ public class DatabaseSeedController extends Controller {
             new EmailQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("email")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("What is your email?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         EmailQuestionDefinition.EmailValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -258,13 +266,13 @@ public class DatabaseSeedController extends Controller {
             new EnumeratorQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("enumerator")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("List all members of your household."))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build(),
                 LocalizedStrings.withDefaultValue("household member")))
         .getResult();
@@ -276,13 +284,13 @@ public class DatabaseSeedController extends Controller {
             new FileUploadQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("file upload")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("Upload anything from your computer"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -293,11 +301,12 @@ public class DatabaseSeedController extends Controller {
             new IdQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("id")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("What is your driver's license ID?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -308,13 +317,13 @@ public class DatabaseSeedController extends Controller {
             new NumberQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("number")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("How many pets do you have?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         NumberQuestionDefinition.NumberValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -345,7 +354,6 @@ public class DatabaseSeedController extends Controller {
             new StaticContentQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("static content")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue(
@@ -357,6 +365,7 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
                     .setValidationPredicates(
                         StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -367,15 +376,13 @@ public class DatabaseSeedController extends Controller {
             new TextQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("text")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("What is your favorite color?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
-                        StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                    .setValidationPredicates(
                         TextQuestionDefinition.TextValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }
@@ -386,12 +393,12 @@ public class DatabaseSeedController extends Controller {
             new PhoneQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("phone")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("what is your phone number"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
                     .setValidationPredicates(
                         PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()))
         .getResult();
   }

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -306,11 +306,16 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new NumberQuestionDefinition(
-                "number",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("How many pets do you have?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("number")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue("How many pets do you have?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        NumberQuestionDefinition.NumberValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -189,11 +189,14 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new DateQuestionDefinition(
-                "enumerator date",
-                Optional.of(enumeratorId),
-                "description",
-                LocalizedStrings.withDefaultValue("When is $this's birthday?"),
-                LocalizedStrings.withDefaultValue("help text for $this's birthday")))
+                QuestionDefinitionConfig.builder()
+                    .setName("enumerator date")
+                    .setEnumeratorId(Optional.of(enumeratorId))
+                    .setDescription("description")
+                    .setQuestionText(LocalizedStrings.withDefaultValue("When is $this's birthday?"))
+                    .setQuestionHelpText(
+                        LocalizedStrings.withDefaultValue("help text for $this's birthday"))
+                    .build()))
         .getResult();
   }
 
@@ -203,11 +206,13 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new DateQuestionDefinition(
-                name,
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue(questionText),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName(name)
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(LocalizedStrings.withDefaultValue(questionText))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -274,11 +274,16 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new FileUploadQuestionDefinition(
-                "file upload",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("Upload anything from your computer"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("file upload")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue("Upload anything from your computer"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .setValidationPredicates(
+                        FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -33,6 +33,7 @@ import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionOption;
 import services.question.QuestionService;
+import services.question.types.*;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.CurrencyQuestionDefinition;
 import services.question.types.DateQuestionDefinition;
@@ -137,11 +138,13 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new AddressQuestionDefinition(
-                "address",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("What is your address?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("address")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(LocalizedStrings.withDefaultValue("What is your address?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .build()))
         .getResult();
   }
 

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -173,11 +173,15 @@ public class DatabaseSeedController extends Controller {
     return questionService
         .create(
             new CurrencyQuestionDefinition(
-                "currency",
-                Optional.empty(),
-                "description",
-                LocalizedStrings.withDefaultValue("How much should a scoop of ice cream cost?"),
-                LocalizedStrings.withDefaultValue("help text")))
+                QuestionDefinitionConfig.builder()
+                    .setName("currency")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("description")
+                    .setQuestionText(
+                        LocalizedStrings.withDefaultValue(
+                            "How much should a scoop of ice cream cost?"))
+                    .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                    .build()))
         .getResult();
   }
 

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -139,7 +139,9 @@ public final class JsonExporter {
     // the json entries for any Question in one line.
     @SuppressWarnings("unchecked")
     ImmutableMap<Path, ?> entries =
-        presenterFactory.create(answerData).getJsonEntries(answerData.createQuestion());
+        presenterFactory
+            .create(answerData.applicantQuestion().getType())
+            .getJsonEntries(answerData.createQuestion());
 
     for (Map.Entry<Path, ?> entry : entries.entrySet()) {
       Path path = entry.getKey();

--- a/server/app/services/export/QuestionJsonPresenter.java
+++ b/server/app/services/export/QuestionJsonPresenter.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeFormatter;
 import javax.inject.Inject;
 import services.LocalizedStrings;
 import services.Path;
-import services.applicant.AnswerData;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
 import services.applicant.question.FileUploadQuestion;
@@ -74,9 +73,8 @@ public interface QuestionJsonPresenter<Q extends Question> {
       this.singleSelectJsonPresenter = checkNotNull(singleSelectJsonPresenter);
     }
 
-    QuestionJsonPresenter create(AnswerData answerData) {
-      QuestionType type = answerData.applicantQuestion().getType();
-      switch (type) {
+    public QuestionJsonPresenter create(QuestionType questionType) {
+      switch (questionType) {
         case ADDRESS:
         case EMAIL:
         case ID:
@@ -111,7 +109,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
           return dateJsonPresenter;
 
         default:
-          throw new RuntimeException(String.format("Unrecognized questionType %s", type));
+          throw new RuntimeException(String.format("Unrecognized questionType %s", questionType));
       }
     }
   }

--- a/server/app/services/question/types/AddressQuestionDefinition.java
+++ b/server/app/services/question/types/AddressQuestionDefinition.java
@@ -4,68 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
 import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines an address question. */
 public final class AddressQuestionDefinition extends QuestionDefinition {
 
-  public AddressQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      AddressValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public AddressQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      AddressValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public AddressQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .build());
+  public AddressQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @JsonDeserialize(

--- a/server/app/services/question/types/AddressQuestionDefinition.java
+++ b/server/app/services/question/types/AddressQuestionDefinition.java
@@ -22,14 +22,16 @@ public final class AddressQuestionDefinition extends QuestionDefinition {
       AddressValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public AddressQuestionDefinition(
@@ -39,7 +41,15 @@ public final class AddressQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       AddressValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public AddressQuestionDefinition(
@@ -49,12 +59,13 @@ public final class AddressQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        AddressValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .build());
   }
 
   @JsonDeserialize(

--- a/server/app/services/question/types/CurrencyQuestionDefinition.java
+++ b/server/app/services/question/types/CurrencyQuestionDefinition.java
@@ -19,14 +19,15 @@ public final class CurrencyQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        CurrencyValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public CurrencyQuestionDefinition(
@@ -36,7 +37,15 @@ public final class CurrencyQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       CurrencyValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public CurrencyQuestionDefinition(
@@ -46,12 +55,13 @@ public final class CurrencyQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        CurrencyValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/CurrencyQuestionDefinition.java
+++ b/server/app/services/question/types/CurrencyQuestionDefinition.java
@@ -2,66 +2,12 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a currency question. */
 public final class CurrencyQuestionDefinition extends QuestionDefinition {
 
-  public CurrencyQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public CurrencyQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      CurrencyValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public CurrencyQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .build());
+  public CurrencyQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -2,48 +2,12 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a date question. */
 public final class DateQuestionDefinition extends QuestionDefinition {
 
-  public DateQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .build());
-  }
-
-  public DateQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
+  public DateQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -17,12 +17,13 @@ public final class DateQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        DateValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .build());
   }
 
   public DateQuestionDefinition(
@@ -34,14 +35,15 @@ public final class DateQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        DateValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/EmailQuestionDefinition.java
+++ b/server/app/services/question/types/EmailQuestionDefinition.java
@@ -17,12 +17,14 @@ public final class EmailQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        EmailQuestionDefinition.EmailValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+            .build());
   }
 
   public EmailQuestionDefinition(
@@ -34,14 +36,16 @@ public final class EmailQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        EmailQuestionDefinition.EmailValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/EmailQuestionDefinition.java
+++ b/server/app/services/question/types/EmailQuestionDefinition.java
@@ -2,50 +2,12 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines an email question. */
 public final class EmailQuestionDefinition extends QuestionDefinition {
 
-  public EmailQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
-            .build());
-  }
-
-  public EmailQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
+  public EmailQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/server/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -3,9 +3,6 @@ package services.question.types;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
 import services.LocalizedStrings;
 
 /**
@@ -24,44 +21,8 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
   private final LocalizedStrings entityType;
 
   public EnumeratorQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      LocalizedStrings entityType,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(EnumeratorValidationPredicates.create())
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-    this.entityType = checkNotNull(entityType);
-  }
-
-  public EnumeratorQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      LocalizedStrings entityType) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(EnumeratorValidationPredicates.create())
-            .build());
+      QuestionDefinitionConfig config, LocalizedStrings entityType) {
+    super(config);
     this.entityType = checkNotNull(entityType);
   }
 

--- a/server/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/server/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -33,14 +33,16 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
       LocalizedStrings entityType,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        EnumeratorValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(EnumeratorValidationPredicates.create())
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
     this.entityType = checkNotNull(entityType);
   }
 
@@ -52,12 +54,14 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       LocalizedStrings entityType) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        EnumeratorValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(EnumeratorValidationPredicates.create())
+            .build());
     this.entityType = checkNotNull(entityType);
   }
 

--- a/server/app/services/question/types/FileUploadQuestionDefinition.java
+++ b/server/app/services/question/types/FileUploadQuestionDefinition.java
@@ -2,50 +2,12 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a file upload question. */
 public final class FileUploadQuestionDefinition extends QuestionDefinition {
 
-  public FileUploadQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(FileUploadValidationPredicates.create())
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public FileUploadQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(FileUploadValidationPredicates.create())
-            .build());
+  public FileUploadQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/FileUploadQuestionDefinition.java
+++ b/server/app/services/question/types/FileUploadQuestionDefinition.java
@@ -19,14 +19,16 @@ public final class FileUploadQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        FileUploadValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(FileUploadValidationPredicates.create())
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public FileUploadQuestionDefinition(
@@ -36,12 +38,14 @@ public final class FileUploadQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        FileUploadValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(FileUploadValidationPredicates.create())
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/IdQuestionDefinition.java
+++ b/server/app/services/question/types/IdQuestionDefinition.java
@@ -4,69 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines an id question. */
 public final class IdQuestionDefinition extends QuestionDefinition {
 
-  public IdQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      IdValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public IdQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      IdValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public IdQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .build());
+  public IdQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @JsonDeserialize(builder = AutoValue_IdQuestionDefinition_IdValidationPredicates.Builder.class)

--- a/server/app/services/question/types/IdQuestionDefinition.java
+++ b/server/app/services/question/types/IdQuestionDefinition.java
@@ -23,14 +23,16 @@ public final class IdQuestionDefinition extends QuestionDefinition {
       IdValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public IdQuestionDefinition(
@@ -40,7 +42,15 @@ public final class IdQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       IdValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public IdQuestionDefinition(
@@ -50,12 +60,13 @@ public final class IdQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        IdValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .build());
   }
 
   @JsonDeserialize(builder = AutoValue_IdQuestionDefinition_IdValidationPredicates.Builder.class)

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -26,14 +26,14 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   public MultiOptionQuestionDefinition(MultiOptionQuestionDefinitionConfig config) {
     super(
         QuestionDefinitionConfig.builder()
-            .setId(config.id())
             .setName(config.name())
-            .setEnumeratorId(config.enumeratorId())
             .setDescription(config.description())
             .setQuestionText(config.questionText())
             .setQuestionHelpText(config.questionHelpText())
             .setValidationPredicates(
                 config.validationPredicates().orElse(MultiOptionValidationPredicates.create()))
+            .setEnumeratorId(config.enumeratorId())
+            .setId(config.id())
             .setLastModifiedTime(config.lastModifiedTime())
             .build());
     this.config = config;

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -25,14 +25,17 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
 
   public MultiOptionQuestionDefinition(MultiOptionQuestionDefinitionConfig config) {
     super(
-        config.id(),
-        config.name(),
-        config.enumeratorId(),
-        config.description(),
-        config.questionText(),
-        config.questionHelpText(),
-        config.validationPredicates().orElse(MultiOptionValidationPredicates.create()),
-        config.lastModifiedTime());
+        QuestionDefinitionConfig.builder()
+            .setId(config.id())
+            .setName(config.name())
+            .setEnumeratorId(config.enumeratorId())
+            .setDescription(config.description())
+            .setQuestionText(config.questionText())
+            .setQuestionHelpText(config.questionHelpText())
+            .setValidationPredicates(
+                config.validationPredicates().orElse(MultiOptionValidationPredicates.create()))
+            .setLastModifiedTime(config.lastModifiedTime())
+            .build());
     this.config = config;
   }
 

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -23,6 +23,7 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
 
   private final MultiOptionQuestionDefinitionConfig config;
 
+  // TODO(MichaelZetune): migrate this constructor to use QuestionDefinitionConfig instead.
   public MultiOptionQuestionDefinition(MultiOptionQuestionDefinitionConfig config) {
     super(
         QuestionDefinitionConfig.builder()

--- a/server/app/services/question/types/NameQuestionDefinition.java
+++ b/server/app/services/question/types/NameQuestionDefinition.java
@@ -20,14 +20,16 @@ public final class NameQuestionDefinition extends QuestionDefinition {
       NameValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public NameQuestionDefinition(
@@ -37,7 +39,15 @@ public final class NameQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       NameValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public NameQuestionDefinition(
@@ -47,12 +57,13 @@ public final class NameQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        NameValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/NameQuestionDefinition.java
+++ b/server/app/services/question/types/NameQuestionDefinition.java
@@ -2,68 +2,12 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a name question. */
 public final class NameQuestionDefinition extends QuestionDefinition {
 
-  public NameQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      NameValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public NameQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      NameValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public NameQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .build());
+  public NameQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/NumberQuestionDefinition.java
+++ b/server/app/services/question/types/NumberQuestionDefinition.java
@@ -22,14 +22,16 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
       NumberQuestionDefinition.NumberValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public NumberQuestionDefinition(
@@ -39,7 +41,15 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       NumberQuestionDefinition.NumberValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public NumberQuestionDefinition(
@@ -49,12 +59,14 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        NumberQuestionDefinition.NumberValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
+            .build());
   }
 
   @JsonDeserialize(

--- a/server/app/services/question/types/NumberQuestionDefinition.java
+++ b/server/app/services/question/types/NumberQuestionDefinition.java
@@ -4,69 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a number question. */
 public final class NumberQuestionDefinition extends QuestionDefinition {
 
-  public NumberQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      NumberQuestionDefinition.NumberValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
-
-  public NumberQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      NumberQuestionDefinition.NumberValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public NumberQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
-            .build());
+  public NumberQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @JsonDeserialize(

--- a/server/app/services/question/types/PhoneQuestionDefinition.java
+++ b/server/app/services/question/types/PhoneQuestionDefinition.java
@@ -2,67 +2,11 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 public final class PhoneQuestionDefinition extends QuestionDefinition {
-  public PhoneQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      PhoneQuestionDefinition.PhoneValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
-  }
 
-  public PhoneQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      PhoneQuestionDefinition.PhoneValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public PhoneQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
-            .build());
+  public PhoneQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/PhoneQuestionDefinition.java
+++ b/server/app/services/question/types/PhoneQuestionDefinition.java
@@ -18,14 +18,16 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
       PhoneQuestionDefinition.PhoneValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   public PhoneQuestionDefinition(
@@ -35,7 +37,15 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       PhoneQuestionDefinition.PhoneValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public PhoneQuestionDefinition(
@@ -45,12 +55,14 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        PhoneQuestionDefinition.PhoneValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -167,13 +167,13 @@ public final class QuestionDefinitionBuilder {
         }
         return new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(addressValidationPredicates)
+                .setId(id)
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -202,25 +202,28 @@ public final class QuestionDefinitionBuilder {
       case CURRENCY:
         return new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(
+                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+                .setId(id)
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
       case DATE:
         return new DateQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
+                .setId(id)
                 .build());
 
       case DROPDOWN:
@@ -240,27 +243,27 @@ public final class QuestionDefinitionBuilder {
       case EMAIL:
         return new EmailQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+                .setEnumeratorId(enumeratorId)
+                .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
       case FILEUPLOAD:
         return new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .setEnumeratorId(enumeratorId)
+                .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -271,13 +274,13 @@ public final class QuestionDefinitionBuilder {
         }
         return new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(idValidationPredicates)
+                .setEnumeratorId(enumeratorId)
+                .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -288,13 +291,13 @@ public final class QuestionDefinitionBuilder {
         }
         return new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(nameValidationPredicates)
+                .setEnumeratorId(enumeratorId)
+                .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -307,13 +310,13 @@ public final class QuestionDefinitionBuilder {
         }
         return new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(numberValidationPredicates)
+                .setId(id)
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -340,14 +343,14 @@ public final class QuestionDefinitionBuilder {
         }
         return new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setId(id)
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build(),
             entityType);
@@ -355,14 +358,14 @@ public final class QuestionDefinitionBuilder {
       case STATIC:
         return new StaticContentQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setId(id)
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
@@ -374,12 +377,11 @@ public final class QuestionDefinitionBuilder {
         return new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .setValidationPredicates(textValidationPredicates)
                 .build());
@@ -390,13 +392,13 @@ public final class QuestionDefinitionBuilder {
         }
         return new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
-                .setId(id)
                 .setName(name)
-                .setEnumeratorId(enumeratorId)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
                 .setValidationPredicates(phoneValidationPredicates)
+                .setEnumeratorId(enumeratorId)
+                .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
       default:

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -17,7 +17,11 @@ import services.question.types.PhoneQuestionDefinition.PhoneValidationPredicates
 import services.question.types.QuestionDefinition.ValidationPredicates;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
-/** Provides helper functions to build a QuestionDefinition. */
+/**
+ * Provides helper functions to build a QuestionDefinition.
+ *
+ * <p>TODO(#4872): Remove this class in favor of QuestionDefinitionConfig.Builder.
+ */
 public final class QuestionDefinitionBuilder {
 
   private OptionalLong id = OptionalLong.empty();
@@ -384,6 +388,7 @@ public final class QuestionDefinitionBuilder {
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .setValidationPredicates(textValidationPredicates)
+                .setId(id)
                 .build());
       case PHONE:
         PhoneValidationPredicates phoneValidationPredicates = PhoneValidationPredicates.create();

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -323,14 +323,18 @@ public final class QuestionDefinitionBuilder {
               LocalizedStrings.withDefaultValue(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);
         }
         return new EnumeratorQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            entityType,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setLastModifiedTime(lastModifiedTime)
+                .build(),
+            entityType);
 
       case STATIC:
         return new StaticContentQuestionDefinition(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -270,14 +270,16 @@ public final class QuestionDefinitionBuilder {
           idValidationPredicates = IdValidationPredicates.parse(validationPredicatesString);
         }
         return new IdQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            idValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(idValidationPredicates)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case NAME:
         NameValidationPredicates nameValidationPredicates = NameValidationPredicates.create();

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -239,7 +239,16 @@ public final class QuestionDefinitionBuilder {
 
       case EMAIL:
         return new EmailQuestionDefinition(
-            id, name, enumeratorId, description, questionText, questionHelpText, lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case FILEUPLOAD:
         return new FileUploadQuestionDefinition(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -213,7 +213,15 @@ public final class QuestionDefinitionBuilder {
 
       case DATE:
         return new DateQuestionDefinition(
-            id, name, enumeratorId, description, questionText, questionHelpText, lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case DROPDOWN:
         return new MultiOptionQuestionDefinition(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -306,14 +306,16 @@ public final class QuestionDefinitionBuilder {
               NumberQuestionDefinition.NumberValidationPredicates.parse(validationPredicatesString);
         }
         return new NumberQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            numberValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(numberValidationPredicates)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case RADIO_BUTTON:
         return new MultiOptionQuestionDefinition(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -252,7 +252,17 @@ public final class QuestionDefinitionBuilder {
 
       case FILEUPLOAD:
         return new FileUploadQuestionDefinition(
-            id, name, enumeratorId, description, questionText, questionHelpText, lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case ID:
         IdValidationPredicates idValidationPredicates = IdValidationPredicates.create();

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -201,7 +201,15 @@ public final class QuestionDefinitionBuilder {
 
       case CURRENCY:
         return new CurrencyQuestionDefinition(
-            id, name, enumeratorId, description, questionText, questionHelpText, lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case DATE:
         return new DateQuestionDefinition(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -372,14 +372,17 @@ public final class QuestionDefinitionBuilder {
           textValidationPredicates = TextValidationPredicates.parse(validationPredicatesString);
         }
         return new TextQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            textValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setLastModifiedTime(lastModifiedTime)
+                .setValidationPredicates(textValidationPredicates)
+                .build());
       case PHONE:
         PhoneValidationPredicates phoneValidationPredicates = PhoneValidationPredicates.create();
         if (!validationPredicatesString.isEmpty()) {

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -354,7 +354,17 @@ public final class QuestionDefinitionBuilder {
 
       case STATIC:
         return new StaticContentQuestionDefinition(
-            id, name, enumeratorId, description, questionText, questionHelpText, lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case TEXT:
         TextValidationPredicates textValidationPredicates = TextValidationPredicates.create();

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -287,14 +287,16 @@ public final class QuestionDefinitionBuilder {
           nameValidationPredicates = NameValidationPredicates.parse(validationPredicatesString);
         }
         return new NameQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            nameValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(nameValidationPredicates)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case NUMBER:
         NumberQuestionDefinition.NumberValidationPredicates numberValidationPredicates =

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -376,14 +376,16 @@ public final class QuestionDefinitionBuilder {
           phoneValidationPredicates = PhoneValidationPredicates.parse(validationPredicatesString);
         }
         return new PhoneQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            phoneValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(phoneValidationPredicates)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
       default:
         throw new UnsupportedQuestionTypeException(this.questionType);
     }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -166,14 +166,16 @@ public final class QuestionDefinitionBuilder {
               AddressValidationPredicates.parse(validationPredicatesString);
         }
         return new AddressQuestionDefinition(
-            id,
-            name,
-            enumeratorId,
-            description,
-            questionText,
-            questionHelpText,
-            addressValidationPredicates,
-            lastModifiedTime);
+            QuestionDefinitionConfig.builder()
+                .setId(id)
+                .setName(name)
+                .setEnumeratorId(enumeratorId)
+                .setDescription(description)
+                .setQuestionText(questionText)
+                .setQuestionHelpText(questionHelpText)
+                .setValidationPredicates(addressValidationPredicates)
+                .setLastModifiedTime(lastModifiedTime)
+                .build());
 
       case CHECKBOX:
         MultiOptionValidationPredicates multiOptionValidationPredicates =

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -15,6 +15,11 @@ public abstract class QuestionDefinitionConfig {
 
   // Note: you must check prefixes anytime you are doing a locale lookup
   // see getQuestionText body comment for explanation.
+
+  /**
+   * Note: you must check prefixes anytime you are doing a locale lookup see {@link
+   * QuestionDefinition#getQuestionText} body comment for explanation.
+   */
   abstract LocalizedStrings questionText();
 
   abstract LocalizedStrings questionHelpText();

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -9,11 +9,7 @@ import services.LocalizedStrings;
 @AutoValue
 public abstract class QuestionDefinitionConfig {
 
-  abstract OptionalLong id();
-
   abstract String name();
-
-  abstract Optional<Long> enumeratorId();
 
   abstract String description();
 
@@ -25,32 +21,50 @@ public abstract class QuestionDefinitionConfig {
 
   abstract QuestionDefinition.ValidationPredicates validationPredicates();
 
+  abstract OptionalLong id();
+
+  abstract Optional<Long> enumeratorId();
+
   abstract Optional<Instant> lastModifiedTime();
 
-  public static Builder builder() {
+  public static RequiredName builder() {
     return new AutoValue_QuestionDefinitionConfig.Builder();
   }
 
+  public interface RequiredName {
+    RequiredDescription setName(String name);
+  }
+
+  public interface RequiredDescription {
+    RequiredQuestionText setDescription(String description);
+  }
+
+  public interface RequiredQuestionText {
+    RequiredQuestionHelpText setQuestionText(LocalizedStrings questionText);
+  }
+
+  public interface RequiredQuestionHelpText {
+    RequiredValidationPredicates setQuestionHelpText(LocalizedStrings questionHelpText);
+  }
+
+  public interface RequiredValidationPredicates {
+    Builder setValidationPredicates(QuestionDefinition.ValidationPredicates validationPredicates);
+  }
+
   @AutoValue.Builder
-  public abstract static class Builder {
+  public abstract static class Builder
+      implements RequiredName,
+          RequiredDescription,
+          RequiredQuestionText,
+          RequiredQuestionHelpText,
+          RequiredValidationPredicates {
     public abstract Builder setId(long id);
 
     public abstract Builder setId(OptionalLong id);
 
-    public abstract Builder setName(String name);
-
     public abstract Builder setEnumeratorId(long enumeratorId);
 
     public abstract Builder setEnumeratorId(Optional<Long> enumeratorId);
-
-    public abstract Builder setDescription(String description);
-
-    public abstract Builder setQuestionText(LocalizedStrings questionText);
-
-    public abstract Builder setQuestionHelpText(LocalizedStrings questionHelpText);
-
-    public abstract Builder setValidationPredicates(
-        QuestionDefinition.ValidationPredicates validationPredicates);
 
     public abstract Builder setLastModifiedTime(Instant lastModifiedTime);
 

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -1,0 +1,61 @@
+package services.question.types;
+
+import com.google.auto.value.AutoValue;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.OptionalLong;
+import services.LocalizedStrings;
+
+@AutoValue
+public abstract class QuestionDefinitionConfig {
+
+  abstract OptionalLong id();
+
+  abstract String name();
+
+  abstract Optional<Long> enumeratorId();
+
+  abstract String description();
+
+  // Note: you must check prefixes anytime you are doing a locale lookup
+  // see getQuestionText body comment for explanation.
+  abstract LocalizedStrings questionText();
+
+  abstract LocalizedStrings questionHelpText();
+
+  abstract QuestionDefinition.ValidationPredicates validationPredicates();
+
+  abstract Optional<Instant> lastModifiedTime();
+
+  public static Builder builder() {
+    return new AutoValue_QuestionDefinitionConfig.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setId(long id);
+
+    public abstract Builder setId(OptionalLong id);
+
+    public abstract Builder setName(String name);
+
+    public abstract Builder setEnumeratorId(long enumeratorId);
+
+    public abstract Builder setEnumeratorId(Optional<Long> enumeratorId);
+
+    public abstract Builder setDescription(String description);
+
+    public abstract Builder setQuestionText(LocalizedStrings questionText);
+
+    public abstract Builder setQuestionHelpText(LocalizedStrings questionHelpText);
+
+    public abstract Builder setValidationPredicates(
+        QuestionDefinition.ValidationPredicates validationPredicates);
+
+    public abstract Builder setLastModifiedTime(Instant lastModifiedTime);
+
+    public abstract Builder setLastModifiedTime(Optional<Instant> lastModifiedTime);
+
+    public abstract QuestionDefinitionConfig build();
+  }
+}

--- a/server/app/services/question/types/StaticContentQuestionDefinition.java
+++ b/server/app/services/question/types/StaticContentQuestionDefinition.java
@@ -20,12 +20,15 @@ public final class StaticContentQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        StaticContentQuestionDefinition.StaticContentValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(
+                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+            .build());
   }
 
   public StaticContentQuestionDefinition(
@@ -37,14 +40,17 @@ public final class StaticContentQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionHelpText,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        StaticContentQuestionDefinition.StaticContentValidationPredicates.create(),
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setId(id)
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(
+                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+            .setLastModifiedTime(lastModifiedTime)
+            .build());
   }
 
   @AutoValue

--- a/server/app/services/question/types/StaticContentQuestionDefinition.java
+++ b/server/app/services/question/types/StaticContentQuestionDefinition.java
@@ -2,10 +2,6 @@ package services.question.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /**
  * Defines a static content question. A static content question displays static content without
@@ -13,44 +9,8 @@ import services.LocalizedStrings;
  */
 public final class StaticContentQuestionDefinition extends QuestionDefinition {
 
-  public StaticContentQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(
-                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-            .build());
-  }
-
-  public StaticContentQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setId(id)
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(
-                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-            .setLastModifiedTime(lastModifiedTime)
-            .build());
+  public StaticContentQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @AutoValue

--- a/server/app/services/question/types/TextQuestionDefinition.java
+++ b/server/app/services/question/types/TextQuestionDefinition.java
@@ -23,14 +23,17 @@ public final class TextQuestionDefinition extends QuestionDefinition {
       TextValidationPredicates validationPredicates,
       Optional<Instant> lastModifiedTime) {
     super(
-        id,
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        validationPredicates,
-        lastModifiedTime);
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(
+                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+            .setLastModifiedTime(lastModifiedTime)
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public TextQuestionDefinition(
@@ -40,7 +43,17 @@ public final class TextQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText,
       TextValidationPredicates validationPredicates) {
-    super(name, enumeratorId, description, questionText, questionHelpText, validationPredicates);
+    super(
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(
+                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+            .setValidationPredicates(validationPredicates)
+            .build());
   }
 
   public TextQuestionDefinition(
@@ -50,12 +63,16 @@ public final class TextQuestionDefinition extends QuestionDefinition {
       LocalizedStrings questionText,
       LocalizedStrings questionHelpText) {
     super(
-        name,
-        enumeratorId,
-        description,
-        questionText,
-        questionHelpText,
-        TextValidationPredicates.create());
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setEnumeratorId(enumeratorId)
+            .setDescription(description)
+            .setQuestionText(questionText)
+            .setQuestionHelpText(questionHelpText)
+            .setValidationPredicates(
+                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+            .setValidationPredicates(TextValidationPredicates.create())
+            .build());
   }
 
   @JsonDeserialize(

--- a/server/app/services/question/types/TextQuestionDefinition.java
+++ b/server/app/services/question/types/TextQuestionDefinition.java
@@ -4,75 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.OptionalLong;
-import services.LocalizedStrings;
 
 /** Defines a text question. */
 public final class TextQuestionDefinition extends QuestionDefinition {
 
-  public TextQuestionDefinition(
-      OptionalLong id,
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      TextValidationPredicates validationPredicates,
-      Optional<Instant> lastModifiedTime) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(
-                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-            .setLastModifiedTime(lastModifiedTime)
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public TextQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText,
-      TextValidationPredicates validationPredicates) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(
-                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-            .setValidationPredicates(validationPredicates)
-            .build());
-  }
-
-  public TextQuestionDefinition(
-      String name,
-      Optional<Long> enumeratorId,
-      String description,
-      LocalizedStrings questionText,
-      LocalizedStrings questionHelpText) {
-    super(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setEnumeratorId(enumeratorId)
-            .setDescription(description)
-            .setQuestionText(questionText)
-            .setQuestionHelpText(questionHelpText)
-            .setValidationPredicates(
-                StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-            .setValidationPredicates(TextValidationPredicates.create())
-            .build());
+  public TextQuestionDefinition(QuestionDefinitionConfig config) {
+    super(config);
   }
 
   @JsonDeserialize(

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -500,10 +500,11 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     return new NameQuestionDefinition(
         QuestionDefinitionConfig.builder()
             .setName(def.getName())
-            .setEnumeratorId(Optional.empty())
             .setDescription(def.getDescription())
             .setQuestionText(def.getQuestionText())
             .setQuestionHelpText(def.getQuestionHelpText())
+            .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+            .setEnumeratorId(Optional.empty())
             .build());
   }
 }

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -28,9 +28,14 @@ import repository.QuestionRepository;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
-import services.question.types.*;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinitionConfig;
 import services.question.types.MultiOptionQuestionDefinitionConfig.MultiOptionQuestionType;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.QuestionType;
 import views.html.helper.CSRF;
 
 public class AdminQuestionControllerTest extends ResetPostgres {

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -504,7 +504,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .setQuestionText(def.getQuestionText())
             .setQuestionHelpText(def.getQuestionHelpText())
             .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-            .setEnumeratorId(Optional.empty())
             .build());
   }
 }

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -28,13 +28,9 @@ import repository.QuestionRepository;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
-import services.question.types.MultiOptionQuestionDefinition;
-import services.question.types.MultiOptionQuestionDefinitionConfig;
+import services.question.types.*;
 import services.question.types.MultiOptionQuestionDefinitionConfig.MultiOptionQuestionType;
-import services.question.types.NameQuestionDefinition;
-import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
-import services.question.types.QuestionType;
 import views.html.helper.CSRF;
 
 public class AdminQuestionControllerTest extends ResetPostgres {
@@ -502,10 +498,12 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   private NameQuestionDefinition createNameQuestionDuplicate(Question question) {
     QuestionDefinition def = question.getQuestionDefinition();
     return new NameQuestionDefinition(
-        def.getName(),
-        Optional.empty(),
-        def.getDescription(),
-        def.getQuestionText(),
-        def.getQuestionHelpText());
+        QuestionDefinitionConfig.builder()
+            .setName(def.getName())
+            .setEnumeratorId(Optional.empty())
+            .setDescription(def.getDescription())
+            .setQuestionText(def.getQuestionText())
+            .setQuestionHelpText(def.getQuestionHelpText())
+            .build());
   }
 }

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -10,7 +10,6 @@ import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import models.Question;
 import models.Version;
 import org.junit.Before;
@@ -206,7 +205,6 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT))
                 .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.
@@ -228,7 +226,6 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
                         .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT))
                 .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -25,6 +25,7 @@ import services.TranslationNotFoundException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 
 public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
@@ -199,11 +200,13 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   private Question createDraftQuestionEnglishOnly() {
     QuestionDefinition definition =
         new NameQuestionDefinition(
-            "applicant name",
-            Optional.empty(),
-            "name of applicant",
-            LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT),
-            LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("name of applicant")
+                .setQuestionText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT))
+                .setQuestionHelpText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT))
+                .build());
     Question question = new Question(definition);
     // Only draft questions are editable.
     question.addVersion(draftVersion);
@@ -214,13 +217,17 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   private Question createDraftQuestionEnglishAndSpanish() {
     QuestionDefinition definition =
         new NameQuestionDefinition(
-            "applicant name",
-            Optional.empty(),
-            "name of applicant",
-            LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT)
-                .updateTranslation(ES_LOCALE, SPANISH_QUESTION_TEXT),
-            LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
-                .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("name of applicant")
+                .setQuestionText(
+                    LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT)
+                        .updateTranslation(ES_LOCALE, SPANISH_QUESTION_TEXT))
+                .setQuestionHelpText(
+                    LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
+                        .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT))
+                .build());
     Question question = new Question(definition);
     // Only draft questions are editable.
     question.addVersion(draftVersion);

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -202,10 +202,11 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("name of applicant")
                 .setQuestionText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT))
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.
@@ -219,7 +220,6 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("name of applicant")
                 .setQuestionText(
                     LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT)
@@ -227,6 +227,8 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                 .setQuestionHelpText(
                     LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
                         .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT))
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.

--- a/server/test/forms/AddressQuestionFormTest.java
+++ b/server/test/forms/AddressQuestionFormTest.java
@@ -27,12 +27,12 @@ public class AddressQuestionFormTest {
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create(true))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -46,12 +46,12 @@ public class AddressQuestionFormTest {
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     AddressQuestionForm form = new AddressQuestionForm(originalQd);

--- a/server/test/forms/AddressQuestionFormTest.java
+++ b/server/test/forms/AddressQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.AddressQuestionDefinition;
@@ -32,7 +31,6 @@ public class AddressQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create(true))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -51,7 +49,6 @@ public class AddressQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     AddressQuestionForm form = new AddressQuestionForm(originalQd);

--- a/server/test/forms/AddressQuestionFormTest.java
+++ b/server/test/forms/AddressQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class AddressQuestionFormTest {
 
@@ -24,12 +25,15 @@ public class AddressQuestionFormTest {
 
     AddressQuestionDefinition expected =
         new AddressQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            AddressQuestionDefinition.AddressValidationPredicates.create(true));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    AddressQuestionDefinition.AddressValidationPredicates.create(true))
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -40,12 +44,15 @@ public class AddressQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     AddressQuestionDefinition originalQd =
         new AddressQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            AddressQuestionDefinition.AddressValidationPredicates.create());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    AddressQuestionDefinition.AddressValidationPredicates.create())
+                .build());
 
     AddressQuestionForm form = new AddressQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/server/test/forms/CurrencyQuestionFormTest.java
+++ b/server/test/forms/CurrencyQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.CurrencyQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class CurrencyQuestionFormTest {
 
@@ -23,11 +24,13 @@ public class CurrencyQuestionFormTest {
 
     CurrencyQuestionDefinition expected =
         new CurrencyQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -38,11 +41,13 @@ public class CurrencyQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     CurrencyQuestionDefinition originalQd =
         new CurrencyQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .build());
 
     CurrencyQuestionForm form = new CurrencyQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/server/test/forms/CurrencyQuestionFormTest.java
+++ b/server/test/forms/CurrencyQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.CurrencyQuestionDefinition;
@@ -31,7 +30,6 @@ public class CurrencyQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -50,7 +48,6 @@ public class CurrencyQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     CurrencyQuestionForm form = new CurrencyQuestionForm(originalQd);

--- a/server/test/forms/CurrencyQuestionFormTest.java
+++ b/server/test/forms/CurrencyQuestionFormTest.java
@@ -26,10 +26,12 @@ public class CurrencyQuestionFormTest {
         new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -43,10 +45,12 @@ public class CurrencyQuestionFormTest {
         new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     CurrencyQuestionForm form = new CurrencyQuestionForm(originalQd);

--- a/server/test/forms/EnumeratorQuestionFormTest.java
+++ b/server/test/forms/EnumeratorQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
@@ -30,7 +29,6 @@ public class EnumeratorQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
 
@@ -50,7 +48,6 @@ public class EnumeratorQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
 

--- a/server/test/forms/EnumeratorQuestionFormTest.java
+++ b/server/test/forms/EnumeratorQuestionFormTest.java
@@ -25,12 +25,12 @@ public class EnumeratorQuestionFormTest {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
 
@@ -45,12 +45,12 @@ public class EnumeratorQuestionFormTest {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
 

--- a/server/test/forms/EnumeratorQuestionFormTest.java
+++ b/server/test/forms/EnumeratorQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class EnumeratorQuestionFormTest {
   @Test
@@ -22,11 +23,15 @@ public class EnumeratorQuestionFormTest {
 
     EnumeratorQuestionDefinition expected =
         new EnumeratorQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.empty());
 
     QuestionDefinition actual = builder.build();
@@ -38,11 +43,15 @@ public class EnumeratorQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     EnumeratorQuestionDefinition originalQd =
         new EnumeratorQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.empty());
 
     EnumeratorQuestionForm form = new EnumeratorQuestionForm(originalQd);

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -25,12 +25,12 @@ public class FileUploadQuestionFormTest {
         new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("file upload")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -44,12 +44,12 @@ public class FileUploadQuestionFormTest {
         new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("file upload")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     FileUploadQuestionForm form = new FileUploadQuestionForm(originalQd);

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class FileUploadQuestionFormTest {
   @Test
@@ -22,11 +23,15 @@ public class FileUploadQuestionFormTest {
 
     FileUploadQuestionDefinition expected =
         new FileUploadQuestionDefinition(
-            "file upload",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("file upload")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -37,11 +42,15 @@ public class FileUploadQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     FileUploadQuestionDefinition originalQd =
         new FileUploadQuestionDefinition(
-            "file upload",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("file upload")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .build());
 
     FileUploadQuestionForm form = new FileUploadQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.FileUploadQuestionDefinition;
@@ -30,7 +29,6 @@ public class FileUploadQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -49,7 +47,6 @@ public class FileUploadQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     FileUploadQuestionForm form = new FileUploadQuestionForm(originalQd);

--- a/server/test/forms/IdQuestionFormTest.java
+++ b/server/test/forms/IdQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class IdQuestionFormTest {
 
@@ -25,12 +26,14 @@ public class IdQuestionFormTest {
 
     IdQuestionDefinition expected =
         new IdQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            IdQuestionDefinition.IdValidationPredicates.create(4, 6));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -41,12 +44,14 @@ public class IdQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     IdQuestionDefinition originalQd =
         new IdQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            IdQuestionDefinition.IdValidationPredicates.create(4, 6));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
+                .build());
 
     IdQuestionForm form = new IdQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -69,12 +74,14 @@ public class IdQuestionFormTest {
 
     IdQuestionDefinition expected =
         new IdQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            IdQuestionDefinition.IdValidationPredicates.create());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+                .build());
 
     QuestionDefinition actual = builder.build();
 

--- a/server/test/forms/IdQuestionFormTest.java
+++ b/server/test/forms/IdQuestionFormTest.java
@@ -28,11 +28,11 @@ public class IdQuestionFormTest {
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -46,11 +46,11 @@ public class IdQuestionFormTest {
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     IdQuestionForm form = new IdQuestionForm(originalQd);
@@ -76,11 +76,11 @@ public class IdQuestionFormTest {
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/IdQuestionFormTest.java
+++ b/server/test/forms/IdQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.IdQuestionDefinition;
@@ -32,7 +31,6 @@ public class IdQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -50,7 +48,6 @@ public class IdQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     IdQuestionForm form = new IdQuestionForm(originalQd);
@@ -80,7 +77,6 @@ public class IdQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/NameQuestionFormTest.java
+++ b/server/test/forms/NameQuestionFormTest.java
@@ -25,10 +25,11 @@ public class NameQuestionFormTest {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -42,10 +43,11 @@ public class NameQuestionFormTest {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     NameQuestionForm form = new NameQuestionForm(originalQd);

--- a/server/test/forms/NameQuestionFormTest.java
+++ b/server/test/forms/NameQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class NameQuestionFormTest {
   @Test
@@ -22,11 +23,13 @@ public class NameQuestionFormTest {
 
     NameQuestionDefinition expected =
         new NameQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -37,11 +40,13 @@ public class NameQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     NameQuestionDefinition originalQd =
         new NameQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .build());
 
     NameQuestionForm form = new NameQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/server/test/forms/NameQuestionFormTest.java
+++ b/server/test/forms/NameQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.NameQuestionDefinition;
@@ -29,7 +28,6 @@ public class NameQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -47,7 +45,6 @@ public class NameQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     NameQuestionForm form = new NameQuestionForm(originalQd);

--- a/server/test/forms/NumberQuestionFormTest.java
+++ b/server/test/forms/NumberQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class NumberQuestionFormTest {
 
@@ -25,12 +26,15 @@ public class NumberQuestionFormTest {
 
     NumberQuestionDefinition expected =
         new NumberQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            NumberQuestionDefinition.NumberValidationPredicates.create(2, 8));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -41,12 +45,15 @@ public class NumberQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     NumberQuestionDefinition originalQd =
         new NumberQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            NumberQuestionDefinition.NumberValidationPredicates.create(2, 8));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
+                .build());
 
     NumberQuestionForm form = new NumberQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -69,12 +76,15 @@ public class NumberQuestionFormTest {
 
     NumberQuestionDefinition expected =
         new NumberQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            NumberQuestionDefinition.NumberValidationPredicates.create());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    NumberQuestionDefinition.NumberValidationPredicates.create())
+                .build());
 
     QuestionDefinition actual = builder.build();
 

--- a/server/test/forms/NumberQuestionFormTest.java
+++ b/server/test/forms/NumberQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.NumberQuestionDefinition;
@@ -33,7 +32,6 @@ public class NumberQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -52,7 +50,6 @@ public class NumberQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     NumberQuestionForm form = new NumberQuestionForm(originalQd);
@@ -83,7 +80,6 @@ public class NumberQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/NumberQuestionFormTest.java
+++ b/server/test/forms/NumberQuestionFormTest.java
@@ -28,12 +28,12 @@ public class NumberQuestionFormTest {
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -47,12 +47,12 @@ public class NumberQuestionFormTest {
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     NumberQuestionForm form = new NumberQuestionForm(originalQd);
@@ -78,12 +78,12 @@ public class NumberQuestionFormTest {
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/PhoneQuestionFormTest.java
+++ b/server/test/forms/PhoneQuestionFormTest.java
@@ -9,6 +9,7 @@ import services.LocalizedStrings;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 
 public class PhoneQuestionFormTest {
   @Test
@@ -22,11 +23,14 @@ public class PhoneQuestionFormTest {
 
     PhoneQuestionDefinition expected =
         new PhoneQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is your phone number?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -37,11 +41,14 @@ public class PhoneQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     PhoneQuestionDefinition originalQd =
         new PhoneQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is your Phone Number?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Phone Number?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .build());
 
     PhoneQuestionForm form = new PhoneQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/server/test/forms/PhoneQuestionFormTest.java
+++ b/server/test/forms/PhoneQuestionFormTest.java
@@ -25,11 +25,11 @@ public class PhoneQuestionFormTest {
         new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -43,11 +43,11 @@ public class PhoneQuestionFormTest {
         new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Phone Number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     PhoneQuestionForm form = new PhoneQuestionForm(originalQd);

--- a/server/test/forms/PhoneQuestionFormTest.java
+++ b/server/test/forms/PhoneQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.PhoneQuestionDefinition;
@@ -29,7 +28,6 @@ public class PhoneQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -47,7 +45,6 @@ public class PhoneQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Phone Number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     PhoneQuestionForm form = new PhoneQuestionForm(originalQd);

--- a/server/test/forms/StaticContentQuestionFormTest.java
+++ b/server/test/forms/StaticContentQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -30,7 +29,6 @@ public class StaticContentQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(actual).isEqualTo(expected);
@@ -48,7 +46,6 @@ public class StaticContentQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     StaticContentQuestionForm form = new StaticContentQuestionForm(originalQd);

--- a/server/test/forms/StaticContentQuestionFormTest.java
+++ b/server/test/forms/StaticContentQuestionFormTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import services.question.types.StaticContentQuestionDefinition;
 
 public class StaticContentQuestionFormTest {
@@ -21,11 +22,16 @@ public class StaticContentQuestionFormTest {
 
     StaticContentQuestionDefinition expected =
         new StaticContentQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "Some text. Not an actual question."),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(
+                    LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .build());
 
     assertThat(actual).isEqualTo(expected);
   }
@@ -34,11 +40,16 @@ public class StaticContentQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     StaticContentQuestionDefinition originalQd =
         new StaticContentQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "Some text. Not an actual question."),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(
+                    LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .build());
 
     StaticContentQuestionForm form = new StaticContentQuestionForm(originalQd);
     QuestionDefinition actual = form.getBuilder().build();

--- a/server/test/forms/StaticContentQuestionFormTest.java
+++ b/server/test/forms/StaticContentQuestionFormTest.java
@@ -24,13 +24,13 @@ public class StaticContentQuestionFormTest {
         new StaticContentQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(actual).isEqualTo(expected);
@@ -42,13 +42,13 @@ public class StaticContentQuestionFormTest {
         new StaticContentQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     StaticContentQuestionForm form = new StaticContentQuestionForm(originalQd);

--- a/server/test/forms/TextQuestionFormTest.java
+++ b/server/test/forms/TextQuestionFormTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class TextQuestionFormTest {
@@ -25,12 +27,17 @@ public class TextQuestionFormTest {
 
     TextQuestionDefinition expected =
         new TextQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(
+                    TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .build());
 
     QuestionDefinition actual = builder.build();
 
@@ -41,12 +48,17 @@ public class TextQuestionFormTest {
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     TextQuestionDefinition originalQd =
         new TextQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(
+                    TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .build());
 
     TextQuestionForm form = new TextQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -69,12 +81,16 @@ public class TextQuestionFormTest {
 
     TextQuestionDefinition expected =
         new TextQuestionDefinition(
-            "name",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "What is the question text?"),
-            LocalizedStrings.empty(),
-            TextQuestionDefinition.TextValidationPredicates.create());
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
 
     QuestionDefinition actual = builder.build();
 

--- a/server/test/forms/TextQuestionFormTest.java
+++ b/server/test/forms/TextQuestionFormTest.java
@@ -3,7 +3,6 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -34,7 +33,6 @@ public class TextQuestionFormTest {
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -54,7 +52,6 @@ public class TextQuestionFormTest {
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     TextQuestionForm form = new TextQuestionForm(originalQd);
@@ -84,7 +81,6 @@ public class TextQuestionFormTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/TextQuestionFormTest.java
+++ b/server/test/forms/TextQuestionFormTest.java
@@ -9,7 +9,6 @@ import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class TextQuestionFormTest {
@@ -29,14 +28,13 @@ public class TextQuestionFormTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -50,14 +48,13 @@ public class TextQuestionFormTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     TextQuestionForm form = new TextQuestionForm(originalQd);
@@ -83,13 +80,11 @@ public class TextQuestionFormTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
@@ -3,7 +3,6 @@ package forms.translation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
@@ -23,7 +22,6 @@ public class EnumeratorQuestionTranslationFormTest {
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("existing"))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.withDefaultValue("existing"));
 
@@ -52,7 +50,6 @@ public class EnumeratorQuestionTranslationFormTest {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.FRANCE, "existing"))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.of(Locale.FRANCE, "existing"));
 

--- a/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
@@ -18,12 +18,12 @@ public class EnumeratorQuestionTranslationFormTest {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("desc")
                 .setQuestionText(LocalizedStrings.withDefaultValue("existing"))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("existing"))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.withDefaultValue("existing"));
 
@@ -47,12 +47,12 @@ public class EnumeratorQuestionTranslationFormTest {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("desc")
                 .setQuestionText(LocalizedStrings.of(Locale.FRANCE, "existing"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.FRANCE, "existing"))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.of(Locale.FRANCE, "existing"));
 

--- a/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 
 public class EnumeratorQuestionTranslationFormTest {
 
@@ -15,11 +16,15 @@ public class EnumeratorQuestionTranslationFormTest {
   public void buildsQuestion_newLocale_savesUpdates() throws Exception {
     QuestionDefinition question =
         new EnumeratorQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "desc",
-            LocalizedStrings.withDefaultValue("existing"),
-            LocalizedStrings.withDefaultValue("existing"),
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("desc")
+                .setQuestionText(LocalizedStrings.withDefaultValue("existing"))
+                .setQuestionHelpText(LocalizedStrings.withDefaultValue("existing"))
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.withDefaultValue("existing"));
 
     EnumeratorQuestionTranslationForm form = new EnumeratorQuestionTranslationForm();
@@ -40,11 +45,15 @@ public class EnumeratorQuestionTranslationFormTest {
   public void buildsQuestion_existingLocale_savesUpdates() throws Exception {
     QuestionDefinition question =
         new EnumeratorQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "desc",
-            LocalizedStrings.of(Locale.FRANCE, "existing"),
-            LocalizedStrings.of(Locale.FRANCE, "existing"),
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("desc")
+                .setQuestionText(LocalizedStrings.of(Locale.FRANCE, "existing"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.FRANCE, "existing"))
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.of(Locale.FRANCE, "existing"));
 
     EnumeratorQuestionTranslationForm form = new EnumeratorQuestionTranslationForm();

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.TestQuestionBank;
 
@@ -49,11 +51,16 @@ public class QuestionTranslationFormTest {
   public void builder_noHelpText_onlyUpdatesQuestionText() throws Exception {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "test",
-            LocalizedStrings.withDefaultValue("question?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("test")
+                .setQuestionText(LocalizedStrings.withDefaultValue("question?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();
     form.setQuestionText("new locale");

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.TestQuestionBank;
 
@@ -53,13 +52,11 @@ public class QuestionTranslationFormTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("test")
                 .setQuestionText(LocalizedStrings.withDefaultValue("question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -3,7 +3,6 @@ package forms.translation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -56,7 +55,6 @@ public class QuestionTranslationFormTest {
                 .setQuestionText(LocalizedStrings.withDefaultValue("question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -33,13 +33,11 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 
@@ -58,13 +56,11 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
     question.save();
@@ -80,13 +76,11 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.of(10L))
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.of(10L))
                 .build());
     Question question = new Question(questionDefinition);
     question.save();
@@ -102,13 +96,11 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 
@@ -128,10 +120,12 @@ public class QuestionTest extends ResetPostgres {
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("address")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    AddressQuestionDefinition.AddressValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(address);
 
@@ -148,13 +142,12 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(TextValidationPredicates.create(0, 128))
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 
@@ -231,13 +224,11 @@ public class QuestionTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.of(10L))
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.of(10L))
                 .build());
     Question initialQuestion = new Question(questionDefinition);
     initialQuestion.save();

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -31,7 +31,16 @@ public class QuestionTest extends ResetPostgres {
   public void canSaveQuestion() throws UnsupportedQuestionTypeException {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "test", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     Question question = new Question(definition);
 
     question.save();
@@ -47,7 +56,16 @@ public class QuestionTest extends ResetPostgres {
   public void canSerializeEnumeratorId_EmptyOptionalLong() {
     QuestionDefinition questionDefinition =
         new TextQuestionDefinition(
-            "test", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     Question question = new Question(questionDefinition);
     question.save();
 
@@ -60,7 +78,16 @@ public class QuestionTest extends ResetPostgres {
   public void canSerializeEnumeratorId_NonEmptyOptionalLong() {
     QuestionDefinition questionDefinition =
         new TextQuestionDefinition(
-            "test", Optional.of(10L), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.of(10L))
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     Question question = new Question(questionDefinition);
     question.save();
 
@@ -73,11 +100,16 @@ public class QuestionTest extends ResetPostgres {
   public void canSerializeLocalizationMaps() {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(Locale.US, "hello"),
-            LocalizedStrings.of(Locale.US, "help"));
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     Question question = new Question(definition);
 
     question.save();
@@ -114,12 +146,16 @@ public class QuestionTest extends ResetPostgres {
   public void canSerializeValidationPredicates() {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(),
-            LocalizedStrings.empty(),
-            TextValidationPredicates.create(0, 128));
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create(0, 128))
+                .build());
     Question question = new Question(definition);
 
     question.save();
@@ -193,7 +229,16 @@ public class QuestionTest extends ResetPostgres {
   public void testTimestamps() throws Exception {
     QuestionDefinition questionDefinition =
         new TextQuestionDefinition(
-            "test", Optional.of(10L), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.of(10L))
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     Question initialQuestion = new Question(questionDefinition);
     initialQuestion.save();
 

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -37,7 +37,6 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 
@@ -60,7 +59,6 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
     question.save();
@@ -100,7 +98,6 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 
@@ -125,7 +122,6 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(address);
 
@@ -147,7 +143,6 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(TextValidationPredicates.create(0, 128))
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
 

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -14,8 +14,14 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.*;
+import services.question.types.AddressQuestionDefinition;
+import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.QuestionType;
+import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
 public class QuestionTest extends ResetPostgres {

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -14,13 +14,8 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.AddressQuestionDefinition;
-import services.question.types.EnumeratorQuestionDefinition;
-import services.question.types.MultiOptionQuestionDefinition;
-import services.question.types.QuestionDefinition;
+import services.question.types.*;
 import services.question.types.QuestionDefinitionBuilder;
-import services.question.types.QuestionType;
-import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
 public class QuestionTest extends ResetPostgres {
@@ -99,7 +94,13 @@ public class QuestionTest extends ResetPostgres {
   public void canSerializeDifferentQuestionTypes() {
     AddressQuestionDefinition address =
         new AddressQuestionDefinition(
-            "address", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("address")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .build());
     Question question = new Question(address);
 
     question.save();

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -15,6 +15,8 @@ import services.LocalizedStrings;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class QuestionRepositoryTest extends ResetPostgres {
@@ -141,11 +143,16 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void insertQuestion() {
     QuestionDefinition questionDefinition =
         new TextQuestionDefinition(
-            "question",
-            Optional.empty(),
-            "applicant's name",
-            LocalizedStrings.of(Locale.US, "What is your name?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("question")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("applicant's name")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
     Question question = new Question(questionDefinition);
 
     repo.insertQuestion(question).toCompletableFuture().join();
@@ -159,11 +166,16 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void insertQuestionSync() {
     QuestionDefinition questionDefinition =
         new TextQuestionDefinition(
-            "question",
-            Optional.empty(),
-            "applicant's name",
-            LocalizedStrings.of(Locale.US, "What is your name?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("question")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("applicant's name")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
     Question question = new Question(questionDefinition);
 
     repo.insertQuestionSync(question);

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -16,7 +16,6 @@ import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class QuestionRepositoryTest extends ResetPostgres {
@@ -145,13 +144,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("question")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("applicant's name")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
 
@@ -168,13 +165,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("question")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("applicant's name")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
 

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -148,7 +148,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
 
@@ -169,7 +168,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(questionDefinition);
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -82,12 +82,8 @@ import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionOption;
 import services.question.QuestionService;
-import services.question.types.FileUploadQuestionDefinition;
-import services.question.types.MultiOptionQuestionDefinition;
-import services.question.types.MultiOptionQuestionDefinitionConfig;
+import services.question.types.*;
 import services.question.types.MultiOptionQuestionDefinitionConfig.MultiOptionQuestionType;
-import services.question.types.NameQuestionDefinition;
-import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
 import views.applicant.AddressCorrectionBlockView;
 
@@ -824,11 +820,15 @@ public class ApplicantServiceTest extends ResetPostgres {
         questionService
             .create(
                 new FileUploadQuestionDefinition(
-                    "fileupload",
-                    Optional.empty(),
-                    "description",
-                    LocalizedStrings.of(Locale.US, "question?"),
-                    LocalizedStrings.of(Locale.US, "help text")))
+                    QuestionDefinitionConfig.builder()
+                        .setName("fileupload")
+                        .setEnumeratorId(Optional.empty())
+                        .setDescription("description")
+                        .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                        .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                        .setValidationPredicates(
+                            FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                        .build()))
             .getResult();
 
     Program firstProgram =

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -827,7 +827,6 @@ public class ApplicantServiceTest extends ResetPostgres {
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                         .setValidationPredicates(
                             FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-                        .setEnumeratorId(Optional.empty())
                         .build()))
             .getResult();
 
@@ -2947,7 +2946,6 @@ public class ApplicantServiceTest extends ResetPostgres {
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                         .setValidationPredicates(
                             NameQuestionDefinition.NameValidationPredicates.create())
-                        .setEnumeratorId(Optional.empty())
                         .build()))
             .getResult();
   }

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2940,11 +2940,13 @@ public class ApplicantServiceTest extends ResetPostgres {
         questionService
             .create(
                 new NameQuestionDefinition(
-                    name,
-                    Optional.empty(),
-                    "description",
-                    LocalizedStrings.of(Locale.US, "question?"),
-                    LocalizedStrings.of(Locale.US, "help text")))
+                    QuestionDefinitionConfig.builder()
+                        .setName(name)
+                        .setEnumeratorId(Optional.empty())
+                        .setDescription("description")
+                        .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                        .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                        .build()))
             .getResult();
   }
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -82,8 +82,13 @@ import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionOption;
 import services.question.QuestionService;
-import services.question.types.*;
+import services.question.types.FileUploadQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinitionConfig;
 import services.question.types.MultiOptionQuestionDefinitionConfig.MultiOptionQuestionType;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.ProgramBuilder;
 import views.applicant.AddressCorrectionBlockView;
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -822,12 +822,12 @@ public class ApplicantServiceTest extends ResetPostgres {
                 new FileUploadQuestionDefinition(
                     QuestionDefinitionConfig.builder()
                         .setName("fileupload")
-                        .setEnumeratorId(Optional.empty())
                         .setDescription("description")
                         .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                         .setValidationPredicates(
                             FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                        .setEnumeratorId(Optional.empty())
                         .build()))
             .getResult();
 
@@ -2942,10 +2942,12 @@ public class ApplicantServiceTest extends ResetPostgres {
                 new NameQuestionDefinition(
                     QuestionDefinitionConfig.builder()
                         .setName(name)
-                        .setEnumeratorId(Optional.empty())
                         .setDescription("description")
                         .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                        .setValidationPredicates(
+                            NameQuestionDefinition.NameValidationPredicates.create())
+                        .setEnumeratorId(Optional.empty())
                         .build()))
             .getResult();
   }

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -46,7 +46,6 @@ public class BlockTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
               .setValidationPredicates(
                   StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(123L))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -23,7 +23,12 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.question.exceptions.QuestionNotFoundException;
-import services.question.types.*;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.ScalarType;
+import services.question.types.StaticContentQuestionDefinition;
+import services.question.types.TextQuestionDefinition;
 import support.QuestionAnswerer;
 import support.TestQuestionBank;
 

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -40,14 +40,14 @@ public class BlockTest {
   private static final StaticContentQuestionDefinition STATIC_QUESTION =
       new StaticContentQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(123L))
               .setName("more info about something")
-              .setEnumeratorId(Optional.empty())
               .setDescription("Shows more info to the applicant")
               .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
               .setValidationPredicates(
                   StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(123L))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -23,11 +23,7 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.question.exceptions.QuestionNotFoundException;
-import services.question.types.NameQuestionDefinition;
-import services.question.types.QuestionDefinition;
-import services.question.types.ScalarType;
-import services.question.types.StaticContentQuestionDefinition;
-import services.question.types.TextQuestionDefinition;
+import services.question.types.*;
 import support.QuestionAnswerer;
 import support.TestQuestionBank;
 
@@ -43,13 +39,17 @@ public class BlockTest {
       (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
   private static final StaticContentQuestionDefinition STATIC_QUESTION =
       new StaticContentQuestionDefinition(
-          OptionalLong.of(123L),
-          "more info about something",
-          Optional.empty(),
-          "Shows more info to the applicant",
-          LocalizedStrings.of(Locale.US, "This is more info"),
-          LocalizedStrings.of(Locale.US, ""),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(123L))
+              .setName("more info about something")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("Shows more info to the applicant")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   @Test
   public void createNewBlock() {

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -30,14 +30,14 @@ public class AddressQuestionTest {
   private static final AddressQuestionDefinition addressQuestionDefinition =
       new AddressQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;
@@ -45,14 +45,14 @@ public class AddressQuestionTest {
   private static final AddressQuestionDefinition noPoBoxAddressQuestionDefinition =
       new AddressQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create(true))
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -36,7 +36,6 @@ public class AddressQuestionTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
@@ -51,7 +50,6 @@ public class AddressQuestionTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create(true))
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -21,6 +21,7 @@ import services.applicant.ValidationErrorMessage;
 import services.geo.ServiceAreaState;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.AddressQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
@@ -28,25 +29,32 @@ public class AddressQuestionTest {
 
   private static final AddressQuestionDefinition addressQuestionDefinition =
       new AddressQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          AddressQuestionDefinition.AddressValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  AddressQuestionDefinition.AddressValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private static final AddressQuestionDefinition noPoBoxAddressQuestionDefinition =
       new AddressQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          AddressQuestionDefinition.AddressValidationPredicates.create(true),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  AddressQuestionDefinition.AddressValidationPredicates.create(true))
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -19,6 +19,7 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.CurrencyQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
@@ -26,13 +27,15 @@ public class CurrencyQuestionTest {
 
   private static final CurrencyQuestionDefinition currencyQuestionDefinition =
       new CurrencyQuestionDefinition(
-          OptionalLong.of(1),
-          "question currency",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question currency")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -28,12 +28,14 @@ public class CurrencyQuestionTest {
   private static final CurrencyQuestionDefinition currencyQuestionDefinition =
       new CurrencyQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question currency")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -34,7 +34,6 @@ public class CurrencyQuestionTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -27,12 +27,13 @@ public class DateQuestionTest extends ResetPostgres {
   private static final DateQuestionDefinition dateQuestionDefinition =
       new DateQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -19,19 +19,22 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.DateQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class DateQuestionTest extends ResetPostgres {
   private static final DateQuestionDefinition dateQuestionDefinition =
       new DateQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -32,7 +32,6 @@ public class DateQuestionTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/EmailQuestionTest.java
+++ b/server/test/services/applicant/question/EmailQuestionTest.java
@@ -27,7 +27,6 @@ public class EmailQuestionTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/EmailQuestionTest.java
+++ b/server/test/services/applicant/question/EmailQuestionTest.java
@@ -14,19 +14,23 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.question.types.EmailQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class EmailQuestionTest extends ResetPostgres {
   private static final EmailQuestionDefinition emailQuestionDefinition =
       new EmailQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/EmailQuestionTest.java
+++ b/server/test/services/applicant/question/EmailQuestionTest.java
@@ -22,13 +22,13 @@ public class EmailQuestionTest extends ResetPostgres {
   private static final EmailQuestionDefinition emailQuestionDefinition =
       new EmailQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -22,6 +22,7 @@ import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 import support.TestQuestionBank;
 
@@ -29,14 +30,18 @@ import support.TestQuestionBank;
 public class EnumeratorQuestionTest extends ResetPostgres {
   private static final EnumeratorQuestionDefinition enumeratorQuestionDefinition =
       new EnumeratorQuestionDefinition(
-          OptionalLong.of(1),
-          "household members",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          LocalizedStrings.empty(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("household members")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build(),
+          LocalizedStrings.empty());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -37,7 +37,6 @@ public class EnumeratorQuestionTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build(),

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -31,14 +31,14 @@ public class EnumeratorQuestionTest extends ResetPostgres {
   private static final EnumeratorQuestionDefinition enumeratorQuestionDefinition =
       new EnumeratorQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("household members")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build(),
           LocalizedStrings.empty());

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -13,19 +13,25 @@ import org.junit.runner.RunWith;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.question.types.FileUploadQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class FileUploadQuestionTest {
   private static final FileUploadQuestionDefinition fileUploadQuestionDefinition =
       new FileUploadQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -27,7 +27,6 @@ public class FileUploadQuestionTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -21,14 +21,14 @@ public class FileUploadQuestionTest {
   private static final FileUploadQuestionDefinition fileUploadQuestionDefinition =
       new FileUploadQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;

--- a/server/test/services/applicant/question/IdQuestionTest.java
+++ b/server/test/services/applicant/question/IdQuestionTest.java
@@ -23,31 +23,37 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.IdQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class IdQuestionTest extends ResetPostgres {
   private static final IdQuestionDefinition idQuestionDefinition =
       new IdQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          IdQuestionDefinition.IdValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private static final IdQuestionDefinition minAndMaxLengthIdQuestionDefinition =
       new IdQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          IdQuestionDefinition.IdValidationPredicates.create(3, 4),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(3, 4))
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/IdQuestionTest.java
+++ b/server/test/services/applicant/question/IdQuestionTest.java
@@ -31,26 +31,26 @@ public class IdQuestionTest extends ResetPostgres {
   private static final IdQuestionDefinition idQuestionDefinition =
       new IdQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
+              .setEnumeratorId(Optional.empty())
               .build());
 
   private static final IdQuestionDefinition minAndMaxLengthIdQuestionDefinition =
       new IdQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(3, 4))
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;

--- a/server/test/services/applicant/question/IdQuestionTest.java
+++ b/server/test/services/applicant/question/IdQuestionTest.java
@@ -38,7 +38,6 @@ public class IdQuestionTest extends ResetPostgres {
               .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
-              .setEnumeratorId(Optional.empty())
               .build());
 
   private static final IdQuestionDefinition minAndMaxLengthIdQuestionDefinition =
@@ -49,7 +48,6 @@ public class IdQuestionTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(3, 4))
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -15,20 +15,23 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class NameQuestionTest {
   private static final NameQuestionDefinition nameQuestionDefinition =
       new NameQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          NameQuestionDefinition.NameValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -28,7 +28,6 @@ public class NameQuestionTest {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -23,13 +23,13 @@ public class NameQuestionTest {
   private static final NameQuestionDefinition nameQuestionDefinition =
       new NameQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -38,7 +38,6 @@ public class NumberQuestionTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
@@ -53,7 +52,6 @@ public class NumberQuestionTest extends ResetPostgres {
               .setValidationPredicates(
                   NumberQuestionDefinition.NumberValidationPredicates.create(50, 100))
               .setId(OptionalLong.of(1))
-              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -33,27 +33,27 @@ public class NumberQuestionTest extends ResetPostgres {
   private static final NumberQuestionDefinition numberQuestionDefinition =
       new NumberQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
 
   private static final NumberQuestionDefinition minAndMaxNumberQuestionDefinition =
       new NumberQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   NumberQuestionDefinition.NumberValidationPredicates.create(50, 100))
+              .setId(OptionalLong.of(1))
+              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -24,6 +24,7 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.NumberQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
@@ -31,25 +32,30 @@ public class NumberQuestionTest extends ResetPostgres {
 
   private static final NumberQuestionDefinition numberQuestionDefinition =
       new NumberQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          NumberQuestionDefinition.NumberValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private static final NumberQuestionDefinition minAndMaxNumberQuestionDefinition =
       new NumberQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          NumberQuestionDefinition.NumberValidationPredicates.create(50, 100),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  NumberQuestionDefinition.NumberValidationPredicates.create(50, 100))
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -28,13 +28,13 @@ public class PhoneQuestionTest {
   private static final PhoneQuestionDefinition phoneQuestionDefinition =
       new PhoneQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("applicant phone")
-              .setEnumeratorId(Optional.empty())
               .setDescription("The applicant Phone Number")
               .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
               .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+              .setId(OptionalLong.of(1))
+              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -34,7 +34,6 @@ public class PhoneQuestionTest {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
               .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
               .setId(OptionalLong.of(1))
-              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -20,20 +20,23 @@ import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class PhoneQuestionTest {
   private static final PhoneQuestionDefinition phoneQuestionDefinition =
       new PhoneQuestionDefinition(
-          OptionalLong.of(1),
-          "applicant phone",
-          Optional.empty(),
-          "The applicant Phone Number",
-          LocalizedStrings.of(Locale.US, "What is your phone number?"),
-          LocalizedStrings.of(Locale.US, "This is sample help text."),
-          PhoneQuestionDefinition.PhoneValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("applicant phone")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("The applicant Phone Number")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+              .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/StaticContentQuestionTest.java
+++ b/server/test/services/applicant/question/StaticContentQuestionTest.java
@@ -29,7 +29,6 @@ public class StaticContentQuestionTest extends ResetPostgres {
               .setValidationPredicates(
                   StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
               .setId(OptionalLong.of(1))
-              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/StaticContentQuestionTest.java
+++ b/server/test/services/applicant/question/StaticContentQuestionTest.java
@@ -22,14 +22,14 @@ public class StaticContentQuestionTest extends ResetPostgres {
   private static final StaticContentQuestionDefinition questionDefinition =
       new StaticContentQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
               .setQuestionHelpText(LocalizedStrings.empty())
               .setValidationPredicates(
                   StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setId(OptionalLong.of(1))
+              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .build());
 

--- a/server/test/services/applicant/question/StaticContentQuestionTest.java
+++ b/server/test/services/applicant/question/StaticContentQuestionTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
+import services.question.types.QuestionDefinitionConfig;
 import services.question.types.StaticContentQuestionDefinition;
 
 @RunWith(JUnitParamsRunner.class)
@@ -20,13 +21,17 @@ public class StaticContentQuestionTest extends ResetPostgres {
 
   private static final StaticContentQuestionDefinition questionDefinition =
       new StaticContentQuestionDefinition(
-          OptionalLong.of(1),
-          "name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "Some text. Not an actual question."),
-          LocalizedStrings.empty(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
+              .setQuestionHelpText(LocalizedStrings.empty())
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -36,6 +36,7 @@ public class TextQuestionTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .setLastModifiedTime(Optional.empty())
+              .setId(123L)
               .build());
 
   private static final TextQuestionDefinition minAndMaxLengthTextQuestionDefinition =
@@ -47,6 +48,7 @@ public class TextQuestionTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create(3, 4))
               .setLastModifiedTime(Optional.empty())
+              .setId(123L)
               .build());
   ;
 

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -36,7 +36,6 @@ public class TextQuestionTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .setLastModifiedTime(Optional.empty())
-              .setEnumeratorId(Optional.empty())
               .build());
 
   private static final TextQuestionDefinition minAndMaxLengthTextQuestionDefinition =
@@ -48,7 +47,6 @@ public class TextQuestionTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create(3, 4))
               .setLastModifiedTime(Optional.empty())
-              .setEnumeratorId(Optional.empty())
               .build());
   ;
 

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -22,7 +22,6 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.QuestionAnswerer;
 
@@ -32,28 +31,24 @@ public class TextQuestionTest extends ResetPostgres {
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-              .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .setEnumeratorId(Optional.empty())
               .build());
 
   private static final TextQuestionDefinition minAndMaxLengthTextQuestionDefinition =
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-              .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create(3, 4))
+              .setLastModifiedTime(Optional.empty())
+              .setEnumeratorId(Optional.empty())
               .build());
   ;
 

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -22,6 +21,8 @@ import services.LocalizedStrings;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.QuestionAnswerer;
 
@@ -29,25 +30,32 @@ import support.QuestionAnswerer;
 public class TextQuestionTest extends ResetPostgres {
   private static final TextQuestionDefinition textQuestionDefinition =
       new TextQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          TextQuestionDefinition.TextValidationPredicates.create(),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+              .build());
 
   private static final TextQuestionDefinition minAndMaxLengthTextQuestionDefinition =
       new TextQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          TextQuestionDefinition.TextValidationPredicates.create(3, 4),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create(3, 4))
+              .build());
+  ;
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -30,7 +30,6 @@ public class QuestionServiceTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .build());
 
   QuestionService questionService;

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -17,8 +17,11 @@ import services.ErrorAnd;
 import services.LocalizedStrings;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.*;
+import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.QuestionType;
+import services.question.types.TextQuestionDefinition;
 import support.ProgramBuilder;
 
 public class QuestionServiceTest extends ResetPostgres {

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -17,20 +17,23 @@ import services.ErrorAnd;
 import services.LocalizedStrings;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.QuestionDefinition;
+import services.question.types.*;
 import services.question.types.QuestionDefinitionBuilder;
-import services.question.types.QuestionType;
-import services.question.types.TextQuestionDefinition;
 import support.ProgramBuilder;
 
 public class QuestionServiceTest extends ResetPostgres {
   private static final QuestionDefinition questionDefinition =
       new TextQuestionDefinition(
-          "my name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"));
+          QuestionDefinitionConfig.builder()
+              .setName("my name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+              .build());
 
   QuestionService questionService;
   VersionRepository versionRepository;

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -26,13 +26,11 @@ public class QuestionServiceTest extends ResetPostgres {
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("my name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
               .build());
 
   QuestionService questionService;

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -134,13 +134,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.isEnumerator()).isFalse();
@@ -152,12 +150,12 @@ public class QuestionDefinitionTest {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
     assertThat(question.isEnumerator()).isTrue();
@@ -169,13 +167,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.isRepeated()).isFalse();
@@ -187,13 +183,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.of(123L))
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.of(123L))
                 .build());
     assertThat(question.isRepeated()).isTrue();
   }
@@ -226,13 +220,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "not french"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionText().get(Locale.FRANCE));
@@ -247,13 +239,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionHelpText().get(Locale.FRANCE));
@@ -268,13 +258,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.getQuestionHelpText().get(Locale.FRANCE)).isEqualTo("");
   }
@@ -285,13 +273,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.withDefaultValue("default"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().getOrDefault(Locale.forLanguageTag("und")))
@@ -304,13 +290,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("default"))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().getOrDefault(Locale.forLanguageTag("und")))
@@ -323,13 +307,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.US)).hasValue("hello");
@@ -341,13 +323,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -359,13 +339,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "world"))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.US)).hasValue("world");
@@ -377,13 +355,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -395,13 +371,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionType()).isEqualTo(QuestionType.TEXT);
@@ -413,13 +387,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("text")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate()).isEmpty();
   }
@@ -430,13 +402,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate())
         .containsOnly(
@@ -525,13 +495,11 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("test")
                 .setQuestionText(LocalizedStrings.of(Locale.US, ""))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate()).containsOnly(CiviFormError.of("Question text cannot be blank"));
   }
@@ -673,7 +641,6 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("test")
                 .setQuestionText(
                     LocalizedStrings.of(
@@ -691,9 +658,8 @@ public class QuestionDefinitionTest {
                         "ayuda",
                         Locale.GERMAN,
                         "Hilfe"))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(definition.getSupportedLocales())
@@ -706,7 +672,6 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("test")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("test")
                 .setQuestionText(
                     LocalizedStrings.of(
@@ -717,9 +682,8 @@ public class QuestionDefinitionTest {
                         Locale.FRANCE,
                         "question"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setValidationPredicates(TextValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(definition.getSupportedLocales())

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -138,7 +138,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.isEnumerator()).isFalse();
@@ -155,7 +154,6 @@ public class QuestionDefinitionTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
     assertThat(question.isEnumerator()).isTrue();
@@ -171,7 +169,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.isRepeated()).isFalse();
@@ -224,7 +221,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "not french"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionText().get(Locale.FRANCE));
@@ -243,7 +239,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionHelpText().get(Locale.FRANCE));
@@ -262,7 +257,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.getQuestionHelpText().get(Locale.FRANCE)).isEqualTo("");
   }
@@ -277,7 +271,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.withDefaultValue("default"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().getOrDefault(Locale.forLanguageTag("und")))
@@ -294,7 +287,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("default"))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().getOrDefault(Locale.forLanguageTag("und")))
@@ -311,7 +303,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.US)).hasValue("hello");
@@ -327,7 +318,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -343,7 +333,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "world"))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.US)).hasValue("world");
@@ -359,7 +348,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -375,7 +363,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(question.getQuestionType()).isEqualTo(QuestionType.TEXT);
@@ -391,7 +378,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate()).isEmpty();
   }
@@ -406,7 +392,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate())
         .containsOnly(
@@ -499,7 +484,6 @@ public class QuestionDefinitionTest {
                 .setQuestionText(LocalizedStrings.of(Locale.US, ""))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     assertThat(question.validate()).containsOnly(CiviFormError.of("Question text cannot be blank"));
   }
@@ -659,7 +643,6 @@ public class QuestionDefinitionTest {
                         Locale.GERMAN,
                         "Hilfe"))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(definition.getSupportedLocales())
@@ -683,7 +666,6 @@ public class QuestionDefinitionTest {
                         "question"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
 
     assertThat(definition.getSupportedLocales())

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -132,7 +132,16 @@ public class QuestionDefinitionTest {
   public void isEnumerator_false() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.isEnumerator()).isFalse();
   }
@@ -158,7 +167,16 @@ public class QuestionDefinitionTest {
   public void isRepeated_false() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.isRepeated()).isFalse();
   }
@@ -167,7 +185,16 @@ public class QuestionDefinitionTest {
   public void isRepeated_true() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.of(123L), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.of(123L))
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     assertThat(question.isRepeated()).isTrue();
   }
 
@@ -197,11 +224,16 @@ public class QuestionDefinitionTest {
   public void getQuestionTextForUnknownLocale_throwsException() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(Locale.US, "not french"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "not french"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionText().get(Locale.FRANCE));
 
@@ -213,11 +245,16 @@ public class QuestionDefinitionTest {
   public void getQuestionHelpTextForUnknownLocale_throwsException() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(),
-            LocalizedStrings.of(Locale.US, "help text"));
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionHelpText().get(Locale.FRANCE));
 
@@ -229,7 +266,16 @@ public class QuestionDefinitionTest {
   public void getEmptyHelpTextForUnknownLocale_succeeds() throws TranslationNotFoundException {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     assertThat(question.getQuestionHelpText().get(Locale.FRANCE)).isEqualTo("");
   }
 
@@ -237,11 +283,16 @@ public class QuestionDefinitionTest {
   public void getQuestionTextOrDefault_returnsDefaultIfNotFound() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text",
-            Optional.empty(),
-            "",
-            LocalizedStrings.withDefaultValue("default"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.withDefaultValue("default"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionText().getOrDefault(Locale.forLanguageTag("und")))
         .isEqualTo("default");
@@ -251,11 +302,16 @@ public class QuestionDefinitionTest {
   public void getQuestionHelpTextOrDefault_returnsDefaultIfNotFound() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(),
-            LocalizedStrings.withDefaultValue("default"));
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.withDefaultValue("default"))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionHelpText().getOrDefault(Locale.forLanguageTag("und")))
         .isEqualTo("default");
@@ -265,11 +321,16 @@ public class QuestionDefinitionTest {
   public void maybeGetQuestionText_returnsOptionalWithText() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(Locale.US, "hello"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.US)).hasValue("hello");
   }
@@ -278,7 +339,16 @@ public class QuestionDefinitionTest {
   public void maybeGetQuestionText_returnsEmptyIfLocaleNotFound() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
   }
@@ -287,11 +357,16 @@ public class QuestionDefinitionTest {
   public void maybeGetQuestionHelpText_returnsOptionalWithText() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(),
-            LocalizedStrings.of(Locale.US, "world"));
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "world"))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.US)).hasValue("world");
   }
@@ -300,7 +375,16 @@ public class QuestionDefinitionTest {
   public void maybeGetQuestionHelpText_returnsEmptyIfLocaleNotFound() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
   }
@@ -309,7 +393,16 @@ public class QuestionDefinitionTest {
   public void newQuestionHasTypeText() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(question.getQuestionType()).isEqualTo(QuestionType.TEXT);
   }
@@ -318,11 +411,16 @@ public class QuestionDefinitionTest {
   public void validateWellFormedQuestion_returnsNoErrors() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "text",
-            Optional.empty(),
-            "description",
-            LocalizedStrings.of(Locale.US, "question?"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("text")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     assertThat(question.validate()).isEmpty();
   }
 
@@ -330,7 +428,16 @@ public class QuestionDefinitionTest {
   public void validateBadQuestion_returnsErrors() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "", Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     assertThat(question.validate())
         .containsOnly(
             CiviFormError.of("Administrative identifier cannot be blank"),
@@ -416,11 +523,16 @@ public class QuestionDefinitionTest {
   public void validate_localeHasBlankText_returnsError() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "test",
-            LocalizedStrings.of(Locale.US, ""),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("test")
+                .setQuestionText(LocalizedStrings.of(Locale.US, ""))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
     assertThat(question.validate()).containsOnly(CiviFormError.of("Question text cannot be blank"));
   }
 
@@ -559,23 +671,30 @@ public class QuestionDefinitionTest {
   public void getSupportedLocales_onlyReturnsFullySupportedLocales() {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "test",
-            LocalizedStrings.of(
-                Locale.US,
-                "question?",
-                Locale.forLanguageTag("es-US"),
-                "pregunta",
-                Locale.FRANCE,
-                "question"),
-            LocalizedStrings.of(
-                Locale.US,
-                "help",
-                Locale.forLanguageTag("es-US"),
-                "ayuda",
-                Locale.GERMAN,
-                "Hilfe"));
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("test")
+                .setQuestionText(
+                    LocalizedStrings.of(
+                        Locale.US,
+                        "question?",
+                        Locale.forLanguageTag("es-US"),
+                        "pregunta",
+                        Locale.FRANCE,
+                        "question"))
+                .setQuestionHelpText(
+                    LocalizedStrings.of(
+                        Locale.US,
+                        "help",
+                        Locale.forLanguageTag("es-US"),
+                        "ayuda",
+                        Locale.GERMAN,
+                        "Hilfe"))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(definition.getSupportedLocales())
         .containsExactly(Locale.US, Locale.forLanguageTag("es-US"));
@@ -585,17 +704,23 @@ public class QuestionDefinitionTest {
   public void getSupportedLocales_emptyHelpText_returnsLocalesForQuestionText() {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "test",
-            Optional.empty(),
-            "test",
-            LocalizedStrings.of(
-                Locale.US,
-                "question?",
-                Locale.forLanguageTag("es-US"),
-                "pregunta",
-                Locale.FRANCE,
-                "question"),
-            LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName("test")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("test")
+                .setQuestionText(
+                    LocalizedStrings.of(
+                        Locale.US,
+                        "question?",
+                        Locale.forLanguageTag("es-US"),
+                        "pregunta",
+                        Locale.FRANCE,
+                        "question"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextValidationPredicates.create())
+                .build());
 
     assertThat(definition.getSupportedLocales())
         .containsExactly(Locale.US, Locale.forLanguageTag("es-US"), Locale.FRANCE);

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -141,11 +141,15 @@ public class QuestionDefinitionTest {
   public void isEnumerator_true() {
     QuestionDefinition question =
         new EnumeratorQuestionDefinition(
-            "",
-            Optional.empty(),
-            "",
-            LocalizedStrings.of(),
-            LocalizedStrings.empty(),
+            QuestionDefinitionConfig.builder()
+                .setName("")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.empty());
     assertThat(question.isEnumerator()).isTrue();
   }

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -19,6 +19,8 @@ import play.inject.Injector;
 import services.LocalizedStrings;
 import services.apikey.ApiKeyService;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class ResourceCreator {
@@ -63,7 +65,16 @@ public class ResourceCreator {
   public Question insertQuestion(String name) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            name, Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
     Question question = new Question(definition);
     question.save();
     return question;
@@ -73,7 +84,16 @@ public class ResourceCreator {
     String name = UUID.randomUUID().toString();
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            name, Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setEnumeratorId(Optional.empty())
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
     Question question = new Question(definition);
     question.save();
     return question;

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -70,7 +70,6 @@ public class ResourceCreator {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     question.save();
@@ -87,7 +86,6 @@ public class ResourceCreator {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     question.save();

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -20,7 +20,6 @@ import services.LocalizedStrings;
 import services.apikey.ApiKeyService;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public class ResourceCreator {
@@ -67,13 +66,11 @@ public class ResourceCreator {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName(name)
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     question.save();
@@ -86,13 +83,11 @@ public class ResourceCreator {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName(name)
-                .setEnumeratorId(Optional.empty())
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     Question question = new Question(definition);
     question.save();

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -388,11 +388,13 @@ public class TestQuestionBank {
   private Question applicantDate(QuestionEnum ignore) {
     QuestionDefinition definition =
         new DateQuestionDefinition(
-            "applicant birth date",
-            Optional.empty(),
-            "The applicant birth date",
-            LocalizedStrings.of(Locale.US, "What is your birthdate?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant birth date")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The applicant birth date")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your birthdate?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -1,6 +1,5 @@
 package support;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -321,11 +320,16 @@ public class TestQuestionBank {
   private Question applicantFile(QuestionEnum ignore) {
     QuestionDefinition definition =
         new FileUploadQuestionDefinition(
-            "applicant file",
-            Optional.empty(),
-            "The file to be uploaded",
-            LocalizedStrings.of(Locale.US, "What is the file you want to upload?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant file")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The file to be uploaded")
+                .setQuestionText(
+                    LocalizedStrings.of(Locale.US, "What is the file you want to upload?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -28,6 +28,7 @@ import services.question.types.NameQuestionDefinition;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import services.question.types.QuestionType;
 import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -1,5 +1,6 @@
 package support;
 
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -285,11 +286,15 @@ public class TestQuestionBank {
   private Question applicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
-            "applicant household members",
-            Optional.empty(),
-            "The applicant's household members",
-            LocalizedStrings.of(Locale.US, "Who are your household members?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."),
+            QuestionDefinitionConfig.builder()
+                .setName("applicant household members")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The applicant's household members")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "Who are your household members?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
   }
@@ -299,11 +304,15 @@ public class TestQuestionBank {
     Question householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
-            "household members jobs",
-            Optional.of(householdMembers.id),
-            "The applicant's household member's jobs",
-            LocalizedStrings.of(Locale.US, "What are the $this's jobs?"),
-            LocalizedStrings.of(Locale.US, "Where does $this work?"),
+            QuestionDefinitionConfig.builder()
+                .setName("household members jobs")
+                .setEnumeratorId(Optional.of(householdMembers.id))
+                .setDescription("The applicant's household member's jobs")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What are the $this's jobs?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "Where does $this work?"))
+                .setValidationPredicates(
+                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
   }

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -216,11 +216,14 @@ public class TestQuestionBank {
   private Question applicantPhone(QuestionEnum ignore) {
     QuestionDefinition definition =
         new PhoneQuestionDefinition(
-            "applicant phone",
-            Optional.empty(),
-            "The applicant Phone Number",
-            LocalizedStrings.of(Locale.US, "What is your phone number?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant phone")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The applicant Phone Number")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -502,11 +502,16 @@ public class TestQuestionBank {
   private Question applicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            "applicant favorite color",
-            Optional.empty(),
-            "Favorite color of applicant",
-            LocalizedStrings.of(Locale.US, "What is your favorite color?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant favorite color")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("Favorite color of applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your favorite color?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -351,11 +351,13 @@ public class TestQuestionBank {
   private Question applicantId(QuestionEnum ignore) {
     QuestionDefinition definition =
         new IdQuestionDefinition(
-            "applicant id",
-            Optional.empty(),
-            "1234",
-            LocalizedStrings.of(Locale.US, "What is the the id?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant id")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("1234")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the the id?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -210,7 +210,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -224,7 +223,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -240,7 +238,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -299,7 +296,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
@@ -335,7 +331,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -351,7 +346,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                 .setValidationPredicates(
                     CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -366,7 +360,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the the id?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -381,7 +374,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "what is your name?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
                 .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -416,7 +408,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -431,7 +422,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your birthdate?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -446,7 +436,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Email?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -504,7 +493,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -518,7 +506,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your favorite color?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setEnumeratorId(Optional.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     return maybeSave(definition);

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -324,11 +324,13 @@ public class TestQuestionBank {
   private Question applicantMonthlyIncome(QuestionEnum ignore) {
     QuestionDefinition definition =
         new CurrencyQuestionDefinition(
-            "applicant monthly income",
-            Optional.empty(),
-            "monthly income of applicant",
-            LocalizedStrings.of(Locale.US, "what is your monthly income?"),
-            LocalizedStrings.of(Locale.US, "help text"));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant monthly income")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("monthly income of applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "what is your monthly income?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -402,11 +402,14 @@ public class TestQuestionBank {
   private Question applicantEmail(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EmailQuestionDefinition(
-            "applicant Email address",
-            Optional.empty(),
-            "The applicant Email address",
-            LocalizedStrings.of(Locale.US, "What is your Email?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant Email address")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The applicant Email address")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Email?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -365,11 +365,13 @@ public class TestQuestionBank {
   private Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
-            "applicant name",
-            Optional.empty(),
-            "name of applicant",
-            LocalizedStrings.of(Locale.US, "what is your name?"),
-            LocalizedStrings.of(Locale.US, "help text"));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant name")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("name of applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "what is your name?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .build());
     return maybeSave(definition);
   }
 
@@ -378,11 +380,14 @@ public class TestQuestionBank {
     Question householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
         new NameQuestionDefinition(
-            "household members name",
-            Optional.of(householdMembers.id),
-            "The applicant's household member's name",
-            LocalizedStrings.of(Locale.US, "What is the $this's name?"),
-            LocalizedStrings.of(Locale.US, "Please provide full name for $this."));
+            QuestionDefinitionConfig.builder()
+                .setName("household members name")
+                .setEnumeratorId(Optional.of(householdMembers.id))
+                .setDescription("The applicant's household member's name")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the $this's name?"))
+                .setQuestionHelpText(
+                    LocalizedStrings.of(Locale.US, "Please provide full name for $this."))
+                .build());
 
     return maybeSave(definition);
   }

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -396,11 +396,16 @@ public class TestQuestionBank {
   private Question applicantJugglingNumber(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NumberQuestionDefinition(
-            "number of items applicant can juggle",
-            Optional.empty(),
-            "The number of items applicant can juggle at once",
-            LocalizedStrings.of(Locale.US, "How many items can you juggle at one time?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("number of items applicant can juggle")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The number of items applicant can juggle at once")
+                .setQuestionText(
+                    LocalizedStrings.of(Locale.US, "How many items can you juggle at one time?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    NumberQuestionDefinition.NumberValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
 
@@ -438,11 +443,19 @@ public class TestQuestionBank {
     Question householdMemberJobs = applicantHouseholdMemberJobs();
     QuestionDefinition definition =
         new NumberQuestionDefinition(
-            "household members days worked",
-            Optional.of(householdMemberJobs.id),
-            "The applicant's household member's number of days worked",
-            LocalizedStrings.of(Locale.US, "How many days has $this.parent worked at $this?"),
-            LocalizedStrings.of(Locale.US, "How many days has $this.parent worked at $this?"));
+            QuestionDefinitionConfig.builder()
+                .setName("household members days worked")
+                .setEnumeratorId(Optional.of(householdMemberJobs.id))
+                .setDescription("The applicant's household member's number of days worked")
+                .setQuestionText(
+                    LocalizedStrings.of(
+                        Locale.US, "How many days has $this.parent worked at $this?"))
+                .setQuestionHelpText(
+                    LocalizedStrings.of(
+                        Locale.US, "How many days has $this.parent worked at $this?"))
+                .setValidationPredicates(
+                    NumberQuestionDefinition.NumberValidationPredicates.create())
+                .build());
 
     return maybeSave(definition);
   }

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -203,11 +203,13 @@ public class TestQuestionBank {
   private Question applicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
-            "applicant address",
-            Optional.empty(),
-            "The address of applicant",
-            LocalizedStrings.of(Locale.US, "What is your address?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant address")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The address of applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your address?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build());
     return maybeSave(definition);
   }
 
@@ -226,11 +228,13 @@ public class TestQuestionBank {
   private Question applicantSecondaryAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
-            "applicant secondary address",
-            Optional.empty(),
-            "The secondary address of applicant",
-            LocalizedStrings.of(Locale.US, "What is your secondary address?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            QuestionDefinitionConfig.builder()
+                .setName("applicant secondary address")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("The secondary address of applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your secondary address?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build());
     return maybeSave(definition);
   }
 

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -487,11 +487,15 @@ public class TestQuestionBank {
   private Question staticContent(QuestionEnum ignore) {
     QuestionDefinition definition =
         new StaticContentQuestionDefinition(
-            "more info about something",
-            Optional.empty(),
-            "Shows more info to the applicant",
-            LocalizedStrings.of(Locale.US, "This is more info"),
-            LocalizedStrings.of(Locale.US, ""));
+            QuestionDefinitionConfig.builder()
+                .setName("more info about something")
+                .setEnumeratorId(Optional.empty())
+                .setDescription("Shows more info to the applicant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
+                .setValidationPredicates(
+                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .build());
     return maybeSave(definition);
   }
   // Text

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -205,10 +205,12 @@ public class TestQuestionBank {
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant address")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The address of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your address?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    AddressQuestionDefinition.AddressValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -218,11 +220,11 @@ public class TestQuestionBank {
         new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant phone")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The applicant Phone Number")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -233,10 +235,12 @@ public class TestQuestionBank {
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant secondary address")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The secondary address of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your secondary address?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(
+                    AddressQuestionDefinition.AddressValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -290,12 +294,12 @@ public class TestQuestionBank {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant household members")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The applicant's household members")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "Who are your household members?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
@@ -308,12 +312,12 @@ public class TestQuestionBank {
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("household members jobs")
-                .setEnumeratorId(Optional.of(householdMembers.id))
                 .setDescription("The applicant's household member's jobs")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What are the $this's jobs?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "Where does $this work?"))
                 .setValidationPredicates(
                     EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
+                .setEnumeratorId(Optional.of(householdMembers.id))
                 .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
@@ -325,13 +329,13 @@ public class TestQuestionBank {
         new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant file")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The file to be uploaded")
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "What is the file you want to upload?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -342,10 +346,12 @@ public class TestQuestionBank {
         new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant monthly income")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("monthly income of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "what is your monthly income?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .setValidationPredicates(
+                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -356,10 +362,11 @@ public class TestQuestionBank {
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant id")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("1234")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the the id?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -370,10 +377,11 @@ public class TestQuestionBank {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant name")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("name of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "what is your name?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -385,11 +393,12 @@ public class TestQuestionBank {
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("household members name")
-                .setEnumeratorId(Optional.of(householdMembers.id))
                 .setDescription("The applicant's household member's name")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the $this's name?"))
                 .setQuestionHelpText(
                     LocalizedStrings.of(Locale.US, "Please provide full name for $this."))
+                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
+                .setEnumeratorId(Optional.of(householdMembers.id))
                 .build());
 
     return maybeSave(definition);
@@ -401,13 +410,13 @@ public class TestQuestionBank {
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("number of items applicant can juggle")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The number of items applicant can juggle at once")
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "How many items can you juggle at one time?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -418,10 +427,11 @@ public class TestQuestionBank {
         new DateQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant birth date")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The applicant birth date")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your birthdate?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -432,11 +442,11 @@ public class TestQuestionBank {
         new EmailQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant Email address")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("The applicant Email address")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Email?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -448,7 +458,6 @@ public class TestQuestionBank {
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("household members days worked")
-                .setEnumeratorId(Optional.of(householdMemberJobs.id))
                 .setDescription("The applicant's household member's number of days worked")
                 .setQuestionText(
                     LocalizedStrings.of(
@@ -458,6 +467,7 @@ public class TestQuestionBank {
                         Locale.US, "How many days has $this.parent worked at $this?"))
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create())
+                .setEnumeratorId(Optional.of(householdMemberJobs.id))
                 .build());
 
     return maybeSave(definition);
@@ -489,12 +499,12 @@ public class TestQuestionBank {
         new StaticContentQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("more info about something")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("Shows more info to the applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
                 .setValidationPredicates(
                     StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .build());
     return maybeSave(definition);
   }
@@ -504,12 +514,11 @@ public class TestQuestionBank {
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
                 .setName("applicant favorite color")
-                .setEnumeratorId(Optional.empty())
                 .setDescription("Favorite color of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your favorite color?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+                .setEnumeratorId(Optional.empty())
                 .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     return maybeSave(definition);

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -49,13 +49,15 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
             new DateQuestionDefinition(
                 QuestionDefinitionConfig.builder()
                     .setName("Applicant Date of Birth")
-                    .setEnumeratorId(Optional.empty())
                     .setDescription("Applicant's date of birth")
                     .setQuestionText(
                         LocalizedStrings.of(
                             Lang.forCode("en-US").toLocale(),
                             "Please enter your date of birth in the format mm/dd/yyyy"))
                     .setQuestionHelpText(LocalizedStrings.empty())
+                    .setValidationPredicates(
+                        DateQuestionDefinition.DateValidationPredicates.create())
+                    .setEnumeratorId(Optional.empty())
                     .build()));
     assertThat(getAllQuestions().size()).isEqualTo(1);
 

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -14,6 +14,7 @@ import services.LocalizedStrings;
 import services.question.QuestionService;
 import services.question.types.DateQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 
 public class DatabaseSeedTaskTest extends ResetPostgres {
 
@@ -46,13 +47,16 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
     instanceOf(QuestionService.class)
         .create(
             new DateQuestionDefinition(
-                /* name= */ "Applicant Date of Birth",
-                /* enumeratorId= */ Optional.empty(),
-                /* description= */ "Applicant's date of birth",
-                /* questionText= */ LocalizedStrings.of(
-                    Lang.forCode("en-US").toLocale(),
-                    "Please enter your date of birth in the format mm/dd/yyyy"),
-                /* questionHelpText= */ LocalizedStrings.empty()));
+                QuestionDefinitionConfig.builder()
+                    .setName("Applicant Date of Birth")
+                    .setEnumeratorId(Optional.empty())
+                    .setDescription("Applicant's date of birth")
+                    .setQuestionText(
+                        LocalizedStrings.of(
+                            Lang.forCode("en-US").toLocale(),
+                            "Please enter your date of birth in the format mm/dd/yyyy"))
+                    .setQuestionHelpText(LocalizedStrings.empty())
+                    .build()));
     assertThat(getAllQuestions().size()).isEqualTo(1);
 
     databaseSeedTask.run();

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -2,7 +2,6 @@ package tasks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import java.util.Set;
 import models.Question;
 import org.junit.Before;
@@ -57,7 +56,6 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
                     .setQuestionHelpText(LocalizedStrings.empty())
                     .setValidationPredicates(
                         DateQuestionDefinition.DateValidationPredicates.create())
-                    .setEnumeratorId(Optional.empty())
                     .build()));
     assertThat(getAllQuestions().size()).isEqualTo(1);
 

--- a/server/test/views/questiontypes/AddressRendererTest.java
+++ b/server/test/views/questiontypes/AddressRendererTest.java
@@ -25,14 +25,14 @@ public class AddressRendererTest extends ResetPostgres {
   private static final AddressQuestionDefinition ADDRESS_QUESTION =
       new AddressQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("Address Question")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;

--- a/server/test/views/questiontypes/AddressRendererTest.java
+++ b/server/test/views/questiontypes/AddressRendererTest.java
@@ -31,7 +31,6 @@ public class AddressRendererTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   AddressQuestionDefinition.AddressValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/views/questiontypes/AddressRendererTest.java
+++ b/server/test/views/questiontypes/AddressRendererTest.java
@@ -17,20 +17,25 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.question.types.AddressQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 public class AddressRendererTest extends ResetPostgres {
 
   private static final AddressQuestionDefinition ADDRESS_QUESTION =
       new AddressQuestionDefinition(
-          OptionalLong.of(1),
-          "Address Question",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          AddressQuestionDefinition.AddressValidationPredicates.create(),
-          Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("Address Question")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  AddressQuestionDefinition.AddressValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private final ApplicantData applicantData = new ApplicantData();
 

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -17,19 +17,23 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.question.types.CurrencyQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
 
 public class CurrencyQuestionRendererTest extends ResetPostgres {
   private static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
       new CurrencyQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private final ApplicantData applicantData = new ApplicantData();
 

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -31,7 +31,6 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(
                   CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -25,12 +25,14 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
   private static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
       new CurrencyQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -31,7 +31,6 @@ public class IdQuestionRendererTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(IdValidationPredicates.create(2, 3))
-              .setEnumeratorId(Optional.empty())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -19,19 +19,23 @@ import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.IdQuestionDefinition.IdValidationPredicates;
+import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 
 public class IdQuestionRendererTest extends ResetPostgres {
   private static final IdQuestionDefinition ID_QUESTION_DEFINITION =
       new IdQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          IdValidationPredicates.create(2, 3),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setId(OptionalLong.of(1))
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(IdValidationPredicates.create(2, 3))
+              .setLastModifiedTime(Optional.empty())
+              .build());
+  ;
 
   private final ApplicantData applicantData = new ApplicantData();
 

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -26,13 +26,13 @@ public class IdQuestionRendererTest extends ResetPostgres {
   private static final IdQuestionDefinition ID_QUESTION_DEFINITION =
       new IdQuestionDefinition(
           QuestionDefinitionConfig.builder()
-              .setId(OptionalLong.of(1))
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(IdValidationPredicates.create(2, 3))
+              .setEnumeratorId(Optional.empty())
+              .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());
   ;

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -32,6 +32,7 @@ public class TextQuestionRendererTest extends ResetPostgres {
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextValidationPredicates.create(2, 3))
+              .setId(123L)
               .build());
 
   private final ApplicantData applicantData = new ApplicantData();

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -30,7 +30,6 @@ public class TextQuestionRendererTest extends ResetPostgres {
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
               .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextValidationPredicates.create(2, 3))
               .build());

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -17,7 +17,6 @@ import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 import support.QuestionAnswerer;
@@ -27,12 +26,11 @@ public class TextQuestionRendererTest extends ResetPostgres {
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("question name")
-              .setEnumeratorId(Optional.empty())
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
+              .setEnumeratorId(Optional.empty())
               .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextValidationPredicates.create(2, 3))
               .build());

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.OptionalLong;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -17,6 +16,8 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 import support.QuestionAnswerer;
@@ -24,14 +25,17 @@ import support.QuestionAnswerer;
 public class TextQuestionRendererTest extends ResetPostgres {
   private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
       new TextQuestionDefinition(
-          OptionalLong.of(1),
-          "question name",
-          Optional.empty(),
-          "description",
-          LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"),
-          TextValidationPredicates.create(2, 3),
-          /* lastModifiedTime= */ Optional.empty());
+          QuestionDefinitionConfig.builder()
+              .setName("question name")
+              .setEnumeratorId(Optional.empty())
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setValidationPredicates(
+                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
+              .setLastModifiedTime(Optional.empty())
+              .setValidationPredicates(TextValidationPredicates.create(2, 3))
+              .build());
 
   private final ApplicantData applicantData = new ApplicantData();
 


### PR DESCRIPTION
### Description

This PR cleans up the construction of `QuestionDefinition` instances. This will make API docs much easier to generate, and reduces constructor bloat and code duplication.

Specifically, we:

* Introduce `QuestionDefinitionConfig`, an `AutoValue` class with all the fields from `QuestionDefinition`
* Make `QuestionDefinitionConfig` the sole instance variable of `QuestionDefinition`
* Remove all constructors from `XQuestionDefinition` classes and replace with `public XQuestionDefinition(QuestionDefinitionConfig config)`
* Update usages, including setting a default `ValidationPredicates` for each one.

Note that `QuestionDefinitionConfig` is an `AutoValue` with some required fields, and we enforce those at compile-time (instead of runtime) using `RequiredX` interfaces, via [step builder](https://github.com/google/auto/blob/main/value/userguide/builders-howto.md#-create-a-step-builder).

https://github.com/civiform/civiform/blob/1754f9a9dbf6742ed6df85e84011f78c5a8e0f9a/server/app/services/question/types/QuestionDefinitionConfig.java#L9-L75


## Release notes

None.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Issue(s) this completes

Relates to #4872