### PR TITLE
Fix name formatting for PDF export.

### DIFF
--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -59,8 +59,11 @@ public final class PdfExporter {
             .join();
     ImmutableList<AnswerData> answers = roApplicantService.getSummaryData();
 
-    String applicantNameWithApplicationId =
-        String.format("%s (%d)", application.getApplicantData().getApplicantName(), application.id);
+    // We expect a name to be present at this point. However, if it's not, we use a placeholder
+    // rather than throwing an error here.
+    String applicantName =
+        application.getApplicantData().getApplicantName().orElse("name-unavailable");
+    String applicantNameWithApplicationId = String.format("%s (%d)", applicantName, application.id);
     String filename = String.format("%s-%s.pdf", applicantNameWithApplicationId, nowProvider.get());
     byte[] bytes =
         buildPDF(

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -154,6 +154,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     Account admin = resourceCreator.insertAccount();
     Applicant applicantOne = resourceCreator.insertApplicantWithAccount();
     Applicant applicantTwo = resourceCreator.insertApplicantWithAccount();
+    applicantTwo.getApplicantData().setUserName("Civiform", null, "User");
     testQuestionBank.getSampleQuestionsForAllTypes().entrySet().stream()
         .forEach(
             entry ->
@@ -250,6 +251,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
             .getContextualizedPath(Optional.empty(), ApplicantData.APPLICANT_PATH);
     // Applicant five have file uploaded for the optional file upload question
     applicantFive = resourceCreator.insertApplicantWithAccount();
+    applicantFive.getApplicantData().setUserName("Example Five");
     QuestionAnswerer.answerNameQuestion(
         applicantFive.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -154,7 +154,6 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     Account admin = resourceCreator.insertAccount();
     Applicant applicantOne = resourceCreator.insertApplicantWithAccount();
     Applicant applicantTwo = resourceCreator.insertApplicantWithAccount();
-    applicantTwo.getApplicantData().setUserName("CiviForm", /* middleName= */ null, "User");
     testQuestionBank.getSampleQuestionsForAllTypes().entrySet().stream()
         .forEach(
             entry ->

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     Account admin = resourceCreator.insertAccount();
     Applicant applicantOne = resourceCreator.insertApplicantWithAccount();
     Applicant applicantTwo = resourceCreator.insertApplicantWithAccount();
-    applicantTwo.getApplicantData().setUserName("Civiform", null, "User");
+    applicantTwo.getApplicantData().setUserName("CiviForm", /* middleName= */ null, "User");
     testQuestionBank.getSampleQuestionsForAllTypes().entrySet().stream()
         .forEach(
             entry ->

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -29,9 +29,9 @@ public class PdfExporterTest extends AbstractExporterTest {
   public void validatePDFExport() throws IOException, DocumentException {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
+    String applicantName = "name-unavailable";
     String applicantNameWithApplicationId =
-        String.format(
-            "%s (%d)", applicationOne.getApplicantData().getApplicantName(), applicationOne.id);
+        String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result = exporter.export(applicationOne);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -74,9 +74,12 @@ public class PdfExporterTest extends AbstractExporterTest {
     createFakeProgramWithOptionalQuestion();
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
+    // The applicant for this application has a value for the name, so ensure that it is reflected
+    // in the generated filename, and later, in the PDF contents.
+    assertThat(applicationFive.getApplicantData().getApplicantName().isPresent()).isTrue();
+    String applicantName = applicationFive.getApplicantData().getApplicantName().get();
     String applicantNameWithApplicationId =
-        String.format(
-            "%s (%d)", applicationFive.getApplicantData().getApplicantName(), applicationFive.id);
+        String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result = exporter.export(applicationFive);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -117,9 +120,9 @@ public class PdfExporterTest extends AbstractExporterTest {
     createFakeProgramWithOptionalQuestion();
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
+    String applicantName = "name-unavailable";
     String applicantNameWithApplicationId =
-        String.format(
-            "%s (%d)", applicationSix.getApplicantData().getApplicantName(), applicationSix.id);
+        String.format("%s (%d)", applicantName, applicationSix.id);
     PdfExporter.InMemoryPdf result = exporter.export(applicationSix);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -149,9 +152,9 @@ public class PdfExporterTest extends AbstractExporterTest {
 
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
+    String applicantName = "name-unavailable";
     String applicantNameWithApplicationId =
-        String.format(
-            "%s (%d)", applicationTwo.getApplicantData().getApplicantName(), applicationTwo.id);
+        String.format("%s (%d)", applicantName, applicationTwo.id);
     PdfExporter.InMemoryPdf result = exporter.export(applicationTwo);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();


### PR DESCRIPTION
### Description

Previously the applicant name in an exported PDF looked like `"Optional[applicant name]"` or `"Optional.empty"`. This change fixes the formatting and handles the missing `Optional` case explicitly. The formatted name is contained in the PDF contents as well as forming part of the file name.

A PDF generated with this fix is attached.

## Release notes

Fixes the applicant name in the generated PDF contents and file name.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: bug
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary
  - n/a

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings)
  - n/a
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
  - n/a
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
  - n/a
- [ ] Manually tested at 200% size
  - n/a
- [ ] Manually evaluated tab order
  - n/a

### Issue(s) this completes

Fixes #5066

[User, Test (1)-2023-07-10T11_20_41.181890.pdf](https://github.com/civiform/civiform/files/12005148/User.Test.1.-2023-07-10T11_20_41.181890.pdf)
