### PR TITLE
Add additional accessor methods to CfJsonDocumentContext

### DIFF
--- a/server/app/services/applicant/question/MultiSelectQuestion.java
+++ b/server/app/services/applicant/question/MultiSelectQuestion.java
@@ -83,7 +83,7 @@ public final class MultiSelectQuestion extends Question {
   /** Get the selected options in the specified locale. */
   public Optional<ImmutableList<LocalizedQuestionOption>> getSelectedOptionsValue(Locale locale) {
     Optional<ImmutableList<Long>> maybeOptionIds =
-        applicantQuestion.getApplicantData().readList(getSelectionPath());
+        applicantQuestion.getApplicantData().readLongList(getSelectionPath());
 
     if (maybeOptionIds.isEmpty()) {
       selectedOptionsValue = Optional.empty();

--- a/server/test/services/CfJsonDocumentContextTest.java
+++ b/server/test/services/CfJsonDocumentContextTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import com.jayway.jsonpath.PathNotFoundException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Optional;
@@ -132,7 +133,33 @@ public class CfJsonDocumentContextTest {
   public void hasValueAtPath_returnsFalseForMissingPath() {
     CfJsonDocumentContext data = new CfJsonDocumentContext();
 
-    assertThat(data.hasValueAtPath(Path.create("not_here!"))).isFalse();
+    assertThat(data.hasValueAtPath(Path.create("not_here"))).isFalse();
+  }
+
+  @Test
+  public void hasNullValueAtPath_returnsTrueForNull() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path path = Path.create("applicant.horses");
+    data.putLong(path, "");
+
+    assertThat(data.hasNullValueAtPath(path)).isTrue();
+  }
+
+  @Test
+  public void hasNullValueAtPath_returnsFalseForValue() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path path = Path.create("applicant.horses");
+    data.putLong(path, 15);
+
+    assertThat(data.hasNullValueAtPath(path)).isFalse();
+  }
+
+  @Test
+  public void hasNullValueAtPath_throwsForMissingPath() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+
+    assertThatThrownBy(() -> data.hasNullValueAtPath(Path.create("not_here")))
+        .isInstanceOf(PathNotFoundException.class);
   }
 
   @Test
@@ -337,6 +364,32 @@ public class CfJsonDocumentContextTest {
   }
 
   @Test
+  public void putNull_putsNullAtSpecifiedPath() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path path = Path.create("applicant.age");
+    String expected = "{\"applicant\":{\"age\":null}}";
+
+    data.putNull(path);
+
+    assertThat(data.asJsonString()).isEqualTo(expected);
+    assertThat(data.hasNullValueAtPath(path)).isTrue();
+  }
+
+  @Test
+  public void putNull_isNoopIfPathIsArrayElement() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path path = Path.create("applicant.allergies[0]");
+    String expected = "{\"applicant\":{\"allergies\":[\"peanut\",\"kiwi\"]}}";
+
+    data.putString(Path.create("applicant.allergies[0]"), "peanut");
+    data.putString(Path.create("applicant.allergies[1]"), "kiwi");
+
+    data.putNull(path);
+
+    assertThat(data.asJsonString()).isEqualTo(expected);
+  }
+
+  @Test
   public void readString_findsCorrectValue() throws Exception {
     String testData = "{ \"applicant\": { \"favorites\": { \"color\": \"orange\"} } }";
     CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
@@ -428,40 +481,82 @@ public class CfJsonDocumentContextTest {
   }
 
   @Test
-  public void readList_findsCorrectValue() {
+  public void readLongList_findsCorrectValue() {
     String testData = "{\"applicant\":{\"favorite_fruits\":[1, 2]}}";
     CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
 
-    Optional<ImmutableList<Long>> found = data.readList(Path.create("applicant.favorite_fruits"));
+    Optional<ImmutableList<Long>> found =
+        data.readLongList(Path.create("applicant.favorite_fruits"));
 
     assertThat(found).hasValue(ImmutableList.of(1L, 2L));
   }
 
   @Test
-  public void readListWithOneValue_findsCorrectValue() {
+  public void readLongList_withOneValue_findsCorrectValue() {
     String testData = "{\"applicant\":{\"favorite_fruits\":[1]}}";
     CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
 
-    Optional<ImmutableList<Long>> found = data.readList(Path.create("applicant.favorite_fruits"));
-
+    Optional<ImmutableList<Long>> found =
+        data.readLongList(Path.create("applicant.favorite_fruits"));
     assertThat(found).hasValue(ImmutableList.of(1L));
   }
 
   @Test
-  public void readList_pathNotPresent_returnsEmptyOptional() {
+  public void readLongList_pathNotPresent_returnsEmptyOptional() {
     CfJsonDocumentContext data = new CfJsonDocumentContext();
 
-    Optional<ImmutableList<Long>> found = data.readList(Path.create("not.here"));
+    Optional<ImmutableList<Long>> found = data.readLongList(Path.create("not.here"));
 
     assertThat(found).isEmpty();
   }
 
   @Test
-  public void readList_returnsEmptyWhenTypeMismatch() {
+  public void readLongList_withTypeMismatch_returnsEmptyOptional() {
+    String testData = "{ \"applicant\": { \"object\": { \"name\": \"Khalid\" } } }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    Optional<ImmutableList<Long>> found = data.readLongList(Path.create("applicant.object.name"));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void readStringList_findsCorrectValue() {
+    String testData = "{\"applicant\":{\"favorite_fruits\":[\"apple\", \"orange\"]}}";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    Optional<ImmutableList<String>> found =
+        data.readStringList(Path.create("applicant.favorite_fruits"));
+
+    assertThat(found).hasValue(ImmutableList.of("apple", "orange"));
+  }
+
+  @Test
+  public void readStringList_withOneValue_findsCorrectValue() {
+    String testData = "{\"applicant\":{\"favorite_fruits\":[\"apple\"]}}";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    Optional<ImmutableList<String>> found =
+        data.readStringList(Path.create("applicant.favorite_fruits"));
+    assertThat(found).hasValue(ImmutableList.of("apple"));
+  }
+
+  @Test
+  public void readStringList_pathNotPresent_returnsEmptyOptional() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+
+    Optional<ImmutableList<String>> found = data.readStringList(Path.create("not.here"));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void readStringList_withTypeMismatch_returnsEmptyOptional() {
     String testData = "{ \"applicant\": { \"object\": { \"age\": 12 } } }";
     CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
 
-    Optional<ImmutableList<Long>> found = data.readList(Path.create("applicant.object.name"));
+    Optional<ImmutableList<String>> found =
+        data.readStringList(Path.create("applicant.object.name"));
 
     assertThat(found).isEmpty();
   }

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -242,7 +242,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
     ApplicantData applicantDataMiddle =
         userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    assertThat(applicantDataMiddle.readList(questionPath.join(Scalar.SELECTIONS))).isNotEmpty();
+    assertThat(applicantDataMiddle.readLongList(questionPath.join(Scalar.SELECTIONS))).isNotEmpty();
 
     // Now put empty updates
     updates = ImmutableMap.of(questionPath.join(Scalar.SELECTIONS).asArrayElement().toString(), "");
@@ -544,7 +544,8 @@ public class ApplicantServiceTest extends ResetPostgres {
         userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
     assertThat(
-            applicantDataAfter.readList(Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
+            applicantDataAfter.readLongList(
+                Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
         .hasValue(ImmutableList.of(1L, 2L, 3L));
 
     // Ensure that we can successfully overwrite the array.
@@ -561,7 +562,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicantDataAfter = userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
     assertThat(
-            applicantDataAfter.readList(Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
+            applicantDataAfter.readLongList(
+                Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
         .hasValue(ImmutableList.of(3L, 1L));
 
     // Clear values by sending an empty item.
@@ -575,7 +577,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicantDataAfter = userRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
     assertThat(
-            applicantDataAfter.readList(Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
+            applicantDataAfter.readLongList(
+                Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
         .isEmpty();
   }
 

--- a/server/test/support/QuestionAnswererTest.java
+++ b/server/test/support/QuestionAnswererTest.java
@@ -53,7 +53,7 @@ public class QuestionAnswererTest {
     QuestionAnswerer.answerMultiSelectQuestion(applicantData, path, 0, 5L);
     QuestionAnswerer.answerMultiSelectQuestion(applicantData, path, 1, 6L);
 
-    assertThat(applicantData.readList(path.join(Scalar.SELECTIONS)))
+    assertThat(applicantData.readLongList(path.join(Scalar.SELECTIONS)))
         .contains(ImmutableList.of(5L, 6L));
   }
 


### PR DESCRIPTION
### Description

Adds `readStringList()` and  `hasNullValueAtPath()` to `CfJsonDocumentContext` to facilitate tests, and renames the existing `readList()` to `readLongList()`.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

n/a

### Issue(s) this completes

Part of the fix for https://github.com/civiform/civiform/issues/5224
