### PR TITLE
Simplify `QuestionDefinitionBuilder`

### DIFF
--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -170,7 +170,7 @@ public abstract class QuestionDefinition {
       return config.questionText().locales();
     } else {
       return ImmutableSet.copyOf(
-          Sets.intersection(config.questionText().locales(), config.questionHelpText().locales()));
+          Sets.intersection(config.questionText().locales(), getQuestionHelpText().locales()));
     }
   }
 
@@ -285,7 +285,7 @@ public abstract class QuestionDefinition {
 
   @Override
   public int hashCode() {
-    return Objects.hash(config.id());
+    return Objects.hash(getId());
   }
 
   /** Two QuestionDefinitions are considered equal if all of their properties are the same. */
@@ -315,24 +315,35 @@ public abstract class QuestionDefinition {
     if (other instanceof QuestionDefinition) {
       QuestionDefinition o = (QuestionDefinition) other;
 
-      return this.getQuestionType().equals(o.getQuestionType())
-          && config.name().equals(o.getName())
-          && config.description().equals(o.getDescription())
-          && config.questionText().equals(o.getQuestionText())
-          && config.questionHelpText().equals(o.getQuestionHelpText())
-          && config.validationPredicates().equals(Optional.of(o.getValidationPredicates()));
+      return getQuestionType().equals(o.getQuestionType())
+          && getName().equals(o.getName())
+          && getDescription().equals(o.getDescription())
+          && getQuestionText().equals(o.getQuestionText())
+          && getQuestionHelpText().equals(o.getQuestionHelpText())
+          && getValidationPredicates().equals(o.getValidationPredicates());
     }
     return false;
   }
 
   private boolean questionTextAndHelpTextContainsRepeatedEntityNameFormatString() {
     boolean textMissingFormatString =
-        config.questionText().translations().values().stream()
+        getQuestionText().translations().values().stream()
             .anyMatch(text -> !text.contains("$this"));
     boolean helpTextMissingFormatString =
-        config.questionHelpText().translations().values().stream()
+        getQuestionHelpText().translations().values().stream()
             .anyMatch(helpText -> !helpText.contains("$this"));
     return !textMissingFormatString && !helpTextMissingFormatString;
+  }
+
+  /**
+   * TODO(#5271): remove this. This is only used for {@link QuestionDefinitionBuilder} in order to
+   * construct new instances, and {@link QuestionDefinitionBuilder} should be removed.
+   *
+   * <p>The {@link QuestionDefinitionConfig} should be entirely internal to {@link
+   * QuestionDefinition}.
+   */
+  QuestionDefinitionConfig getConfig() {
+    return config;
   }
 
   /**

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -22,7 +22,11 @@ public abstract class QuestionDefinitionConfig {
    */
   abstract LocalizedStrings questionText();
 
-  abstract LocalizedStrings questionHelpText();
+  LocalizedStrings questionHelpText() {
+    return questionHelpTextInternal().orElse(LocalizedStrings.empty());
+  }
+
+  abstract Optional<LocalizedStrings> questionHelpTextInternal();
 
   abstract Optional<QuestionDefinition.ValidationPredicates> validationPredicates();
 
@@ -49,16 +53,12 @@ public abstract class QuestionDefinitionConfig {
   }
 
   public interface RequiredQuestionText {
-    RequiredQuestionHelpText setQuestionText(LocalizedStrings questionText);
-  }
-
-  public interface RequiredQuestionHelpText {
-    Builder setQuestionHelpText(LocalizedStrings questionHelpText);
+    Builder setQuestionText(LocalizedStrings questionText);
   }
 
   @AutoValue.Builder
   public abstract static class Builder
-      implements RequiredName, RequiredDescription, RequiredQuestionText, RequiredQuestionHelpText {
+      implements RequiredName, RequiredDescription, RequiredQuestionText {
     public abstract Builder setId(long id);
 
     public abstract Builder setId(OptionalLong id);
@@ -73,6 +73,12 @@ public abstract class QuestionDefinitionConfig {
 
     public abstract Builder setValidationPredicates(
         QuestionDefinition.ValidationPredicates validationPredicates);
+
+    public Builder setQuestionHelpText(LocalizedStrings questionHelpText) {
+      return setQuestionHelpTextInternal(questionHelpText);
+    }
+
+    abstract Builder setQuestionHelpTextInternal(LocalizedStrings questionHelpText);
 
     public abstract QuestionDefinitionConfig build();
   }


### PR DESCRIPTION
### Description

`QuestionDefinitionBuilder` exists as technical debt, now that `QuestionDefinition` is constructed with a `QuestionDefinitionConfig.Builder`.

It's very hard to remove, since it has so many usages throughout CiviForm. This PR works towards making `QuestionDefinitionBuilder` use `QuestionDefinitionConfig` internally, so that there is at least less risk of divergence in behavior.

Changes:
* Instead of storing all of the `QuestionDefinition` vars in `QuestionDefinitionBuilder`, we now just store a `QuestionDefinitionConfig.Builder`.
* Stop constructing the `QuestionDefinitionConfig` for each question type; reuse the original one in the switch statement.
* In `QuestionDefinition`, use `config` as little as possible (i.e. use `this.getName()` instead of `config.getName()`.

Note: `questionHelpText` was a tricky thing to fix here. In `QuestionDefinitionConfig.Builder`, we had it as a required field, both at compile time and AutoValue's runtime checks. However, it turns out that the many usages of `QuestionDefinitionBuilder` allow `questionHelpText` to be unset, defaulting to `LocalizedStrings.empty()`. In order to accomodate this, we modify the `QuestionDefinitionConfig` AutoValue to allow `questionHelpText` to be unset. Using some clever internal methods, we can avoid the complexity of an `Optional<LocalizedStrings>`, which we don't want since the `LocalizedStrings` itself can be empty anyways.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - Refactor, not necessary
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary


### Issue(s) this completes

Progress towards #5271.