### PR TITLE
Strip whitespace from API key

### DIFF
--- a/server/app/services/apikey/ApiKeyService.java
+++ b/server/app/services/apikey/ApiKeyService.java
@@ -225,6 +225,7 @@ public final class ApiKeyService {
   // apiKey is mutable and modified here, form is immutable so a new instance is returned
   private DynamicForm resolveSubnet(DynamicForm form, ApiKey apiKey) {
     String subnetInputString = form.rawData().getOrDefault(FORM_FIELD_NAME_SUBNET, "");
+    subnetInputString = subnetInputString.trim();
 
     if (subnetInputString.isBlank()) {
       return form.withError(FORM_FIELD_NAME_SUBNET, "Subnet cannot be blank.");


### PR DESCRIPTION
### Description

Strip whitespace from the API key the user enters into the form.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Fixes #5157
