### PR TITLE
Only use applicant_portal_name if whitelabel_civic_entity_full_name is not present

### DIFF
--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -64,9 +64,18 @@ public class MainModule extends AbstractModule {
   public String provideApplicantAuthProviderName(Config config) {
     checkNotNull(config);
 
-    if (config.hasPath("applicant_portal_name")
-        && !config.getString("applicant_portal_name").isBlank()) {
-      return config.getString("applicant_portal_name");
+    boolean applicantPortalNamePresent =
+        config.hasPath("applicant_portal_name")
+            && !config.getString("applicant_portal_name").isBlank();
+
+    boolean whiteLabelPortalNamePresent =
+        config.hasPath("whitelabel_civic_entity_full_name")
+            && !config.getString("whitelabel_civic_entity_full_name").isBlank();
+
+    if (applicantPortalNamePresent && !whiteLabelPortalNamePresent) {
+      String applicantPortalName = config.getString("applicant_portal_name");
+
+      return applicantPortalName;
     }
 
     return config.getString("whitelabel_civic_entity_full_name");

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -68,16 +68,16 @@ public class MainModule extends AbstractModule {
         config.hasPath("applicant_portal_name")
             && !config.getString("applicant_portal_name").isBlank();
 
-    boolean whiteLabelPortalNamePresent =
+    boolean civicEntityNameIsPresent =
         config.hasPath("whitelabel_civic_entity_full_name")
             && !config.getString("whitelabel_civic_entity_full_name").isBlank();
 
-    if (applicantPortalNamePresent && !whiteLabelPortalNamePresent) {
-      String applicantPortalName = config.getString("applicant_portal_name");
-
-      return applicantPortalName;
+    if (applicantPortalNamePresent) {
+      return config.getString("applicant_portal_name");
+    } else if (civicEntityNameIsPresent) {
+      return config.getString("whitelabel_civic_entity_full_name");
     }
 
-    return config.getString("whitelabel_civic_entity_full_name");
+    return "TestPortal";
   }
 }

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -28,3 +28,5 @@ reporting_use_deterministic_stats = true
 publish_single_program_enabled = true
 
 admin_settings_panel_enabled = false
+
+applicant_portal_name = "TestPortal"

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -18,6 +18,8 @@ azure.blob.account = "my awesome azure account name"
 
 civiform_applicant_idp = "disabled"
 
+applicant_portal_name = "TestPortal"
+
 # Feature flags.
 feature_flag_overrides_enabled = true
 feature_flag_overrides_enabled = ${?FEATURE_FLAG_OVERRIDES_ENABLED}

--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -28,7 +28,6 @@ applicant_register_uri = ${?APPLICANT_REGISTER_URI}
 
 # The name of the authentication provider. Defaults to the full name of the civic
 # entity if not set, or TestPortal if neither is set.
-applicant_portal_name = "TestPortal"
 applicant_portal_name = ${?APPLICANT_PORTAL_NAME}
 
 ## IDCS integration

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -132,6 +132,15 @@ public class SettingsServiceTest extends ResetPostgres {
   }
 
   private void createTestSettings() {
+    // Since ResetPostres#resetTables create a settings group as well, if this
+    // is created too fast it can attempt to create two settings group with the
+    // same timestamp. Delaying by a millisecond prevents that.
+    try {
+      Thread.sleep(1);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
     new SettingsGroup(TEST_SETTINGS, "test").save();
   }
 }


### PR DESCRIPTION
### Description

This PR changes the code for resolving the login portal name so that "TestPortal" is only used if `applicant_portal_name` and `whitelabel_civic_entity_full_name` are both not present.

See https://github.com/civiform/civiform/issues/5134

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5134