### PR TITLE
Rename `errorsPresenter()` to more descriptive `getQuestions()`.

### DIFF
--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -267,22 +267,22 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     for (Block block : blocks) {
       ImmutableList<ApplicantQuestion> questions = block.getQuestions();
       for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
-        ApplicantQuestion question = questions.get(questionIndex);
+        ApplicantQuestion applicantQuestion = questions.get(questionIndex);
         // Don't include static content in summary data.
-        if (question.getType().equals(QuestionType.STATIC)) {
+        if (applicantQuestion.getType().equals(QuestionType.STATIC)) {
           continue;
         }
-        boolean isAnswered = question.isAnswered();
-        boolean isEligible = isQuestionEligibleInBlock(block, question);
-        String questionText = question.getQuestionText();
-        String questionTextForScreenReader = question.getQuestionTextForScreenReader();
-        String answerText = question.errorsPresenter().getAnswerString();
-        Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
-        Optional<Long> updatedProgram = question.getUpdatedInProgramMetadata();
+        boolean isAnswered = applicantQuestion.isAnswered();
+        boolean isEligible = isQuestionEligibleInBlock(block, applicantQuestion);
+        String questionText = applicantQuestion.getQuestionText();
+        String questionTextForScreenReader = applicantQuestion.getQuestionTextForScreenReader();
+        String answerText = applicantQuestion.getQuestion().getAnswerString();
+        Optional<Long> timestamp = applicantQuestion.getLastUpdatedTimeMetadata();
+        Optional<Long> updatedProgram = applicantQuestion.getUpdatedInProgramMetadata();
         Optional<String> originalFileName = Optional.empty();
         Optional<String> encodedFileKey = Optional.empty();
-        if (isAnswered && question.isFileUploadQuestion()) {
-          FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
+        if (isAnswered && applicantQuestion.isFileUploadQuestion()) {
+          FileUploadQuestion fileUploadQuestion = applicantQuestion.createFileUploadQuestion();
           originalFileName = fileUploadQuestion.getOriginalFileName();
           encodedFileKey =
               fileUploadQuestion
@@ -295,9 +295,9 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
             AnswerData.builder()
                 .setProgramId(programDefinition.id())
                 .setBlockId(block.getId())
-                .setContextualizedPath(question.getContextualizedPath())
-                .setQuestionDefinition(question.getQuestionDefinition())
-                .setApplicantQuestion(question)
+                .setContextualizedPath(applicantQuestion.getContextualizedPath())
+                .setQuestionDefinition(applicantQuestion.getQuestionDefinition())
+                .setApplicantQuestion(applicantQuestion)
                 .setRepeatedEntity(block.getRepeatedEntity())
                 .setQuestionIndex(questionIndex)
                 .setQuestionText(questionText)
@@ -311,7 +311,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))
                 .setIsPreviousResponse(isPreviousResponse)
                 .setScalarAnswersInDefaultLocale(
-                    getScalarAnswers(question, LocalizedStrings.DEFAULT_LOCALE))
+                    getScalarAnswers(applicantQuestion, LocalizedStrings.DEFAULT_LOCALE))
                 .build();
         builder.add(data);
       }

--- a/server/app/services/applicant/question/ApplicantQuestion.java
+++ b/server/app/services/applicant/question/ApplicantQuestion.java
@@ -114,7 +114,7 @@ public final class ApplicantQuestion {
   }
 
   public boolean isAnswered() {
-    return errorsPresenter().isAnswered();
+    return getQuestion().isAnswered();
   }
 
   /** Returns true if this question was most recently updated in this program. */
@@ -187,7 +187,7 @@ public final class ApplicantQuestion {
   }
 
   public boolean hasErrors() {
-    return !errorsPresenter().getValidationErrors().isEmpty();
+    return !getQuestion().getValidationErrors().isEmpty();
   }
 
   public Optional<Long> getUpdatedInProgramMetadata() {
@@ -279,7 +279,7 @@ public final class ApplicantQuestion {
     return new TextQuestion(this);
   }
 
-  public Question errorsPresenter() {
+  public Question getQuestion() {
     switch (getType()) {
       case ADDRESS:
         return createAddressQuestion();

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -393,7 +393,7 @@ public final class CsvExporterService {
         ProgramQuestionDefinition pqd =
             ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
         Question applicantQuestion =
-            new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()).errorsPresenter();
+            new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()).getQuestion();
         for (Path path : applicantQuestion.getAllPaths()) {
           columnsBuilder.add(
               Column.builder()

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -45,7 +45,7 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    AddressQuestion addressQuestion = question.createAddressQuestion();
+    AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
     FieldWithLabel streetAddressField =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -28,21 +28,21 @@ import views.style.ReferenceClasses;
  */
 abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
 
-  protected final ApplicantQuestion question;
+  protected final ApplicantQuestion applicantQuestion;
   // HTML id tags for various elements within this question.
   private final String questionId;
   private final String descriptionId;
   private final String errorId;
 
-  ApplicantQuestionRendererImpl(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+  ApplicantQuestionRendererImpl(ApplicantQuestion applicantQuestion) {
+    this.applicantQuestion = checkNotNull(applicantQuestion);
     this.questionId = RandomStringUtils.randomAlphabetic(8);
     this.descriptionId = String.format("%s-description", questionId);
     this.errorId = String.format("%s-error", questionId);
   }
 
   private String getRequiredClass() {
-    return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
+    return applicantQuestion.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
 
   /** Renders the question tag. */
@@ -70,7 +70,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
                         ApplicantStyles.QUESTION_HELP_TEXT)
                     .with(
                         TextFormatter.createLinksAndEscapeText(
-                            question.getQuestionHelpText(),
+                            applicantQuestion.getQuestionHelpText(),
                             TextFormatter.UrlOpenAction.NewTab,
                             /*addRequiredIndicator= */ false)))
             .withClasses("mb-4");
@@ -81,7 +81,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
         validationErrors = ImmutableMap.of();
         break;
       case DISPLAY_ERRORS:
-        validationErrors = question.errorsPresenter().getValidationErrors();
+        validationErrors = applicantQuestion.getQuestion().getValidationErrors();
         break;
       default:
         throw new IllegalArgumentException(
@@ -89,7 +89,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     }
 
     ImmutableSet<ValidationErrorMessage> questionErrors =
-        validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());
+        validationErrors.getOrDefault(applicantQuestion.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
       questionSecondaryTextDiv.with(
@@ -101,9 +101,9 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
 
     ImmutableList<DomContent> questionTextDoms =
         TextFormatter.createLinksAndEscapeText(
-            question.getQuestionText(),
+            applicantQuestion.getQuestionText(),
             TextFormatter.UrlOpenAction.NewTab,
-            /*addRequiredIndicator= */ !question.isOptional());
+            /*addRequiredIndicator= */ !applicantQuestion.isOptional());
     // Reverse the list to have errors appear first.
     ImmutableList<String> ariaDescribedByIds = ariaDescribedByBuilder.build().reverse();
 
@@ -114,7 +114,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
             ariaDescribedByIds,
             questionTextDoms,
             questionSecondaryTextDiv,
-            question.isOptional());
+            applicantQuestion.isOptional());
 
     return div()
         .withId(questionId)

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -38,7 +38,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
       boolean isOptional) {
 
     boolean hasErrors = !validationErrors.isEmpty();
-    MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
+    MultiSelectQuestion multiOptionQuestion = applicantQuestion.createMultiSelectQuestion();
 
     DivTag checkboxQuestionFormContent =
         div()
@@ -71,7 +71,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
       boolean isSelected,
       boolean hasErrors,
       boolean isOptional) {
-    String id = "checkbox-" + question.getContextualizedPath() + "-" + option.id();
+    String id = "checkbox-" + applicantQuestion.getContextualizedPath() + "-" + option.id();
     LabelTag labelTag =
         label()
             .withClasses(

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -30,13 +30,13 @@ public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
+    CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
 
     FieldWithLabel currencyField =
         FieldWithLabel.currency()
             .setFieldName(currencyQuestion.getCurrencyPath().toString())
             .addReferenceClass(ReferenceClasses.CURRENCY_VALUE)
-            .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -31,12 +31,12 @@ public class DateQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    DateQuestion dateQuestion = question.createDateQuestion();
+    DateQuestion dateQuestion = applicantQuestion.createDateQuestion();
 
     FieldWithLabel dateField =
         FieldWithLabel.date()
             .setFieldName(dateQuestion.getDatePath().toString())
-            .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -35,7 +35,7 @@ public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
     Messages messages = params.messages();
-    SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
+    SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
 
     SelectWithLabel select =
         new SelectWithLabel()
@@ -57,7 +57,7 @@ public class DropdownQuestionRenderer extends ApplicantSingleQuestionRenderer {
     if (!validationErrors.isEmpty()) {
       select.forceAriaInvalid();
     }
-    select.setScreenReaderText(question.getQuestionTextForScreenReader());
+    select.setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader());
 
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -30,7 +30,7 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    EmailQuestion emailQuestion = question.createEmailQuestion();
+    EmailQuestion emailQuestion = applicantQuestion.createEmailQuestion();
 
     FieldWithLabel emailField =
         FieldWithLabel.email()
@@ -42,7 +42,7 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
                 params.messages(),
                 validationErrors.getOrDefault(emailQuestion.getEmailPath(), ImmutableSet.of()))
             .setAriaDescribedByIds(ariaDescribedByIds)
-            .setScreenReaderText(question.getQuestionTextForScreenReader());
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader());
 
     if (!validationErrors.isEmpty()) {
       emailField.forceAriaInvalid();

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -55,7 +55,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
+    EnumeratorQuestion enumeratorQuestion = applicantQuestion.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();
     ImmutableList<String> entityNames = enumeratorQuestion.getEntityNames();
     boolean hasErrors = !validationErrors.isEmpty();
@@ -66,7 +66,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
           enumeratorField(
               messages,
               localizedEntityType,
-              question.getContextualizedPath(),
+              applicantQuestion.getContextualizedPath(),
               /* existingEntity= */ Optional.of(entityNames.get(index)),
               /* existingIndex= */ Optional.of(index),
               /* extraStyle= */ Optional.empty(),
@@ -101,7 +101,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
                 enumeratorField(
                         messages,
                         localizedEntityType,
-                        question.getContextualizedPath(),
+                        applicantQuestion.getContextualizedPath(),
                         /* existingEntity= */ Optional.empty(),
                         /* existingIndex= */ Optional.empty(),
                         /* extraStyle= */ Optional.of("hidden"),

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -65,7 +65,7 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
             label()
                 .withFor(fileInputId)
                 .withClass("sr-only")
-                .withText(question.getQuestionTextForScreenReader()))
+                .withText(applicantQuestion.getQuestionTextForScreenReader()))
         .with(
             fileUploadViewStrategy.signedFileUploadFields(
                 params, fileUploadQuestion, fileInputId, ariaDescribedByIds, hasErrors))

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -28,7 +28,7 @@ public class IdQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    IdQuestion idQuestion = question.createIdQuestion();
+    IdQuestion idQuestion = applicantQuestion.createIdQuestion();
 
     FieldWithLabel idField =
         FieldWithLabel.input()
@@ -39,7 +39,7 @@ public class IdQuestionRenderer extends ApplicantSingleQuestionRenderer {
                 params.messages(),
                 validationErrors.getOrDefault(idQuestion.getIdPath(), ImmutableSet.of()))
             .setAriaDescribedByIds(ariaDescribedByIds)
-            .setScreenReaderText(question.getQuestionTextForScreenReader());
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader());
 
     if (!validationErrors.isEmpty()) {
       idField.forceAriaInvalid();

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -33,7 +33,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
     Messages messages = params.messages();
-    NameQuestion nameQuestion = question.createNameQuestion();
+    NameQuestion nameQuestion = applicantQuestion.createNameQuestion();
 
     FieldWithLabel firstNameField =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -31,12 +31,12 @@ public class NumberQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    NumberQuestion numberQuestion = question.createNumberQuestion();
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
     FieldWithLabel numberField =
         FieldWithLabel.number()
             .setFieldName(numberQuestion.getNumberPath().toString())
-            .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .setMin(numberQuestion.getQuestionDefinition().getMin())
             .setMax(numberQuestion.getQuestionDefinition().getMax())
             .setAriaRequired(!isOptional)

--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -32,7 +32,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    PhoneQuestion phoneQuestion = question.createPhoneQuestion();
+    PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
 
     Messages messages = params.messages();
 
@@ -69,7 +69,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
                 validationErrors.getOrDefault(
                     phoneQuestion.getPhoneNumberPath(), ImmutableSet.of()))
             .setAriaDescribedByIds(ariaDescribedByIds)
-            .setScreenReaderText(question.getQuestionTextForScreenReader())
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .addReferenceClass(ReferenceClasses.PHONE_NUMBER)
             .setId(ReferenceClasses.PHONE_NUMBER);
 

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -38,7 +38,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       boolean isOptional) {
-    SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
+    SingleSelectQuestion singleOptionQuestion = applicantQuestion.createSingleSelectQuestion();
     boolean hasErrors = !validationErrors.isEmpty();
 
     DivTag radioQuestionFormContent =

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -28,7 +28,7 @@ public class TextQuestionRenderer extends ApplicantSingleQuestionRenderer {
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
       ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
-    TextQuestion textQuestion = question.createTextQuestion();
+    TextQuestion textQuestion = applicantQuestion.createTextQuestion();
 
     FieldWithLabel textField =
         FieldWithLabel.input()
@@ -39,7 +39,7 @@ public class TextQuestionRenderer extends ApplicantSingleQuestionRenderer {
                 params.messages(),
                 validationErrors.getOrDefault(textQuestion.getTextPath(), ImmutableSet.of()))
             .setAriaDescribedByIds(ariaDescribedByIds)
-            .setScreenReaderText(question.getQuestionTextForScreenReader());
+            .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader());
 
     if (!validationErrors.isEmpty()) {
       textField.forceAriaInvalid();

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -512,7 +512,7 @@ public class BlockTest {
                 .anyMatch(
                     q ->
                         q
-                            .errorsPresenter()
+                            .getQuestion()
                             .getValidationErrors()
                             .get(q.getContextualizedPath())
                             .stream()

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -67,13 +67,13 @@ public class ApplicantQuestionTest {
   public void errorsPresenterExtendedForAllTypes(QuestionType questionType) {
     QuestionDefinition definition =
         testQuestionBank.getSampleQuestionsForAllTypes().get(questionType).getQuestionDefinition();
-    ApplicantQuestion question =
+    ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(
             ProgramQuestionDefinition.create(definition, Optional.empty()).setOptional(true),
             new ApplicantData(),
             Optional.empty());
 
-    assertThat(question.errorsPresenter().getValidationErrors().isEmpty()).isTrue();
+    assertThat(applicantQuestion.getQuestion().getValidationErrors().isEmpty()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Description

Rename `errorsPresenter()` to more descriptive `getQuestions()`.

## Release notes

Rename `errorsPresenter()` to more descriptive `getQuestions()`. With only that substitution, there were several examples of `question.getQuestion()`, so in these cases, the variables have been renamed to `applicantQuestion` to make the relationship clearer.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
