### PR TITLE
Remove `USE_APPLICATION_PATH_TYPES` set

### DIFF
--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -1,18 +1,9 @@
 package services.export;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static services.question.types.QuestionType.ADDRESS;
-import static services.question.types.QuestionType.DROPDOWN;
-import static services.question.types.QuestionType.EMAIL;
-import static services.question.types.QuestionType.FILEUPLOAD;
-import static services.question.types.QuestionType.ID;
-import static services.question.types.QuestionType.NAME;
-import static services.question.types.QuestionType.RADIO_BUTTON;
-import static services.question.types.QuestionType.TEXT;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.jayway.jsonpath.DocumentContext;
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +24,6 @@ import services.applicant.ReadOnlyApplicantProgramService;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
-import services.question.types.QuestionType;
 
 /** Exports all applications for a given program as JSON. */
 public final class JsonExporter {
@@ -42,11 +32,6 @@ public final class JsonExporter {
   private final ProgramService programService;
   private final DateConverter dateConverter;
   private final QuestionJsonPresenter.Factory presenterFactory;
-
-  // Question types for which we should call getApplicationPath() on their path
-  // when constructing the API response.
-  private static final ImmutableSet<QuestionType> USE_APPLICATION_PATH_TYPES =
-      ImmutableSet.of(NAME, ID, TEXT, EMAIL, ADDRESS, DROPDOWN, RADIO_BUTTON, FILEUPLOAD);
 
   @Inject
   JsonExporter(
@@ -144,11 +129,7 @@ public final class JsonExporter {
             .getJsonEntries(answerData.createQuestion());
 
     for (Map.Entry<Path, ?> entry : entries.entrySet()) {
-      Path path = entry.getKey();
-
-      if (USE_APPLICATION_PATH_TYPES.contains(answerData.questionDefinition().getQuestionType())) {
-        path = path.asApplicationPath();
-      }
+      Path path = entry.getKey().asApplicationPath();
 
       Object value = entry.getValue();
       if (value instanceof String) {

--- a/server/app/services/export/QuestionJsonPresenter.java
+++ b/server/app/services/export/QuestionJsonPresenter.java
@@ -145,7 +145,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
 
     @Override
     public ImmutableMap<Path, ImmutableList<String>> getJsonEntries(MultiSelectQuestion question) {
-      Path path = question.getSelectionPath().asApplicationPath();
+      Path path = question.getSelectionPath();
 
       if (question.getSelectedOptionsValue().isPresent()) {
         ImmutableList<String> selectedOptions =
@@ -180,8 +180,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
   class CurrencyJsonPresenter implements QuestionJsonPresenter<CurrencyQuestion> {
     @Override
     public ImmutableMap<Path, Double> getJsonEntries(CurrencyQuestion question) {
-      Path path =
-          question.getCurrencyPath().asApplicationPath().replacingLastSegment("currency_dollars");
+      Path path = question.getCurrencyPath().replacingLastSegment("currency_dollars");
 
       if (question.getCurrencyValue().isPresent()) {
         Long centsTotal = Long.valueOf(question.getCurrencyValue().get().getCents());
@@ -196,7 +195,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
   class DateJsonPresenter implements QuestionJsonPresenter<DateQuestion> {
     @Override
     public ImmutableMap<Path, String> getJsonEntries(DateQuestion question) {
-      Path path = question.getDatePath().asApplicationPath();
+      Path path = question.getDatePath();
 
       if (question.getDateValue().isPresent()) {
         LocalDate date = question.getDateValue().get();
@@ -217,7 +216,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
   class NumberJsonPresenter implements QuestionJsonPresenter<NumberQuestion> {
     @Override
     public ImmutableMap<Path, Long> getJsonEntries(NumberQuestion question) {
-      Path path = question.getNumberPath().asApplicationPath();
+      Path path = question.getNumberPath();
 
       if (question.getNumberValue().isPresent()) {
         return ImmutableMap.of(path, question.getNumberValue().get());
@@ -233,7 +232,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
 
     @Override
     public ImmutableMap<Path, String> getJsonEntries(PhoneQuestion question) {
-      Path path = question.getPhoneNumberPath().asApplicationPath();
+      Path path = question.getPhoneNumberPath();
 
       if (question.getPhoneNumberValue().isPresent()
           && question.getCountryCodeValue().isPresent()) {


### PR DESCRIPTION
### Description

Currently we have a `USE_APPLICATION_PATH_TYPES` set which is supposedly the set of question types for which we need to replace "applicant" with "application". 

https://github.com/civiform/civiform/blob/ded406b264d3d09cf3c7cb7188c5e344e21938e8/server/app/services/export/JsonExporter.java#L46-L49

It's used on line 149 here:

https://github.com/civiform/civiform/blob/ded406b264d3d09cf3c7cb7188c5e344e21938e8/server/app/services/export/JsonExporter.java#L135-L166

In practice, all question types get their path replaced. Remove this set and call `asApplicationPath` in all remaining `QuestionJsonPresenter`s.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - None, but I diff checked the full API response on a large program [here](https://www.diffchecker.com/5f8wCYdC/).
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

None.

### Issue(s) this completes

None.
