### PR TITLE
More Database Seeding Logic Cleaning

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -13,7 +13,7 @@ import {BASE_URL} from './support/config'
 describe('normal question lifecycle', () => {
   const ctx = createTestContext()
 
-  it('canonical question seeding works', async () => {
+  it('sample question seeding works', async () => {
     const {page, adminQuestions} = ctx
     await dropTables(page)
     await seedQuestions(page)
@@ -22,8 +22,9 @@ describe('normal question lifecycle', () => {
     await loginAsAdmin(page)
 
     await adminQuestions.gotoAdminQuestionsPage()
+    await adminQuestions.expectDraftQuestionExist('Sample Address Question')
+    await adminQuestions.expectDraftQuestionExist('Sample Number Question')
     await adminQuestions.expectDraftQuestionExist('Name')
-    await adminQuestions.expectDraftQuestionExist('Applicant Date of Birth')
   })
 
   // Run create-update-publish test for each question type individually to keep

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -1,59 +1,29 @@
 package controllers.dev.seeding;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.CHECKBOX_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.CURRENCY_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.DROPDOWN_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.EMAIL_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.ENUMERATOR_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.FILE_UPLOAD_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.ID_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.NUMBER_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.PHONE_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.RADIO_BUTTON_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.STATIC_CONTENT_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.TEXT_QUESTION_DEFINITION;
-import static controllers.dev.seeding.SampleQuestionDefinitions.dateQuestionDefinition;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import forms.BlockForm;
 import io.ebean.DB;
 import io.ebean.Database;
-import java.util.ArrayList;
-import java.util.Optional;
-import models.DisplayMode;
 import models.LifecycleStage;
 import models.Models;
 import models.Version;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import services.CiviFormError;
 import services.DeploymentType;
-import services.ErrorAnd;
-import services.applicant.question.Scalar;
 import services.program.ActiveAndDraftPrograms;
-import services.program.ProgramDefinition;
 import services.program.ProgramService;
-import services.program.ProgramType;
-import services.program.predicate.LeafOperationExpressionNode;
-import services.program.predicate.Operator;
-import services.program.predicate.PredicateAction;
-import services.program.predicate.PredicateDefinition;
-import services.program.predicate.PredicateExpressionNode;
-import services.program.predicate.PredicateValue;
 import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
-import services.seeding.DatabaseSeedTask;
 import services.settings.SettingsService;
 import views.dev.DatabaseSeedView;
 
 /** Controller for seeding the development database with test content. */
 public class DevDatabaseSeedController extends Controller {
 
-  private final DatabaseSeedTask databaseSeedTask;
+  private final DevDatabaseSeedTask devDatabaseSeedTask;
   private final DatabaseSeedView view;
   private final Database database;
   private final QuestionService questionService;
@@ -63,13 +33,13 @@ public class DevDatabaseSeedController extends Controller {
 
   @Inject
   public DevDatabaseSeedController(
-      DatabaseSeedTask databaseSeedTask,
+      DevDatabaseSeedTask devDatabaseSeedTask,
       DatabaseSeedView view,
       QuestionService questionService,
       ProgramService programService,
       SettingsService settingsService,
       DeploymentType deploymentType) {
-    this.databaseSeedTask = checkNotNull(databaseSeedTask);
+    this.devDatabaseSeedTask = checkNotNull(devDatabaseSeedTask);
     this.view = checkNotNull(view);
     this.database = DB.getDefault();
     this.questionService = checkNotNull(questionService);
@@ -99,7 +69,7 @@ public class DevDatabaseSeedController extends Controller {
       return notFound();
     }
 
-    databaseSeedTask.run();
+    devDatabaseSeedTask.seedQuestions();
 
     return redirect(routes.DevDatabaseSeedController.index().url())
         .flashing("success", "Sample questions seeded");
@@ -110,13 +80,10 @@ public class DevDatabaseSeedController extends Controller {
     if (!isDevOrStaging) {
       return notFound();
     }
-    QuestionDefinition sampleNameQuestion =
-        databaseSeedTask.run().stream()
-            .filter(q -> q.getName().equals("Name"))
-            .findFirst()
-            .orElseThrow();
-    insertComprehensiveSampleProgram(sampleNameQuestion);
-    insertMinimalSampleProgram(sampleNameQuestion);
+    ImmutableList<QuestionDefinition> createdSampleQuestions = devDatabaseSeedTask.seedQuestions();
+
+    devDatabaseSeedTask.insertMinimalSampleProgram(createdSampleQuestions);
+    devDatabaseSeedTask.insertComprehensiveSampleProgram(createdSampleQuestions);
     return redirect(routes.DevDatabaseSeedController.index().url())
         .flashing("success", "The database has been seeded");
   }
@@ -133,178 +100,6 @@ public class DevDatabaseSeedController extends Controller {
 
   // Create a date question definition with the given name and questionText. We currently create
   // multiple date questions in a single program for testing.
-
-  private void insertComprehensiveSampleProgram(QuestionDefinition nameQuestion) {
-    try {
-      ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
-          programService.createProgramDefinition(
-              "comprehensive-sample-program",
-              "desc",
-              "Comprehensive sample program",
-              "display description",
-              /* defaultConfirmationMessage= */ "",
-              "https://github.com/seattle-uat/civiform",
-              DisplayMode.PUBLIC.getValue(),
-              /* programType= */ ProgramType.DEFAULT,
-              /* isIntakeFormFeatureEnabled= */ false,
-              ImmutableList.copyOf(new ArrayList<>()));
-      if (programDefinitionResult.isError()) {
-        throw new Exception(programDefinitionResult.getErrors().toString());
-      }
-      ProgramDefinition programDefinition = programDefinitionResult.getResult();
-      long programId = programDefinition.id();
-
-      long blockId = 1L;
-      BlockForm blockForm = new BlockForm();
-      blockForm.setName("Block 1");
-      blockForm.setDescription("one of each question type - part 1");
-      programService.updateBlock(programId, blockId, blockForm).getResult();
-      programService.addQuestionsToBlock(
-          programId,
-          blockId,
-          ImmutableList.of(
-              questionService.create(STATIC_CONTENT_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(ADDRESS_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(CHECKBOX_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(CURRENCY_QUESTION_DEFINITION).getResult().getId(),
-              questionService
-                  .create(dateQuestionDefinition("Sample Date Question", "When is your birthday?"))
-                  .getResult()
-                  .getId(),
-              questionService.create(DROPDOWN_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(PHONE_QUESTION_DEFINITION).getResult().getId()));
-
-      blockId =
-          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
-      blockForm.setName("Block 2");
-      blockForm.setDescription("one of each question type - part 2");
-      programService.updateBlock(programId, blockId, blockForm);
-      programService.addQuestionsToBlock(
-          programId,
-          blockId,
-          ImmutableList.of(
-              questionService.create(EMAIL_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(ID_QUESTION_DEFINITION).getResult().getId(),
-              nameQuestion.getId(),
-              questionService.create(NUMBER_QUESTION_DEFINITION).getResult().getId(),
-              questionService.create(TEXT_QUESTION_DEFINITION).getResult().getId()));
-
-      blockId =
-          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
-      blockForm.setName("enumerator");
-      blockForm.setDescription("this is for an enumerator");
-      programService.updateBlock(programId, blockId, blockForm);
-      long enumeratorId =
-          questionService.create(ENUMERATOR_QUESTION_DEFINITION).getResult().getId();
-      programService.addQuestionsToBlock(programId, blockId, ImmutableList.of(enumeratorId));
-      // Create repeated screens based on enumerator.
-      long enumeratorBlockId = blockId;
-      blockId =
-          programService
-              .addRepeatedBlockToProgram(programId, enumeratorBlockId)
-              .getResult()
-              .maybeAddedBlock()
-              .get()
-              .id();
-      blockForm.setName("repeated screen for enumerator");
-      blockForm.setDescription("this is a repeated screen for an enumerator");
-      programService.updateBlock(programId, blockId, blockForm);
-      programService.addQuestionsToBlock(
-          programId,
-          blockId,
-          ImmutableList.of(
-              questionService.create(dateQuestionDefinition(enumeratorId)).getResult().getId()));
-
-      blockId =
-          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
-      blockForm.setName("Block 3");
-      blockForm.setDescription("Random information");
-      programService.updateBlock(programId, blockId, blockForm);
-      long radioButtonQuestionId =
-          questionService.create(RADIO_BUTTON_QUESTION_DEFINITION).getResult().getId();
-      programService.addQuestionsToBlock(
-          programId, blockId, ImmutableList.of(radioButtonQuestionId));
-
-      blockId =
-          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
-      blockForm.setName("Block with Predicate");
-      blockForm.setDescription("May be hidden");
-      programService.updateBlock(programId, blockId, blockForm);
-      // Add an unanswered question to the block so it is considered incomplete.
-      programService.addQuestionsToBlock(
-          programId,
-          blockId,
-          ImmutableList.of(
-              questionService
-                  .create(
-                      dateQuestionDefinition(
-                          "Sample Predicate Date Question", "When is your birthday?"))
-                  .getResult()
-                  .getId()));
-      // Add a predicate based on the "favorite season" radio button question in Block 3
-      LeafOperationExpressionNode operation =
-          LeafOperationExpressionNode.create(
-              radioButtonQuestionId,
-              Scalar.SELECTION,
-              Operator.IN,
-              PredicateValue.listOfStrings(ImmutableList.of("2", "3")));
-      PredicateDefinition predicate =
-          PredicateDefinition.create(
-              PredicateExpressionNode.create(operation), PredicateAction.SHOW_BLOCK);
-      programService.setBlockVisibilityPredicate(programId, blockId, Optional.of(predicate));
-
-      // Add file upload as optional to make local testing easier.
-      blockId =
-          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
-      blockForm.setName("file upload");
-      blockForm.setDescription("this is for file upload");
-      programService.updateBlock(programId, blockId, blockForm);
-      long fileQuestionId =
-          questionService.create(FILE_UPLOAD_QUESTION_DEFINITION).getResult().getId();
-      programService.addQuestionsToBlock(programId, blockId, ImmutableList.of(fileQuestionId));
-      programService.setProgramQuestionDefinitionOptionality(
-          programId, blockId, fileQuestionId, true);
-
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void insertMinimalSampleProgram(QuestionDefinition nameQuestion) {
-    try {
-      ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
-          programService.createProgramDefinition(
-              "minimal-sample-program",
-              "desc",
-              "Minimal Sample Program",
-              "display description",
-              /* defaultConfirmationMessage= */ "",
-              /* externalLink= */ "https://github.com/seattle-uat/civiform",
-              DisplayMode.PUBLIC.getValue(),
-              /* programType= */ ProgramType.DEFAULT,
-              /* isIntakeFormFeatureEnabled= */ false,
-              ImmutableList.copyOf(new ArrayList<>()));
-      if (programDefinitionResult.isError()) {
-        throw new Exception(programDefinitionResult.getErrors().toString());
-      }
-      ProgramDefinition programDefinition = programDefinitionResult.getResult();
-      long programId = programDefinition.id();
-
-      long blockId = 1L;
-      BlockForm blockForm = new BlockForm();
-      blockForm.setName("Block 1");
-      blockForm.setDescription("Block 1");
-      programService.updateBlock(programId, blockId, blockForm).getResult();
-
-      programService.addQuestionsToBlock(
-          programId, blockId, ImmutableList.of(nameQuestion.getId()));
-      programService.setProgramQuestionDefinitionOptionality(
-          programId, blockId, nameQuestion.getId(), true);
-
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   private void resetTables() {
     Models.truncate(database);

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -1,0 +1,359 @@
+package controllers.dev.seeding;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.CHECKBOX_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.CURRENCY_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.DATE_PREDICATE_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.DATE_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.DROPDOWN_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.EMAIL_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.ENUMERATOR_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.FILE_UPLOAD_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.ID_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.NAME_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.NUMBER_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.PHONE_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.RADIO_BUTTON_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.STATIC_CONTENT_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.TEXT_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.dateEnumeratedQuestionDefinition;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import forms.BlockForm;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.SerializableConflictException;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
+import io.ebean.annotation.TxIsolation;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.persistence.NonUniqueResultException;
+import javax.persistence.RollbackException;
+import models.DisplayMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import repository.VersionRepository;
+import services.CiviFormError;
+import services.ErrorAnd;
+import services.applicant.question.Scalar;
+import services.program.ProgramDefinition;
+import services.program.ProgramService;
+import services.program.ProgramType;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
+import services.program.predicate.PredicateAction;
+import services.program.predicate.PredicateDefinition;
+import services.program.predicate.PredicateExpressionNode;
+import services.program.predicate.PredicateValue;
+import services.question.QuestionService;
+import services.question.types.QuestionDefinition;
+
+/**
+ * Task for seeding the development database for manual and automated testing. Seeding for prod
+ * should take place in {@link services.seeding.DatabaseSeedTask}.
+ *
+ * <p>To avoid attempting to insert duplicate resources it uses a thread-local database transaction
+ * with a transaction scope of SERIALIZABLE. If the transaction fails it retries up to {@code
+ * MAX_RETRIES} times, sleeping the thread with exponential backoff + jitter before each retry.
+ *
+ * <p>If the task fails {@code MAX_RETRIES} times, it throws a {@code RuntimeException} wrapping the
+ * exception causing it to fail. This will not cause the server itself to crash or prevent it from
+ * starting and serving requests.
+ */
+public final class DevDatabaseSeedTask {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DevDatabaseSeedTask.class);
+  private static final int MAX_RETRIES = 10;
+
+  private final QuestionService questionService;
+  private final ProgramService programService;
+
+  private final VersionRepository versionRepository;
+  private final Database database;
+
+  @Inject
+  public DevDatabaseSeedTask(
+      QuestionService questionService,
+      ProgramService programService,
+      VersionRepository versionRepository) {
+    this.questionService = checkNotNull(questionService);
+    this.versionRepository = checkNotNull(versionRepository);
+    this.programService = checkNotNull(programService);
+    this.database = DB.getDefault();
+  }
+
+  /**
+   * Ensures that all questions in {@link SampleQuestionDefinitions} are present in the database,
+   * inserting the definitions in if any aren't found.
+   */
+  public ImmutableList<QuestionDefinition> seedQuestions() {
+    ImmutableList<QuestionDefinition> sampleQuestionDefinitions =
+        SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS;
+    ImmutableSet<String> sampleQuestionNames =
+        sampleQuestionDefinitions.stream()
+            .map(QuestionDefinition::getName)
+            .collect(ImmutableSet.toImmutableSet());
+    ImmutableMap<String, QuestionDefinition> existingSampleQuestions =
+        questionService.getExistingQuestions(sampleQuestionNames);
+    if (existingSampleQuestions.size() < sampleQuestionNames.size()) {
+      // Ensure a draft version exists to avoid transaction collisions with getDraftVersion.
+      versionRepository.getDraftVersion();
+    }
+
+    ImmutableList.Builder<QuestionDefinition> questionDefinitions = ImmutableList.builder();
+    for (QuestionDefinition questionDefinition : sampleQuestionDefinitions) {
+      if (existingSampleQuestions.containsKey(questionDefinition.getName())) {
+        LOGGER.info("Sample question \"{}\" exists at server start", questionDefinition.getName());
+        questionDefinitions.add(existingSampleQuestions.get(questionDefinition.getName()));
+      } else {
+        inSerializableTransaction(
+            () -> {
+              Optional<QuestionDefinition> question = createQuestion(questionDefinition);
+              question.ifPresent(questionDefinitions::add);
+            },
+            1);
+      }
+    }
+    return questionDefinitions.build();
+  }
+
+  private Optional<QuestionDefinition> createQuestion(QuestionDefinition questionDefinition) {
+    ErrorAnd<QuestionDefinition, CiviFormError> result = questionService.create(questionDefinition);
+
+    if (result.isError()) {
+      String errorMessages =
+          result.getErrors().stream().map(CiviFormError::message).collect(Collectors.joining(", "));
+
+      LOGGER.error(
+          String.format(
+              "Unable to create sample question \"%s\" due to %s",
+              questionDefinition.getName(), errorMessages));
+      return Optional.empty();
+    } else {
+      LOGGER.info("Sample sample question \"{}\"", questionDefinition.getName());
+      return Optional.of(result.getResult());
+    }
+  }
+
+  public void insertMinimalSampleProgram(ImmutableList<QuestionDefinition> createdSampleQuestions) {
+    try {
+      ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
+          programService.createProgramDefinition(
+              "minimal-sample-program",
+              "desc",
+              "Minimal Sample Program",
+              "display description",
+              /* defaultConfirmationMessage= */ "",
+              /* externalLink= */ "https://github.com/seattle-uat/civiform",
+              DisplayMode.PUBLIC.getValue(),
+              /* programType= */ ProgramType.DEFAULT,
+              /* isIntakeFormFeatureEnabled= */ false,
+              ImmutableList.copyOf(new ArrayList<>()));
+      if (programDefinitionResult.isError()) {
+        throw new Exception(programDefinitionResult.getErrors().toString());
+      }
+      ProgramDefinition programDefinition = programDefinitionResult.getResult();
+      long programId = programDefinition.id();
+
+      long blockId = 1L;
+      BlockForm blockForm = new BlockForm();
+      blockForm.setName("Block 1");
+      blockForm.setDescription("Block 1");
+      programService.updateBlock(programId, blockId, blockForm).getResult();
+
+      long nameQuestionId = getCreatedId(NAME_QUESTION_DEFINITION, createdSampleQuestions);
+      programService.addQuestionsToBlock(programId, blockId, ImmutableList.of(nameQuestionId));
+      programService.setProgramQuestionDefinitionOptionality(
+          programId, blockId, nameQuestionId, true);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void insertComprehensiveSampleProgram(
+      ImmutableList<QuestionDefinition> createdSampleQuestions) {
+    try {
+      ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
+          programService.createProgramDefinition(
+              "comprehensive-sample-program",
+              "desc",
+              "Comprehensive sample program",
+              "display description",
+              /* defaultConfirmationMessage= */ "",
+              "https://github.com/seattle-uat/civiform",
+              DisplayMode.PUBLIC.getValue(),
+              /* programType= */ ProgramType.DEFAULT,
+              /* isIntakeFormFeatureEnabled= */ false,
+              ImmutableList.copyOf(new ArrayList<>()));
+      if (programDefinitionResult.isError()) {
+        throw new Exception(programDefinitionResult.getErrors().toString());
+      }
+      ProgramDefinition programDefinition = programDefinitionResult.getResult();
+      long programId = programDefinition.id();
+
+      long blockId = 1L;
+      BlockForm blockForm = new BlockForm();
+      blockForm.setName("Block 1");
+      blockForm.setDescription("one of each question type - part 1");
+      programService.updateBlock(programId, blockId, blockForm).getResult();
+      programService.addQuestionsToBlock(
+          programId,
+          blockId,
+          ImmutableList.of(
+              getCreatedId(STATIC_CONTENT_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(ADDRESS_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(CHECKBOX_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(CURRENCY_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(DATE_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(DROPDOWN_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(PHONE_QUESTION_DEFINITION, createdSampleQuestions)));
+
+      blockId =
+          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
+      blockForm.setName("Block 2");
+      blockForm.setDescription("one of each question type - part 2");
+      programService.updateBlock(programId, blockId, blockForm);
+      programService.addQuestionsToBlock(
+          programId,
+          blockId,
+          ImmutableList.of(
+              getCreatedId(EMAIL_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(ID_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(NAME_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(NUMBER_QUESTION_DEFINITION, createdSampleQuestions),
+              getCreatedId(TEXT_QUESTION_DEFINITION, createdSampleQuestions)));
+
+      blockId =
+          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
+      blockForm.setName("enumerator");
+      blockForm.setDescription("this is for an enumerator");
+      programService.updateBlock(programId, blockId, blockForm);
+      long enumeratorId = getCreatedId(ENUMERATOR_QUESTION_DEFINITION, createdSampleQuestions);
+      programService.addQuestionsToBlock(programId, blockId, ImmutableList.of(enumeratorId));
+      // Create repeated screens based on enumerator.
+      long enumeratorBlockId = blockId;
+      blockId =
+          programService
+              .addRepeatedBlockToProgram(programId, enumeratorBlockId)
+              .getResult()
+              .maybeAddedBlock()
+              .get()
+              .id();
+      blockForm.setName("repeated screen for enumerator");
+      blockForm.setDescription("this is a repeated screen for an enumerator");
+      programService.updateBlock(programId, blockId, blockForm);
+      programService.addQuestionsToBlock(
+          programId,
+          blockId,
+          ImmutableList.of(
+              // This is the only sample question for which we must call create here, because it
+              // includes an enumeratorId that only gets generated after
+              // ENUMERATOR_QUESTION_DEFINITION is created.
+              questionService
+                  .create(dateEnumeratedQuestionDefinition(enumeratorId))
+                  .getResult()
+                  .getId()));
+
+      blockId =
+          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
+      blockForm.setName("Block 3");
+      blockForm.setDescription("Random information");
+      programService.updateBlock(programId, blockId, blockForm);
+      long radioButtonQuestionId =
+          getCreatedId(RADIO_BUTTON_QUESTION_DEFINITION, createdSampleQuestions);
+      programService.addQuestionsToBlock(
+          programId, blockId, ImmutableList.of(radioButtonQuestionId));
+
+      blockId =
+          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
+      blockForm.setName("Block with Predicate");
+      blockForm.setDescription("May be hidden");
+      programService.updateBlock(programId, blockId, blockForm);
+      // Add an unanswered question to the block so it is considered incomplete.
+      programService.addQuestionsToBlock(
+          programId,
+          blockId,
+          ImmutableList.of(
+              getCreatedId(DATE_PREDICATE_QUESTION_DEFINITION, createdSampleQuestions)));
+      // Add a predicate based on the "favorite season" radio button question in Block 3
+      LeafOperationExpressionNode operation =
+          LeafOperationExpressionNode.create(
+              radioButtonQuestionId,
+              Scalar.SELECTION,
+              Operator.IN,
+              PredicateValue.listOfStrings(ImmutableList.of("2", "3")));
+      PredicateDefinition predicate =
+          PredicateDefinition.create(
+              PredicateExpressionNode.create(operation), PredicateAction.SHOW_BLOCK);
+      programService.setBlockVisibilityPredicate(programId, blockId, Optional.of(predicate));
+
+      // Add file upload as optional to make local testing easier.
+      blockId =
+          programService.addBlockToProgram(programId).getResult().maybeAddedBlock().get().id();
+      blockForm.setName("file upload");
+      blockForm.setDescription("this is for file upload");
+      programService.updateBlock(programId, blockId, blockForm);
+      long fileQuestionId = getCreatedId(FILE_UPLOAD_QUESTION_DEFINITION, createdSampleQuestions);
+      programService.addQuestionsToBlock(programId, blockId, ImmutableList.of(fileQuestionId));
+      programService.setProgramQuestionDefinitionOptionality(
+          programId, blockId, fileQuestionId, true);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void inSerializableTransaction(Runnable fn, int tryCount) {
+    Transaction transaction =
+        database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
+
+    try {
+      fn.run();
+      transaction.commit();
+    } catch (NonUniqueResultException | SerializableConflictException | RollbackException e) {
+      LOGGER.warn("Database seed transaction failed: %s", e);
+
+      if (tryCount > MAX_RETRIES) {
+        throw new RuntimeException(e);
+      }
+
+      transaction.end();
+
+      long sleepDurMillis = Math.round(Math.pow(2, tryCount)) + new Random().nextInt(100);
+
+      try {
+        Thread.sleep(sleepDurMillis);
+      } catch (InterruptedException ie) {
+        throw new RuntimeException(ie);
+      }
+
+      inSerializableTransaction(fn, ++tryCount);
+    } finally {
+      if (transaction.isActive()) {
+        transaction.end();
+      }
+    }
+  }
+
+  /**
+   * Gets the seeded question definition's ID from the list of created sample questions. The ID is
+   * necessarily not available in {@link SampleQuestionDefinitions}.
+   */
+  private long getCreatedId(
+      QuestionDefinition questionDefinition,
+      ImmutableList<QuestionDefinition> createdSampleQuestions) {
+    return createdSampleQuestions.stream()
+        .filter(q -> q.getName().equals(questionDefinition.getName()))
+        .findFirst()
+        .map(QuestionDefinition::getId)
+        .orElseThrow();
+  }
+}

--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -1,6 +1,8 @@
 package controllers.dev.seeding;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import play.i18n.Lang;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.types.AddressQuestionDefinition;
@@ -12,15 +14,17 @@ import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
+import services.question.types.NameQuestionDefinition;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
+import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 public final class SampleQuestionDefinitions {
 
-  public static final AddressQuestionDefinition ADDRESS_QUESTION_DEFINITION =
+  static final AddressQuestionDefinition ADDRESS_QUESTION_DEFINITION =
       new AddressQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Address Question")
@@ -45,13 +49,13 @@ public final class SampleQuestionDefinitions {
           QuestionOption.create(2L, 2L, LocalizedStrings.withDefaultValue("pepper grinder")),
           QuestionOption.create(3L, 3L, LocalizedStrings.withDefaultValue("garlic press")));
 
-  public static final MultiOptionQuestionDefinition CHECKBOX_QUESTION_DEFINITION =
+  static final MultiOptionQuestionDefinition CHECKBOX_QUESTION_DEFINITION =
       new MultiOptionQuestionDefinition(
           CHECKBOX_QUESTION_DEFINITION_CONFIG,
           CHECKBOX_QUESTION_OPTIONS,
           MultiOptionQuestionType.CHECKBOX);
 
-  public static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
+  static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
       new CurrencyQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Currency Question")
@@ -77,11 +81,11 @@ public final class SampleQuestionDefinitions {
           QuestionOption.create(3L, 3L, LocalizedStrings.withDefaultValue("vanilla")),
           QuestionOption.create(4L, 4L, LocalizedStrings.withDefaultValue("coffee")));
 
-  public static final MultiOptionQuestionDefinition DROPDOWN_QUESTION_DEFINITION =
+  static final MultiOptionQuestionDefinition DROPDOWN_QUESTION_DEFINITION =
       new MultiOptionQuestionDefinition(
           DROPDOWN_QUESTION_CONFIG, DROPDOWN_QUESTION_OPTIONS, MultiOptionQuestionType.DROPDOWN);
 
-  public static final EmailQuestionDefinition EMAIL_QUESTION_DEFINITION =
+  static final EmailQuestionDefinition EMAIL_QUESTION_DEFINITION =
       new EmailQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Email Question")
@@ -90,7 +94,7 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  public static final EnumeratorQuestionDefinition ENUMERATOR_QUESTION_DEFINITION =
+  static final EnumeratorQuestionDefinition ENUMERATOR_QUESTION_DEFINITION =
       new EnumeratorQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Enumerator Question")
@@ -101,7 +105,7 @@ public final class SampleQuestionDefinitions {
               .build(),
           LocalizedStrings.withDefaultValue("household member"));
 
-  public static final FileUploadQuestionDefinition FILE_UPLOAD_QUESTION_DEFINITION =
+  static final FileUploadQuestionDefinition FILE_UPLOAD_QUESTION_DEFINITION =
       new FileUploadQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample File Upload Question")
@@ -111,7 +115,7 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  public static final IdQuestionDefinition ID_QUESTION_DEFINITION =
+  static final IdQuestionDefinition ID_QUESTION_DEFINITION =
       new IdQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample ID Question")
@@ -121,7 +125,56 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  public static final NumberQuestionDefinition NUMBER_QUESTION_DEFINITION =
+  static final QuestionDefinition NAME_QUESTION_DEFINITION =
+      new NameQuestionDefinition(
+          QuestionDefinitionConfig.builder()
+              .setName("Name")
+              .setDescription("The applicant's name")
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("am").toLocale(),
+                          "ስም (የመጀመሪያ ስም እና የመጨረሻ ስም አህጽሮት ይሆናል)",
+                          Lang.forCode("ko").toLocale(),
+                          "성함 (이름 및 성의 경우 이니셜도 괜찮음)",
+                          Lang.forCode("so").toLocale(),
+                          "Magaca (magaca koowaad iyo kan dambe okay)",
+                          Lang.forCode("lo").toLocale(),
+                          "ຊື່ (ນາມສະກຸນ ແລະ ຕົວອັກສອນທຳອິດຂອງນາມສະກຸນແມ່ນຖືກຕ້ອງ)",
+                          Lang.forCode("tl").toLocale(),
+                          "Pangalan (unang pangalan at ang unang titik ng apilyedo ay okay)",
+                          Lang.forCode("vi").toLocale(),
+                          "Tên (tên và họ viết tắt đều được)",
+                          Lang.forCode("en-US").toLocale(),
+                          "Please enter your first and last name",
+                          Lang.forCode("es-US").toLocale(),
+                          "Nombre (nombre y la inicial del apellido está bien)",
+                          Lang.forCode("zh-TW").toLocale(),
+                          "姓名（名字和姓氏第一個字母便可）")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("am").toLocale(),
+                          "የእርዳታ ጽሑፍ",
+                          Lang.forCode("ko").toLocale(),
+                          "도움말 텍스트",
+                          Lang.forCode("so").toLocale(),
+                          "qoraalka caawinta",
+                          Lang.forCode("lo").toLocale(),
+                          "ຂໍ້ຄວາມຊ່ວຍ",
+                          Lang.forCode("tl").toLocale(),
+                          "tulong text",
+                          Lang.forCode("vi").toLocale(),
+                          "văn bản trợ giúp",
+                          Lang.forCode("en-US").toLocale(),
+                          "Help text",
+                          Lang.forCode("es-US").toLocale(),
+                          "texto de ayuda",
+                          Lang.forCode("zh-TW").toLocale(),
+                          "帮助文本")))
+              .build());
+
+  static final NumberQuestionDefinition NUMBER_QUESTION_DEFINITION =
       new NumberQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Number Question")
@@ -147,13 +200,13 @@ public final class SampleQuestionDefinitions {
           QuestionOption.create(
               4L, 4L, LocalizedStrings.withDefaultValue("fall (will hide next block)")));
 
-  public static final MultiOptionQuestionDefinition RADIO_BUTTON_QUESTION_DEFINITION =
+  static final MultiOptionQuestionDefinition RADIO_BUTTON_QUESTION_DEFINITION =
       new MultiOptionQuestionDefinition(
           RADIO_BUTTON_QUESTION_CONFIG,
           RADIO_BUTTON_QUESTION_OPTIONS,
           MultiOptionQuestionType.RADIO_BUTTON);
 
-  public static final StaticContentQuestionDefinition STATIC_CONTENT_QUESTION_DEFINITION =
+  static final StaticContentQuestionDefinition STATIC_CONTENT_QUESTION_DEFINITION =
       new StaticContentQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Static Content Question")
@@ -168,7 +221,7 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
               .build());
 
-  public static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
+  static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Text Question")
@@ -177,7 +230,7 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  public static final PhoneQuestionDefinition PHONE_QUESTION_DEFINITION =
+  static final PhoneQuestionDefinition PHONE_QUESTION_DEFINITION =
       new PhoneQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Phone Question")
@@ -186,25 +239,55 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  public static DateQuestionDefinition dateQuestionDefinition(String name, String questionText) {
+  static final DateQuestionDefinition DATE_QUESTION_DEFINITION =
+      new DateQuestionDefinition(
+          QuestionDefinitionConfig.builder()
+              .setName("Sample Date Question")
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.withDefaultValue("When is your birthday?"))
+              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .build());
+
+  static final DateQuestionDefinition DATE_PREDICATE_QUESTION_DEFINITION =
+      new DateQuestionDefinition(
+          QuestionDefinitionConfig.builder()
+              .setName("Sample Predicate Date Question")
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.withDefaultValue("When is your birthday?"))
+              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .build());
+
+  private static final QuestionDefinitionConfig.Builder
+      DATE_ENUMERATED_QUESTION_DEFINITION_BUILDER =
+          QuestionDefinitionConfig.builder()
+              .setName("Sample Enumerated Date Question")
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.withDefaultValue("When is $this's birthday?"))
+              .setQuestionHelpText(
+                  LocalizedStrings.withDefaultValue("help text for $this's birthday"));
+
+  static DateQuestionDefinition dateEnumeratedQuestionDefinition(long enumeratorId) {
     return new DateQuestionDefinition(
-        QuestionDefinitionConfig.builder()
-            .setName(name)
-            .setDescription("description")
-            .setQuestionText(LocalizedStrings.withDefaultValue(questionText))
-            .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
-            .build());
+        DATE_ENUMERATED_QUESTION_DEFINITION_BUILDER.setEnumeratorId(enumeratorId).build());
   }
 
-  public static DateQuestionDefinition dateQuestionDefinition(long enumeratorId) {
-    return new DateQuestionDefinition(
-        QuestionDefinitionConfig.builder()
-            .setName("Sample Enumerator Date Question")
-            .setDescription("description")
-            .setQuestionText(LocalizedStrings.withDefaultValue("When is $this's birthday?"))
-            .setQuestionHelpText(
-                LocalizedStrings.withDefaultValue("help text for $this's birthday"))
-            .setEnumeratorId(enumeratorId)
-            .build());
-  }
+  /** All members of this class that are of type {@link QuestionDefinition}. */
+  public static final ImmutableList<QuestionDefinition> ALL_SAMPLE_QUESTION_DEFINITIONS =
+      ImmutableList.of(
+          ADDRESS_QUESTION_DEFINITION,
+          CHECKBOX_QUESTION_DEFINITION,
+          CURRENCY_QUESTION_DEFINITION,
+          DATE_PREDICATE_QUESTION_DEFINITION,
+          DATE_QUESTION_DEFINITION,
+          DROPDOWN_QUESTION_DEFINITION,
+          EMAIL_QUESTION_DEFINITION,
+          ENUMERATOR_QUESTION_DEFINITION,
+          FILE_UPLOAD_QUESTION_DEFINITION,
+          ID_QUESTION_DEFINITION,
+          NAME_QUESTION_DEFINITION,
+          NUMBER_QUESTION_DEFINITION,
+          PHONE_QUESTION_DEFINITION,
+          RADIO_BUTTON_QUESTION_DEFINITION,
+          STATIC_CONTENT_QUESTION_DEFINITION,
+          TEXT_QUESTION_DEFINITION);
 }

--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -30,7 +30,7 @@ import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
 /**
- * Task for seeding the database.
+ * Task for seeding the production database.
  *
  * <p>Logic for seeding different resources should be factored into separate methods for clarity.
  *
@@ -46,7 +46,7 @@ public final class DatabaseSeedTask {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSeedTask.class);
   private static final int MAX_RETRIES = 10;
-  private static final ImmutableList<QuestionDefinition> SAMPLE_QUESTIONS =
+  private static final ImmutableList<QuestionDefinition> CANONICAL_QUESTIONS =
       ImmutableList.of(
           new QuestionDefinitionBuilder()
               .setQuestionType(QuestionType.NAME)
@@ -96,27 +96,27 @@ public final class DatabaseSeedTask {
   }
 
   public ImmutableList<QuestionDefinition> run() {
-    return seedQuestions();
+    return seedCanonicalQuestions();
   }
 
   /**
-   * Ensures that questions with names matching those in {@code SAMPLE_QUESTIONS} are present in the
-   * database, inserting the definitions in {@code SAMPLE_QUESTIONS} if any aren't found.
+   * Ensures that questions with names matching those in {@code CANONICAL_QUESTIONS} are present in
+   * the database, inserting the definitions in {@code CANONICAL_QUESTIONS} if any aren't found.
    */
-  private ImmutableList<QuestionDefinition> seedQuestions() {
-    ImmutableSet<String> sampleQuestionNames =
-        SAMPLE_QUESTIONS.stream()
+  private ImmutableList<QuestionDefinition> seedCanonicalQuestions() {
+    ImmutableSet<String> canonicalQuestionNames =
+        CANONICAL_QUESTIONS.stream()
             .map(QuestionDefinition::getName)
             .collect(ImmutableSet.toImmutableSet());
     ImmutableMap<String, QuestionDefinition> existingCanonicalQuestions =
-        questionService.getExistingQuestions(sampleQuestionNames);
-    if (existingCanonicalQuestions.size() < sampleQuestionNames.size()) {
+        questionService.getExistingQuestions(canonicalQuestionNames);
+    if (existingCanonicalQuestions.size() < canonicalQuestionNames.size()) {
       // Ensure a draft version exists to avoid transaction collisions with getDraftVersion.
       versionRepository.getDraftVersion();
     }
 
     ImmutableList.Builder<QuestionDefinition> questionDefinitions = ImmutableList.builder();
-    for (QuestionDefinition questionDefinition : SAMPLE_QUESTIONS) {
+    for (QuestionDefinition questionDefinition : CANONICAL_QUESTIONS) {
       if (existingCanonicalQuestions.containsKey(questionDefinition.getName())) {
         LOGGER.info(
             "Canonical question \"%s\" exists at server start", questionDefinition.getName());

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
@@ -1,0 +1,67 @@
+package controllers.dev.seeding;
+
+import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Set;
+import models.Question;
+import org.junit.Before;
+import org.junit.Test;
+import repository.ProgramRepository;
+import repository.QuestionRepository;
+import repository.ResetPostgres;
+import services.question.QuestionService;
+import services.question.types.QuestionDefinition;
+
+public class DevDatabaseSeedTaskTest extends ResetPostgres {
+
+  private QuestionRepository questionRepository;
+  private ProgramRepository programRepository;
+  private DevDatabaseSeedTask devDatabaseSeedTask;
+
+  @Before
+  public void setUp() {
+    questionRepository = instanceOf(QuestionRepository.class);
+    programRepository = instanceOf(ProgramRepository.class);
+    devDatabaseSeedTask = instanceOf(DevDatabaseSeedTask.class);
+  }
+
+  @Test
+  public void seedQuestions_whenQuestionsNotSeededYet_itSeedsTheQuestions() throws Exception {
+    assertThat(getAllQuestions().size()).isEqualTo(0);
+
+    devDatabaseSeedTask.seedQuestions();
+
+    // All questions from the sample questions file are seeded.
+    assertThat(getAllQuestions().size())
+        .isEqualTo(SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.size());
+  }
+
+  @Test
+  public void seedQuestions_whenSomeQuestionsAlreadySeeded_itSeedsTheMissingOnes() {
+    instanceOf(QuestionService.class).create(ADDRESS_QUESTION_DEFINITION);
+    assertThat(getAllQuestions().size()).isEqualTo(1);
+
+    // Seeding should be idempotent and skip the already seeded ADDRESS_QUESTION_DEFINITION.
+    devDatabaseSeedTask.seedQuestions();
+
+    assertThat(getAllQuestions().size())
+        .isEqualTo(SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.size());
+  }
+
+  @Test
+  public void insertPrograms_seedsPrograms() {
+    ImmutableList<QuestionDefinition> seededQuestions = devDatabaseSeedTask.seedQuestions();
+
+    devDatabaseSeedTask.insertMinimalSampleProgram(seededQuestions);
+    devDatabaseSeedTask.insertComprehensiveSampleProgram(seededQuestions);
+
+    assertThat(programRepository.getAllProgramNames())
+        .containsExactlyInAnyOrder("comprehensive-sample-program", "minimal-sample-program");
+  }
+
+  private Set<Question> getAllQuestions() {
+    return questionRepository.listQuestions().toCompletableFuture().join();
+  }
+}


### PR DESCRIPTION
### Description

This cleans up and centralizes the database seeding logic further, building on #5213 in preparation for API docs testing.

Changes include:
* Create `DevDatabaseSeedTask` and (mostly) leave `DatabaseSeedTask` alone. The former is only for dev, and the latter is only for prod. Previously, `DevDatabaseSeedController` would use `DatabaseSeedTask` for seeding some questions, commingling these two functions; we remove that dependency.
* Remove all unnecessary `dateQuestionDefininition()` methods in `SampleQuestionDefinitions`. The only one we need is the one that helps create enumerated date questions.
* Move `insertMinimalSampleProgram` and `insertComprehensiveSampleProgram` from `DatabaseSeedController` to `DevDatabaseSeedTask`.
* Remove the need for this code:
  ```java
  QuestionDefinition sampleNameQuestion =
      databaseSeedTask.run().stream()
          .filter(q -> q.getName().equals("Name"))
          .findFirst()
          .orElseThrow();
  ```
  to build the minimal program with a name question.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - Refactor, not needed
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary
   - Refactor, not needed

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

None.

### Issue(s) this completes

None, but relates to generated API docs (testing it)