### PR TITLE
Publish versions in a serializable transaction

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -91,7 +91,7 @@ public final class VersionRepository {
       // Regardless of whether changes are published or not, we still perform
       // this operation inside of a transaction in order to ensure we have
       // consistent reads.
-      database.beginTransaction();
+      database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
       Version draft = getDraftVersion();
       Version active = getActiveVersion();
 


### PR DESCRIPTION
We are continuing to see bugs related to inconsistent data in newly published versions.