### PR TITLE
Use canonical identifiers for question and program translations

### DIFF
--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -100,15 +100,13 @@ public class AdminProgramTranslationsController extends CiviFormController {
   }
 
   private ProgramDefinition getDraftProgramDefinition(String programName) {
-    ProgramDefinition program =
-        service
-            .getActiveAndDraftPrograms()
-            .getDraftProgramDefinition(programName)
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format("No draft found for program: \"%s\"", programName)));
-    return program;
+    return service
+        .getActiveAndDraftPrograms()
+        .getDraftProgramDefinition(programName)
+        .orElseThrow(
+            () ->
+                new BadRequestException(
+                    String.format("No draft found for program: \"%s\"", programName)));
   }
 
   /**

--- a/server/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/server/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.data.FormFactory;
-import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.VersionRepository;
@@ -32,7 +31,6 @@ import views.components.ToastMessage;
 /** Provides controller methods for editing and updating question translations. */
 public class AdminQuestionTranslationsController extends CiviFormController {
 
-  private final HttpExecutionContext httpExecutionContext;
   private final QuestionService questionService;
   private final QuestionTranslationView translationView;
   private final FormFactory formFactory;
@@ -43,13 +41,11 @@ public class AdminQuestionTranslationsController extends CiviFormController {
   public AdminQuestionTranslationsController(
       ProfileUtils profileUtils,
       VersionRepository versionRepository,
-      HttpExecutionContext httpExecutionContext,
       QuestionService questionService,
       QuestionTranslationView translationView,
       FormFactory formFactory,
       TranslationLocales translationLocales) {
     super(profileUtils, versionRepository);
-    this.httpExecutionContext = checkNotNull(httpExecutionContext);
     this.questionService = checkNotNull(questionService);
     this.translationView = checkNotNull(translationView);
     this.formFactory = checkNotNull(formFactory);

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -98,10 +98,18 @@ public final class ActiveAndDraftPrograms {
   }
 
   public Optional<ProgramDefinition> getActiveProgramDefinition(String name) {
+    if (!versionedByName.containsKey(name)) {
+      return Optional.empty();
+    }
+
     return versionedByName.get(name).first();
   }
 
   public Optional<ProgramDefinition> getDraftProgramDefinition(String name) {
+    if (!versionedByName.containsKey(name)) {
+      return Optional.empty();
+    }
+
     return versionedByName.get(name).second();
   }
 

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -50,10 +50,10 @@ public abstract class TranslationFormView extends BaseHtmlView {
   }
 
   /**
-   * Given the ID of the entity to translate and a locale for translation, returns a link
+   * Given the name of the entity to translate and a locale for translation, returns a link
    * destination URL for the edit form to translate the entity in the given locale.
    */
-  protected abstract String languageLinkDestination(String entityId, Locale locale);
+  protected abstract String languageLinkDestination(String entityName, Locale locale);
 
   /**
    * Renders a single locale as the English version of the language (ex: es-US would read

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -36,14 +36,14 @@ public abstract class TranslationFormView extends BaseHtmlView {
   }
 
   /** Render a list of languages, with the currently selected language underlined. */
-  protected final DivTag renderLanguageLinks(long entityId, Locale currentlySelected) {
+  protected final DivTag renderLanguageLinks(String entityName, Locale currentlySelected) {
     return div()
         .withClasses("m-2")
         .with(
             each(
                 translationLocales.translatableLocales(),
                 locale -> {
-                  String linkDestination = languageLinkDestination(entityId, locale);
+                  String linkDestination = languageLinkDestination(entityName, locale);
                   return renderLanguageLink(
                       linkDestination, locale, locale.equals(currentlySelected));
                 }));
@@ -53,7 +53,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
    * Given the ID of the entity to translate and a locale for translation, returns a link
    * destination URL for the edit form to translate the entity in the given locale.
    */
-  protected abstract String languageLinkDestination(long entityId, Locale locale);
+  protected abstract String languageLinkDestination(String entityId, Locale locale);
 
   /**
    * Renders a single locale as the English version of the language (ex: es-US would read

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -409,7 +409,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       return Optional.empty();
     }
     String linkDestination =
-        routes.AdminProgramTranslationsController.redirectToFirstLocale(program.id()).url();
+        routes.AdminProgramTranslationsController.redirectToFirstLocale(program.adminName()).url();
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withId("program-translations-link-" + program.id())

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -146,7 +146,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
       return Optional.empty();
     }
     String linkDestination =
-        routes.AdminProgramTranslationsController.redirectToFirstLocale(program.id()).url();
+        routes.AdminProgramTranslationsController.redirectToFirstLocale(program.adminName()).url();
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withClass(ButtonStyles.OUTLINED_WHITE_WITH_ICON);

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -49,7 +49,7 @@ public final class ProgramTranslationView extends TranslationFormView {
       Optional<ToastMessage> message) {
     String formAction =
         controllers.admin.routes.AdminProgramTranslationsController.update(
-                program.id(), locale.toLanguageTag())
+                program.adminName(), locale.toLanguageTag())
             .url();
     FormTag form =
         renderTranslationForm(request, locale, formAction, formFields(program, translationForm));
@@ -61,7 +61,8 @@ public final class ProgramTranslationView extends TranslationFormView {
         layout
             .getBundle(request)
             .setTitle(title)
-            .addMainContent(renderHeader(title), renderLanguageLinks(program.id(), locale), form);
+            .addMainContent(
+                renderHeader(title), renderLanguageLinks(program.adminName(), locale), form);
 
     message.ifPresent(htmlBundle::addToastMessages);
 
@@ -69,8 +70,9 @@ public final class ProgramTranslationView extends TranslationFormView {
   }
 
   @Override
-  protected String languageLinkDestination(long programId, Locale locale) {
-    return routes.AdminProgramTranslationsController.edit(programId, locale.toLanguageTag()).url();
+  protected String languageLinkDestination(String programName, Locale locale) {
+    return routes.AdminProgramTranslationsController.edit(programName, locale.toLanguageTag())
+        .url();
   }
 
   private ImmutableList<DomContent> formFields(

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -58,7 +58,7 @@ public final class QuestionTranslationView extends TranslationFormView {
       Optional<ToastMessage> message) {
     String formAction =
         controllers.admin.routes.AdminQuestionTranslationsController.update(
-                question.getId(), locale.toLanguageTag())
+                question.getName(), locale.toLanguageTag())
             .url();
 
     // Add form fields for questions.
@@ -82,16 +82,16 @@ public final class QuestionTranslationView extends TranslationFormView {
             .getBundle(request)
             .setTitle(title)
             .addMainContent(
-                renderHeader(title), renderLanguageLinks(question.getId(), locale), form);
+                renderHeader(title), renderLanguageLinks(question.getName(), locale), form);
     message.ifPresent(htmlBundle::addToastMessages);
 
     return layout.renderCentered(htmlBundle);
   }
 
   @Override
-  protected String languageLinkDestination(long questionId, Locale locale) {
+  protected String languageLinkDestination(String questionName, Locale locale) {
     return controllers.admin.routes.AdminQuestionTranslationsController.edit(
-            questionId, locale.toLanguageTag())
+            questionName, locale.toLanguageTag())
         .url();
   }
 

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -579,7 +579,7 @@ public final class QuestionsListView extends BaseHtmlView {
     }
     String link =
         controllers.admin.routes.AdminQuestionTranslationsController.redirectToFirstLocale(
-                definition.getId())
+                definition.getName())
             .url();
 
     ButtonTag button =

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -39,9 +39,9 @@ GET     /admin/programs/:programId/statuses controllers.admin.AdminProgramStatus
 POST    /admin/programs/:programId/statuses/delete controllers.admin.AdminProgramStatusesController.delete(request: Request, programId: Long)
 
 # Routes for managing program localization
-GET     /admin/programs/:programId/translations/edit controllers.admin.AdminProgramTranslationsController.redirectToFirstLocale(request: Request, programId: Long)
-GET     /admin/programs/:programId/translations/:locale/edit    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programId: Long, locale: String)
-POST    /admin/programs/:programId/translations/:locale         controllers.admin.AdminProgramTranslationsController.update(request: Request, programId: Long, locale: String)
+GET     /admin/programs/:programName/translations/edit            controllers.admin.AdminProgramTranslationsController.redirectToFirstLocale(request: Request, programName: String)
+GET     /admin/programs/:programName/translations/:locale/edit    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programName: String, locale: String)
+POST    /admin/programs/:programName/translations/:locale         controllers.admin.AdminProgramTranslationsController.update(request: Request, programName: String, locale: String)
 
 
 # A controller for pages for an admin to create and maintain blocks for a program
@@ -86,9 +86,9 @@ POST    /admin/questions/:id/restore controllers.admin.AdminQuestionController.r
 POST    /admin/questions/:id/archive controllers.admin.AdminQuestionController.archive(request: Request, id: Long)
 
 # Routes for editing question localizations
-GET     /admin/questions/:questionId/translations/edit controllers.admin.AdminQuestionTranslationsController.redirectToFirstLocale(request: Request, questionId: Long)
-GET     /admin/questions/:questionId/translations/:locale/edit  controllers.admin.AdminQuestionTranslationsController.edit(request: Request, questionId: Long, locale: String)
-POST    /admin/questions/:questionId/translations/:locale       controllers.admin.AdminQuestionTranslationsController.update(request: Request, questionId: Long, locale: String)
+GET     /admin/questions/:questionName/translations/edit          controllers.admin.AdminQuestionTranslationsController.redirectToFirstLocale(request: Request, questionName: String)
+GET     /admin/questions/:questionName/translations/:locale/edit  controllers.admin.AdminQuestionTranslationsController.edit(request: Request, questionName: String, locale: String)
+POST    /admin/questions/:questionName/translations/:locale       controllers.admin.AdminQuestionTranslationsController.update(request: Request, questionName: String, locale: String)
 
 # Trusted Intermediary routes
 GET     /admin/tiGroups                    controllers.admin.TrustedIntermediaryManagementController.index(request: Request)

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -10,6 +10,7 @@ import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import controllers.BadRequestException;
 import java.util.Locale;
 import java.util.Optional;
 import models.Program;
@@ -57,7 +58,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
   public void edit_defaultLocaleRedirectsWithError() throws ProgramNotFoundException {
     Program program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), program.id, "en-US");
+    Result result =
+        controller.edit(
+            addCSRFToken(fakeRequest()).build(),
+            program.getProgramDefinition().adminName(),
+            "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
@@ -69,7 +74,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
   public void edit_rendersFormWithExistingContent_otherLocale() throws ProgramNotFoundException {
     Program program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), program.id, "es-US");
+    Result result =
+        controller.edit(
+            addCSRFToken(fakeRequest()).build(),
+            program.getProgramDefinition().adminName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -98,7 +107,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
       throws ProgramNotFoundException {
     Program program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_NO_EMAIL);
 
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), program.id, "es-US");
+    Result result =
+        controller.edit(
+            addCSRFToken(fakeRequest()).build(),
+            program.getProgramDefinition().adminName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -121,8 +134,12 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_programNotFound_returnsNotFound() {
-    assertThatThrownBy(() -> controller.edit(addCSRFToken(fakeRequest()).build(), 1000L, "es-US"))
-        .isInstanceOf(ProgramNotFoundException.class);
+    assertThatThrownBy(
+            () ->
+                controller.edit(
+                    addCSRFToken(fakeRequest()).build(), "non-existent program name", "es-US"))
+        .hasMessage("No draft found for program: \"non-existent program name\"")
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test
@@ -143,7 +160,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
                     .put("localized-email-1", "updated spanish second status email")
                     .build());
 
-    Result result = controller.update(addCSRFToken(requestBuilder).build(), program.id, "es-US");
+    Result result =
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            program.getProgramDefinition().adminName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation().orElse(""))
@@ -201,8 +222,12 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void update_programNotFound() {
-    assertThatThrownBy(() -> controller.update(addCSRFToken(fakeRequest()).build(), 1000L, "es-US"))
-        .isInstanceOf(ProgramNotFoundException.class);
+    assertThatThrownBy(
+            () ->
+                controller.update(
+                    addCSRFToken(fakeRequest()).build(), "non-existent program name", "es-US"))
+        .hasMessage("No draft found for program: \"non-existent program name\"")
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test
@@ -226,7 +251,11 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
                     .put("localized-email-1", "new second status email")
                     .build());
 
-    Result result = controller.update(addCSRFToken(requestBuilder).build(), program.id, "es-US");
+    Result result =
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            program.getProgramDefinition().adminName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -262,12 +291,17 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
                     .put("localized-email-1", "updated spanish second status email")
                     .build());
 
-    Result result = controller.update(addCSRFToken(requestBuilder).build(), program.id, "es-US");
+    Result result =
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            program.getProgramDefinition().adminName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation().orElse(""))
         .isEqualTo(
-            controllers.admin.routes.AdminProgramTranslationsController.edit(program.id, "es-US")
+            controllers.admin.routes.AdminProgramTranslationsController.edit(
+                    program.getProgramDefinition().adminName(), "es-US")
                 .url());
     assertThat(result.flash().get("error").get())
         .isEqualTo("The program's associated statuses are out of date.");

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -1,14 +1,15 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
+import controllers.BadRequestException;
 import java.util.Locale;
 import models.Question;
 import models.Version;
@@ -53,10 +54,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     Question question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller
-            .edit(addCSRFToken(fakeRequest()).build(), question.id, "en-US")
-            .toCompletableFuture()
-            .join();
+        controller.edit(
+            addCSRFToken(fakeRequest()).build(),
+            question.getQuestionDefinition().getName(),
+            "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminQuestionController.index().url());
@@ -69,10 +70,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     Question question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller
-            .edit(addCSRFToken(fakeRequest()).build(), question.id, "es-US")
-            .toCompletableFuture()
-            .join();
+        controller.edit(
+            addCSRFToken(fakeRequest()).build(),
+            question.getQuestionDefinition().getName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -88,13 +89,12 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_questionNotFound_returnsNotFound() {
-    Result result =
-        controller
-            .edit(addCSRFToken(fakeRequest()).build(), 1000L, "es-US")
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThatThrownBy(
+            () ->
+                controller.edit(
+                    addCSRFToken(fakeRequest()).build(), "non-existent question name", "es-US"))
+        .hasMessage("No draft found for question: \"non-existent question name\"")
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test
@@ -110,10 +110,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     "updated spanish help text"));
 
     Result result =
-        controller
-            .update(addCSRFToken(requestBuilder).build(), question.id, "es-US")
-            .toCompletableFuture()
-            .join();
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            question.getQuestionDefinition().getName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
@@ -144,10 +144,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     "updated spanish question help text"));
 
     Result result =
-        controller
-            .update(addCSRFToken(requestBuilder).build(), question.id, "es-US")
-            .toCompletableFuture()
-            .join();
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            question.getQuestionDefinition().getName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
@@ -166,13 +166,12 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void update_questionNotFound_returnsNotFound() {
-    Result result =
-        controller
-            .update(addCSRFToken(fakeRequest()).build(), 1000L, "es-US")
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThatThrownBy(
+            () ->
+                controller.update(
+                    addCSRFToken(fakeRequest()).build(), "non-existent question name", "es-US"))
+        .hasMessage("No draft found for question: \"non-existent question name\"")
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test
@@ -183,10 +182,10 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
         fakeRequest().bodyForm(ImmutableMap.of("questionText", "", "questionHelpText", ""));
 
     Result result =
-        controller
-            .update(addCSRFToken(requestBuilder).build(), question.id, "es-US")
-            .toCompletableFuture()
-            .join();
+        controller.update(
+            addCSRFToken(requestBuilder).build(),
+            question.getQuestionDefinition().getName(),
+            "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))


### PR DESCRIPTION
### Description

UI for editing translations use specific question/program (QP) IDs, so that when the form is rendered and submitted it is with regard to a specific version of a QP. This could potentially cause data inconsistency issues if a user has browser pages open to stale versions of the question since the code to update a translation calls [QuestionService#update](https://github.com/civiform/civiform/blob/use-canonical-references-for-programs-and-questions/server/app/services/question/QuestionService.java) which calls [createOrUpdateDraft](https://github.com/civiform/civiform/blob/use-canonical-references-for-programs-and-questions/server/app/services/question/QuestionService.java#L147) -- since the draft has a new ID, multiple drafts could be created this way.

This PR changes all IDs in URLs in the questions and programs translation UI to use the QP name, which is immutable across multiple versions, to ensure that the regardless of stale browser state, the server loads the current draft for the question or program, or throws a `BadRequestException` if no draft is available.

A possible follow up to this PR would be to create a draft is one does not exist yet for a better admin experience, but it should a rare occurrence  (only possible with stale browser state) given that the button to access the translation UI is only available after creating a new draft of the QP.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Contributes to https://github.com/civiform/civiform/issues/5282