### PR TITLE
Remove setting default ValidationPredicates

### DIFF
--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -42,7 +42,6 @@ import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -143,8 +142,6 @@ public class DatabaseSeedController extends Controller {
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("What is your address?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        AddressQuestionDefinition.AddressValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -158,8 +155,6 @@ public class DatabaseSeedController extends Controller {
                 LocalizedStrings.withDefaultValue(
                     "Which of the following kitchen instruments do you own?"))
             .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -184,8 +179,6 @@ public class DatabaseSeedController extends Controller {
                         LocalizedStrings.withDefaultValue(
                             "How much should a scoop of ice cream cost?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -200,8 +193,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(LocalizedStrings.withDefaultValue("When is $this's birthday?"))
                     .setQuestionHelpText(
                         LocalizedStrings.withDefaultValue("help text for $this's birthday"))
-                    .setValidationPredicates(
-                        DateQuestionDefinition.DateValidationPredicates.create())
                     .setEnumeratorId(Optional.of(enumeratorId))
                     .build()))
         .getResult();
@@ -218,8 +209,6 @@ public class DatabaseSeedController extends Controller {
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue(questionText))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        DateQuestionDefinition.DateValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -233,7 +222,6 @@ public class DatabaseSeedController extends Controller {
                 LocalizedStrings.withDefaultValue(
                     "Select your favorite ice cream flavor from the following"))
             .setQuestionHelpText(LocalizedStrings.withDefaultValue("this is sample help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -257,8 +245,6 @@ public class DatabaseSeedController extends Controller {
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("What is your email?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        EmailQuestionDefinition.EmailValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -273,8 +259,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("List all members of your household."))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                     .build(),
                 LocalizedStrings.withDefaultValue("household member")))
         .getResult();
@@ -290,8 +274,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("Upload anything from your computer"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -306,7 +288,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("What is your driver's license ID?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -321,8 +302,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("How many pets do you have?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        NumberQuestionDefinition.NumberValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -334,8 +313,6 @@ public class DatabaseSeedController extends Controller {
             .setDescription("favorite season in the year")
             .setQuestionText(LocalizedStrings.withDefaultValue("What is your favorite season?"))
             .setQuestionHelpText(LocalizedStrings.withDefaultValue("this is sample help text"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -368,8 +345,6 @@ public class DatabaseSeedController extends Controller {
                                 + "### What are the eligibility requirements? \n"
                                 + ">You are 18 years or older."))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
-                    .setValidationPredicates(
-                        StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -384,8 +359,6 @@ public class DatabaseSeedController extends Controller {
                     .setQuestionText(
                         LocalizedStrings.withDefaultValue("What is your favorite color?"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        TextQuestionDefinition.TextValidationPredicates.create())
                     .build()))
         .getResult();
   }
@@ -399,8 +372,6 @@ public class DatabaseSeedController extends Controller {
                     .setDescription("description")
                     .setQuestionText(LocalizedStrings.withDefaultValue("what is your phone number"))
                     .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-                    .setValidationPredicates(
-                        PhoneQuestionDefinition.PhoneValidationPredicates.create())
                     .build()))
         .getResult();
   }

--- a/server/app/services/question/types/AddressQuestionDefinition.java
+++ b/server/app/services/question/types/AddressQuestionDefinition.java
@@ -61,6 +61,11 @@ public final class AddressQuestionDefinition extends QuestionDefinition {
     return QuestionType.ADDRESS;
   }
 
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return AddressValidationPredicates.create();
+  }
+
   public boolean getDisallowPoBox() {
     return getAddressValidationPredicates().disallowPoBox().orElse(false);
   }

--- a/server/app/services/question/types/CurrencyQuestionDefinition.java
+++ b/server/app/services/question/types/CurrencyQuestionDefinition.java
@@ -35,4 +35,9 @@ public final class CurrencyQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.CURRENCY;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return CurrencyValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -35,4 +35,9 @@ public final class DateQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.DATE;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return DateValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/EmailQuestionDefinition.java
+++ b/server/app/services/question/types/EmailQuestionDefinition.java
@@ -35,4 +35,9 @@ public final class EmailQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.EMAIL;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return EmailValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/server/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -35,6 +35,11 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
     return QuestionType.ENUMERATOR;
   }
 
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return EnumeratorValidationPredicates.create();
+  }
+
   public LocalizedStrings getEntityType() {
     return entityType;
   }

--- a/server/app/services/question/types/FileUploadQuestionDefinition.java
+++ b/server/app/services/question/types/FileUploadQuestionDefinition.java
@@ -36,4 +36,9 @@ public final class FileUploadQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.FILEUPLOAD;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return FileUploadValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/IdQuestionDefinition.java
+++ b/server/app/services/question/types/IdQuestionDefinition.java
@@ -70,6 +70,11 @@ public final class IdQuestionDefinition extends QuestionDefinition {
     return QuestionType.ID;
   }
 
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return IdValidationPredicates.create();
+  }
+
   public OptionalInt getMinLength() {
     return getIdValidationPredicates().minLength();
   }

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -68,6 +68,11 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return MultiOptionValidationPredicates.create();
+  }
+
+  @Override
   public ImmutableSet<Locale> getSupportedLocales() {
     ImmutableSet<Locale> questionTextLocales = super.getSupportedLocales();
     return ImmutableSet.copyOf(Sets.intersection(questionTextLocales, getSupportedOptionLocales()));

--- a/server/app/services/question/types/NameQuestionDefinition.java
+++ b/server/app/services/question/types/NameQuestionDefinition.java
@@ -35,4 +35,9 @@ public final class NameQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.NAME;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return NameValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/NumberQuestionDefinition.java
+++ b/server/app/services/question/types/NumberQuestionDefinition.java
@@ -73,6 +73,11 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
     return QuestionType.NUMBER;
   }
 
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return NumberValidationPredicates.create();
+  }
+
   public OptionalLong getMin() {
     return getNumberValidationPredicates().min();
   }

--- a/server/app/services/question/types/PhoneQuestionDefinition.java
+++ b/server/app/services/question/types/PhoneQuestionDefinition.java
@@ -35,4 +35,9 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.PHONE;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return PhoneValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -174,7 +174,7 @@ public abstract class QuestionDefinition {
 
   /** Get the validation predicates. */
   public final ValidationPredicates getValidationPredicates() {
-    return config.validationPredicates().orElse(getDefaultValidationPredicates());
+    return config.validationPredicates().orElseGet(this::getDefaultValidationPredicates);
   }
 
   /** Serialize validation predicates as a string. This is used for persisting in database. */

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -24,6 +24,10 @@ public abstract class QuestionDefinition {
   private final QuestionDefinitionConfig config;
 
   protected QuestionDefinition(QuestionDefinitionConfig config) {
+    if (config.validationPredicates().isEmpty()) {
+      config = config.toBuilder().setValidationPredicates(getDefaultValidationPredicates()).build();
+    }
+
     this.config = config;
   }
 
@@ -170,16 +174,19 @@ public abstract class QuestionDefinition {
 
   /** Get the validation predicates. */
   public final ValidationPredicates getValidationPredicates() {
-    return config.validationPredicates();
+    return config.validationPredicates().orElse(getDefaultValidationPredicates());
   }
 
   /** Serialize validation predicates as a string. This is used for persisting in database. */
   public final String getValidationPredicatesAsString() {
-    return config.validationPredicates().serializeAsString();
+    return getValidationPredicates().serializeAsString();
   }
 
   /** Get the type of this question. */
   public abstract QuestionType getQuestionType();
+
+  /** Get the default validation predicates for this question type. */
+  abstract ValidationPredicates getDefaultValidationPredicates();
 
   /** Validate that all required fields are present and valid for the question. */
   public final ImmutableSet<CiviFormError> validate() {
@@ -311,7 +318,7 @@ public abstract class QuestionDefinition {
           && config.description().equals(o.getDescription())
           && config.questionText().equals(o.getQuestionText())
           && config.questionHelpText().equals(o.getQuestionHelpText())
-          && config.validationPredicates().equals(o.getValidationPredicates());
+          && config.validationPredicates().equals(Optional.of(o.getValidationPredicates()));
     }
     return false;
   }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -13,6 +13,7 @@ import services.question.types.IdQuestionDefinition.IdValidationPredicates;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.NameQuestionDefinition.NameValidationPredicates;
+import services.question.types.NumberQuestionDefinition.NumberValidationPredicates;
 import services.question.types.PhoneQuestionDefinition.PhoneValidationPredicates;
 import services.question.types.QuestionDefinition.ValidationPredicates;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
@@ -163,46 +164,40 @@ public final class QuestionDefinitionBuilder {
   public QuestionDefinition build() throws UnsupportedQuestionTypeException {
     switch (this.questionType) {
       case ADDRESS:
-        AddressValidationPredicates addressValidationPredicates =
-            AddressValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          addressValidationPredicates =
-              AddressValidationPredicates.parse(validationPredicatesString);
-        }
-        return new AddressQuestionDefinition(
+        QuestionDefinitionConfig.Builder addressConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(addressValidationPredicates)
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
-                .setLastModifiedTime(lastModifiedTime)
-                .build());
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          addressConfig.setValidationPredicates(
+              AddressValidationPredicates.parse(validationPredicatesString));
+        }
+        return new AddressQuestionDefinition(addressConfig.build());
 
       case CHECKBOX:
-        MultiOptionValidationPredicates multiOptionValidationPredicates =
-            MultiOptionValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          multiOptionValidationPredicates =
-              MultiOptionValidationPredicates.parse(validationPredicatesString);
-        }
-
-        QuestionDefinitionConfig checkboxConfig =
+        QuestionDefinitionConfig.Builder checkboxConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(multiOptionValidationPredicates)
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
-                .setLastModifiedTime(lastModifiedTime)
-                .build();
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          checkboxConfig.setValidationPredicates(
+              MultiOptionValidationPredicates.parse(validationPredicatesString));
+        }
 
         return new MultiOptionQuestionDefinition(
-            checkboxConfig, questionOptions, MultiOptionQuestionType.CHECKBOX);
+            checkboxConfig.build(), questionOptions, MultiOptionQuestionType.CHECKBOX);
 
       case CURRENCY:
         return new CurrencyQuestionDefinition(
@@ -211,8 +206,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(
-                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
@@ -225,7 +218,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .setId(id)
@@ -238,7 +230,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(MultiOptionValidationPredicates.create())
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
@@ -254,7 +245,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
                 .setEnumeratorId(enumeratorId)
                 .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
@@ -267,65 +257,61 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(
-                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                 .setEnumeratorId(enumeratorId)
                 .setId(id)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
       case ID:
-        IdValidationPredicates idValidationPredicates = IdValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          idValidationPredicates = IdValidationPredicates.parse(validationPredicatesString);
-        }
-        return new IdQuestionDefinition(
+        QuestionDefinitionConfig.Builder idQuestionConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(idValidationPredicates)
                 .setEnumeratorId(enumeratorId)
                 .setId(id)
-                .setLastModifiedTime(lastModifiedTime)
-                .build());
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          idQuestionConfig.setValidationPredicates(
+              IdValidationPredicates.parse(validationPredicatesString));
+        }
+        return new IdQuestionDefinition(idQuestionConfig.build());
 
       case NAME:
-        NameValidationPredicates nameValidationPredicates = NameValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          nameValidationPredicates = NameValidationPredicates.parse(validationPredicatesString);
-        }
-        return new NameQuestionDefinition(
+        QuestionDefinitionConfig.Builder nameConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(nameValidationPredicates)
                 .setEnumeratorId(enumeratorId)
                 .setId(id)
-                .setLastModifiedTime(lastModifiedTime)
-                .build());
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          nameConfig.setValidationPredicates(
+              NameValidationPredicates.parse(validationPredicatesString));
+        }
+        return new NameQuestionDefinition(nameConfig.build());
 
       case NUMBER:
-        NumberQuestionDefinition.NumberValidationPredicates numberValidationPredicates =
-            NumberQuestionDefinition.NumberValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          numberValidationPredicates =
-              NumberQuestionDefinition.NumberValidationPredicates.parse(validationPredicatesString);
-        }
-        return new NumberQuestionDefinition(
+        QuestionDefinitionConfig.Builder numberConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(numberValidationPredicates)
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
-                .setLastModifiedTime(lastModifiedTime)
-                .build());
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          numberConfig.setValidationPredicates(
+              NumberValidationPredicates.parse(validationPredicatesString));
+        }
+        return new NumberQuestionDefinition(numberConfig.build());
 
       case RADIO_BUTTON:
         QuestionDefinitionConfig radioButtonConfig =
@@ -334,7 +320,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(MultiOptionValidationPredicates.create())
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
@@ -356,8 +341,6 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
@@ -371,46 +354,44 @@ public final class QuestionDefinitionBuilder {
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .setId(id)
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
                 .build());
 
       case TEXT:
-        TextValidationPredicates textValidationPredicates = TextValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          textValidationPredicates = TextValidationPredicates.parse(validationPredicatesString);
-        }
-        return new TextQuestionDefinition(
+        QuestionDefinitionConfig.Builder textConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setEnumeratorId(enumeratorId)
                 .setLastModifiedTime(lastModifiedTime)
-                .setValidationPredicates(textValidationPredicates)
-                .setId(id)
-                .build());
+                .setId(id);
+
+        if (!validationPredicatesString.isEmpty()) {
+          textConfig.setValidationPredicates(
+              TextValidationPredicates.parse(validationPredicatesString));
+        }
+
+        return new TextQuestionDefinition(textConfig.build());
       case PHONE:
-        PhoneValidationPredicates phoneValidationPredicates = PhoneValidationPredicates.create();
-        if (!validationPredicatesString.isEmpty()) {
-          phoneValidationPredicates = PhoneValidationPredicates.parse(validationPredicatesString);
-        }
-        return new PhoneQuestionDefinition(
+        QuestionDefinitionConfig.Builder phoneConfig =
             QuestionDefinitionConfig.builder()
                 .setName(name)
                 .setDescription(description)
                 .setQuestionText(questionText)
                 .setQuestionHelpText(questionHelpText)
-                .setValidationPredicates(phoneValidationPredicates)
                 .setEnumeratorId(enumeratorId)
                 .setId(id)
-                .setLastModifiedTime(lastModifiedTime)
-                .build());
+                .setLastModifiedTime(lastModifiedTime);
+
+        if (!validationPredicatesString.isEmpty()) {
+          phoneConfig.setValidationPredicates(
+              PhoneValidationPredicates.parse(validationPredicatesString));
+        }
+        return new PhoneQuestionDefinition(phoneConfig.build());
       default:
         throw new UnsupportedQuestionTypeException(this.questionType);
     }

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -24,7 +24,7 @@ public abstract class QuestionDefinitionConfig {
 
   abstract LocalizedStrings questionHelpText();
 
-  abstract QuestionDefinition.ValidationPredicates validationPredicates();
+  abstract Optional<QuestionDefinition.ValidationPredicates> validationPredicates();
 
   abstract OptionalLong id();
 
@@ -53,20 +53,12 @@ public abstract class QuestionDefinitionConfig {
   }
 
   public interface RequiredQuestionHelpText {
-    RequiredValidationPredicates setQuestionHelpText(LocalizedStrings questionHelpText);
-  }
-
-  public interface RequiredValidationPredicates {
-    Builder setValidationPredicates(QuestionDefinition.ValidationPredicates validationPredicates);
+    Builder setQuestionHelpText(LocalizedStrings questionHelpText);
   }
 
   @AutoValue.Builder
   public abstract static class Builder
-      implements RequiredName,
-          RequiredDescription,
-          RequiredQuestionText,
-          RequiredQuestionHelpText,
-          RequiredValidationPredicates {
+      implements RequiredName, RequiredDescription, RequiredQuestionText, RequiredQuestionHelpText {
     public abstract Builder setId(long id);
 
     public abstract Builder setId(OptionalLong id);
@@ -78,6 +70,9 @@ public abstract class QuestionDefinitionConfig {
     public abstract Builder setLastModifiedTime(Instant lastModifiedTime);
 
     public abstract Builder setLastModifiedTime(Optional<Instant> lastModifiedTime);
+
+    public abstract Builder setValidationPredicates(
+        QuestionDefinition.ValidationPredicates validationPredicates);
 
     public abstract QuestionDefinitionConfig build();
   }

--- a/server/app/services/question/types/StaticContentQuestionDefinition.java
+++ b/server/app/services/question/types/StaticContentQuestionDefinition.java
@@ -42,4 +42,9 @@ public final class StaticContentQuestionDefinition extends QuestionDefinition {
   public QuestionType getQuestionType() {
     return QuestionType.STATIC;
   }
+
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return StaticContentValidationPredicates.create();
+  }
 }

--- a/server/app/services/question/types/TextQuestionDefinition.java
+++ b/server/app/services/question/types/TextQuestionDefinition.java
@@ -71,6 +71,11 @@ public final class TextQuestionDefinition extends QuestionDefinition {
     return QuestionType.TEXT;
   }
 
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return TextValidationPredicates.create();
+  }
+
   public OptionalInt getMinLength() {
     return getTextValidationPredicates().minLength();
   }

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -363,8 +363,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .setQuestionText(
                 LocalizedStrings.of(Locale.US, "Ice cream?", Locale.FRENCH, "crème glacée?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help", Locale.FRENCH, "aider"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -405,8 +403,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .setQuestionText(
                 LocalizedStrings.of(Locale.US, "Ice cream?", Locale.FRENCH, "crème glacée?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help", Locale.FRENCH, "aider"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -515,7 +511,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .setDescription(def.getDescription())
             .setQuestionText(def.getQuestionText())
             .setQuestionHelpText(def.getQuestionHelpText())
-            .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
             .build());
   }
 }

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -204,7 +204,6 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                 .setDescription("name of applicant")
                 .setQuestionText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT))
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.
@@ -225,7 +224,6 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                 .setQuestionHelpText(
                     LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
                         .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT))
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
     // Only draft questions are editable.

--- a/server/test/forms/AddressQuestionFormTest.java
+++ b/server/test/forms/AddressQuestionFormTest.java
@@ -47,8 +47,6 @@ public class AddressQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    AddressQuestionDefinition.AddressValidationPredicates.create())
                 .build());
 
     AddressQuestionForm form = new AddressQuestionForm(originalQd);

--- a/server/test/forms/CheckboxQuestionFormTest.java
+++ b/server/test/forms/CheckboxQuestionFormTest.java
@@ -10,7 +10,6 @@ import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
 
@@ -34,8 +33,6 @@ public class CheckboxQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -58,7 +55,6 @@ public class CheckboxQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =

--- a/server/test/forms/CurrencyQuestionFormTest.java
+++ b/server/test/forms/CurrencyQuestionFormTest.java
@@ -28,8 +28,6 @@ public class CurrencyQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -46,8 +44,6 @@ public class CurrencyQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
                 .build());
 
     CurrencyQuestionForm form = new CurrencyQuestionForm(originalQd);

--- a/server/test/forms/DropdownQuestionFormTest.java
+++ b/server/test/forms/DropdownQuestionFormTest.java
@@ -10,7 +10,6 @@ import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
 
@@ -34,8 +33,6 @@ public class DropdownQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -58,7 +55,6 @@ public class DropdownQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(

--- a/server/test/forms/EnumeratorQuestionFormTest.java
+++ b/server/test/forms/EnumeratorQuestionFormTest.java
@@ -27,8 +27,6 @@ public class EnumeratorQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.empty());
 
@@ -46,8 +44,6 @@ public class EnumeratorQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.empty());
 

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -27,8 +27,6 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -45,8 +43,6 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                 .build());
 
     FileUploadQuestionForm form = new FileUploadQuestionForm(originalQd);

--- a/server/test/forms/IdQuestionFormTest.java
+++ b/server/test/forms/IdQuestionFormTest.java
@@ -76,7 +76,6 @@ public class IdQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/MultiOptionQuestionFormTest.java
@@ -93,7 +93,6 @@ public class MultiOptionQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     MultiOptionQuestionDefinition expected =
         new MultiOptionQuestionDefinition(

--- a/server/test/forms/NameQuestionFormTest.java
+++ b/server/test/forms/NameQuestionFormTest.java
@@ -27,7 +27,6 @@ public class NameQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -44,7 +43,6 @@ public class NameQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .build());
 
     NameQuestionForm form = new NameQuestionForm(originalQd);

--- a/server/test/forms/NumberQuestionFormTest.java
+++ b/server/test/forms/NumberQuestionFormTest.java
@@ -78,8 +78,6 @@ public class NumberQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    NumberQuestionDefinition.NumberValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/PhoneQuestionFormTest.java
+++ b/server/test/forms/PhoneQuestionFormTest.java
@@ -27,7 +27,6 @@ public class PhoneQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -44,7 +43,6 @@ public class PhoneQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Phone Number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
                 .build());
 
     PhoneQuestionForm form = new PhoneQuestionForm(originalQd);

--- a/server/test/forms/RadioButtonQuestionFormTest.java
+++ b/server/test/forms/RadioButtonQuestionFormTest.java
@@ -10,7 +10,6 @@ import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
 
@@ -34,7 +33,6 @@ public class RadioButtonQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -57,7 +55,6 @@ public class RadioButtonQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =

--- a/server/test/forms/StaticContentQuestionFormTest.java
+++ b/server/test/forms/StaticContentQuestionFormTest.java
@@ -27,8 +27,6 @@ public class StaticContentQuestionFormTest {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .build());
 
     assertThat(actual).isEqualTo(expected);
@@ -44,8 +42,6 @@ public class StaticContentQuestionFormTest {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .build());
 
     StaticContentQuestionForm form = new StaticContentQuestionForm(originalQd);

--- a/server/test/forms/TextQuestionFormTest.java
+++ b/server/test/forms/TextQuestionFormTest.java
@@ -30,7 +30,6 @@ public class TextQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
                 .build());
@@ -49,7 +48,6 @@ public class TextQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
                 .build());
@@ -80,7 +78,6 @@ public class TextQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
@@ -20,8 +20,6 @@ public class EnumeratorQuestionTranslationFormTest {
                 .setDescription("desc")
                 .setQuestionText(LocalizedStrings.withDefaultValue("existing"))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("existing"))
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.withDefaultValue("existing"));
 
@@ -48,8 +46,6 @@ public class EnumeratorQuestionTranslationFormTest {
                 .setDescription("desc")
                 .setQuestionText(LocalizedStrings.of(Locale.FRANCE, "existing"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.FRANCE, "existing"))
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.of(Locale.FRANCE, "existing"));
 

--- a/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
@@ -10,7 +10,6 @@ import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 
@@ -24,8 +23,6 @@ public class MultiOptionQuestionTranslationFormTest {
             .setDescription("desc")
             .setQuestionText(LocalizedStrings.empty())
             .setQuestionHelpText(LocalizedStrings.empty())
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
@@ -50,7 +47,6 @@ public class MultiOptionQuestionTranslationFormTest {
             .setDescription("desc")
             .setQuestionText(LocalizedStrings.empty())
             .setQuestionHelpText(LocalizedStrings.empty())
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -54,7 +54,6 @@ public class QuestionTranslationFormTest {
                 .setDescription("test")
                 .setQuestionText(LocalizedStrings.withDefaultValue("question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -42,7 +42,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
 
@@ -64,7 +63,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(questionDefinition);
     question.save();
@@ -83,7 +81,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setEnumeratorId(Optional.of(10L))
                 .build());
     Question question = new Question(questionDefinition);
@@ -103,7 +100,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
 
@@ -126,8 +122,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    AddressQuestionDefinition.AddressValidationPredicates.create())
                 .build());
     Question question = new Question(address);
 
@@ -147,7 +141,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setValidationPredicates(TextValidationPredicates.create(0, 128))
                 .build());
     Question question = new Question(definition);
@@ -228,7 +221,6 @@ public class QuestionTest extends ResetPostgres {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setEnumeratorId(Optional.of(10L))
                 .build());
     Question initialQuestion = new Question(questionDefinition);

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -147,7 +147,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setDescription("applicant's name")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(questionDefinition);
 
@@ -167,7 +166,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setDescription("applicant's name")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(questionDefinition);
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -508,8 +508,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-            .setValidationPredicates(
-                MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -835,8 +833,6 @@ public class ApplicantServiceTest extends ResetPostgres {
                         .setDescription("description")
                         .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                        .setValidationPredicates(
-                            FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                         .build()))
             .getResult();
 
@@ -2954,8 +2950,6 @@ public class ApplicantServiceTest extends ResetPostgres {
                         .setDescription("description")
                         .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                         .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                        .setValidationPredicates(
-                            NameQuestionDefinition.NameValidationPredicates.create())
                         .build()))
             .getResult();
   }

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -49,8 +49,6 @@ public class BlockTest {
               .setDescription("Shows more info to the applicant")
               .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
               .setId(OptionalLong.of(123L))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -34,8 +34,6 @@ public class AddressQuestionTest {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  AddressQuestionDefinition.AddressValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -32,8 +32,6 @@ public class CurrencyQuestionTest {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -31,7 +31,6 @@ public class DateQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/EmailQuestionTest.java
+++ b/server/test/services/applicant/question/EmailQuestionTest.java
@@ -26,7 +26,6 @@ public class EmailQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -35,8 +35,6 @@ public class EnumeratorQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build(),

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -25,8 +25,6 @@ public class FileUploadQuestionTest {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/IdQuestionTest.java
+++ b/server/test/services/applicant/question/IdQuestionTest.java
@@ -35,7 +35,6 @@ public class IdQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -27,7 +27,6 @@ public class NameQuestionTest {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -37,7 +37,6 @@ public class NumberQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(NumberQuestionDefinition.NumberValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -32,7 +32,6 @@ public class PhoneQuestionTest {
               .setDescription("The applicant Phone Number")
               .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-              .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -26,8 +26,6 @@ public class SingleSelectQuestionTest {
           .setDescription("description")
           .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
           .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-          .setValidationPredicates(
-              MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create())
           .setId(OptionalLong.of(1))
           .setLastModifiedTime(Optional.empty())
           .build();

--- a/server/test/services/applicant/question/StaticContentQuestionTest.java
+++ b/server/test/services/applicant/question/StaticContentQuestionTest.java
@@ -26,8 +26,6 @@ public class StaticContentQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
               .setQuestionHelpText(LocalizedStrings.empty())
-              .setValidationPredicates(
-                  StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -34,7 +34,6 @@ public class TextQuestionTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .setLastModifiedTime(Optional.empty())
               .setId(123L)
               .build());

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -32,7 +32,6 @@ public class QuestionServiceTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .build());
 
   QuestionService questionService;

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -137,7 +137,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.isEnumerator()).isFalse();
@@ -152,8 +151,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.empty());
     assertThat(question.isEnumerator()).isTrue();
@@ -168,7 +165,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.isRepeated()).isFalse();
@@ -183,7 +179,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .setEnumeratorId(Optional.of(123L))
                 .build());
     assertThat(question.isRepeated()).isTrue();
@@ -220,7 +215,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "not french"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionText().get(Locale.FRANCE));
@@ -238,7 +232,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionHelpText().get(Locale.FRANCE));
@@ -256,7 +249,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     assertThat(question.getQuestionHelpText().get(Locale.FRANCE)).isEqualTo("");
   }
@@ -270,7 +262,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.withDefaultValue("default"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionText().getOrDefault(Locale.forLanguageTag("und")))
@@ -286,7 +277,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue("default"))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionHelpText().getOrDefault(Locale.forLanguageTag("und")))
@@ -302,7 +292,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.US)).hasValue("hello");
@@ -317,7 +306,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -332,7 +320,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "world"))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.US)).hasValue("world");
@@ -347,7 +334,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionHelpText().maybeGet(Locale.forLanguageTag("und"))).isEmpty();
@@ -362,7 +348,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(question.getQuestionType()).isEqualTo(QuestionType.TEXT);
@@ -377,7 +362,6 @@ public class QuestionDefinitionTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     assertThat(question.validate()).isEmpty();
   }
@@ -391,7 +375,6 @@ public class QuestionDefinitionTest {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     assertThat(question.validate())
         .containsOnly(
@@ -483,7 +466,6 @@ public class QuestionDefinitionTest {
                 .setDescription("test")
                 .setQuestionText(LocalizedStrings.of(Locale.US, ""))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     assertThat(question.validate()).containsOnly(CiviFormError.of("Question text cannot be blank"));
   }
@@ -496,7 +478,6 @@ public class QuestionDefinitionTest {
             .setDescription("test")
             .setQuestionText(LocalizedStrings.withDefaultValue("test"))
             .setQuestionHelpText(LocalizedStrings.empty())
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
@@ -513,7 +494,6 @@ public class QuestionDefinitionTest {
             .setDescription("test")
             .setQuestionText(LocalizedStrings.withDefaultValue("test"))
             .setQuestionHelpText(LocalizedStrings.empty())
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
@@ -532,7 +512,6 @@ public class QuestionDefinitionTest {
             .setDescription("test")
             .setQuestionText(LocalizedStrings.withDefaultValue("test"))
             .setQuestionHelpText(LocalizedStrings.empty())
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -646,7 +625,6 @@ public class QuestionDefinitionTest {
                         "ayuda",
                         Locale.GERMAN,
                         "Hilfe"))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(definition.getSupportedLocales())
@@ -669,7 +647,6 @@ public class QuestionDefinitionTest {
                         Locale.FRANCE,
                         "question"))
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
 
     assertThat(definition.getSupportedLocales())

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -69,7 +69,6 @@ public class ResourceCreator {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
     question.save();
@@ -85,7 +84,6 @@ public class ResourceCreator {
                 .setDescription("")
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     Question question = new Question(definition);
     question.save();

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -23,7 +23,6 @@ import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
@@ -209,8 +208,6 @@ public class TestQuestionBank {
                 .setDescription("The address of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your address?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    AddressQuestionDefinition.AddressValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -223,7 +220,6 @@ public class TestQuestionBank {
                 .setDescription("The applicant Phone Number")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(PhoneQuestionDefinition.PhoneValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -237,8 +233,6 @@ public class TestQuestionBank {
                 .setDescription("The secondary address of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your secondary address?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    AddressQuestionDefinition.AddressValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -253,7 +247,6 @@ public class TestQuestionBank {
                 LocalizedStrings.of(
                     Locale.US, "Which of the following kitchen instruments do you own?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -276,7 +269,6 @@ public class TestQuestionBank {
                 LocalizedStrings.of(
                     Locale.US, "Select your favorite ice cream flavor from the following"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -299,8 +291,6 @@ public class TestQuestionBank {
                 .setDescription("The applicant's household members")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "Who are your household members?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .build(),
             LocalizedStrings.empty());
     return maybeSave(definition);
@@ -316,8 +306,6 @@ public class TestQuestionBank {
                 .setDescription("The applicant's household member's jobs")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What are the $this's jobs?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "Where does $this work?"))
-                .setValidationPredicates(
-                    EnumeratorQuestionDefinition.EnumeratorValidationPredicates.create())
                 .setEnumeratorId(Optional.of(householdMembers.id))
                 .build(),
             LocalizedStrings.empty());
@@ -334,8 +322,6 @@ public class TestQuestionBank {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "What is the file you want to upload?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    FileUploadQuestionDefinition.FileUploadValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -349,8 +335,6 @@ public class TestQuestionBank {
                 .setDescription("monthly income of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "what is your monthly income?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                .setValidationPredicates(
-                    CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -364,7 +348,6 @@ public class TestQuestionBank {
                 .setDescription("1234")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the the id?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -378,7 +361,6 @@ public class TestQuestionBank {
                 .setDescription("name of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "what is your name?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -394,7 +376,6 @@ public class TestQuestionBank {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the $this's name?"))
                 .setQuestionHelpText(
                     LocalizedStrings.of(Locale.US, "Please provide full name for $this."))
-                .setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())
                 .setEnumeratorId(Optional.of(householdMembers.id))
                 .build());
 
@@ -411,8 +392,6 @@ public class TestQuestionBank {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "How many items can you juggle at one time?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(
-                    NumberQuestionDefinition.NumberValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -426,7 +405,6 @@ public class TestQuestionBank {
                 .setDescription("The applicant birth date")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your birthdate?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(DateQuestionDefinition.DateValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -440,7 +418,6 @@ public class TestQuestionBank {
                 .setDescription("The applicant Email address")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Email?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(EmailQuestionDefinition.EmailValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -459,8 +436,6 @@ public class TestQuestionBank {
                 .setQuestionHelpText(
                     LocalizedStrings.of(
                         Locale.US, "How many days has $this.parent worked at $this?"))
-                .setValidationPredicates(
-                    NumberQuestionDefinition.NumberValidationPredicates.create())
                 .setEnumeratorId(Optional.of(householdMemberJobs.id))
                 .build());
 
@@ -475,7 +450,6 @@ public class TestQuestionBank {
             .setDescription("Favorite season in the year")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is your favorite season?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-            .setValidationPredicates(MultiOptionValidationPredicates.create())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
@@ -498,8 +472,6 @@ public class TestQuestionBank {
                 .setDescription("Shows more info to the applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "This is more info"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, ""))
-                .setValidationPredicates(
-                    StaticContentQuestionDefinition.StaticContentValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }
@@ -512,8 +484,6 @@ public class TestQuestionBank {
                 .setDescription("Favorite color of applicant")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your favorite color?"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
-                .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
                 .build());
     return maybeSave(definition);
   }

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -54,8 +54,6 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
                             Lang.forCode("en-US").toLocale(),
                             "Please enter your date of birth in the format mm/dd/yyyy"))
                     .setQuestionHelpText(LocalizedStrings.empty())
-                    .setValidationPredicates(
-                        DateQuestionDefinition.DateValidationPredicates.create())
                     .build()));
     assertThat(getAllQuestions().size()).isEqualTo(1);
 

--- a/server/test/views/questiontypes/AddressRendererTest.java
+++ b/server/test/views/questiontypes/AddressRendererTest.java
@@ -29,8 +29,6 @@ public class AddressRendererTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  AddressQuestionDefinition.AddressValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -29,8 +29,6 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(
-                  CurrencyQuestionDefinition.CurrencyValidationPredicates.create())
               .setId(OptionalLong.of(1))
               .setLastModifiedTime(Optional.empty())
               .build());

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -20,7 +20,6 @@ import services.applicant.question.ApplicantQuestion;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
@@ -33,7 +32,6 @@ public class DropdownQuestionRendererTest extends ResetPostgres {
           .setDescription("description")
           .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
           .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-          .setValidationPredicates(MultiOptionValidationPredicates.create())
           .setLastModifiedTime(Optional.empty())
           .setId(OptionalLong.of(1))
           .build();

--- a/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -19,7 +19,6 @@ import services.applicant.question.ApplicantQuestion;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
-import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
 import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
@@ -32,7 +31,6 @@ public class RadioButtonQuestionRendererTest {
           .setDescription("description")
           .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
           .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-          .setValidationPredicates(MultiOptionValidationPredicates.create())
           .setId(OptionalLong.of(1))
           .setLastModifiedTime(Optional.empty())
           .build();

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -29,7 +29,6 @@ public class TextQuestionRendererTest extends ResetPostgres {
               .setDescription("description")
               .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
               .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setValidationPredicates(TextQuestionDefinition.TextValidationPredicates.create())
               .setLastModifiedTime(Optional.empty())
               .setValidationPredicates(TextValidationPredicates.create(2, 3))
               .setId(123L)


### PR DESCRIPTION
### Description

Currently, we require a `ValidationPredicates` to construct a `QuestionDefinitionConfig`:

https://github.com/civiform/civiform/blob/3717ab8fec91c414c018d467f039937705c279e4/server/app/services/question/types/QuestionDefinitionConfig.java#L10-L33

However, the vast majority of the time, this is set to the default one, like:

https://github.com/civiform/civiform/blob/3717ab8fec91c414c018d467f039937705c279e4/server/test/forms/NameQuestionFormTest.java#L39-L48

Instead, we can simply set it to the default in the `QuestionDefinitionConfig` abstract constructor, using a new `getDefaultValidationPredicates()` abstract method. This allows us to delete all the code like `.setValidationPredicates(NameQuestionDefinition.NameValidationPredicates.create())`, which there is **a lot** of.


## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - Not applicable
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
   - Not applicable
- [ ] Extended the README / documentation, if necessary
   - Not applicable

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

None.

### Issue(s) this completes

None.