### PR TITLE
Clear the redirect target if the user navigates to the index page.

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -1,6 +1,7 @@
 package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
@@ -70,14 +71,17 @@ public final class ApplicantProgramsController extends CiviFormController {
             httpContext.current())
         .thenApplyAsync(
             applicationPrograms -> {
-              return ok(
-                  programIndexView.render(
+              return ok(programIndexView.render(
                       messagesApi.preferred(request),
                       request,
                       applicantId,
                       applicantStage.toCompletableFuture().join(),
                       applicationPrograms,
-                      banner));
+                      banner))
+                  // If the user has been to the index page, any existing redirects should be
+                  // cleared to avoid an experience where they're unexpectedly redirected after
+                  // logging in.
+                  .removingFromSession(request, REDIRECT_TO_SESSION_KEY);
             },
             httpContext.current())
         .exceptionally(

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.applicant;
 
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
@@ -27,8 +26,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Http.Request;
-import play.test.Helpers;
 import play.mvc.Result;
+import play.test.Helpers;
 import repository.VersionRepository;
 import services.Path;
 import services.applicant.ApplicantData;
@@ -84,7 +83,8 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void index_clearsRedirectToSessionKey() {
-    Request request = addCSRFToken(Helpers.fakeRequest().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
+    Request request =
+        addCSRFToken(Helpers.fakeRequest().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
     assertThat(result.session().get(REDIRECT_TO_SESSION_KEY)).isEmpty();
   }

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -1,5 +1,7 @@
 package controllers.applicant;
 
+import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
@@ -25,6 +27,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Http.Request;
+import play.test.Helpers;
 import play.mvc.Result;
 import repository.VersionRepository;
 import services.Path;
@@ -77,6 +80,13 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(contentAsString(result)).contains("one");
     assertThat(contentAsString(result)).contains("two");
     assertThat(contentAsString(result)).doesNotContain("three");
+  }
+
+  @Test
+  public void index_clearsRedirectToSessionKey() {
+    Request request = addCSRFToken(Helpers.fakeRequest().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
+    Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
+    assertThat(result.session().get(REDIRECT_TO_SESSION_KEY)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
### Description

This is a patch for #5167. The REDIRECT_TO_SESSION_KEY is set when the navigating to a program by the slug and doesn't get cleared properly. This is only a temporary fix that clears it if the user goes to the index page. We should follow up with a solution that fixes the underlying problem. Filed #5171 to track that.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #5167 
