### PR TITLE
Fix admin_settings test for probers

### DIFF
--- a/browser-test/src/admin_settings.test.ts
+++ b/browser-test/src/admin_settings.test.ts
@@ -35,15 +35,15 @@ describe('Managing system-wide settings', () => {
     const adminSettings = new AdminSettings(page)
     await adminSettings.gotoAdminSettings()
 
-    await adminSettings.enableSetting('ESRI_ADDRESS_CORRECTION_ENABLED')
+    await adminSettings.disableSetting('CF_OPTIONAL_QUESTIONS')
     await adminSettings.saveChanges()
-    await adminSettings.expectEnabled('ESRI_ADDRESS_CORRECTION_ENABLED')
+    await adminSettings.expectDisabled('CF_OPTIONAL_QUESTIONS')
 
-    await adminSettings.disableSetting('ESRI_ADDRESS_CORRECTION_ENABLED')
+    await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
     await adminSettings.saveChanges()
-    await adminSettings.expectDisabled('ESRI_ADDRESS_CORRECTION_ENABLED')
+    await adminSettings.expectEnabled('CF_OPTIONAL_QUESTIONS')
 
-    await adminSettings.disableSetting('ESRI_ADDRESS_CORRECTION_ENABLED')
+    await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
     await adminSettings.saveChanges(/* expectUpdated= */ false)
   })
 })


### PR DESCRIPTION
### Description

Because we have ESRI_ADDRESS_CORRECTION_ENABLED on staging, while this test would pass in the hermetic test env, it would fail on staging since it would be trying to enable something that's already enabled. This switches it to use the CF_OPTIONAL_QUESTIONS setting instead, since this should probably always be enabled, and to test disabling, re-enabling, then saving with it still enabled.

This has been tested against probers manually and passes, along with running in the hermetic env.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Performed prober testing
