### PR TITLE
Fix Program Slug Redirect

### DIFF
--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -135,4 +135,21 @@ describe('navigating to a deep link', () => {
 
     await logout(page)
   })
+
+  it('Going to a deep link does not retain redirect in session', async () => {
+    await resetContext(ctx)
+    const {page, browserContext} = ctx
+    await browserContext.clearCookies()
+
+    // Go to a deep link
+    await gotoEndpoint(page, '/programs/test-deep-link')
+    await page.click('text="Continue to application"')
+
+    // Logging out should not take us back to /programs/test-deep-link, but rather
+    // to the program index page.
+    await logout(page)
+    expect(await page.innerText('h1')).toContain(
+      'Save time when applying for benefits',
+    )
+  })
 })

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -125,14 +125,9 @@ public final class RedirectController extends CiviFormController {
                                           programSlug,
                                           request))
                               .exceptionally(
-                                  ex -> {
-                                    Throwable cause = ex.getCause().getCause();
-                                    if (cause instanceof ProgramNotFoundException) {
-                                      return notFound()
-                                          .removingFromSession(request, REDIRECT_TO_SESSION_KEY);
-                                    }
-                                    throw new RuntimeException(ex);
-                                  });
+                                  ex ->
+                                      notFound(ex.getMessage())
+                                          .removingFromSession(request, REDIRECT_TO_SESSION_KEY));
                         }
                       },
                       httpContext.current());

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -123,7 +123,16 @@ public final class RedirectController extends CiviFormController {
                                           activeProgramDefinition.id(),
                                           applicantId,
                                           programSlug,
-                                          request));
+                                          request))
+                              .exceptionally(
+                                  ex -> {
+                                    Throwable cause = ex.getCause().getCause();
+                                    if (cause instanceof ProgramNotFoundException) {
+                                      return notFound()
+                                          .removingFromSession(request, REDIRECT_TO_SESSION_KEY);
+                                    }
+                                    throw new RuntimeException(ex);
+                                  });
                         }
                       },
                       httpContext.current());

--- a/server/app/controllers/applicant/RedirectController.java
+++ b/server/app/controllers/applicant/RedirectController.java
@@ -113,13 +113,13 @@ public final class RedirectController extends CiviFormController {
                         if (programForExistingApplication.isPresent()) {
                           long programId = programForExistingApplication.get().id();
                           return CompletableFuture.completedFuture(
-                              goToActiveProgram(programId, applicantId, programSlug, request));
+                              redirectToReviewPage(programId, applicantId, programSlug, request));
                         } else {
                           return programService
                               .getActiveProgramDefinitionAsync(programSlug)
                               .thenApply(
                                   activeProgramDefinition ->
-                                      goToActiveProgram(
+                                      redirectToReviewPage(
                                           activeProgramDefinition.id(),
                                           applicantId,
                                           programSlug,
@@ -131,7 +131,7 @@ public final class RedirectController extends CiviFormController {
             httpContext.current());
   }
 
-  private Result goToActiveProgram(
+  private Result redirectToReviewPage(
       long programId, long applicantId, String programSlug, Http.Request request) {
     return redirect(
             controllers.applicant.routes.ApplicantProgramReviewController.review(


### PR DESCRIPTION
### Description

`RedirectController.programBySlug` inserts a `REDIRECT_TO_SESSION_KEY` if the user doesn't have a profile yet, so that they are redirected to the `/programs/slug-link` URL again after getting a guest profile.

Previously we did not clear this out after sending the user to the full program link, which led to #5171. This fixes that by `removingFromSession` the `REDIRECT_TO_SESSION_KEY` before redirecting them to the full program link.

## Release notes

Fixes a bug with program slug links.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5171
