### PR TITLE
Fix eligibility condition validation for multi option input types.

### DIFF
--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -93,10 +93,28 @@ class AdminPredicateConfiguration {
     // Check if any inputs are missing a value.
     document
       ?.querySelector('#predicate-config-value-row-container')
-      ?.querySelectorAll('input')
-      .forEach((input) => {
-        if (input.value == '') {
-          hasValueMissing = true
+      ?.querySelectorAll('[data-question-id')
+      .forEach((questionAnswerGroup) => {
+        const inputs = questionAnswerGroup?.querySelectorAll('input')
+        // Single input field that needs a value, e.g. a textbox or date field.
+        if (inputs.length == 1) {
+          if (inputs[0].value == '') {
+            hasValueMissing = true
+            return // Return early if we've found an issue.
+          }
+        }
+        // Multi-input field that needs a checked option, e.g. checkboxes or dropdowns.
+        if (inputs.length > 1) {
+          let hasCheckedOption = false
+          inputs.forEach((input) => {
+            if (input.checked) {
+              hasCheckedOption = true
+            }
+          })
+          if (!hasCheckedOption) {
+            hasValueMissing = true
+            return // Return early if we've found an issue.
+          }
         }
       })
 


### PR DESCRIPTION
### Description

Before this change, the admin would see a server error if they save an eligibility condition for question types that have multiple options, e.g. checkbox questions, without selecting an option. This updates the validation logic, using the number of input tags within a question group as a heuristic for determining if the question needs a `.checked` field versus needing a `.value`.

I think we should try to refactor this validation logic in the future so that it happens in the Java code rather than in the Typescript code to make testing easier and to make sure we're covering all question types. Filed #5265 for that.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #5101
