### PR TITLE
Fix use of quotes in predicates

### DIFF
--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -135,7 +135,26 @@ public abstract class PredicateValue {
         .orElse("<obsolete>");
   }
 
+  /**
+   * Remove any double quotes currently in the string, as this would interfere with how we store the
+   * predicate, then surround the string with a pair of double quotes.
+   *
+   * @param s the string to surround in double quotes
+   * @return the same string with double quotes removed, then surrounded by double quotes
+   */
   private static String surroundWithQuotes(String s) {
-    return "\"" + s + "\"";
+    return '"' + s.replace("\"", "") + '"';
+  }
+
+  /**
+   * Get the stringified value of the predicate without surrounding quotes. Used for displaying the
+   * predicate string in the UI. Only removes surrounding quotes from plain string predicate types.
+   * Lists of strings will still contain double quotes around each item in the list.
+   *
+   * @return A plain string with surrounding double quotes removed, or the result of value() if it
+   *     is not a plain string type.
+   */
+  public String valueWithoutSurroundingQuotes() {
+    return type() == OperatorRightHandType.STRING ? value().replace("\"", "") : value();
   }
 }

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -814,7 +814,7 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
                 .collect(Collectors.joining(","));
           }
 
-          return predicateValue.value();
+          return predicateValue.valueWithoutSurroundingQuotes();
         }
 
       default:

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -100,4 +100,29 @@ public class PredicateValueTest {
 
     assertThat(value.toDisplayString(multiOption)).isEqualTo("[chocolate, <obsolete>]");
   }
+
+  @Test
+  public void valueWithoutSurroundingQuotes_parsesCorrectly() {
+    PredicateValue value = PredicateValue.of("hello");
+    assertThat(value.valueWithoutSurroundingQuotes()).isEqualTo("hello");
+
+    // Should only strip plain strings. Everything else should remain the same.
+    value = PredicateValue.listOfStrings(ImmutableList.of("hello", "world"));
+    assertThat(value.valueWithoutSurroundingQuotes()).isEqualTo("[\"hello\", \"world\"]");
+
+    value = PredicateValue.of(10001);
+    assertThat(value.valueWithoutSurroundingQuotes()).isEqualTo("10001");
+
+    value = PredicateValue.of(LocalDate.ofYearDay(2021, 1));
+    assertThat(value.valueWithoutSurroundingQuotes()).isEqualTo("1609459200000");
+
+    value = PredicateValue.listOfLongs(ImmutableList.of(1L, 2L, 3L));
+    assertThat(value.valueWithoutSurroundingQuotes()).isEqualTo("[1, 2, 3]");
+  }
+
+  @Test
+  public void surroundWithQuotes_stripsQuotesThenAppendsCorrectly() {
+    PredicateValue value = PredicateValue.of("\"\"h\"el\"\"lo\"\"\"\"\"");
+    assertThat(value.value()).isEqualTo("\"hello\"");
+  }
 }


### PR DESCRIPTION
When saving a string used in a predicate, we must wrap double quotes around the string in order for it to be handled correctly. When editing an existing predicate, it would render the string with the double quotes intact. This meant that when it saved the predicate, it would wrap it again in double quotes. This would cause an unhandled exception when a user went to apply for a program.

With these changes, we now render the predicate string without double quotes. Then upon saving, we strip the value of all double quotes, then wrap it with double quotes. This should ensure the value is always in the format of "value" and won't result in JSON pathing errors.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5146
