### PR TITLE
Remove dangling reference to deleted feature flag.

### DIFF
--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -24,6 +24,4 @@ api_keys_ban_global_subnet = false
 # deterministic reporting stats for browser tests
 reporting_use_deterministic_stats = true
 
-publish_single_program_enabled = true
-
 admin_settings_panel_enabled = true


### PR DESCRIPTION
### Description

Missed this last reference to a feature flag when removing it.

