### PR TITLE
Add criteria for picking a new version number

### DIFF
--- a/.github/ISSUE_TEMPLATE/oncall-rotation.md
+++ b/.github/ISSUE_TEMPLATE/oncall-rotation.md
@@ -21,6 +21,15 @@ Resources:
 
 ## Release
 
+- [ ] Choose a new version number in the format `vX.Y.Z`. If any of the following apply to the release, bump the minor version (Y). Otherwise, bump the patch version (Z). Do not bump the major version (X) without discussing with #engineering, as this will need more extensive communication and planning.
+
+  - A brand new feature (both when adding the feature behind a feature flag, and when removing the feature flag)
+  - New APIs or API version (e.g. `/v2/` in the path instead of `/v1/`)
+  - A database evolution
+  - File key naming changes
+  - Changes to other stateful parts of the application (i.e. changes to the format of things stored in the database not necessarily requiring an evolution)
+  - Config setting addition or removal
+
 - [ ] Create a Draft Release by 12 PT Wed
 - [ ] Contact Matthew Sprenke for QA on Slack
 - [ ] If Matthew is unavailable have the general team attempt a best-effort QA.


### PR DESCRIPTION
This adds a list of items to look for when decided if a new release should increment the minor or patch version.