### PR TITLE
Fix incorrect comment and make method names more accurate.

### DIFF
--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -254,7 +254,7 @@ describe('address applicant flow', () => {
         ['address-test-required-q'],
         'address-test-optional-q',
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/admin_api_keys.test.ts
+++ b/browser-test/src/admin_api_keys.test.ts
@@ -14,7 +14,7 @@ describe('Managing API keys', () => {
       programDescription,
       'https://usa.gov',
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await adminApiKeys.gotoNewApiKeyPage()
     await validateScreenshot(page, 'new-api-key-page')
 

--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -23,7 +23,7 @@ describe('Program list page.', () => {
     await expectProgramListElements(adminPrograms, [programTwo, programOne])
 
     // Publish all programs, order should be maintained.
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await expectProgramListElements(adminPrograms, [programTwo, programOne])
 
     // Now create a draft version of the previously last program. After,
@@ -82,7 +82,7 @@ describe('Program list page.', () => {
 
     const programOne = 'List test program one'
     await adminPrograms.addProgram(programOne)
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await adminPrograms.createNewVersion(programOne)
     await adminPrograms.expectDraftProgram(programOne)
 

--- a/browser-test/src/admin_program_preview.test.ts
+++ b/browser-test/src/admin_program_preview.test.ts
@@ -43,7 +43,7 @@ describe('admin program preview', () => {
     await adminPrograms.editProgramBlock(programName, 'description', [
       'email-q',
     ])
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await adminPrograms.gotoViewActiveProgramPage(programName)
 
     await page.click('button:has-text("Preview as applicant")')

--- a/browser-test/src/admin_program_viewing.test.ts
+++ b/browser-test/src/admin_program_viewing.test.ts
@@ -14,7 +14,7 @@ describe('admin program view page', () => {
 
     const programName = 'Apc program'
     await adminPrograms.addProgram(programName)
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await adminPrograms.gotoViewActiveProgramPage(programName)
     await validateScreenshot(page, 'program-read-only-view')
     await adminPrograms.gotoAdminProgramsPage()
@@ -43,7 +43,7 @@ describe('admin program view page', () => {
       'date-q',
       'email-q',
     ])
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     await adminPrograms.gotoViewActiveProgramPage(programName)
 

--- a/browser-test/src/admin_program_visibility.test.ts
+++ b/browser-test/src/admin_program_visibility.test.ts
@@ -28,7 +28,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
       'https://usa.gov',
       ProgramVisibility.HIDDEN,
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Login as applicant
     await logout(page)
@@ -55,7 +55,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Login as applicant
     await logout(page)
@@ -82,7 +82,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
       'https://usa.gov',
       ProgramVisibility.TI_ONLY,
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Login as applicant, verify program is hidden
     await logout(page)
@@ -141,7 +141,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
       /* isCommonIntake= */ false,
       'groupTwo',
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Login as applicant, verify program is hidden
     await logout(page)
@@ -217,7 +217,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
       /* isCommonIntake= */ false,
       'groupTwo',
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Login as applicant, verify program is hidden
     await logout(page)
@@ -253,7 +253,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     // login again as Admin and change the visibility to TI_Only, check if they can see the program
     await loginAsAdmin(page)
     await adminPrograms.editProgram(programName, ProgramVisibility.TI_ONLY)
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await logout(page)
 
     await loginAsTrustedIntermediary(page)

--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -45,7 +45,7 @@ describe('applicant program index page', () => {
       'first-q',
     ])
 
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await logout(page)
   })
 
@@ -163,7 +163,7 @@ describe('applicant program index page', () => {
       'admin description',
       /* isCommonIntake= */ true,
     )
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await logout(page)
 
     await applicantQuestions.applyProgram(primaryProgramName)

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -389,7 +389,7 @@ describe('Applicant navigation flow', () => {
         secondProgramCorrectAnswer,
       )
 
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
       // TODO(#4509): Once this is a beforeAll(), it'll automatically go back
       // to the home page when it's done and we can remove this line.
       await logout(page)

--- a/browser-test/src/auth.test.ts
+++ b/browser-test/src/auth.test.ts
@@ -95,7 +95,7 @@ describe('applicant auth', () => {
     await loginAsAdmin(page)
     const programName = 'Test program'
     await adminPrograms.addProgram(programName)
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     await logout(page)
     await applicantQuestions.clickApplyProgramButton(programName)

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -160,7 +160,7 @@ describe('Checkbox question for applicant flow', () => {
         ['checkbox-fave-color-q'],
         'checkbox-vacation-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/civiform_admin_publish.test.ts
+++ b/browser-test/src/civiform_admin_publish.test.ts
@@ -53,7 +53,7 @@ describe('publishing all draft questions and programs', () => {
     )
 
     // Publish.
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Make an edit to the program with no questions.
     await adminPrograms.createNewVersion(hiddenProgramNoQuestions)
@@ -75,7 +75,7 @@ describe('publishing all draft questions and programs', () => {
   })
 
   it('validate screenshot', async () => {
-    await adminPrograms.openPublishAllProgramsModal()
+    await adminPrograms.openPublishAllDraftsModal()
     await validateScreenshot(
       adminPrograms.publishAllProgramsModalLocator(),
       'publish-modal',

--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -23,8 +23,7 @@ describe('Admin question list', () => {
       questionText: questionTwoPublishedText,
     })
 
-    // A question cannot be published in isolation. In order to allow making created questions
-    // active, create a fake program.
+    // Create a program so that the question bank can be accessed.
     const programName = 'Question list test program'
     await adminPrograms.addProgram(programName)
 
@@ -39,7 +38,7 @@ describe('Admin question list', () => {
     ])
 
     // Publish all programs and questions, order should be maintained.
-    await adminPrograms.publishProgram(programName)
+    await adminPrograms.publishAllDrafts()
     // Create a draft version of the program so that the question bank can be accessed.
     await adminPrograms.createNewVersion(programName)
     await expectQuestionListElements(adminQuestions, [
@@ -179,7 +178,7 @@ describe('Admin question list', () => {
     })
 
     // Publish questions
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     await adminQuestions.createNewVersion(questionTwo)
     await adminQuestions.archiveQuestion({
@@ -213,7 +212,7 @@ describe('Admin question list', () => {
     })
 
     // Publish questions
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     await adminQuestions.archiveQuestion({
       questionName: questionThreeToBeArchived,

--- a/browser-test/src/civiform_admin_question_references.test.ts
+++ b/browser-test/src/civiform_admin_question_references.test.ts
@@ -44,7 +44,7 @@ describe('view program references from question view', () => {
     })
 
     // Publish.
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
 
     // Add a reference from a new program in the draft version.
     const thirdProgramName = 'Third program'

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -89,7 +89,7 @@ describe('currency applicant flow', () => {
         ['currency-b-q'],
         'currency-a-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -81,7 +81,7 @@ describe('Date question for applicant flow', () => {
         ['birthday-date-q'],
         'todays-date-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -128,7 +128,7 @@ describe('Dropdown question for applicant flow', () => {
         ['dropdown-fave-color-q'],
         'dropdown-fave-vacation-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -80,7 +80,7 @@ describe('Email question for applicant flow', () => {
         ['my-email-q'],
         'your-email-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -114,7 +114,7 @@ describe('file upload applicant flow', () => {
         [],
         'file-upload-test-optional-q',
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -125,7 +125,7 @@ describe('Id question for applicant flow', () => {
         ['my-id-q'],
         'your-id-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/mobile_views.test.ts
+++ b/browser-test/src/mobile_views.test.ts
@@ -39,7 +39,7 @@ describe('views render well on mobile', () => {
       'second-q',
     ])
 
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await logout(page)
 
     // Use mobile view for all tests in this file. We must set it here so that the

--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -176,7 +176,7 @@ describe('name applicant flow', () => {
         ['name-test-required-q'],
         'name-test-optional-q',
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -100,7 +100,7 @@ describe('Number question for applicant flow', () => {
         ['my-number-q'],
         'your-number-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/phone.test.ts
+++ b/browser-test/src/phone.test.ts
@@ -217,7 +217,7 @@ describe('phone question for applicant flow', () => {
         ['second-phone-q'],
         'first-phone-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -34,7 +34,7 @@ describe('navigating to a deep link', () => {
 
     await adminPrograms.gotoAdminProgramsPage()
     await adminPrograms.expectDraftProgram(programName)
-    await adminPrograms.publishAllPrograms()
+    await adminPrograms.publishAllDrafts()
     await adminPrograms.expectActiveProgram(programName)
 
     await logout(page)

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -130,7 +130,7 @@ describe('Radio button question for applicant flow', () => {
         ['fave-ice-cream-q'],
         'fave-vacation-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -618,7 +618,7 @@ export class AdminPrograms {
   async publishProgram(programName: string) {
     await this.gotoAdminProgramsPage()
     await this.expectDraftProgram(programName)
-    await this.publishAllPrograms()
+    await this.publishAllDrafts()
     await this.expectActiveProgram(programName)
   }
 
@@ -631,16 +631,16 @@ export class AdminPrograms {
     )
   }
 
-  async publishAllPrograms() {
+  async publishAllDrafts() {
     await this.gotoAdminProgramsPage()
-    const modal = await this.openPublishAllProgramsModal()
+    const modal = await this.openPublishAllDraftsModal()
     const confirmHandle = (await modal.$('button:has-text("Confirm")'))!
     await confirmHandle.click()
 
     await waitForPageJsLoad(this.page)
   }
 
-  async openPublishAllProgramsModal() {
+  async openPublishAllDraftsModal() {
     await this.page.click('button:has-text("Publish all drafts")')
     const modal = await waitForAnyModal(this.page)
     expect(await modal.innerText()).toContain(
@@ -656,7 +656,7 @@ export class AdminPrograms {
     expectedQuestionsContents: string[]
     expectedProgramsContents: string[]
   }) {
-    const modal = await this.openPublishAllProgramsModal()
+    const modal = await this.openPublishAllDraftsModal()
 
     const editedQuestions = await modal.$$(
       '.cf-admin-publish-references-question li',

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -188,7 +188,7 @@ describe('Text question for applicant flow', () => {
         ['second-text-q'],
         'first-text-q', // optional
       )
-      await adminPrograms.publishAllPrograms()
+      await adminPrograms.publishAllDrafts()
 
       await logout(page)
     })


### PR DESCRIPTION
### Description

Clean up outdated comment that claimed questions could only be published if a program was edited. Also rename `*publishAllPrograms*` methods to be more accurate since questions can be published without program edits.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Fixes #5222
