### PR TITLE
Fix AutoValue generation in `build.sbt`

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -81,7 +81,6 @@ lazy val root = (project in file("."))
       // Autovalue
       "com.google.auto.value" % "auto-value-annotations" % "1.10.2",
       "com.google.auto.value" % "auto-value" % "1.10.2",
-      "com.google.auto.value" % "auto-value-parent" % "1.10.2" pomOnly (),
 
       // Errorprone
       "com.google.errorprone" % "error_prone_core" % "2.19.1",
@@ -119,7 +118,13 @@ lazy val root = (project in file("."))
       // code contains it - we can't control that.
       "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR",
       "-implicit:class",
-      "-Werror"
+      "-Werror",
+      // The compile option below is a hack that preserves generated files. Normally,
+      // AutoValue generates .java files, compiles them into .class files, and then deletes
+      // the .java files. This option keeps the .java files in the specified directory,
+      // which allows an IDE to recognize the symbols.
+      "-s",
+      "target/scala-2.13/src_managed/main"
     ),
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
     // Recompile everything if >30% files have changed, to help avoid infinate

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -124,7 +124,7 @@ lazy val root = (project in file("."))
       // the .java files. This option keeps the .java files in the specified directory,
       // which allows an IDE to recognize the symbols.
       "-s",
-      "target/scala-2.13/src_managed/main"
+      generateSourcePath(scalaVersion = scalaVersion.value)
     ),
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
     // Recompile everything if >30% files have changed, to help avoid infinate
@@ -238,3 +238,10 @@ addCommandAlias(
   "runBrowserTestsServer",
   ";eval System.setProperty(\"config.file\", \"conf/application.dev-browser-tests.conf\");run"
 )
+
+// scalaVersion is formatted as x.y.z, but we only want x.y in our path. This function
+// removes the .z component and returns the path to the generated source file directory.
+def generateSourcePath(scalaVersion: String): String = {
+  val version = scalaVersion.split("\\.").take(2).mkString(".")
+  s"target/scala-$version/src_managed/main"
+}


### PR DESCRIPTION
### Description

`AutoValue` has been used in the project and working for a while, but IntelliJ has had trouble recognizing the symbols for many developers (including myself).

Notably, AutoValue is generating `.class` files for all AutoValue classes, but `.java` files are missing. This seems to be an intentional feature of AutoValue to clean up files unnecessary to compilation.

It's not clear to me why some developers have their IDE recognize the `.class` files and some don't, but this PR introduces a "hack" that keeps those `.java` files around, even though this is not `AutoValue`'s intent.

In my testing, making this change and then running `bin/build-dev` or running `compile` in the IntelliJ sbt shell fixes all red AutoValue errors.

Debugged using [ChatGPT conversation](https://chat.openai.com/share/1508061e-4db6-4a86-a107-6f2ad53ffd96).