### PR TITLE
Include required attribute on SettingDescription

### DIFF
--- a/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
+++ b/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
@@ -103,17 +103,18 @@ def render_group(group: ParsedGroup) -> str:
 
 
 def render_variable(name: str, variable: Variable) -> str:
+    is_required = str(variable.required).lower()
     setting_type = _get_java_setting_type(variable)
     setting_mode = str(variable.mode).replace("Mode.", "")
 
     if setting_type == "ENUM" and variable.values:
         allowable_values = ", ".join([f'"{val}"' for val in variable.values])
-        return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", SettingType.{setting_type}, SettingMode.{setting_mode}, ImmutableList.of({allowable_values}))'
+        return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", /* isRequired= */ {is_required}, SettingType.{setting_type}, SettingMode.{setting_mode}, ImmutableList.of({allowable_values}))'
 
     if setting_type == "STRING" and variable.regex:
-        return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", SettingType.{setting_type}, SettingMode.{setting_mode}, Pattern.compile("{variable.regex}"))'
+        return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", /* isRequired= */ {is_required}, SettingType.{setting_type}, SettingMode.{setting_mode}, Pattern.compile("{variable.regex}"))'
 
-    return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", SettingType.{setting_type}, SettingMode.{setting_mode})'
+    return f'SettingDescription.create("{name}", "{_escape_double_quotes(variable.description)}", /* isRequired= */ {is_required}, SettingType.{setting_type}, SettingMode.{setting_mode})'
 
 
 def _get_java_setting_type(variable: Variable) -> str:

--- a/env-var-docs/parser-package/tests/settings_manifest_test.py
+++ b/env-var-docs/parser-package/tests/settings_manifest_test.py
@@ -52,7 +52,7 @@ class TestGenerateSettingsManifest(unittest.TestCase):
                     Variable(
                         description="Fake string variable for testing",
                         type="string",
-                        required=True,
+                        required=False,
                         values=None,
                         regex="^regex$",
                         regex_tests=None,
@@ -65,9 +65,9 @@ class TestGenerateSettingsManifest(unittest.TestCase):
             result,
             """ImmutableMap.of("Test section", SettingsSection.create("Test section", "Fake section for testing.", \
 ImmutableList.of(SettingsSection.create("Test subsection", "Fake subsection for testing", ImmutableList.of(), \
-ImmutableList.of(SettingDescription.create("SUBSECTION_VARIABLE", "Fake subsection variable for testing", SettingType.STRING, SettingMode.HIDDEN)))), \
+ImmutableList.of(SettingDescription.create("SUBSECTION_VARIABLE", "Fake subsection variable for testing", /* isRequired= */ true, SettingType.STRING, SettingMode.HIDDEN)))), \
 ImmutableList.of()), "Miscellaneous", SettingsSection.create("Miscellaneous", "Top level vars", ImmutableList.of(), \
-ImmutableList.of(SettingDescription.create("STRING_VARIABLE", "Fake string variable for testing", SettingType.STRING, SettingMode.ADMIN_READABLE), \
-SettingDescription.create("ENUM_VARIABLE", "Fake string variable for testing", SettingType.ENUM, SettingMode.ADMIN_READABLE, ImmutableList.of("one", "two")), \
-SettingDescription.create("REGEX_VARIABLE", "Fake string variable for testing", SettingType.STRING, SettingMode.ADMIN_READABLE, Pattern.compile("^regex$")))))"""
+ImmutableList.of(SettingDescription.create("STRING_VARIABLE", "Fake string variable for testing", /* isRequired= */ true, SettingType.STRING, SettingMode.ADMIN_READABLE), \
+SettingDescription.create("ENUM_VARIABLE", "Fake string variable for testing", /* isRequired= */ true, SettingType.ENUM, SettingMode.ADMIN_READABLE, ImmutableList.of("one", "two")), \
+SettingDescription.create("REGEX_VARIABLE", "Fake string variable for testing", /* isRequired= */ false, SettingType.STRING, SettingMode.ADMIN_READABLE, Pattern.compile("^regex$")))))"""
         )

--- a/server/app/services/settings/SettingDescription.java
+++ b/server/app/services/settings/SettingDescription.java
@@ -13,11 +13,13 @@ public abstract class SettingDescription {
   public static SettingDescription create(
       String variableName,
       String variableDescription,
+      boolean isRequired,
       SettingType settingType,
       SettingMode settingMode) {
     return new AutoValue_SettingDescription(
         variableName,
         variableDescription,
+        isRequired,
         settingType,
         settingMode,
         /* allowableValues= */ Optional.empty(),
@@ -27,12 +29,14 @@ public abstract class SettingDescription {
   public static SettingDescription create(
       String variableName,
       String variableDescription,
+      boolean isRequired,
       SettingType settingType,
       SettingMode settingMode,
       ImmutableList<String> allowableValues) {
     return new AutoValue_SettingDescription(
         variableName,
         variableDescription,
+        isRequired,
         settingType,
         settingMode,
         Optional.of(allowableValues),
@@ -42,12 +46,14 @@ public abstract class SettingDescription {
   public static SettingDescription create(
       String variableName,
       String variableDescription,
+      boolean isRequired,
       SettingType settingType,
       SettingMode settingMode,
       Pattern validationRegex) {
     return new AutoValue_SettingDescription(
         variableName,
         variableDescription,
+        isRequired,
         settingType,
         settingMode,
         /* allowableValues= */ Optional.empty(),
@@ -59,6 +65,9 @@ public abstract class SettingDescription {
 
   /** A sentence or two describing the setting. */
   public abstract String settingDescription();
+
+  // True if the setting must be present.
+  public abstract boolean isRequired();
 
   /** The type of this setting. */
   public abstract SettingType settingType();

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -705,17 +705,20 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                   SettingDescription.create(
                       "WHITELABEL_SMALL_LOGO_URL",
                       "Small logo for the civic entity used on the login page.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "WHITELABEL_CIVIC_ENTITY_SHORT_NAME",
                       "The short display name of the civic entity, will use 'TestCity' if not set.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "WHITELABEL_CIVIC_ENTITY_FULL_NAME",
                       "The full display name of the civic entity, will use 'City of TestCity' if"
                           + " not set.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
@@ -723,6 +726,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The URL of a 32x32 or 16x16 pixel"
                           + " [favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon)"
                           + " image, in GIF, PNG, or ICO format.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE))),
           "External Services",
@@ -748,6 +752,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " Connect) to request data from authorization servers,"
                                           + " specifically communicating with IDCS. A Civiform"
                                           + " instance is always the client.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -757,12 +762,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " systems. This secret essentially acts as the"
                                           + " client’s “password” for accessing data from the auth"
                                           + " server.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "IDCS_DISCOVERY_URI",
                                       "A URL that returns a JSON listing of OIDC (OpenID Connect)"
                                           + " data associated with the IDCS auth provider.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN))),
                           SettingsSection.create(
@@ -775,35 +782,41 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_API_KEY",
                                       "The API key used to interact with LoginRadius.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_METADATA_URI",
                                       "The base URL to construct SAML endpoints, based on the"
                                           + " SAML2 spec.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_SAML_APP_NAME",
                                       "The name for the app, based on the SAML2 spec.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_KEYSTORE_NAME",
                                       "Name of the SAML2 keystore, used to store digital"
                                           + " certificates and private keys for SAML auth.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_KEYSTORE_PASS",
                                       "The password used the protect the integrity of the SAML"
                                           + " keystore file.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_PRIVATE_KEY_PASS",
                                       "The password used to protect the private key of the SAML"
                                           + " digital certificate.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN))),
                           SettingsSection.create(
@@ -817,6 +830,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "APPLICANT_OIDC_PROVIDER_LOGOUT",
                                       "Enables [central"
                                           + " logout](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#logout).",
+                                      /* isRequired= */ false,
                                       SettingType.BOOLEAN,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -826,6 +840,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " logout endpoint. However for some integrations that"
                                           + " standard flow might not work and we need to override"
                                           + " logout URL.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -838,12 +853,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " and instead it needs to be hardcoded on the the auth"
                                           + " provider (otherwise the user won't be redirected"
                                           + " back to civiform after logout).",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_PROVIDER_NAME",
                                       "The name of the OIDC (OpenID Connect) auth provider"
                                           + " (server), such as “Auth0” or “LoginRadius”.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -851,6 +868,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "An opaque public identifier for apps that use OIDC (OpenID"
                                           + " Connect) to request data from authorization servers."
                                           + " A Civiform instance is always the client.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -859,18 +877,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " authorization server. This secret essentially acts"
                                           + " as the client’s “password” for accessing data from"
                                           + " the auth server.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_DISCOVERY_URI",
                                       "A URL that returns a JSON listing of OIDC (OpenID Connect)"
                                           + " data associated with a given auth provider.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_RESPONSE_MODE",
                                       "Informs the auth server of the desired auth processing"
                                           + " flow, based on the OpenID Connect spec.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -878,6 +899,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "Informs the auth server of the mechanism to be used for"
                                           + " returning response params from the auth endpoint,"
                                           + " based on the OpenID Connect spec.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -885,31 +907,37 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "Scopes the client (CiviForm) is requesting in addition to"
                                           + " the standard scopes the OpenID Connect spec"
                                           + " provides.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_LOCALE_ATTRIBUTE",
                                       "The locale of the user, such as “en-US”.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_EMAIL_ATTRIBUTE",
                                       "The OIDC attribute name for the user’s email address.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_FIRST_NAME_ATTRIBUTE",
                                       "The OIDC attribute name for the user’s first name.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE",
                                       "The OIDC attribute name for the user’s middle name.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_LAST_NAME_ATTRIBUTE",
                                       "The OIDC attribute name for the user’s last name.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN))),
                           SettingsSection.create(
@@ -925,6 +953,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " Connect) to request data from authorization servers,"
                                           + " specifically communicating with Login.gov. A"
                                           + " Civiform instance is always the client.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -932,6 +961,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "A URL that returns a JSON listing of OIDC (OpenID Connect)"
                                           + " data associated with a given auth provider,"
                                           + " specifically for Login.gov.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -939,6 +969,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "Scopes the client (CiviForm) is requesting in addition to"
                                           + " the standard scopes the OpenID Connect spec"
                                           + " provides. Scopes should be separated by a space.",
+                                      /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
@@ -947,6 +978,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                           + " requests](https://developers.login.gov/oidc/#request-parameters)."
                                           + " ial/1 is for open registration, email only. ial/2 is"
                                           + " for requiring identity verification.",
+                                      /* isRequired= */ false,
                                       SettingType.ENUM,
                                       SettingMode.HIDDEN,
                                       ImmutableList.of(
@@ -956,6 +988,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "CIVIFORM_APPLICANT_IDP",
                               "What identity provider to use for applicants.",
+                              /* isRequired= */ false,
                               SettingType.ENUM,
                               SettingMode.ADMIN_READABLE,
                               ImmutableList.of(
@@ -968,12 +1001,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "APPLICANT_REGISTER_URI",
                               "URI to create a new account in the applicant identity provider.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "APPLICANT_PORTAL_NAME",
                               "The name of the portal that applicants log into, used in sentences"
                                   + " like 'Log into your APPLICANT_PORTAL_NAME account.'",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.ADMIN_WRITEABLE))),
                   SettingsSection.create(
@@ -988,6 +1023,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   + " to request data from authorization servers, specifically"
                                   + " communicating with ADFS. A Civiform instance is always the"
                                   + " client.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
@@ -995,18 +1031,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "A secret known only to the client (Civiform) and authorization"
                                   + " server. This secret essentially acts as the client’s"
                                   + " “password” for accessing data from the auth server.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "ADFS_DISCOVERY_URI",
                               "A URL that returns a JSON listing of OIDC (OpenID Connect) data"
                                   + " associated with the IDCS auth provider.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "ADFS_GLOBAL_ADMIN_GROUP",
                               "The name of the admin group in Active Directory, typically used to"
                                   + " tell if a user is a global admin.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
@@ -1014,12 +1053,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "Scopes the client (CiviForm) is requesting in addition to the"
                                   + " standard scopes the OpenID Connect spec provides. Scopes"
                                   + " should be separated by a space.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "AD_GROUPS_ATTRIBUTE_NAME",
                               "The attribute name for looking up the groups associated with a"
                                   + " particular user.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN))),
                   SettingsSection.create(
@@ -1032,26 +1073,31 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "If enabled, [playframework down"
                                   + " evolutions](https://www.playframework.com/documentation/2.8.x/Evolutions#Evolutions-scripts)"
                                   + " are automatically applied on server start if needed.",
+                              /* isRequired= */ false,
                               SettingType.BOOLEAN,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DATABASE_CONNECTION_POOL_SIZE",
                               "Sets how many connections to the database are maintained.",
+                              /* isRequired= */ false,
                               SettingType.INT,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DB_JDBC_STRING",
                               "The database URL.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DB_USERNAME",
                               "The username used to connect to the database.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DB_PASSWORD",
                               "The password used to connect to the database.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN))),
                   SettingsSection.create(
@@ -1062,27 +1108,32 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "STORAGE_SERVICE_NAME",
                               "What static file storage provider to use.",
+                              /* isRequired= */ false,
                               SettingType.ENUM,
                               SettingMode.HIDDEN,
                               ImmutableList.of("s3", "azure-blob")),
                           SettingDescription.create(
                               "AWS_S3_BUCKET_NAME",
                               "s3 bucket to store files in.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "AWS_S3_FILE_LIMIT_MB",
                               "The max size (in Mb) of files uploaded to s3.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "AZURE_STORAGE_ACCOUNT_NAME",
                               "The azure account name where the blob storage service exists.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "AZURE_STORAGE_ACCOUNT_CONTAINER",
                               "Azure blob storage container name to store files in.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
@@ -1090,6 +1141,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "Allows local [Azurite"
                                   + " emulator](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)"
                                   + " to be used for developer deployments.",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN))),
                   SettingsSection.create(
@@ -1102,18 +1154,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "ESRI_FIND_ADDRESS_CANDIDATES_URL",
                               "The URL CiviForm will use to call Esri’s [findAddressCandidates"
                                   + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS",
                               "Human readable labels used to present the service area validation"
                                   + " options in CiviForm’s admin UI.",
+                              /* isRequired= */ false,
                               SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_IDS",
                               "The value CiviForm uses to validate if an address is in a service"
                                   + " area.",
+                              /* isRequired= */ false,
                               SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
@@ -1121,18 +1176,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               "The URL CiviForm will use to call Esri’s [map query"
                                   + " service](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm)"
                                   + " for service area validation.",
+                              /* isRequired= */ false,
                               SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ATTRIBUTES",
                               "The attribute CiviForm checks from the service area validation"
                                   + " response to get the service area validation ID.",
+                              /* isRequired= */ false,
                               SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "ESRI_EXTERNAL_CALL_TRIES",
                               "The number of tries CiviForm will attempt requests to external Esri"
                                   + " services.",
+                              /* isRequired= */ false,
                               SettingType.INT,
                               SettingMode.ADMIN_READABLE)))),
               ImmutableList.of(
@@ -1140,12 +1198,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "AWS_REGION",
                       "Region where the AWS SES service exists. If STORAGE_SERVICE_NAME is set to"
                           + " 'aws', it is also the region where the AWS s3 service exists.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "AWS_SES_SENDER",
                       "The email address used for the 'from' email header for emails sent by"
                           + " CiviForm.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN))),
           "Email Addresses",
@@ -1159,12 +1219,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "SUPPORT_EMAIL_ADDRESS",
                       "This email address is listed in the footer for applicants to contact"
                           + " support.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "IT_EMAIL_ADDRESS",
                       "This email address receives error notifications from CiviForm when things"
                           + " break.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
@@ -1172,6 +1234,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the program administrator's email"
                           + " address.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1179,12 +1242,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the trusted intermediary's email"
                           + " address.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "STAGING_APPLICANT_LIST",
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the applicant's email address.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN))),
           "Custom Text",
@@ -1198,6 +1263,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The text for a link on the Common Intake confirmation page that links to"
                           + " more resources. Shown when the applicant is not eligible for any"
                           + " programs in CiviForm.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
@@ -1205,6 +1271,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The HREF for a link on the Common Intake confirmation page that links to"
                           + " more resources. Shown when the applicant is not eligible for any"
                           + " programs in CiviForm.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_WRITEABLE,
                       Pattern.compile("^(http://|https://).+")))),
@@ -1218,12 +1285,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "CIVIFORM_SERVER_METRICS_ENABLED",
                       "If enabled, allows server Prometheus metrics to be retrieved via the"
                           + " '/metrics' URL path.  If disabled, '/metrics' returns a 404.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "MEASUREMENT_ID",
                       "The Google Analytics tracking ID.  If set, Google Analytics JavaScript"
                           + " scripts are added to the CiviForm pages.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE))),
           "Data Export API",
@@ -1242,18 +1311,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " secret has been leaked or otherwise comprised it should be changed"
                           + " and all active API keys should be retired and reissued. Default"
                           + " value is 'changeme'.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET",
                       "When true prevents the CiviForm admin from issuing API keys that allow"
                           + " callers from all IP addresses (i.e. a CIDR mask of /0).",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE_SIZE",
                       "An integer specifying the maximum number of entries returned in a page of"
                           + " results for the applications export API.",
+                      /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE))),
           "Durable Jobs",
@@ -1269,6 +1341,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " results in jobs running sooner when they are scheduled to be run"
                           + " immediately, at the cost of more pressure on the database. Default"
                           + " value is 5.",
+                      /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1276,6 +1349,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "An integer specifying the timeout in minutes for durable jobs i.e. how long"
                           + " a single job is allowed to run before the system attempts to"
                           + " interrupt it. Default value is 30.",
+                      /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1283,6 +1357,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The number of server threads available for the durable job runner. More"
                           + " than a single thread will the server execute multiple jobs in"
                           + " parallel. Default value is 1.",
+                      /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.HIDDEN))),
           "Feature Flags",
@@ -1295,40 +1370,47 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED",
                       "Enables the feature that allows for service area validation of a corrected"
                           + " address. ESRI_ADDRESS_CORRECTION_ENABLED needs to be enabled.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "ESRI_ADDRESS_CORRECTION_ENABLED",
                       "Enables the feature that allows address correction for address questions.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "ADMIN_SETTINGS_PANEL_ENABLED",
                       "If enabled, adds a page in the CiviForm Admin UI for accessing application"
                           + " settings.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "CF_OPTIONAL_QUESTIONS",
                       "If enabled, allows questions to be optional in programs. Is enabled by"
                           + " default.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS",
                       "If enabled, CiviForm Admins are able to see all applications for all"
                           + " programs. Is disabled by default.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE",
                       "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login"
                           + " screen. Is disabled by default.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "INTAKE_FORM_ENABLED",
                       "Enables the Common Intake Form feature.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
@@ -1337,17 +1419,20 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)"
                           + " metadata tag is added to the CiviForm pages. This causes the staging"
                           + " site to not be listed on search engines.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "STAGING_DISABLE_DEMO_MODE_LOGINS",
                       "If this is a staging deployment and this variable is set to true, the 'DEMO"
                           + " MODE. LOGIN AS:' buttons are not shown on the login page.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "PHONE_QUESTION_TYPE_ENABLED",
                       "Enables the phone number question type.",
+                      /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE))),
           "Miscellaneous",
@@ -1362,12 +1447,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " key](http://www.playframework.com/documentation/latest/ApplicationSecret)"
                           + " is used to sign Play's session cookie. This must be changed for"
                           + " production.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "BASE_URL",
                       "The URL of the CiviForm deployment.  Must start with 'https://' or"
                           + " 'http://'.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE,
                       Pattern.compile("^(http://|https://).+")),
@@ -1375,6 +1462,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "STAGING_HOSTNAME",
                       "DNS name of the staging deployment.  Must not start with 'https://' or"
                           + " 'http://'.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN,
                       Pattern.compile("^(?!http://|https://).+")),
@@ -1383,6 +1471,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The languages that applicants can choose from when specifying their"
                           + " language preference and that admins can choose from when adding"
                           + " translations for programs and applications.",
+                      /* isRequired= */ false,
                       SettingType.LIST_OF_STRINGS,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1392,6 +1481,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " indicating the time zone for this CiviForm deployment. All times in"
                           + " the system will be calculated in this zone. Default value is"
                           + " 'America/Los_Angeles'",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
@@ -1401,6 +1491,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
                           + " shown on the login page if CIVIFORM_VERSION is the empty string or"
                           + " set to 'latest'.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
@@ -1409,6 +1500,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
                           + " shown on the login page if it a value other than the empty string or"
                           + " 'latest'.",
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
@@ -1417,6 +1509,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " where the IP address of the request is the originating IP address."
                           + " If \"FORWARDED\" then request has been reverse proxied and the"
                           + " originating IP address is stored in the X-Forwarded-For header.",
+                      /* isRequired= */ false,
                       SettingType.ENUM,
                       SettingMode.ADMIN_READABLE,
                       ImmutableList.of("DIRECT", "FORWARDED")))));

--- a/server/test/services/settings/SettingDescriptionTest.java
+++ b/server/test/services/settings/SettingDescriptionTest.java
@@ -9,12 +9,13 @@ public class SettingDescriptionTest {
   @Test
   public void shouldDisplay() {
     assertThat(
-            SettingDescription.create("HIDDEN_NAME", "", SettingType.STRING, SettingMode.HIDDEN)
+            SettingDescription.create(
+                    "HIDDEN_NAME", "", true, SettingType.STRING, SettingMode.HIDDEN)
                 .shouldDisplay())
         .isFalse();
     assertThat(
             SettingDescription.create(
-                    "READABLE_NAME", "", SettingType.STRING, SettingMode.ADMIN_READABLE)
+                    "READABLE_NAME", "", true, SettingType.STRING, SettingMode.ADMIN_READABLE)
                 .shouldDisplay())
         .isTrue();
   }

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -19,18 +19,21 @@ public class SettingsManifestTest {
       SettingDescription.create(
           "BOOL_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.BOOLEAN,
           SettingMode.ADMIN_READABLE);
   private static SettingDescription STRING_VARIABLE =
       SettingDescription.create(
           "STRING_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.STRING,
           SettingMode.ADMIN_READABLE);
   private static SettingDescription ENUM_VARIABLE =
       SettingDescription.create(
           "ENUM_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.ENUM,
           SettingMode.ADMIN_READABLE,
           ImmutableList.of("foo", "bar", "baz"));
@@ -38,18 +41,21 @@ public class SettingsManifestTest {
       SettingDescription.create(
           "LIST_OF_STRINGS_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.LIST_OF_STRINGS,
           SettingMode.ADMIN_READABLE);
   private static SettingDescription INT_VARIABLE =
       SettingDescription.create(
           "INT_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.INT,
           SettingMode.ADMIN_READABLE);
   private static SettingDescription UNSET_STRING_VARIABLE =
       SettingDescription.create(
           "UNSET_STRING_VARIABLE",
           "Fake subsection variable for testing",
+          true,
           SettingType.INT,
           SettingMode.ADMIN_READABLE);
 
@@ -90,6 +96,7 @@ public class SettingsManifestTest {
                   SettingDescription.create(
                       "STRING_VARIABLE",
                       "Fake string variable for testing",
+                      true,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE))));
   private SettingsManifest testManifest = new SettingsManifest(SECTIONS, CONFIG);

--- a/server/test/services/settings/SettingsSectionTest.java
+++ b/server/test/services/settings/SettingsSectionTest.java
@@ -10,10 +10,10 @@ public class SettingsSectionTest {
   @Test
   public void shouldDisplay() {
     var hiddenSetting =
-        SettingDescription.create("HIDDEN_NAME", "", SettingType.STRING, SettingMode.HIDDEN);
+        SettingDescription.create("HIDDEN_NAME", "", true, SettingType.STRING, SettingMode.HIDDEN);
     var readableSetting =
         SettingDescription.create(
-            "READABLE_NAME", "", SettingType.STRING, SettingMode.ADMIN_READABLE);
+            "READABLE_NAME", "", true, SettingType.STRING, SettingMode.ADMIN_READABLE);
 
     assertThat(
             SettingsSection.create(

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -40,22 +40,26 @@ public class SettingsServiceTest extends ResetPostgres {
                       SettingDescription.create(
                           "TEST_BOOL",
                           "test description",
+                          true,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
                           "TEST_BOOL_READABLE",
                           "test description",
+                          true,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "TEST_ENUM",
                           "test enum",
+                          true,
                           SettingType.ENUM,
                           SettingMode.ADMIN_WRITEABLE,
                           ImmutableList.of("test", "test-2")),
                       SettingDescription.create(
                           "TEST_REGEX_VALIDATED_STRING",
                           "test regex validated",
+                          true,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE,
                           Pattern.compile("^test$"))))),


### PR DESCRIPTION
### Description

Passes the `required` attribute through from variables in env-var-docs.json to `SettingDescription` in the server. The value of the attribute will be consumed in upcoming PRs.

### Checklist

Contributes to https://github.com/civiform/civiform/issues/5217