### PR TITLE
Remove "required" from vars we don't want in the config.sh

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1085,19 +1085,19 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "DB_JDBC_STRING",
                               "The database URL.",
-                              /* isRequired= */ true,
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DB_USERNAME",
                               "The username used to connect to the database.",
-                              /* isRequired= */ true,
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "DB_PASSWORD",
                               "The password used to connect to the database.",
-                              /* isRequired= */ true,
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN))),
                   SettingsSection.create(
@@ -1447,7 +1447,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " key](http://www.playframework.com/documentation/latest/ApplicationSecret)"
                           + " is used to sign Play's session cookie. This must be changed for"
                           + " production.",
-                      /* isRequired= */ true,
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1491,7 +1491,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
                           + " shown on the login page if CIVIFORM_VERSION is the empty string or"
                           + " set to 'latest'.",
-                      /* isRequired= */ true,
+                      /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -275,20 +275,17 @@
           "DB_JDBC_STRING": {
             "mode": "HIDDEN",
             "description": "The database URL.",
-            "type": "string",
-            "required": true
+            "type": "string"
           },
           "DB_USERNAME": {
             "mode": "HIDDEN",
             "description": "The username used to connect to the database.",
-            "type": "string",
-            "required": true
+            "type": "string"
           },
           "DB_PASSWORD": {
             "mode": "HIDDEN",
             "description": "The password used to connect to the database.",
-            "type": "string",
-            "required": true
+            "type": "string"
           }
         }
       },
@@ -430,8 +427,7 @@
   "SECRET_KEY": {
     "mode": "HIDDEN",
     "description": "The [secret key](http://www.playframework.com/documentation/latest/ApplicationSecret) is used to sign Play's session cookie. This must be changed for production.",
-    "type": "string",
-    "required": true
+    "type": "string"
   },
   "BASE_URL": {
     "mode": "ADMIN_READABLE",
@@ -470,8 +466,7 @@
   "CIVIFORM_IMAGE_TAG": {
     "mode": "ADMIN_READABLE",
     "description": "The tag of the docker image this server is running inside. Is added as a HTML meta tag with name 'civiform-build-tag'. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if CIVIFORM_VERSION is the empty string or set to 'latest'.",
-    "type": "string",
-    "required": true
+    "type": "string"
   },
   "CIVIFORM_VERSION": {
     "mode": "ADMIN_READABLE",


### PR DESCRIPTION
### Description

With server variable autogeneration turned on in the deployment system, any variables marked "required" will be expected to be in the `config.sh` file for that deployment. This PR removes "required" from vars that we don't want to add the `config.sh` file.

Right now deploying with server var autogeneration turned on results in the following error:
![image](https://github.com/civiform/civiform/assets/24319951/357269b1-4b68-44cc-9a4c-dcc741fa144d)


### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
