### PR TITLE
Add JsonExporter tests for unanswered repeated questions

### DIFF
--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -25,6 +25,7 @@ import services.applicant.JsonPathProvider;
 import services.applicant.exception.JsonPathTypeMismatchException;
 import services.applicant.predicate.JsonPathPredicate;
 import services.applicant.question.Scalar;
+import services.export.JsonPrettifier;
 
 // NON_ABSTRACT_CLASS_ALLOWS_SUBCLASSING CfJsonDocumentContext
 
@@ -595,6 +596,20 @@ public class CfJsonDocumentContext {
 
   public String asJsonString() {
     return jsonData.jsonString();
+  }
+
+  /**
+   * Pretty-print the JSON document, below the specified {@link Path}.
+   *
+   * <p>If the document is only a {@code null} value (for example, if the path points to a {@code
+   * null} leaf node), then this returns the String "null".
+   *
+   * @param path the path to the subtree that should be pretty-printed
+   * @return the pretty-printed document
+   */
+  public String asPrettyJsonString(Path path) {
+    Object subtreeAtPath = jsonData.read(path.toString());
+    return JsonPrettifier.asPrettyJsonString(subtreeAtPath);
   }
 
   @Override

--- a/server/app/services/export/JsonPrettifier.java
+++ b/server/app/services/export/JsonPrettifier.java
@@ -6,14 +6,35 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 /** Provides methods related to "prettifying" (formatting) JSON strings. */
 public final class JsonPrettifier {
-  public static String asPrettyJsonString(String original) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-    objectMapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .enable(SerializationFeature.INDENT_OUTPUT)
+          .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 
+  /**
+   * Pretty-print the JSON document
+   *
+   * @param jsonObject the JSON document as an {@link Object}
+   * @return the pretty-printed document
+   */
+  public static String asPrettyJsonString(Object jsonObject) {
     try {
-      Object jsonObject = objectMapper.readValue(original, Object.class);
-      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+      return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+    } catch (JsonProcessingException e) {
+      return "Error parsing json";
+    }
+  }
+
+  /**
+   * Pretty-print the JSON document
+   *
+   * @param jsonString the JSON document as a {@link String}
+   * @return the pretty-printed document
+   */
+  public static String asPrettyJsonString(String jsonString) {
+    try {
+      Object jsonObject = OBJECT_MAPPER.readValue(jsonString, Object.class);
+      return asPrettyJsonString(jsonObject);
     } catch (JsonProcessingException e) {
       return "Error parsing json";
     }

--- a/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
+++ b/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
@@ -40,7 +40,7 @@ public class ProgramApplicationsApiControllerTest extends AbstractExporterTest {
   public void setUp() {
     // This inherited method creates a program and three applications to it.
     // The applications have submission/creation times of 2022-01-15, 2022-02-15, and 2022-03-15.
-    createFakeProgramWithEnumerator();
+    createFakeProgramWithEnumeratorAndAnswerQuestions();
     januaryApplication = applicationOne;
     februaryApplication = applicationTwo;
     marchApplication = applicationThree;

--- a/server/test/services/CfJsonDocumentContextTest.java
+++ b/server/test/services/CfJsonDocumentContextTest.java
@@ -615,6 +615,46 @@ public class CfJsonDocumentContextTest {
   }
 
   @Test
+  public void asPrettyJsonString_prettyPrintsDocumentAtPath() {
+    String testData =
+        "{ \"deeply\": { \"nested\": { \"value\": \"long text to stop formatter de-wrapping\" } }"
+            + " }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply"));
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"nested\" : {\n"
+                + "    \"value\" : \"long text to stop formatter de-wrapping\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullString() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": \"null\" } } }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply.nested.age"));
+
+    // If the leaf node is the String "null", then pretty-print it as a JSON string.
+    assertThat(prettyJson).isEqualTo("\"null\"");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullValue() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": null } } }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply.nested.age"));
+
+    // If the leaf node is the value "null", then pretty-print it as the null value.
+    assertThat(prettyJson).isEqualTo("null");
+  }
+
+  @Test
   public void locked_makesCfJsonDocumentContextImmutable() {
     CfJsonDocumentContext data = new CfJsonDocumentContext();
     // Can mutate before CfJsonDocumentContext is locked.

--- a/server/test/services/export/CsvExporterTest.java
+++ b/server/test/services/export/CsvExporterTest.java
@@ -196,7 +196,7 @@ public class CsvExporterTest extends AbstractExporterTest {
     createFakeQuestions();
     createFakeProgram();
     createFakeApplications();
-    createFakeProgramWithEnumerator();
+    createFakeProgramWithEnumeratorAndAnswerQuestions();
 
     CsvExporterService exporterService = instanceOf(CsvExporterService.class);
     CSVParser parser =
@@ -236,7 +236,7 @@ public class CsvExporterTest extends AbstractExporterTest {
     createFakeQuestions();
     createFakeProgram();
     createFakeApplications();
-    createFakeProgramWithEnumerator();
+    createFakeProgramWithEnumeratorAndAnswerQuestions();
 
     // Generate default CSV
     CsvExporterService exporterService = instanceOf(CsvExporterService.class);

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -127,7 +127,7 @@ public class JsonExporterTest extends AbstractExporterTest {
 
   @Test
   public void testQuestionTypesWithEnumerators() throws Exception {
-    createFakeProgramWithEnumerator();
+    createFakeProgramWithEnumeratorAndAnswerQuestions();
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
     String resultJsonString =
@@ -186,8 +186,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenAddressQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller()
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantAddress()).build();
+    new FakeApplicationFiller(fakeProgram)
         .answerAddressQuestion("12345 E South St", "Apt 8i", "CityVille Township", "OR", "54321")
         .submit();
 
@@ -212,8 +213,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenAddressQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantAddress()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -236,8 +238,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenCheckboxQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller()
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
+    new FakeApplicationFiller(fakeProgram)
         .answerCheckboxQuestion(
             ImmutableList.of(
                 2L, // "pepper grinder"
@@ -263,8 +266,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenCheckboxQuestionIsNotAnswered_valueInResponseIsEmptyArray() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -283,8 +287,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenCurrencyQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().answerCurrencyQuestion("5,444.33").submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
+    new FakeApplicationFiller(fakeProgram).answerCurrencyQuestion("5,444.33").submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -304,8 +309,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenCurrencyQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -324,8 +330,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenDateQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().answerDateQuestion("2015-10-21").submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
+    new FakeApplicationFiller(fakeProgram).answerDateQuestion("2015-10-21").submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -344,8 +351,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenDateQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -364,8 +372,11 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenEmailQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().answerEmailQuestion("chell@aperturescience.com").submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantEmail()).build();
+    new FakeApplicationFiller(fakeProgram)
+        .answerEmailQuestion("chell@aperturescience.com")
+        .submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -385,8 +396,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenEmailQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantEmail()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -405,8 +417,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenNumberQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().answerNumberQuestion(42).submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
+    new FakeApplicationFiller(fakeProgram).answerNumberQuestion(42).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -425,8 +438,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenNumberQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -445,8 +459,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenPhoneQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().answerPhoneQuestion("US", "(555) 867-5309").submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
+    new FakeApplicationFiller(fakeProgram).answerPhoneQuestion("US", "(555) 867-5309").submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -465,8 +480,9 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void export_whenPhoneQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
-    createFakeProgram();
-    new FakeApplicationFiller().submit();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
 
     JsonExporter exporter = instanceOf(JsonExporter.class);
 
@@ -480,6 +496,74 @@ public class JsonExporterTest extends AbstractExporterTest {
     ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
 
     resultAsserter.assertNullValueAtApplicationPath(".applicant_phone.phone_number");
+  }
+
+  @Test
+  public void
+      export_whenEnumeratorAndRepeatedQuestionsAreAnswered_repeatedEntitiesHaveAnswerInResponse() {
+    createFakeQuestions();
+    Program fakeProgram = new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
+    new FakeApplicationFiller(fakeProgram)
+        .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
+        .answerRepeatedTextQuestion("tswift", "hearts")
+        .answerRepeatedTextQuestion("carly rae", "stars")
+        .submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter
+            .export(
+                fakeProgram.getProgramDefinition(),
+                IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+                SubmittedApplicationFilter.EMPTY)
+            .getLeft();
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_household_members",
+        "[ {\n"
+            + "  \"household_member_favorite_shape\" : {\n"
+            + "    \"text\" : \"stars\"\n"
+            + "  }\n"
+            + "}, {\n"
+            + "  \"household_member_favorite_shape\" : {\n"
+            + "    \"text\" : \"hearts\"\n"
+            + "  }\n"
+            + "} ]");
+  }
+
+  @Test
+  public void
+      export_whenEnumeratorQuestionIsAnsweredAndRepeatedQuestionIsNot_repeatedEntitiesHaveNullAnswers() {
+    createFakeQuestions();
+    Program fakeProgram = new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
+    new FakeApplicationFiller(fakeProgram)
+        .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
+        .submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter
+            .export(
+                fakeProgram.getProgramDefinition(),
+                IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+                SubmittedApplicationFilter.EMPTY)
+            .getLeft();
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_household_members",
+        "[ {\n"
+            + "  \"household_member_favorite_shape\" : {\n"
+            + "    \"text\" : null\n"
+            + "  }\n"
+            + "}, {\n"
+            + "  \"household_member_favorite_shape\" : {\n"
+            + "    \"text\" : null\n"
+            + "  }\n"
+            + "} ]");
   }
 
   @Test
@@ -572,6 +656,11 @@ public class JsonExporterTest extends AbstractExporterTest {
     private void assertNullValueAtApplicationPath(int resultNumber, String innerPath) {
       Path path = Path.create("$[" + resultNumber + "].application" + innerPath);
       assertThat(resultJson.hasNullValueAtPath(path)).isTrue();
+    }
+
+    private void assertJsonAtApplicationPath(String innerPath, String prettyJson) {
+      Path path = Path.create("$[0].application" + innerPath);
+      assertThat(resultJson.asPrettyJsonString(path)).isEqualTo(prettyJson);
     }
   }
 }

--- a/server/test/services/export/JsonPrettifierTest.java
+++ b/server/test/services/export/JsonPrettifierTest.java
@@ -1,0 +1,62 @@
+package services.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static services.export.JsonPrettifier.asPrettyJsonString;
+
+import org.junit.Test;
+import services.applicant.JsonPathProvider;
+
+public class JsonPrettifierTest {
+  @Test
+  public void asPrettyJsonString_prettyPrintsJsonString() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": 12 } } }";
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"deeply\" : {\n"
+                + "    \"nested\" : {\n"
+                + "      \"age\" : 12\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullString() {
+    String testData = "\"null\""; // A JSON document that is the string "null"
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson).isEqualTo("\"null\"");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsJsonObject() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": 12 } } }";
+    Object jsonObject = JsonPathProvider.getJsonPath().parse(testData).json();
+
+    String prettyJson = asPrettyJsonString(jsonObject);
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"deeply\" : {\n"
+                + "    \"nested\" : {\n"
+                + "      \"age\" : 12\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullValue() {
+    Object testData = null; // A JSON document that is the value `null`
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson).isEqualTo("null");
+  }
+}

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -170,6 +170,15 @@ public class TestQuestionBank {
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME, this::applicantHouseholdMemberName);
   }
 
+  // Repeated test
+  public Question applicantHouseholdMemberFavoriteShape() {
+    // Make sure the next call will have the question ready
+    applicantHouseholdMembers();
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE,
+        this::applicantHouseholdMemberFavoriteShape);
+  }
+
   // Number
   public Question applicantJugglingNumber() {
     return questionCache.computeIfAbsent(
@@ -382,6 +391,21 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  // Repeated text
+  private Question applicantHouseholdMemberFavoriteShape(QuestionEnum ignore) {
+    Question householdMembers = applicantHouseholdMembers();
+    QuestionDefinition definition =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("household member favorite shape")
+                .setDescription("The applicant household member's favorite shape")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is $this's favorite shape?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setEnumeratorId(Optional.of(householdMembers.id))
+                .build());
+    return maybeSave(definition);
+  }
+
   // Number
   private Question applicantJugglingNumber(QuestionEnum ignore) {
     QuestionDefinition definition =
@@ -535,6 +559,7 @@ public class TestQuestionBank {
     APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
     APPLICANT_HOUSEHOLD_MEMBER_NAME,
+    APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE,
     APPLICANT_HOUSEHOLD_MEMBER_JOBS,
     APPLICANT_MONTHLY_INCOME,
     APPLICANT_ICE_CREAM,


### PR DESCRIPTION
### Description

- Adds tests to JsonExporter for unanswered repeated questions
- Adds a `FakeProgramBuilder` to `AbstractExporterTest` to ease building fake programs to use for testing
- No changes are necessary to the actual exporter after #5225, but this should catch future regressions

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

n/a

### Issue(s) this completes

Fixes #5277
