### PR TITLE
Centralize new guest logic

### DIFF
--- a/server/app/auth/DefaultToGuestRedirector.java
+++ b/server/app/auth/DefaultToGuestRedirector.java
@@ -8,6 +8,9 @@ import controllers.routes;
 import play.mvc.Http;
 import play.mvc.Result;
 
+/**
+ * Contains methods related to redirecting for the purpose of creating guest accounts for new users.
+ */
 public final class DefaultToGuestRedirector {
 
   /**

--- a/server/app/auth/DefaultToGuestRedirector.java
+++ b/server/app/auth/DefaultToGuestRedirector.java
@@ -1,0 +1,21 @@
+package auth;
+
+import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
+import static play.mvc.Results.redirect;
+
+import com.google.common.collect.ImmutableMap;
+import controllers.routes;
+import play.mvc.Http;
+import play.mvc.Result;
+
+public final class DefaultToGuestRedirector {
+
+  /**
+   * This method is used when the user's profile is empty, and we want to create a guest profile for
+   * them, redirecting them to the original page afterward.
+   */
+  public static Result createGuestSessionAndRedirect(Http.Request request) {
+    return redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url())
+        .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
+  }
+}

--- a/server/app/controllers/HomeController.java
+++ b/server/app/controllers/HomeController.java
@@ -1,9 +1,9 @@
 package controllers;
 
+import static auth.DefaultToGuestRedirector.createGuestSessionAndRedirect;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
-import auth.GuestClient;
 import auth.ProfileUtils;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
@@ -49,8 +49,7 @@ public class HomeController extends Controller {
 
     // If the user isn't already logged in within their browser session, consider them a guest.
     if (maybeProfile.isEmpty()) {
-      return CompletableFuture.completedFuture(
-          redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url()));
+      return CompletableFuture.completedFuture(createGuestSessionAndRedirect(request));
     }
 
     // Otherwise, get the profile and go to the appropriate landing page.

--- a/server/app/controllers/applicant/DeepLinkController.java
+++ b/server/app/controllers/applicant/DeepLinkController.java
@@ -1,15 +1,13 @@
 package controllers.applicant;
 
+import static auth.DefaultToGuestRedirector.createGuestSessionAndRedirect;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 
 import auth.CiviFormProfile;
-import auth.GuestClient;
 import auth.ProfileUtils;
-import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import controllers.LanguageUtils;
-import controllers.routes;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -55,13 +53,7 @@ public final class DeepLinkController extends CiviFormController {
     Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 
     if (profile.isEmpty()) {
-      // If there isn't currently a session, create a guest session using the CallbackController,
-      // and add a session key that asks it to redirect back here when the profile will be present.
-      Result result =
-          redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url())
-              .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
-
-      return CompletableFuture.completedFuture(result);
+      return CompletableFuture.completedFuture(createGuestSessionAndRedirect(request));
     }
 
     return profile


### PR DESCRIPTION
### Description

When an unauthenticated user opens CiviForm, we use the `CallbackController` to create a guest profile for them and redirect them back to the page they were on.

Centralize this logic in a new `DefaultToGuestRedirector` class. Primary motivation is that the API generated docs will need this soon, and I don't want to further increase the duplication.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - Not needed; refactor
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

None.

### Issue(s) this completes

None.
