### PR TITLE
Fix string formatting in log messages

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -319,7 +319,7 @@ public final class DevDatabaseSeedTask {
       fn.run();
       transaction.commit();
     } catch (NonUniqueResultException | SerializableConflictException | RollbackException e) {
-      LOGGER.warn("Database seed transaction failed: %s", e);
+      LOGGER.warn("Database seed transaction failed: {}", e);
 
       if (tryCount > MAX_RETRIES) {
         throw new RuntimeException(e);

--- a/server/app/filters/ApiKeyUsageFilter.java
+++ b/server/app/filters/ApiKeyUsageFilter.java
@@ -78,7 +78,7 @@ public class ApiKeyUsageFilter extends EssentialFilter {
                           }
                         }
                       } catch (RuntimeException e) {
-                        LOGGER.error("Error updating ApiKey usage: %s", e.toString());
+                        LOGGER.error("Error updating ApiKey usage: {}", e.toString());
                       }
 
                       return result;

--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -119,7 +119,7 @@ public final class DatabaseSeedTask {
     for (QuestionDefinition questionDefinition : CANONICAL_QUESTIONS) {
       if (existingCanonicalQuestions.containsKey(questionDefinition.getName())) {
         LOGGER.info(
-            "Canonical question \"%s\" exists at server start", questionDefinition.getName());
+            "Canonical question \"{}\" exists at server start", questionDefinition.getName());
         questionDefinitions.add(existingCanonicalQuestions.get(questionDefinition.getName()));
       } else {
         inSerializableTransaction(
@@ -146,7 +146,7 @@ public final class DatabaseSeedTask {
               questionDefinition.getName(), errorMessages));
       return Optional.empty();
     } else {
-      LOGGER.info("Created canonical question \"%s\"", questionDefinition.getName());
+      LOGGER.info("Created canonical question \"{}\"", questionDefinition.getName());
       return Optional.of(result.getResult());
     }
   }
@@ -159,7 +159,7 @@ public final class DatabaseSeedTask {
       fn.run();
       transaction.commit();
     } catch (NonUniqueResultException | SerializableConflictException | RollbackException e) {
-      LOGGER.warn("Database seed transaction failed: %s", e);
+      LOGGER.warn("Database seed transaction failed: {}", e);
 
       if (tryCount > MAX_RETRIES) {
         throw new RuntimeException(e);


### PR DESCRIPTION
`String.format` substitutes argument strings into a format string by replacing the `%s` char sequence.
`org.slf4j.Logger` substitutes argument strings into a format string by replacing the `{}` char sequence.

This PR fixes a few places where we are using the former syntax in calls to the latter method.