### PR TITLE
remove aria-hidden true from logo

### DIFF
--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -265,7 +265,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
 
     cityImage
         .withAlt(settingsManifest.getWhitelabelCivicEntityFullName(request).get() + " Logo")
-        .attr("aria-hidden", "true")
         .withClasses("w-16", "py-1");
 
     return a().withHref(routes.HomeController.index().url())


### PR DESCRIPTION
### Description

This pr removes aria-hidden true from the CE logo so that the alt text can be read by screen readers.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Run the app and load the home page. Inspect the logo on the homepage. The `aria-hidden=true` label should not be present. 

Alternatively, turn on screen reader, navigate to logo, and confirm that the logo alt text is read out loud.

### Issue(s) this completes

Fixes #3569
