### PR TITLE
Replace assertEquals with assertThat.

### DIFF
--- a/server/test/controllers/geo/AddressSuggestionJsonSerializerTest.java
+++ b/server/test/controllers/geo/AddressSuggestionJsonSerializerTest.java
@@ -1,6 +1,6 @@
 package controllers.geo;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
@@ -52,6 +52,6 @@ public class AddressSuggestionJsonSerializerTest {
     ImmutableList<AddressSuggestion> deserialzedSuggestions =
         addressSuggestionJsonSerializer.deserialize(serializedSuggestions);
 
-    assertEquals(suggestions, deserialzedSuggestions);
+    assertThat(deserialzedSuggestions).isEqualTo(suggestions);
   }
 }

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -1,7 +1,6 @@
 package models;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
@@ -51,7 +50,7 @@ public class QuestionTest extends ResetPostgres {
 
     QuestionDefinition expected =
         new QuestionDefinitionBuilder(definition).setId(question.id).build();
-    assertEquals(expected, found.getQuestionDefinition());
+    assertThat(found.getQuestionDefinition()).isEqualTo(expected);
   }
 
   @Test

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -2,7 +2,6 @@ package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -721,7 +720,7 @@ public class BlockTest {
     Optional<ImmutableList<String>> serviceAreaIds = block.getLeafAddressNodeServiceAreaIds();
 
     assertThat(serviceAreaIds.isPresent()).isTrue();
-    assertEquals("Seattle", serviceAreaIds.get().get(0));
+    assertThat(serviceAreaIds.get().get(0)).isEqualTo("Seattle");
   }
 
   @Test

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -1,7 +1,6 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -1059,7 +1058,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
     ImmutableList<AnswerData> result = subject.getSummaryData();
 
-    assertEquals(9, result.size());
+    assertThat(result).hasSize(9);
     assertThat(result.get(0).answerText()).isEqualTo("Alice Middle Last");
     assertThat(result.get(1).answerText()).isEqualTo("mauve");
     assertThat(result.get(2).answerText()).isEqualTo("123 Rhode St.\nSeattle, WA 12345");
@@ -1168,7 +1167,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
     ImmutableList<AnswerData> result = subject.getSummaryData();
 
-    assertEquals(2, result.size());
+    assertThat(result).hasSize(2);
     // Non-fileupload question does not have a file key
     assertThat(result.get(0).encodedFileKey()).isEmpty();
     // Fileupload question has a file key
@@ -1213,7 +1212,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
     ImmutableList<AnswerData> result = subject.getSummaryData();
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     assertThat(result.get(0).isEligible()).isEqualTo(expectedResult);
   }
 

--- a/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
+++ b/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
@@ -1,7 +1,6 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
@@ -100,9 +99,8 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
         serviceAreaUpdateFuture.toCompletableFuture().join();
     assertThat(maybeServiceAreaUpdate.isPresent()).isTrue();
     ServiceAreaUpdate serviceAreaUpdate = maybeServiceAreaUpdate.get();
-    assertEquals(
-        serviceAreaUpdate.path(),
-        Path.create("applicant.applicant_address").join(Scalar.SERVICE_AREA));
+    assertThat(serviceAreaUpdate.path())
+        .isEqualTo(Path.create("applicant.applicant_address").join(Scalar.SERVICE_AREA));
     ServiceAreaInclusion bloomington =
         ServiceAreaInclusion.builder()
             .setServiceAreaId("Bloomington")
@@ -115,12 +113,14 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
             .setState(ServiceAreaState.IN_AREA)
             .setTimeStamp(1234)
             .build();
-    assertEquals(serviceAreaUpdate.value().get(0).getServiceAreaId(), seattle.getServiceAreaId());
-    assertEquals(serviceAreaUpdate.value().get(0).getState(), seattle.getState());
-    assertEquals(
-        serviceAreaUpdate.value().get(1).getServiceAreaId(), bloomington.getServiceAreaId());
-    assertEquals(serviceAreaUpdate.value().get(1).getState(), bloomington.getState());
-    assertEquals(serviceAreaUpdate.value().get(1).getTimeStamp(), bloomington.getTimeStamp());
+    assertThat(serviceAreaUpdate.value().get(0).getServiceAreaId())
+        .isEqualTo(seattle.getServiceAreaId());
+    assertThat(serviceAreaUpdate.value().get(0).getState()).isEqualTo(seattle.getState());
+    assertThat(serviceAreaUpdate.value().get(1).getServiceAreaId())
+        .isEqualTo(bloomington.getServiceAreaId());
+    assertThat(serviceAreaUpdate.value().get(1).getState()).isEqualTo(bloomington.getState());
+    assertThat(serviceAreaUpdate.value().get(1).getTimeStamp())
+        .isEqualTo(bloomington.getTimeStamp());
   }
 
   @Test
@@ -279,9 +279,8 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
         serviceAreaUpdateFuture.toCompletableFuture().join();
     assertThat(maybeServiceAreaUpdate.isPresent()).isTrue();
     ServiceAreaUpdate serviceAreaUpdate = maybeServiceAreaUpdate.get();
-    assertEquals(
-        serviceAreaUpdate.path(),
-        Path.create("applicant.applicant_address").join(Scalar.SERVICE_AREA));
+    assertThat(serviceAreaUpdate.path())
+        .isEqualTo(Path.create("applicant.applicant_address").join(Scalar.SERVICE_AREA));
     ServiceAreaInclusion bloomington =
         ServiceAreaInclusion.builder()
             .setServiceAreaId("Bloomington")
@@ -294,12 +293,14 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
             .setState(ServiceAreaState.IN_AREA)
             .setTimeStamp(4567)
             .build();
-    assertEquals(
-        serviceAreaUpdate.value().get(0).getServiceAreaId(), bloomington.getServiceAreaId());
-    assertEquals(serviceAreaUpdate.value().get(0).getState(), bloomington.getState());
-    assertEquals(serviceAreaUpdate.value().get(0).getTimeStamp(), bloomington.getTimeStamp());
-    assertEquals(serviceAreaUpdate.value().get(1).getServiceAreaId(), seattle.getServiceAreaId());
-    assertEquals(serviceAreaUpdate.value().get(1).getState(), seattle.getState());
-    assertEquals(serviceAreaUpdate.value().get(1).getTimeStamp(), seattle.getTimeStamp());
+    assertThat(serviceAreaUpdate.value().get(0).getServiceAreaId())
+        .isEqualTo(bloomington.getServiceAreaId());
+    assertThat(serviceAreaUpdate.value().get(0).getState()).isEqualTo(bloomington.getState());
+    assertThat(serviceAreaUpdate.value().get(0).getTimeStamp())
+        .isEqualTo(bloomington.getTimeStamp());
+    assertThat(serviceAreaUpdate.value().get(1).getServiceAreaId())
+        .isEqualTo(seattle.getServiceAreaId());
+    assertThat(serviceAreaUpdate.value().get(1).getState()).isEqualTo(seattle.getState());
+    assertThat(serviceAreaUpdate.value().get(1).getTimeStamp()).isEqualTo(seattle.getTimeStamp());
   }
 }

--- a/server/test/services/geo/ServiceAreaInclusionGroupTest.java
+++ b/server/test/services/geo/ServiceAreaInclusionGroupTest.java
@@ -1,6 +1,6 @@
 package services.geo;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -11,9 +11,9 @@ public class ServiceAreaInclusionGroupTest {
     ImmutableList<ServiceAreaInclusion> serviceAreaInclusionList =
         ServiceAreaInclusionGroup.deserialize(
             "bloomington_Failed_1234,king-county_InArea_2222,seattle_InArea_5678,Arkansas_NotInArea_8765");
-    assertEquals("bloomington", serviceAreaInclusionList.get(0).getServiceAreaId());
-    assertEquals(ServiceAreaState.FAILED, serviceAreaInclusionList.get(0).getState());
-    assertEquals(1234, serviceAreaInclusionList.get(0).getTimeStamp());
+    assertThat(serviceAreaInclusionList.get(0).getServiceAreaId()).isEqualTo("bloomington");
+    assertThat(serviceAreaInclusionList.get(0).getState()).isEqualTo(ServiceAreaState.FAILED);
+    assertThat(serviceAreaInclusionList.get(0).getTimeStamp()).isEqualTo(1234);
   }
 
   @Test
@@ -45,8 +45,8 @@ public class ServiceAreaInclusionGroupTest {
                 .setTimeStamp(8765)
                 .build());
     String serialized = ServiceAreaInclusionGroup.serialize(listBuilder.build());
-    assertEquals(
-        "bloomington_Failed_1234,king-county_InArea_2222,seattle_InArea_5678,Arkansas_NotInArea_8765",
-        serialized);
+    assertThat(serialized)
+        .isEqualTo(
+            "bloomington_Failed_1234,king-county_InArea_2222,seattle_InArea_5678,Arkansas_NotInArea_8765");
   }
 }

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -1,7 +1,6 @@
 package services.geo.esri;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -36,8 +35,8 @@ public class EsriClientTest {
             .join();
     Optional<ServiceAreaInclusion> area = inclusionList.stream().findFirst();
     assertThat(area.isPresent()).isTrue();
-    assertEquals("Seattle", area.get().getServiceAreaId());
-    assertEquals(ServiceAreaState.IN_AREA, area.get().getState());
+    assertThat(area.get().getServiceAreaId()).isEqualTo("Seattle");
+    assertThat(area.get().getState()).isEqualTo(ServiceAreaState.IN_AREA);
     assertThat(area.get().getTimeStamp()).isInstanceOf(Long.class);
   }
 
@@ -53,8 +52,8 @@ public class EsriClientTest {
             .join();
     Optional<ServiceAreaInclusion> area = inclusionList.stream().findFirst();
     assertThat(area.isPresent()).isTrue();
-    assertEquals("Seattle", area.get().getServiceAreaId());
-    assertEquals(ServiceAreaState.NOT_IN_AREA, area.get().getState());
+    assertThat(area.get().getServiceAreaId()).isEqualTo("Seattle");
+    assertThat(area.get().getState()).isEqualTo(ServiceAreaState.NOT_IN_AREA);
     assertThat(area.get().getTimeStamp()).isInstanceOf(Long.class);
   }
 
@@ -70,8 +69,8 @@ public class EsriClientTest {
             .join();
     Optional<ServiceAreaInclusion> area = inclusionList.stream().findFirst();
     assertThat(area.isPresent()).isTrue();
-    assertEquals("Seattle", area.get().getServiceAreaId());
-    assertEquals(ServiceAreaState.NOT_IN_AREA, area.get().getState());
+    assertThat(area.get().getServiceAreaId()).isEqualTo("Seattle");
+    assertThat(area.get().getState()).isEqualTo(ServiceAreaState.NOT_IN_AREA);
     assertThat(area.get().getTimeStamp()).isInstanceOf(Long.class);
   }
 
@@ -87,8 +86,8 @@ public class EsriClientTest {
             .join();
     Optional<ServiceAreaInclusion> area = inclusionList.stream().findFirst();
     assertThat(area.isPresent()).isTrue();
-    assertEquals("Seattle", area.get().getServiceAreaId());
-    assertEquals(ServiceAreaState.FAILED, area.get().getState());
+    assertThat(area.get().getServiceAreaId()).isEqualTo("Seattle");
+    assertThat(area.get().getState()).isEqualTo(ServiceAreaState.FAILED);
     assertThat(area.get().getTimeStamp()).isInstanceOf(Long.class);
   }
 
@@ -114,7 +113,7 @@ public class EsriClientTest {
     Optional<AddressSuggestion> addressSuggestion = suggestions.stream().findFirst();
     assertThat(addressSuggestion.isPresent()).isTrue();
     String street = addressSuggestion.get().getAddress().getStreet();
-    assertEquals("Address In Area", street);
+    assertThat(street).isEqualTo("Address In Area");
   }
 
   @Test
@@ -133,11 +132,11 @@ public class EsriClientTest {
         helper.getClient().getAddressSuggestions(address);
     Address originalAddress = group.toCompletableFuture().join().getOriginalAddress();
 
-    assertEquals(address.getStreet(), originalAddress.getStreet());
-    assertEquals(address.getLine2(), originalAddress.getLine2());
-    assertEquals(address.getCity(), originalAddress.getCity());
-    assertEquals(address.getState(), originalAddress.getState());
-    assertEquals(address.getZip(), originalAddress.getZip());
+    assertThat(originalAddress.getStreet()).isEqualTo(address.getStreet());
+    assertThat(originalAddress.getLine2()).isEqualTo(address.getLine2());
+    assertThat(originalAddress.getCity()).isEqualTo(address.getCity());
+    assertThat(originalAddress.getState()).isEqualTo(address.getState());
+    assertThat(originalAddress.getZip()).isEqualTo(address.getZip());
   }
 
   @Test
@@ -155,8 +154,8 @@ public class EsriClientTest {
     AddressSuggestionGroup group =
         helper.getClient().getAddressSuggestions(address).toCompletableFuture().join();
     ImmutableList<AddressSuggestion> suggestions = group.getAddressSuggestions();
-    assertEquals(0, suggestions.size());
-    assertEquals(address, group.getOriginalAddress());
+    assertThat(suggestions).isEmpty();
+    assertThat(group.getOriginalAddress()).isEqualTo(address);
   }
 
   @Test
@@ -174,8 +173,8 @@ public class EsriClientTest {
     AddressSuggestionGroup group =
         helper.getClient().getAddressSuggestions(address).toCompletableFuture().join();
     ImmutableList<AddressSuggestion> suggestions = group.getAddressSuggestions();
-    assertEquals(0, suggestions.size());
-    assertEquals(0, group.getWellKnownId());
-    assertEquals(address, group.getOriginalAddress());
+    assertThat(suggestions).isEmpty();
+    assertThat(group.getWellKnownId()).isEqualTo(0);
+    assertThat(group.getOriginalAddress()).isEqualTo(address);
   }
 }

--- a/server/test/services/geo/esri/EsriServiceAreaValidationConfigTest.java
+++ b/server/test/services/geo/esri/EsriServiceAreaValidationConfigTest.java
@@ -1,7 +1,6 @@
 package services.geo.esri;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -24,7 +23,7 @@ public class EsriServiceAreaValidationConfigTest {
 
   @Test
   public void isConfigurationValid() {
-    assertEquals(true, esriServiceAreaValidationConfig.isConfigurationValid());
+    assertThat(esriServiceAreaValidationConfig.isConfigurationValid()).isTrue();
   }
 
   @Test
@@ -32,24 +31,27 @@ public class EsriServiceAreaValidationConfigTest {
     ImmutableMap<String, EsriServiceAreaValidationOption> map =
         esriServiceAreaValidationConfig.getImmutableMap();
     EsriServiceAreaValidationOption option = map.get("Seattle");
-    assertEquals("Seattle", option.getLabel());
-    assertEquals("Seattle", option.getId());
-    assertEquals("/query", option.getUrl());
-    assertEquals("CITYNAME", option.getAttribute());
+    assertThat(option.getLabel()).isEqualTo("Seattle");
+    assertThat(option.getId()).isEqualTo("Seattle");
+    assertThat(option.getUrl()).isEqualTo("/query");
+    assertThat(option.getAttribute()).isEqualTo("CITYNAME");
   }
 
   @Test
   public void getImmutableMapStored() {
-    assertEquals(esriServiceAreaValidationConfig.esriServiceAreaValidationMap, null);
+    assertThat(esriServiceAreaValidationConfig.esriServiceAreaValidationMap).isNull();
     esriServiceAreaValidationConfig.getImmutableMap();
-    assertEquals(
-        "CITYNAME",
-        esriServiceAreaValidationConfig.esriServiceAreaValidationMap.get("Seattle").getAttribute());
+    assertThat(
+            esriServiceAreaValidationConfig
+                .esriServiceAreaValidationMap
+                .get("Seattle")
+                .getAttribute())
+        .isEqualTo("CITYNAME");
   }
 
   @Test
   public void getOptionsWithSharedBackend() {
-    assertEquals(true, esriServiceAreaValidationConfig.isConfigurationValid());
+    assertThat(esriServiceAreaValidationConfig.isConfigurationValid()).isTrue();
     ImmutableMap<String, EsriServiceAreaValidationOption> map =
         esriServiceAreaValidationConfig.getImmutableMap();
     EsriServiceAreaValidationOption option = map.get("Seattle");
@@ -60,28 +62,28 @@ public class EsriServiceAreaValidationConfigTest {
     Optional<EsriServiceAreaValidationOption> maybeOptionFromList = optionList.stream().findFirst();
     assertThat(maybeOptionFromList.isPresent()).isTrue();
     EsriServiceAreaValidationOption optionFromList = maybeOptionFromList.get();
-    assertEquals("Seattle", optionFromList.getLabel());
-    assertEquals("Seattle", optionFromList.getId());
-    assertEquals("/query", optionFromList.getUrl());
-    assertEquals("CITYNAME", optionFromList.getAttribute());
+    assertThat(optionFromList.getLabel()).isEqualTo("Seattle");
+    assertThat(optionFromList.getId()).isEqualTo("Seattle");
+    assertThat(optionFromList.getUrl()).isEqualTo("/query");
+    assertThat(optionFromList.getAttribute()).isEqualTo("CITYNAME");
   }
 
   @Test
   public void getOptionByServiceAreaId() {
     Optional<EsriServiceAreaValidationOption> serviceAreaOption =
         esriServiceAreaValidationConfig.getOptionByServiceAreaId("Seattle");
-    assertEquals(true, serviceAreaOption.isPresent());
-    assertEquals("Seattle", serviceAreaOption.get().getLabel());
-    assertEquals("Seattle", serviceAreaOption.get().getId());
-    assertEquals("/query", serviceAreaOption.get().getUrl());
-    assertEquals("CITYNAME", serviceAreaOption.get().getAttribute());
+    assertThat(serviceAreaOption.isPresent()).isTrue();
+    assertThat(serviceAreaOption.get().getLabel()).isEqualTo("Seattle");
+    assertThat(serviceAreaOption.get().getId()).isEqualTo("Seattle");
+    assertThat(serviceAreaOption.get().getUrl()).isEqualTo("/query");
+    assertThat(serviceAreaOption.get().getAttribute()).isEqualTo("CITYNAME");
   }
 
   @Test
   public void getOptionByServiceAreaIdDoesNotExist() {
     Optional<EsriServiceAreaValidationOption> serviceAreaOption =
         esriServiceAreaValidationConfig.getOptionByServiceAreaId("Mars");
-    assertEquals(true, serviceAreaOption.isEmpty());
+    assertThat(serviceAreaOption).isEmpty();
   }
 
   @Test
@@ -89,10 +91,10 @@ public class EsriServiceAreaValidationConfigTest {
     Optional<ImmutableList<EsriServiceAreaValidationOption>> serviceAreaOptions =
         esriServiceAreaValidationConfig.getOptionsByServiceAreaIds(
             ImmutableList.of("Seattle", "Bloomington"));
-    assertEquals(true, serviceAreaOptions.isPresent());
-    assertEquals("Seattle", serviceAreaOptions.get().get(0).getLabel());
-    assertEquals("Seattle", serviceAreaOptions.get().get(0).getId());
-    assertEquals("/query", serviceAreaOptions.get().get(0).getUrl());
-    assertEquals("CITYNAME", serviceAreaOptions.get().get(0).getAttribute());
+    assertThat(serviceAreaOptions.isPresent()).isTrue();
+    assertThat(serviceAreaOptions.get().get(0).getLabel()).isEqualTo("Seattle");
+    assertThat(serviceAreaOptions.get().get(0).getId()).isEqualTo("Seattle");
+    assertThat(serviceAreaOptions.get().get(0).getUrl()).isEqualTo("/query");
+    assertThat(serviceAreaOptions.get().get(0).getAttribute()).isEqualTo("CITYNAME");
   }
 }

--- a/server/test/services/geo/esri/EsriServiceAreaValidationOptionTest.java
+++ b/server/test/services/geo/esri/EsriServiceAreaValidationOptionTest.java
@@ -1,6 +1,6 @@
 package services.geo.esri;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
@@ -55,8 +55,8 @@ public class EsriServiceAreaValidationOptionTest {
 
   @Test
   public void isServiceAreaOptionInInclusionGroup() {
-    assertEquals(
-        true, esriServiceAreaValidationOption.isServiceAreaOptionInInclusionGroup(inclusionGroup));
+    assertThat(esriServiceAreaValidationOption.isServiceAreaOptionInInclusionGroup(inclusionGroup))
+        .isTrue();
   }
 
   @Test
@@ -69,6 +69,6 @@ public class EsriServiceAreaValidationOptionTest {
             .setAttribute("CITYNAME")
             .build();
 
-    assertEquals(false, option.isServiceAreaOptionInInclusionGroup(inclusionGroup));
+    assertThat(option.isServiceAreaOptionInInclusionGroup(inclusionGroup)).isFalse();
   }
 }

--- a/server/test/services/geo/esri/FakeEsriClientTest.java
+++ b/server/test/services/geo/esri/FakeEsriClientTest.java
@@ -2,7 +2,6 @@ package services.geo.esri;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -32,8 +31,8 @@ public class FakeEsriClientTest {
     assertThat(maybeResp.isPresent()).isTrue();
     JsonNode resp = maybeResp.get();
     ArrayNode candidates = (ArrayNode) resp.get("candidates");
-    assertEquals(4326, resp.get("spatialReference").get("wkid").asInt());
-    assertEquals(5, candidates.size());
+    assertThat(resp.get("spatialReference").get("wkid").asInt()).isEqualTo(4326);
+    assertThat(candidates).hasSize(5);
   }
 
   @Test
@@ -45,7 +44,7 @@ public class FakeEsriClientTest {
     assertThat(maybeResp.isPresent()).isTrue();
     JsonNode resp = maybeResp.get();
     ArrayNode candidates = (ArrayNode) resp.get("candidates");
-    assertEquals(0, candidates.size());
+    assertThat(candidates).isEmpty();
   }
 
   @Test
@@ -54,7 +53,7 @@ public class FakeEsriClientTest {
     addressJson.put("street", "Error Address");
     Optional<JsonNode> maybeResp =
         helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
-    assertEquals(Optional.empty(), maybeResp);
+    assertThat(maybeResp.isPresent()).isFalse();
   }
 
   @Test
@@ -81,7 +80,7 @@ public class FakeEsriClientTest {
     List<String> features = ctx.read("features[*].attributes.CITYNAME");
     Optional<String> feature = features.stream().filter(val -> "Seattle".equals(val)).findFirst();
     assertThat(feature.isPresent()).isTrue();
-    assertEquals("Seattle", feature.get());
+    assertThat(feature.get()).isEqualTo("Seattle");
   }
 
   @Test
@@ -98,7 +97,7 @@ public class FakeEsriClientTest {
     JsonNode resp = maybeResp.get();
     ReadContext ctx = JsonPath.parse(resp.toString());
     List<String> features = ctx.read("features[*]");
-    assertEquals(0, features.size());
+    assertThat(features).isEmpty();
   }
 
   @Test
@@ -129,6 +128,6 @@ public class FakeEsriClientTest {
             .fetchServiceAreaFeatures(location, "/query")
             .toCompletableFuture()
             .join();
-    assertEquals(Optional.empty(), maybeResp);
+    assertThat(maybeResp.isPresent()).isFalse();
   }
 }

--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -1,7 +1,6 @@
 package services.geo.esri;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -33,8 +32,8 @@ public class RealEsriClientTest {
         helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
     JsonNode resp = maybeResp.get();
     ArrayNode candidates = (ArrayNode) resp.get("candidates");
-    assertEquals(4326, resp.get("spatialReference").get("wkid").asInt());
-    assertEquals(5, candidates.size());
+    assertThat(resp.get("spatialReference").get("wkid").asInt()).isEqualTo(4326);
+    assertThat(candidates).hasSize(5);
   }
 
   @Test
@@ -46,7 +45,7 @@ public class RealEsriClientTest {
         helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
     JsonNode resp = maybeResp.get();
     ArrayNode candidates = (ArrayNode) resp.get("candidates");
-    assertEquals(0, candidates.size());
+    assertThat(candidates).isEmpty();
   }
 
   @Test
@@ -56,7 +55,7 @@ public class RealEsriClientTest {
     addressJson.put("street", "380 New York St");
     Optional<JsonNode> maybeResp =
         helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
-    assertEquals(Optional.empty(), maybeResp);
+    assertThat(maybeResp.isPresent()).isFalse();
   }
 
   @Test
@@ -73,7 +72,7 @@ public class RealEsriClientTest {
     List<String> features = ctx.read("features[*].attributes.CITYNAME");
     Optional<String> feature = features.stream().filter(val -> "Seattle".equals(val)).findFirst();
     assertThat(feature.isPresent()).isTrue();
-    assertEquals("Seattle", feature.get());
+    assertThat(feature.get()).isEqualTo("Seattle");
   }
 
   @Test
@@ -85,6 +84,6 @@ public class RealEsriClientTest {
             .fetchServiceAreaFeatures(EsriTestHelper.LOCATION, "/query")
             .toCompletableFuture()
             .join();
-    assertEquals(Optional.empty(), maybeResp);
+    assertThat(maybeResp.isPresent()).isFalse();
   }
 }

--- a/server/test/views/style/StyleUtilsTest.java
+++ b/server/test/views/style/StyleUtilsTest.java
@@ -1,6 +1,6 @@
 package views.style;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -12,7 +12,7 @@ public class StyleUtilsTest {
     String expected = "hover:bg-blue-100";
     String result = StyleUtils.applyUtilityClass(StyleUtils.HOVER, "bg-blue-100");
 
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
@@ -21,61 +21,61 @@ public class StyleUtilsTest {
     String result =
         StyleUtils.applyUtilityClass(StyleUtils.FOCUS, ImmutableList.of("outline-none", "ring-2"));
 
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   public void focus_returnsExpected() {
     String expected = "focus:outline-none focus:ring-2";
     String result = StyleUtils.focus(ImmutableList.of("outline-none", "ring-2"));
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
 
     expected = "focus:outline-none";
     result = StyleUtils.focus("outline-none");
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   public void hover_returnsExpected() {
     String expected = "hover:outline-none hover:ring-2";
     String result = StyleUtils.hover(ImmutableList.of("outline-none", "ring-2"));
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
 
     expected = "hover:outline-none";
     result = StyleUtils.hover("outline-none");
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   public void responsiveSmall_returnsExpected() {
     String expected = "sm:outline-none sm:ring-2";
     String result = StyleUtils.responsiveSmall(ImmutableList.of("outline-none", "ring-2"));
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
 
     expected = "sm:outline-none";
     result = StyleUtils.responsiveSmall("outline-none");
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   public void responsiveMedium_returnsExpected() {
     String expected = "md:outline-none md:ring-2";
     String result = StyleUtils.responsiveMedium(ImmutableList.of("outline-none", "ring-2"));
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
 
     expected = "md:outline-none";
     result = StyleUtils.responsiveMedium("outline-none");
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   public void responsiveLarge_returnsExpected() {
     String expected = "lg:outline-none lg:ring-2";
     String result = StyleUtils.responsiveLarge(ImmutableList.of("outline-none", "ring-2"));
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
 
     expected = "lg:outline-none";
     result = StyleUtils.responsiveLarge("outline-none");
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
### Description

Make assertion library usage consistent across the codebase.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Fixes #5223
