### PR TITLE
Create `QuestionJsonSampler`

### DIFF
--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -1,5 +1,6 @@
 package controllers.dev.seeding;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import play.i18n.Lang;
@@ -24,7 +25,8 @@ import services.question.types.TextQuestionDefinition;
 
 public final class SampleQuestionDefinitions {
 
-  static final AddressQuestionDefinition ADDRESS_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final AddressQuestionDefinition ADDRESS_QUESTION_DEFINITION =
       new AddressQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Address Question")
@@ -55,7 +57,8 @@ public final class SampleQuestionDefinitions {
           CHECKBOX_QUESTION_OPTIONS,
           MultiOptionQuestionType.CHECKBOX);
 
-  static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final CurrencyQuestionDefinition CURRENCY_QUESTION_DEFINITION =
       new CurrencyQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Currency Question")
@@ -266,7 +269,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(
                   LocalizedStrings.withDefaultValue("help text for $this's birthday"));
 
-  static DateQuestionDefinition dateEnumeratedQuestionDefinition(long enumeratorId) {
+  @VisibleForTesting
+  public static DateQuestionDefinition dateEnumeratedQuestionDefinition(long enumeratorId) {
     return new DateQuestionDefinition(
         DATE_ENUMERATED_QUESTION_DEFINITION_BUILDER.setEnumeratorId(enumeratorId).build());
   }

--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -97,7 +97,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  static final EnumeratorQuestionDefinition ENUMERATOR_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final EnumeratorQuestionDefinition ENUMERATOR_QUESTION_DEFINITION =
       new EnumeratorQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Enumerator Question")
@@ -209,7 +210,8 @@ public final class SampleQuestionDefinitions {
           RADIO_BUTTON_QUESTION_OPTIONS,
           MultiOptionQuestionType.RADIO_BUTTON);
 
-  static final StaticContentQuestionDefinition STATIC_CONTENT_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final StaticContentQuestionDefinition STATIC_CONTENT_QUESTION_DEFINITION =
       new StaticContentQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Static Content Question")

--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -51,7 +51,8 @@ public final class SampleQuestionDefinitions {
           QuestionOption.create(2L, 2L, LocalizedStrings.withDefaultValue("pepper grinder")),
           QuestionOption.create(3L, 3L, LocalizedStrings.withDefaultValue("garlic press")));
 
-  static final MultiOptionQuestionDefinition CHECKBOX_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final MultiOptionQuestionDefinition CHECKBOX_QUESTION_DEFINITION =
       new MultiOptionQuestionDefinition(
           CHECKBOX_QUESTION_DEFINITION_CONFIG,
           CHECKBOX_QUESTION_OPTIONS,
@@ -88,7 +89,8 @@ public final class SampleQuestionDefinitions {
       new MultiOptionQuestionDefinition(
           DROPDOWN_QUESTION_CONFIG, DROPDOWN_QUESTION_OPTIONS, MultiOptionQuestionType.DROPDOWN);
 
-  static final EmailQuestionDefinition EMAIL_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final EmailQuestionDefinition EMAIL_QUESTION_DEFINITION =
       new EmailQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Email Question")
@@ -109,7 +111,8 @@ public final class SampleQuestionDefinitions {
               .build(),
           LocalizedStrings.withDefaultValue("household member"));
 
-  static final FileUploadQuestionDefinition FILE_UPLOAD_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final FileUploadQuestionDefinition FILE_UPLOAD_QUESTION_DEFINITION =
       new FileUploadQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample File Upload Question")
@@ -119,7 +122,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  static final IdQuestionDefinition ID_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final IdQuestionDefinition ID_QUESTION_DEFINITION =
       new IdQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample ID Question")
@@ -129,7 +133,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  static final QuestionDefinition NAME_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final QuestionDefinition NAME_QUESTION_DEFINITION =
       new NameQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Name")
@@ -178,7 +183,8 @@ public final class SampleQuestionDefinitions {
                           "帮助文本")))
               .build());
 
-  static final NumberQuestionDefinition NUMBER_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final NumberQuestionDefinition NUMBER_QUESTION_DEFINITION =
       new NumberQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Number Question")
@@ -204,7 +210,8 @@ public final class SampleQuestionDefinitions {
           QuestionOption.create(
               4L, 4L, LocalizedStrings.withDefaultValue("fall (will hide next block)")));
 
-  static final MultiOptionQuestionDefinition RADIO_BUTTON_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final MultiOptionQuestionDefinition RADIO_BUTTON_QUESTION_DEFINITION =
       new MultiOptionQuestionDefinition(
           RADIO_BUTTON_QUESTION_CONFIG,
           RADIO_BUTTON_QUESTION_OPTIONS,
@@ -226,7 +233,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
               .build());
 
-  static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
       new TextQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Text Question")
@@ -235,7 +243,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  static final PhoneQuestionDefinition PHONE_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final PhoneQuestionDefinition PHONE_QUESTION_DEFINITION =
       new PhoneQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Phone Question")
@@ -244,7 +253,8 @@ public final class SampleQuestionDefinitions {
               .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
               .build());
 
-  static final DateQuestionDefinition DATE_QUESTION_DEFINITION =
+  @VisibleForTesting
+  public static final DateQuestionDefinition DATE_QUESTION_DEFINITION =
       new DateQuestionDefinition(
           QuestionDefinitionConfig.builder()
               .setName("Sample Date Question")

--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -2,6 +2,9 @@ package services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.jayway.jsonpath.DocumentContext;
@@ -556,6 +559,17 @@ public class CfJsonDocumentContext {
 
   public String asJsonString() {
     return jsonData.jsonString();
+  }
+
+  public String asPrettyJsonString() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    try {
+      Object jsonObject = getDocumentContext().json();
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+    } catch (JsonProcessingException e) {
+      return "Error parsing json";
+    }
   }
 
   @Override

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -128,26 +128,27 @@ public final class JsonExporter {
             .create(answerData.applicantQuestion().getType())
             .getJsonEntries(answerData.createQuestion());
 
-    for (Map.Entry<Path, ?> entry : entries.entrySet()) {
-      exportToJsonApplication(jsonApplication, entry);
-    }
+    exportEntriesToJsonApplication(jsonApplication, entries);
   }
 
-  public static void exportToJsonApplication(
-      CfJsonDocumentContext jsonApplication, Map.Entry<Path, ?> entry) {
-    Path path = entry.getKey().asApplicationPath();
+  public static void exportEntriesToJsonApplication(
+      CfJsonDocumentContext jsonApplication, ImmutableMap<Path, ?> entries) {
 
-    Object value = entry.getValue();
-    if (value instanceof String) {
-      jsonApplication.putString(path, (String) value);
-    } else if (value instanceof Long) {
-      jsonApplication.putLong(path, (Long) value);
-    } else if (value instanceof Double) {
-      jsonApplication.putDouble(path, (Double) value);
-    } else if (instanceOfNonEmptyImmutableListOfString(value)) {
-      @SuppressWarnings("unchecked")
-      ImmutableList<String> list = (ImmutableList<String>) value;
-      jsonApplication.putArray(path, list);
+    for (Map.Entry<Path, ?> entry : entries.entrySet()) {
+      Path path = entry.getKey().asApplicationPath();
+
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        jsonApplication.putString(path, (String) value);
+      } else if (value instanceof Long) {
+        jsonApplication.putLong(path, (Long) value);
+      } else if (value instanceof Double) {
+        jsonApplication.putDouble(path, (Double) value);
+      } else if (instanceOfNonEmptyImmutableListOfString(value)) {
+        @SuppressWarnings("unchecked")
+        ImmutableList<String> list = (ImmutableList<String>) value;
+        jsonApplication.putArray(path, list);
+      }
     }
   }
 

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -129,20 +129,25 @@ public final class JsonExporter {
             .getJsonEntries(answerData.createQuestion());
 
     for (Map.Entry<Path, ?> entry : entries.entrySet()) {
-      Path path = entry.getKey().asApplicationPath();
+      exportToJsonApplication(jsonApplication, entry);
+    }
+  }
 
-      Object value = entry.getValue();
-      if (value instanceof String) {
-        jsonApplication.putString(path, (String) value);
-      } else if (value instanceof Long) {
-        jsonApplication.putLong(path, (Long) value);
-      } else if (value instanceof Double) {
-        jsonApplication.putDouble(path, (Double) value);
-      } else if (instanceOfNonEmptyImmutableListOfString(value)) {
-        @SuppressWarnings("unchecked")
-        ImmutableList<String> list = (ImmutableList<String>) value;
-        jsonApplication.putArray(path, list);
-      }
+  public static void exportToJsonApplication(
+      CfJsonDocumentContext jsonApplication, Map.Entry<Path, ?> entry) {
+    Path path = entry.getKey().asApplicationPath();
+
+    Object value = entry.getValue();
+    if (value instanceof String) {
+      jsonApplication.putString(path, (String) value);
+    } else if (value instanceof Long) {
+      jsonApplication.putLong(path, (Long) value);
+    } else if (value instanceof Double) {
+      jsonApplication.putDouble(path, (Double) value);
+    } else if (instanceOfNonEmptyImmutableListOfString(value)) {
+      @SuppressWarnings("unchecked")
+      ImmutableList<String> list = (ImmutableList<String>) value;
+      jsonApplication.putArray(path, list);
     }
   }
 

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -38,6 +38,11 @@ import services.question.types.QuestionType;
 public interface QuestionJsonSampler<Q extends Question> {
 
   default CfJsonDocumentContext getSampleJson(QuestionDefinition questionDefinition) {
+    if (questionDefinition.getEnumeratorId().isPresent()) {
+      // TODO(#5238): support enumerated questions.
+      return new CfJsonDocumentContext();
+    }
+
     ProgramQuestionDefinition programQuestionDefinition =
         ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
     ApplicantData applicantData = new ApplicantData();

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -1,7 +1,7 @@
 package services.export;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static services.export.JsonExporter.exportToJsonApplication;
+import static services.export.JsonExporter.exportEntriesToJsonApplication;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -56,7 +56,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
     CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
 
-    entries.entrySet().forEach(entry -> exportToJsonApplication(jsonApplication, entry));
+    exportEntriesToJsonApplication(jsonApplication, entries);
 
     return jsonApplication;
   }
@@ -207,7 +207,7 @@ public interface QuestionJsonSampler<Q extends Question> {
       ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
       CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
 
-      entries.entrySet().forEach(entry -> exportToJsonApplication(jsonApplication, entry));
+      exportEntriesToJsonApplication(jsonApplication, entries);
 
       return jsonApplication;
     }

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -1,0 +1,521 @@
+package services.export;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static services.export.JsonExporter.exportToJsonApplication;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
+import javax.inject.Inject;
+import services.CfJsonDocumentContext;
+import services.Path;
+import services.applicant.ApplicantData;
+import services.applicant.question.AddressQuestion;
+import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.CurrencyQuestion;
+import services.applicant.question.DateQuestion;
+import services.applicant.question.EmailQuestion;
+import services.applicant.question.FileUploadQuestion;
+import services.applicant.question.IdQuestion;
+import services.applicant.question.MultiSelectQuestion;
+import services.applicant.question.NameQuestion;
+import services.applicant.question.NumberQuestion;
+import services.applicant.question.PhoneQuestion;
+import services.applicant.question.Question;
+import services.applicant.question.SingleSelectQuestion;
+import services.applicant.question.TextQuestion;
+import services.program.ProgramQuestionDefinition;
+import services.question.LocalizedQuestionOption;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
+import services.settings.SettingsManifest;
+
+/**
+ * A {@link QuestionJsonSampler} for a Question {@link Q} provides a strategy for showing the
+ * question's answers in JSON form.
+ *
+ * <p>Some {@link QuestionType}s share the same {@link QuestionJsonSampler}.
+ */
+public interface QuestionJsonSampler<Q extends Question> {
+
+  default CfJsonDocumentContext getSampleJson(QuestionDefinition questionDefinition) {
+    ProgramQuestionDefinition programQuestionDefinition =
+        ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
+    ApplicantData applicantData = new ApplicantData();
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(programQuestionDefinition, applicantData, Optional.empty());
+
+    Q question = getQuestion(applicantQuestion);
+    addSampleData(applicantData, question);
+
+    @SuppressWarnings("unchecked")
+    ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
+    CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
+
+    entries.entrySet().forEach(entry -> exportToJsonApplication(jsonApplication, entry));
+
+    return jsonApplication;
+  }
+
+  Q getQuestion(ApplicantQuestion applicantQuestion);
+
+  void addSampleData(ApplicantData applicantData, Q question);
+
+  QuestionJsonPresenter getJsonPresenter();
+
+  final class Factory {
+
+    private final AddressJsonSampler addressJsonSampler;
+    private final CurrencyJsonSampler currencyJsonSampler;
+    private final DateJsonSampler dateJsonSampler;
+    private final EmailJsonSampler emailJsonSampler;
+    private final EmptyJsonSampler emptyJsonSampler;
+    private final FileUploadJsonSampler fileUploadJsonSampler;
+    private final IdJsonSampler idJsonSampler;
+    private final MultiSelectJsonSampler multiSelectJsonSampler;
+    private final NameJsonSampler nameJsonSampler;
+    private final NumberJsonSampler numberJsonSampler;
+    private final PhoneJsonSampler phoneJsonSampler;
+    private final SingleSelectJsonSampler singleSelectJsonSampler;
+    private final TextJsonSampler textJsonSampler;
+
+    @Inject
+    Factory(
+        AddressJsonSampler addressJsonSampler,
+        CurrencyJsonSampler currencyJsonSampler,
+        DateJsonSampler dateJsonSampler,
+        EmailJsonSampler emailJsonSampler,
+        EmptyJsonSampler emptyJsonSampler,
+        FileUploadJsonSampler fileUploadJsonSampler,
+        IdJsonSampler idJsonSampler,
+        MultiSelectJsonSampler multiSelectJsonSampler,
+        NameJsonSampler nameJsonSampler,
+        NumberJsonSampler numberJsonSampler,
+        PhoneJsonSampler phoneJsonSampler,
+        SingleSelectJsonSampler singleSelectJsonSampler,
+        TextJsonSampler textJsonSampler) {
+      this.addressJsonSampler = checkNotNull(addressJsonSampler);
+      this.currencyJsonSampler = checkNotNull(currencyJsonSampler);
+      this.dateJsonSampler = checkNotNull(dateJsonSampler);
+      this.emailJsonSampler = checkNotNull(emailJsonSampler);
+      this.emptyJsonSampler = checkNotNull(emptyJsonSampler);
+      this.fileUploadJsonSampler = checkNotNull(fileUploadJsonSampler);
+      this.idJsonSampler = checkNotNull(idJsonSampler);
+      this.multiSelectJsonSampler = checkNotNull(multiSelectJsonSampler);
+      this.nameJsonSampler = checkNotNull(nameJsonSampler);
+      this.numberJsonSampler = checkNotNull(numberJsonSampler);
+      this.phoneJsonSampler = checkNotNull(phoneJsonSampler);
+      this.singleSelectJsonSampler = checkNotNull(singleSelectJsonSampler);
+      this.textJsonSampler = checkNotNull(textJsonSampler);
+    }
+
+    public QuestionJsonSampler create(QuestionType questionType) {
+      switch (questionType) {
+        case ADDRESS:
+          return addressJsonSampler;
+        case EMAIL:
+          return emailJsonSampler;
+        case ID:
+          return idJsonSampler;
+        case NAME:
+          return nameJsonSampler;
+        case TEXT:
+          return textJsonSampler;
+
+          // Answers to enumerator questions are not included. This is because enumerators store an
+          // identifier value for each repeated entity, which with the current export logic
+          // conflicts with the answers stored for repeated entities.
+        case ENUMERATOR:
+
+          // Static content questions are not included in API responses because they
+          // do not include an answer from the user.
+        case STATIC:
+          return emptyJsonSampler;
+
+        case CHECKBOX:
+          return multiSelectJsonSampler;
+        case FILEUPLOAD:
+          return fileUploadJsonSampler;
+        case NUMBER:
+          return numberJsonSampler;
+        case PHONE:
+          return phoneJsonSampler;
+        case RADIO_BUTTON:
+        case DROPDOWN:
+          return singleSelectJsonSampler;
+        case CURRENCY:
+          return currencyJsonSampler;
+        case DATE:
+          return dateJsonSampler;
+
+        default:
+          throw new RuntimeException(String.format("Unrecognized questionType %s", questionType));
+      }
+    }
+  }
+
+  class AddressJsonSampler extends ContextualizedScalarsJsonSampler<AddressQuestion> {
+    private final QuestionJsonPresenter addressJsonPresenter;
+
+    @Inject
+    AddressJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.addressJsonPresenter = questionJsonPresenterFactory.create(QuestionType.ADDRESS);
+    }
+
+    @Override
+    public AddressQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createAddressQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, AddressQuestion question) {
+      applicantData.putString(question.getStreetPath(), "742 Evergreen Terrace");
+      applicantData.putString(question.getCityPath(), "Springfield");
+      applicantData.putString(question.getStatePath(), "OR");
+      applicantData.putString(question.getZipPath(), "97403");
+      applicantData.putString(question.getLatitudePath(), "44.0462");
+      applicantData.putString(question.getLongitudePath(), "-123.0236");
+      applicantData.putString(question.getWellKnownIdPath(), "23214");
+      applicantData.putString(question.getServiceAreaPath(), "springfield_county");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return addressJsonPresenter;
+    }
+  }
+
+  abstract class ContextualizedScalarsJsonSampler<Q extends Question>
+      implements QuestionJsonSampler<Q> {
+
+    @Override
+    public CfJsonDocumentContext getSampleJson(QuestionDefinition questionDefinition) {
+      ProgramQuestionDefinition programQuestionDefinition =
+          ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
+      ApplicantData applicantData = new ApplicantData();
+      ApplicantQuestion applicantQuestion =
+          new ApplicantQuestion(programQuestionDefinition, applicantData, Optional.empty());
+
+      Q question = getQuestion(applicantQuestion);
+      addSampleData(applicantData, question);
+
+      @SuppressWarnings("unchecked")
+      ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
+      CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
+
+      entries.entrySet().forEach(entry -> exportToJsonApplication(jsonApplication, entry));
+
+      return jsonApplication;
+    }
+  }
+
+  class CurrencyJsonSampler implements QuestionJsonSampler<CurrencyQuestion> {
+
+    private final QuestionJsonPresenter currencyJsonPresenter;
+
+    @Inject
+    CurrencyJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.currencyJsonPresenter = questionJsonPresenterFactory.create(QuestionType.CURRENCY);
+    }
+
+    @Override
+    public CurrencyQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createCurrencyQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, CurrencyQuestion question) {
+      applicantData.putCurrencyDollars(question.getCurrencyPath(), "123.45");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return currencyJsonPresenter;
+    }
+  }
+
+  class DateJsonSampler implements QuestionJsonSampler<DateQuestion> {
+    private final QuestionJsonPresenter dateJsonPresenter;
+
+    @Inject
+    DateJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.dateJsonPresenter = questionJsonPresenterFactory.create(QuestionType.DATE);
+    }
+
+    @Override
+    public DateQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createDateQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, DateQuestion question) {
+      applicantData.putDate(question.getDatePath(), "2023-01-02");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return dateJsonPresenter;
+    }
+  }
+
+  class EmailJsonSampler extends ContextualizedScalarsJsonSampler<EmailQuestion> {
+    private final QuestionJsonPresenter emailJsonPresenter;
+
+    @Inject
+    EmailJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.emailJsonPresenter = questionJsonPresenterFactory.create(QuestionType.EMAIL);
+    }
+
+    @Override
+    public EmailQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createEmailQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, EmailQuestion question) {
+      applicantData.putString(question.getEmailPath(), "homer.simpson@springfield.gov");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return emailJsonPresenter;
+    }
+  }
+
+  class EmptyJsonSampler implements QuestionJsonSampler<Question> {
+
+    @Override
+    public CfJsonDocumentContext getSampleJson(QuestionDefinition questionDefinition) {
+      return new CfJsonDocumentContext();
+    }
+
+    @Override
+    public Question getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createCurrencyQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, Question question) {
+      // no-op
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return null;
+    }
+  }
+
+  class FileUploadJsonSampler implements QuestionJsonSampler<FileUploadQuestion> {
+    private final QuestionJsonPresenter fileUploadJsonPresenter;
+
+    @Inject
+    FileUploadJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.fileUploadJsonPresenter = questionJsonPresenterFactory.create(QuestionType.FILEUPLOAD);
+    }
+
+    @Override
+    public FileUploadQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createFileUploadQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, FileUploadQuestion question) {
+      applicantData.putString(question.getFileKeyPath(), "my-file-key");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return fileUploadJsonPresenter;
+    }
+  }
+
+  class IdJsonSampler extends ContextualizedScalarsJsonSampler<IdQuestion> {
+    private final QuestionJsonPresenter idJsonPresenter;
+
+    @Inject
+    IdJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.idJsonPresenter = questionJsonPresenterFactory.create(QuestionType.ID);
+    }
+
+    @Override
+    public IdQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createIdQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, IdQuestion question) {
+      applicantData.putLong(question.getIdPath(), 12345L);
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return idJsonPresenter;
+    }
+  }
+
+  class MultiSelectJsonSampler implements QuestionJsonSampler<MultiSelectQuestion> {
+
+    private final QuestionJsonPresenter multiSelectJsonPresenter;
+
+    @Inject
+    MultiSelectJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      // Any multi-select QuestionType passed to create() works here (as of writing, only CHECKBOX).
+      this.multiSelectJsonPresenter = questionJsonPresenterFactory.create(QuestionType.CHECKBOX);
+    }
+
+    @Override
+    public MultiSelectQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createMultiSelectQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, MultiSelectQuestion question) {
+      LocalizedQuestionOption firstOption = question.getOptions().get(0);
+      LocalizedQuestionOption secondOption = question.getOptions().get(1);
+
+      applicantData.putArray(
+          question.getSelectionPath(), ImmutableList.of(firstOption.id(), secondOption.id()));
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return multiSelectJsonPresenter;
+    }
+  }
+
+  class NameJsonSampler extends ContextualizedScalarsJsonSampler<NameQuestion> {
+    private final QuestionJsonPresenter nameJsonPresenter;
+
+    @Inject
+    NameJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.nameJsonPresenter = questionJsonPresenterFactory.create(QuestionType.NAME);
+    }
+
+    @Override
+    public NameQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createNameQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, NameQuestion question) {
+      applicantData.putString(question.getFirstNamePath(), "Homer");
+      applicantData.putString(question.getMiddleNamePath(), "Jay");
+      applicantData.putString(question.getLastNamePath(), "Simpson");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return nameJsonPresenter;
+    }
+  }
+
+  class NumberJsonSampler implements QuestionJsonSampler<NumberQuestion> {
+
+    private final QuestionJsonPresenter numberJsonPresenter;
+
+    @Inject
+    NumberJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.numberJsonPresenter = questionJsonPresenterFactory.create(QuestionType.NUMBER);
+    }
+
+    @Override
+    public NumberQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createNumberQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, NumberQuestion question) {
+      applicantData.putLong(question.getNumberPath(), 12321);
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return numberJsonPresenter;
+    }
+  }
+
+  class PhoneJsonSampler implements QuestionJsonSampler<PhoneQuestion> {
+    private final QuestionJsonPresenter phoneJsonPresenter;
+
+    @Inject
+    PhoneJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      this.phoneJsonPresenter = questionJsonPresenterFactory.create(QuestionType.PHONE);
+    }
+
+    @Override
+    public PhoneQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createPhoneQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, PhoneQuestion question) {
+      applicantData.putPhoneNumber(question.getPhoneNumberPath(), "(214)-367-3764");
+      applicantData.putString(question.getCountryCodePath(), "US");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return phoneJsonPresenter;
+    }
+  }
+
+  class SingleSelectJsonSampler implements QuestionJsonSampler<SingleSelectQuestion> {
+
+    private final QuestionJsonPresenter singleSelectJsonPresenter;
+
+    @Inject
+    SingleSelectJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
+      // Any single-select QuestionType passed to create() works here.
+      this.singleSelectJsonPresenter =
+          questionJsonPresenterFactory.create(QuestionType.RADIO_BUTTON);
+    }
+
+    @Override
+    public SingleSelectQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createSingleSelectQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, SingleSelectQuestion question) {
+      if (question.getOptions().size() != 0) {
+        LocalizedQuestionOption firstOption = question.getOptions().get(0);
+        applicantData.putLong(question.getSelectionPath(), firstOption.id());
+      }
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return singleSelectJsonPresenter;
+    }
+  }
+
+  class TextJsonSampler extends ContextualizedScalarsJsonSampler<TextQuestion> {
+    private final QuestionJsonPresenter emailJsonPresenter;
+    private final SettingsManifest settingsManifest;
+
+    @Inject
+    TextJsonSampler(
+        QuestionJsonPresenter.Factory questionJsonPresenterFactory,
+        SettingsManifest settingsManifest) {
+      this.emailJsonPresenter = questionJsonPresenterFactory.create(QuestionType.TEXT);
+      this.settingsManifest = settingsManifest;
+    }
+
+    @Override
+    public TextQuestion getQuestion(ApplicantQuestion applicantQuestion) {
+      return applicantQuestion.createTextQuestion();
+    }
+
+    @Override
+    public void addSampleData(ApplicantData applicantData, TextQuestion question) {
+      applicantData.putString(
+          question.getTextPath(),
+          "I love " + settingsManifest.getWhitelabelCivicEntityShortName().get() + "!");
+    }
+
+    @Override
+    public QuestionJsonPresenter getJsonPresenter() {
+      return emailJsonPresenter;
+    }
+  }
+}

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -161,7 +161,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
   }
 
-  class AddressJsonSampler extends ContextualizedScalarsJsonSampler<AddressQuestion> {
+  class AddressJsonSampler implements QuestionJsonSampler<AddressQuestion> {
     private final QuestionJsonPresenter addressJsonPresenter;
 
     @Inject
@@ -189,32 +189,6 @@ public interface QuestionJsonSampler<Q extends Question> {
     @Override
     public QuestionJsonPresenter getJsonPresenter() {
       return addressJsonPresenter;
-    }
-  }
-
-  abstract class ContextualizedScalarsJsonSampler<Q extends Question>
-      implements QuestionJsonSampler<Q> {
-
-    @Override
-    public CfJsonDocumentContext getSampleJson(QuestionDefinition questionDefinition) {
-      ProgramQuestionDefinition programQuestionDefinition =
-          ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
-      ApplicantData applicantData = new ApplicantData();
-      ApplicantQuestion applicantQuestion =
-          new ApplicantQuestion(programQuestionDefinition, applicantData, Optional.empty());
-
-      Q question = getQuestion(applicantQuestion);
-      addSampleData(applicantData, question);
-
-      // Suppress warning about unchecked assignment because the JSON presenter is parameterized on
-      // the question type, which we know matches Q.
-      @SuppressWarnings("unchecked")
-      ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
-      CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
-
-      exportEntriesToJsonApplication(jsonApplication, entries);
-
-      return jsonApplication;
     }
   }
 
@@ -267,7 +241,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
   }
 
-  class EmailJsonSampler extends ContextualizedScalarsJsonSampler<EmailQuestion> {
+  class EmailJsonSampler implements QuestionJsonSampler<EmailQuestion> {
     private final QuestionJsonPresenter emailJsonPresenter;
 
     @Inject
@@ -338,7 +312,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
   }
 
-  class IdJsonSampler extends ContextualizedScalarsJsonSampler<IdQuestion> {
+  class IdJsonSampler implements QuestionJsonSampler<IdQuestion> {
     private final QuestionJsonPresenter idJsonPresenter;
 
     @Inject
@@ -398,7 +372,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
   }
 
-  class NameJsonSampler extends ContextualizedScalarsJsonSampler<NameQuestion> {
+  class NameJsonSampler implements QuestionJsonSampler<NameQuestion> {
     private final QuestionJsonPresenter nameJsonPresenter;
 
     @Inject
@@ -504,7 +478,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
   }
 
-  class TextJsonSampler extends ContextualizedScalarsJsonSampler<TextQuestion> {
+  class TextJsonSampler implements QuestionJsonSampler<TextQuestion> {
     private final QuestionJsonPresenter emailJsonPresenter;
 
     @Inject

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -28,7 +28,6 @@ import services.program.ProgramQuestionDefinition;
 import services.question.LocalizedQuestionOption;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
-import services.settings.SettingsManifest;
 
 /**
  * A {@link QuestionJsonSampler} for a Question {@link Q} provides a strategy for showing the
@@ -491,14 +490,10 @@ public interface QuestionJsonSampler<Q extends Question> {
 
   class TextJsonSampler extends ContextualizedScalarsJsonSampler<TextQuestion> {
     private final QuestionJsonPresenter emailJsonPresenter;
-    private final SettingsManifest settingsManifest;
 
     @Inject
-    TextJsonSampler(
-        QuestionJsonPresenter.Factory questionJsonPresenterFactory,
-        SettingsManifest settingsManifest) {
+    TextJsonSampler(QuestionJsonPresenter.Factory questionJsonPresenterFactory) {
       this.emailJsonPresenter = questionJsonPresenterFactory.create(QuestionType.TEXT);
-      this.settingsManifest = settingsManifest;
     }
 
     @Override
@@ -508,9 +503,7 @@ public interface QuestionJsonSampler<Q extends Question> {
 
     @Override
     public void addSampleData(ApplicantData applicantData, TextQuestion question) {
-      applicantData.putString(
-          question.getTextPath(),
-          "I love " + settingsManifest.getWhitelabelCivicEntityShortName().get() + "!");
+      applicantData.putString(question.getTextPath(), "I love CiviForm!");
     }
 
     @Override

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -52,6 +52,8 @@ public interface QuestionJsonSampler<Q extends Question> {
     Q question = getQuestion(applicantQuestion);
     addSampleData(applicantData, question);
 
+    // Suppress warning about unchecked assignment because the JSON presenter is parameterized on
+    // the question type, which we know matches Q.
     @SuppressWarnings("unchecked")
     ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
     CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
@@ -130,6 +132,7 @@ public interface QuestionJsonSampler<Q extends Question> {
           // identifier value for each repeated entity, which with the current export logic
           // conflicts with the answers stored for repeated entities.
         case ENUMERATOR:
+          return emptyJsonSampler;
 
           // Static content questions are not included in API responses because they
           // do not include an answer from the user.
@@ -203,6 +206,8 @@ public interface QuestionJsonSampler<Q extends Question> {
       Q question = getQuestion(applicantQuestion);
       addSampleData(applicantData, question);
 
+      // Suppress warning about unchecked assignment because the JSON presenter is parameterized on
+      // the question type, which we know matches Q.
       @SuppressWarnings("unchecked")
       ImmutableMap<Path, ?> entries = getJsonPresenter().getJsonEntries(question);
       CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext();
@@ -295,7 +300,7 @@ public interface QuestionJsonSampler<Q extends Question> {
 
     @Override
     public Question getQuestion(ApplicantQuestion applicantQuestion) {
-      return applicantQuestion.createCurrencyQuestion();
+      return null;
     }
 
     @Override

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -374,11 +374,17 @@ public interface QuestionJsonSampler<Q extends Question> {
 
     @Override
     public void addSampleData(ApplicantData applicantData, MultiSelectQuestion question) {
-      LocalizedQuestionOption firstOption = question.getOptions().get(0);
-      LocalizedQuestionOption secondOption = question.getOptions().get(1);
+      ImmutableList.Builder<Long> localizedOptionsBuilder = ImmutableList.builder();
 
-      applicantData.putArray(
-          question.getSelectionPath(), ImmutableList.of(firstOption.id(), secondOption.id()));
+      // Add up to two options to the sample data.
+      if (question.getOptions().size() > 0) {
+        localizedOptionsBuilder.add(question.getOptions().get(0).id());
+      }
+      if (question.getOptions().size() > 1) {
+        localizedOptionsBuilder.add(question.getOptions().get(1).id());
+      }
+
+      applicantData.putArray(question.getSelectionPath(), localizedOptionsBuilder.build());
     }
 
     @Override

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Random;
 import services.CiviFormError;
 import services.LocalizedStrings;
 import services.Path;
@@ -341,7 +342,7 @@ public abstract class QuestionDefinition {
    */
   @VisibleForTesting
   public QuestionDefinition withPopulatedTestId() {
-    config = config.toBuilder().setId(123L).build();
+    config = config.toBuilder().setId(new Random().nextLong()).build();
     return this;
   }
 }

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.time.Instant;
@@ -21,7 +22,7 @@ import services.question.QuestionOption;
 /** Superclass for all question types. */
 public abstract class QuestionDefinition {
 
-  private final QuestionDefinitionConfig config;
+  private QuestionDefinitionConfig config;
 
   protected QuestionDefinition(QuestionDefinitionConfig config) {
     if (config.validationPredicates().isEmpty()) {
@@ -331,5 +332,16 @@ public abstract class QuestionDefinition {
         config.questionHelpText().translations().values().stream()
             .anyMatch(helpText -> !helpText.contains("$this"));
     return !textMissingFormatString && !helpTextMissingFormatString;
+  }
+
+  /**
+   * Tests that use {@link QuestionDefinition} are required to have an ID in the question at some
+   * points, but usually it's not populated until it's inserted in the DB. This method populates the
+   * ID for testing purposes only.
+   */
+  @VisibleForTesting
+  public QuestionDefinition withPopulatedTestId() {
+    config = config.toBuilder().setId(123L).build();
+    return this;
   }
 }

--- a/server/test/services/export/QuestionJsonSamplerTest.java
+++ b/server/test/services/export/QuestionJsonSamplerTest.java
@@ -1,9 +1,19 @@
 package services.export;
 
 import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.CHECKBOX_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.CURRENCY_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.DATE_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.EMAIL_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.ENUMERATOR_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.FILE_UPLOAD_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.ID_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.NAME_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.NUMBER_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.PHONE_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.RADIO_BUTTON_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.STATIC_CONTENT_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.TEXT_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.dateEnumeratedQuestionDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,6 +74,190 @@ public class QuestionJsonSamplerTest extends ResetPostgres {
                 + "  \"application\" : {\n"
                 + "    \"sample_currency_question\" : {\n"
                 + "      \"currency_dollars\" : 123.45\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesDateQuestion() {
+
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.DATE)
+            .getSampleJson(DATE_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_date_question\" : {\n"
+                + "      \"date\" : \"2023-01-02\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesEmailQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.EMAIL)
+            .getSampleJson(EMAIL_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_email_question\" : {\n"
+                + "      \"email\" : \"homer.simpson@springfield.gov\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesFileUploadQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.FILEUPLOAD)
+            .getSampleJson(FILE_UPLOAD_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_file_upload_question\" : {\n"
+                + "      \"file_key\" :"
+                + " \"http://localhost:9000/admin/applicant-files/my-file-key\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesIdQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.ID)
+            .getSampleJson(ID_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_id_question\" : {\n"
+                + "      \"id\" : \"12345\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesMultiSelectQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.CHECKBOX)
+            .getSampleJson(CHECKBOX_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_checkbox_question\" : {\n"
+                + "      \"selections\" : [ \"toaster\", \"pepper grinder\" ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesNameQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.NAME)
+            .getSampleJson(NAME_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"name\" : {\n"
+                + "      \"last_name\" : \"Simpson\",\n"
+                + "      \"middle_name\" : \"Jay\",\n"
+                + "      \"first_name\" : \"Homer\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesNumberQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.NUMBER)
+            .getSampleJson(NUMBER_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_number_question\" : {\n"
+                + "      \"number\" : 12321\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesPhoneQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.PHONE)
+            .getSampleJson(PHONE_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_phone_question\" : {\n"
+                + "      \"phone_number\" : \"+12143673764\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesSingleSelectQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.RADIO_BUTTON)
+            .getSampleJson(RADIO_BUTTON_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_radio_button_question\" : {\n"
+                + "      \"selection\" : \"winter (will hide next block)\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesTextQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.TEXT)
+            .getSampleJson(TEXT_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_text_question\" : {\n"
+                + "      \"text\" : \"I love CiviForm!\"\n"
                 + "    }\n"
                 + "  }\n"
                 + "}");

--- a/server/test/services/export/QuestionJsonSamplerTest.java
+++ b/server/test/services/export/QuestionJsonSamplerTest.java
@@ -2,6 +2,8 @@ package services.export;
 
 import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.CURRENCY_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.ENUMERATOR_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.STATIC_CONTENT_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.dateEnumeratedQuestionDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,20 +70,34 @@ public class QuestionJsonSamplerTest extends ResetPostgres {
   }
 
   @Test
-  public void samplesEnumeratedDateQuestion() {
+  public void staticQuestions_returnEmpty() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.STATIC)
+            .getSampleJson(STATIC_CONTENT_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString()).isEqualTo("{ }");
+  }
+
+  // TODO(#4975): update this test once enumerator questions are supported.
+  @Test
+  public void enumeratorQuestions_returnEmpty() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.ENUMERATOR)
+            .getSampleJson(ENUMERATOR_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString()).isEqualTo("{ }");
+  }
+
+  // TODO(#5238): update this test once enumerated questions are supported.
+  @Test
+  public void enumeratedQuestions_returnEmpty() {
     CfJsonDocumentContext json =
         questionJsonSamplerFactory
             .create(QuestionType.DATE)
             .getSampleJson(dateEnumeratedQuestionDefinition(1L).withPopulatedTestId());
 
-    assertThat(json.asPrettyJsonString())
-        .isEqualTo(
-            "{\n"
-                + "  \"application\" : {\n"
-                + "    \"sample_enumerated_date_question\" : {\n"
-                + "      \"date\" : \"2023-01-02\"\n"
-                + "    }\n"
-                + "  }\n"
-                + "}");
+    assertThat(json.asPrettyJsonString()).isEqualTo("{ }");
   }
 }

--- a/server/test/services/export/QuestionJsonSamplerTest.java
+++ b/server/test/services/export/QuestionJsonSamplerTest.java
@@ -1,0 +1,87 @@
+package services.export;
+
+import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.CURRENCY_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.dateEnumeratedQuestionDefinition;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.CfJsonDocumentContext;
+import services.question.types.QuestionType;
+
+public class QuestionJsonSamplerTest extends ResetPostgres {
+
+  private QuestionJsonSampler.Factory questionJsonSamplerFactory;
+
+  @Before
+  public void setUp() {
+    questionJsonSamplerFactory = instanceOf(QuestionJsonSampler.Factory.class);
+  }
+
+  @Test
+  public void samplesAddressQuestion() {
+
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.ADDRESS)
+            .getSampleJson(ADDRESS_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_address_question\" : {\n"
+                + "      \"zip\" : \"97403\",\n"
+                + "      \"city\" : \"Springfield\",\n"
+                + "      \"street\" : \"742 Evergreen Terrace\",\n"
+                + "      \"latitude\" : \"44.0462\",\n"
+                + "      \"well_known_id\" : \"23214\",\n"
+                + "      \"service_area\" : \"springfield_county\",\n"
+                + "      \"state\" : \"OR\",\n"
+                + "      \"line2\" : null,\n"
+                + "      \"corrected\" : null,\n"
+                + "      \"longitude\" : \"-123.0236\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesCurrencyQuestion() {
+
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.CURRENCY)
+            .getSampleJson(CURRENCY_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_currency_question\" : {\n"
+                + "      \"currency_dollars\" : 123.45\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void samplesEnumeratedDateQuestion() {
+    CfJsonDocumentContext json =
+        questionJsonSamplerFactory
+            .create(QuestionType.DATE)
+            .getSampleJson(dateEnumeratedQuestionDefinition(1L).withPopulatedTestId());
+
+    assertThat(json.asPrettyJsonString())
+        .isEqualTo(
+            "{\n"
+                + "  \"application\" : {\n"
+                + "    \"sample_enumerated_date_question\" : {\n"
+                + "      \"date\" : \"2023-01-02\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+}


### PR DESCRIPTION
### Description

This PR creates `QuestionJsonSampler`, which is the precursor to API generated docs.

The goal of the class is simple: for any given `Question`, seed some sample data then use the corresponding `QuestionJsonPresenter` to show JSON for it. In a future PR, API generated docs will use this class to present the API Response Preview.

Note that the following don't return sample JSON:
* `STATIC` questions: these don't have responses from a user.
* `ENUMERATOR` questions: these are not supported by the API, so they shouldn't be sampled. See #4975.
* Enumerat**ed** questions: (any question where the `enumeratorId` is set): this turns out to be *very* complicated, so I will punt it to a future PR.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None yet.

### Instructions for manual testing

None.

### Issue(s) this completes

Relates to #4872, #5238.