### PR TITLE
Adding script to set the applications.is_admin field values

### DIFF
--- a/server/conf/evolutions/default/55.sql
+++ b/server/conf/evolutions/default/55.sql
@@ -1,0 +1,22 @@
+# --- !Ups
+
+with admin_check as 
+(
+	select 
+		applications.id as application_id, 
+		case when (accounts.global_admin or cardinality(accounts.admin_of) > 0) then true else false end as is_admin
+	from applications 
+	inner join applicants
+		on applications.applicant_id = applicants.id
+	inner join accounts
+		on applicants.account_id = accounts.id
+)
+
+update applications 
+set is_admin = ac.is_admin
+from admin_check as ac
+where ac.application_id = applications.id;
+
+
+# --- !Downs
+


### PR DESCRIPTION
### Description

Sets the applications.is_admin field to value based on if the account is an admin. The [previous script](https://github.com/civiform/civiform/blob/main/server/conf/evolutions/default/53.sql) has an incorrect join.


## Release notes

Sets the applications.is_admin field to value based on if the account is an admin.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

Fixes : #5268