### PR TITLE
Use `QuestionAnswerer` in `QuestionJsonSampler`

### DIFF
--- a/server/app/controllers/api/ApiDocsController.java
+++ b/server/app/controllers/api/ApiDocsController.java
@@ -48,10 +48,10 @@ public final class ApiDocsController {
 
     ImmutableSet<String> allProgramSlugs = programService.getAllProgramSlugs();
 
+    ProgramDefinition programDefinition;
     try {
-      ProgramDefinition programDefinition =
+      programDefinition =
           programService.getActiveProgramDefinitionAsync(programSlug).toCompletableFuture().join();
-      return ok(docsView.render(request, programDefinition, allProgramSlugs));
     } catch (Exception e) {
       return notFound(
           String.format(
@@ -59,5 +59,7 @@ public final class ApiDocsController {
                   + " to continue.",
               programSlug));
     }
+
+    return ok(docsView.render(request, programDefinition, allProgramSlugs));
   }
 }

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -26,6 +26,7 @@ import services.applicant.question.SingleSelectQuestion;
 import services.applicant.question.TextQuestion;
 import services.program.ProgramQuestionDefinition;
 import services.question.LocalizedQuestionOption;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 
@@ -50,7 +51,7 @@ public interface QuestionJsonSampler<Q extends Question> {
         new ApplicantQuestion(programQuestionDefinition, applicantData, Optional.empty());
 
     Q question = getQuestion(applicantQuestion);
-    addSampleData(applicantData, question);
+    addSampleData(applicantData, applicantQuestion);
 
     // Suppress warning about unchecked assignment because the JSON presenter is parameterized on
     // the question type, which we know matches Q.
@@ -65,7 +66,7 @@ public interface QuestionJsonSampler<Q extends Question> {
 
   Q getQuestion(ApplicantQuestion applicantQuestion);
 
-  void addSampleData(ApplicantData applicantData, Q question);
+  void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion);
 
   QuestionJsonPresenter getJsonPresenter();
 
@@ -175,15 +176,20 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, AddressQuestion question) {
-      applicantData.putString(question.getStreetPath(), "742 Evergreen Terrace");
-      applicantData.putString(question.getCityPath(), "Springfield");
-      applicantData.putString(question.getStatePath(), "OR");
-      applicantData.putString(question.getZipPath(), "97403");
-      applicantData.putString(question.getLatitudePath(), "44.0462");
-      applicantData.putString(question.getLongitudePath(), "-123.0236");
-      applicantData.putString(question.getWellKnownIdPath(), "23214");
-      applicantData.putString(question.getServiceAreaPath(), "springfield_county");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerAddressQuestion(
+          applicantData,
+          applicantQuestion.getContextualizedPath(),
+          /* street= */ "742 Evergreen Terrace",
+          /* line2= */ "",
+          /* city= */ "Springfield",
+          /* state= */ "OR",
+          /* zip= */ "97403",
+          /* corrected= */ "",
+          /* latitude= */ 44.0462,
+          /* longitude= */ -123.0236,
+          /* wellKnownId= */ 23214L,
+          /* serviceArea= */ "springfield_county");
     }
 
     @Override
@@ -207,8 +213,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, CurrencyQuestion question) {
-      applicantData.putCurrencyDollars(question.getCurrencyPath(), "123.45");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerCurrencyQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "123.45");
     }
 
     @Override
@@ -231,8 +238,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, DateQuestion question) {
-      applicantData.putDate(question.getDatePath(), "2023-01-02");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerDateQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "2023-01-02");
     }
 
     @Override
@@ -255,8 +263,11 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, EmailQuestion question) {
-      applicantData.putString(question.getEmailPath(), "homer.simpson@springfield.gov");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerEmailQuestion(
+          applicantData,
+          applicantQuestion.getContextualizedPath(),
+          "homer.simpson@springfield.gov");
     }
 
     @Override
@@ -278,7 +289,7 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, Question question) {
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
       // no-op
     }
 
@@ -302,8 +313,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, FileUploadQuestion question) {
-      applicantData.putString(question.getFileKeyPath(), "my-file-key");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerFileQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "my-file-key");
     }
 
     @Override
@@ -326,8 +338,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, IdQuestion question) {
-      applicantData.putLong(question.getIdPath(), 12345L);
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerIdQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "12345");
     }
 
     @Override
@@ -352,18 +365,25 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, MultiSelectQuestion question) {
-      ImmutableList.Builder<Long> localizedOptionsBuilder = ImmutableList.builder();
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      ImmutableList<LocalizedQuestionOption> questionOptions =
+          applicantQuestion.createMultiSelectQuestion().getOptions();
 
       // Add up to two options to the sample data.
-      if (question.getOptions().size() > 0) {
-        localizedOptionsBuilder.add(question.getOptions().get(0).id());
+      if (questionOptions.size() > 0) {
+        QuestionAnswerer.answerMultiSelectQuestion(
+            applicantData,
+            applicantQuestion.getContextualizedPath(),
+            /* index= */ 0,
+            questionOptions.get(0).id());
       }
-      if (question.getOptions().size() > 1) {
-        localizedOptionsBuilder.add(question.getOptions().get(1).id());
+      if (questionOptions.size() > 1) {
+        QuestionAnswerer.answerMultiSelectQuestion(
+            applicantData,
+            applicantQuestion.getContextualizedPath(),
+            /* index= */ 1,
+            questionOptions.get(1).id());
       }
-
-      applicantData.putArray(question.getSelectionPath(), localizedOptionsBuilder.build());
     }
 
     @Override
@@ -386,10 +406,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, NameQuestion question) {
-      applicantData.putString(question.getFirstNamePath(), "Homer");
-      applicantData.putString(question.getMiddleNamePath(), "Jay");
-      applicantData.putString(question.getLastNamePath(), "Simpson");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerNameQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "Homer", "Jay", "Simpson");
     }
 
     @Override
@@ -413,8 +432,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, NumberQuestion question) {
-      applicantData.putLong(question.getNumberPath(), 12321);
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerNumberQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), 12321);
     }
 
     @Override
@@ -437,9 +457,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, PhoneQuestion question) {
-      applicantData.putPhoneNumber(question.getPhoneNumberPath(), "(214)-367-3764");
-      applicantData.putString(question.getCountryCodePath(), "US");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerPhoneQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "US", "(214)-367-3764");
     }
 
     @Override
@@ -465,10 +485,14 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, SingleSelectQuestion question) {
-      if (question.getOptions().size() != 0) {
-        LocalizedQuestionOption firstOption = question.getOptions().get(0);
-        applicantData.putLong(question.getSelectionPath(), firstOption.id());
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      ImmutableList<LocalizedQuestionOption> questionOptions =
+          applicantQuestion.createSingleSelectQuestion().getOptions();
+
+      if (questionOptions.size() != 0) {
+        LocalizedQuestionOption firstOption = questionOptions.get(0);
+        QuestionAnswerer.answerSingleSelectQuestion(
+            applicantData, applicantQuestion.getContextualizedPath(), firstOption.id());
       }
     }
 
@@ -492,8 +516,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     }
 
     @Override
-    public void addSampleData(ApplicantData applicantData, TextQuestion question) {
-      applicantData.putString(question.getTextPath(), "I love CiviForm!");
+    public void addSampleData(ApplicantData applicantData, ApplicantQuestion applicantQuestion) {
+      QuestionAnswerer.answerTextQuestion(
+          applicantData, applicantQuestion.getContextualizedPath(), "I love CiviForm!");
     }
 
     @Override

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -49,10 +49,9 @@ public interface QuestionJsonSampler<Q extends Question> {
     ApplicantData applicantData = new ApplicantData();
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(programQuestionDefinition, applicantData, Optional.empty());
-
-    Q question = getQuestion(applicantQuestion);
     addSampleData(applicantData, applicantQuestion);
 
+    Q question = getQuestion(applicantQuestion);
     // Suppress warning about unchecked assignment because the JSON presenter is parameterized on
     // the question type, which we know matches Q.
     @SuppressWarnings("unchecked")

--- a/server/app/services/question/QuestionAnswerer.java
+++ b/server/app/services/question/QuestionAnswerer.java
@@ -7,7 +7,7 @@ import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
 
 /** A class that has static methods used to answer {@link ApplicantQuestion}s for each type. */
-public class QuestionAnswerer {
+public final class QuestionAnswerer {
 
   public static void answerAddressQuestion(
       ApplicantData applicantData,

--- a/server/app/services/question/QuestionAnswerer.java
+++ b/server/app/services/question/QuestionAnswerer.java
@@ -1,4 +1,4 @@
-package support;
+package services.question;
 
 import com.google.common.collect.ImmutableList;
 import services.Path;

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -31,9 +31,9 @@ import play.test.Helpers;
 import repository.VersionRepository;
 import services.Path;
 import services.applicant.ApplicantData;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.QuestionAnswerer;
 
 public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -24,8 +24,8 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
+import services.question.QuestionAnswerer;
 import support.ProgramBuilder;
-import support.QuestionAnswerer;
 
 public class UpsellControllerTest extends WithMockedProfiles {
 

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -33,9 +33,9 @@ import services.application.ApplicationEventDetails.StatusEvent;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramType;
 import services.program.StatusDefinitions;
+import services.question.QuestionAnswerer;
 import support.CfTestHelpers;
 import support.ProgramBuilder;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class ProgramRepositoryTest extends ResetPostgres {

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -21,6 +21,7 @@ import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
+import services.question.QuestionAnswerer;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -28,7 +29,6 @@ import services.question.types.QuestionDefinitionConfig;
 import services.question.types.ScalarType;
 import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
-import support.QuestionAnswerer;
 import support.TestQuestionBank;
 
 public class BlockTest {

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -31,10 +31,10 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
 import services.question.types.ScalarType;
 import support.ProgramBuilder;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -20,9 +20,9 @@ import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.geo.ServiceAreaState;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class AddressQuestionTest {

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -15,12 +15,12 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 import services.question.types.ScalarType;
-import support.QuestionAnswerer;
 import support.TestQuestionBank;
 
 @RunWith(JUnitParamsRunner.class)

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -18,9 +18,9 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.CurrencyQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class CurrencyQuestionTest {

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -18,9 +18,9 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.DateQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class DateQuestionTest extends ResetPostgres {

--- a/server/test/services/applicant/question/EmailQuestionTest.java
+++ b/server/test/services/applicant/question/EmailQuestionTest.java
@@ -13,9 +13,9 @@ import org.junit.runner.RunWith;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
+import services.question.QuestionAnswerer;
 import services.question.types.EmailQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class EmailQuestionTest extends ResetPostgres {

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -20,10 +20,10 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 import support.TestQuestionBank;
 
 @RunWith(JUnitParamsRunner.class)

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -12,9 +12,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
+import services.question.QuestionAnswerer;
 import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class FileUploadQuestionTest {

--- a/server/test/services/applicant/question/IdQuestionTest.java
+++ b/server/test/services/applicant/question/IdQuestionTest.java
@@ -22,9 +22,9 @@ import services.LocalizedStrings;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class IdQuestionTest extends ResetPostgres {

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -16,12 +16,12 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 public class MultiSelectQuestionTest {
 

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -14,9 +14,9 @@ import org.junit.runner.RunWith;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class NameQuestionTest {

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -23,9 +23,9 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class NumberQuestionTest extends ResetPostgres {

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -19,9 +19,9 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class PhoneQuestionTest {

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -12,11 +12,11 @@ import org.junit.Test;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.question.LocalizedQuestionOption;
+import services.question.QuestionAnswerer;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 public class SingleSelectQuestionTest {
 

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -21,9 +21,9 @@ import services.LocalizedStrings;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.TextQuestionDefinition;
-import support.QuestionAnswerer;
 
 @RunWith(JUnitParamsRunner.class)
 public class TextQuestionTest extends ResetPostgres {

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -30,10 +30,10 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionType;
 import support.CfTestHelpers;
 import support.ProgramBuilder;
-import support.QuestionAnswerer;
 
 /**
  * Superclass for tests that exercise exporters. Helps with generating programs, questions, and

--- a/server/test/services/question/QuestionAnswererTest.java
+++ b/server/test/services/question/QuestionAnswererTest.java
@@ -1,4 +1,4 @@
-package support;
+package services.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/server/test/views/questiontypes/AddressRendererTest.java
+++ b/server/test/views/questiontypes/AddressRendererTest.java
@@ -16,9 +16,9 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionAnswerer;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 public class AddressRendererTest extends ResetPostgres {
 

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -17,12 +17,12 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionAnswerer;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 public class CheckboxQuestionRendererTest extends ResetPostgres {
 

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -16,9 +16,9 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionAnswerer;
 import services.question.types.CurrencyQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
 
 public class CurrencyQuestionRendererTest extends ResetPostgres {

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -17,11 +17,11 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionAnswerer;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
 
 public class DropdownQuestionRendererTest extends ResetPostgres {

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -17,10 +17,10 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.IdQuestionDefinition.IdValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 
 public class IdQuestionRendererTest extends ResetPostgres {
   private static final IdQuestionDefinition ID_QUESTION_DEFINITION =

--- a/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -16,11 +16,11 @@ import play.i18n.Messages;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionAnswerer;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.QuestionDefinitionConfig;
-import support.QuestionAnswerer;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
 
 public class RadioButtonQuestionRendererTest {

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -16,10 +16,10 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
+import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
-import support.QuestionAnswerer;
 
 public class TextQuestionRendererTest extends ResetPostgres {
   private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =


### PR DESCRIPTION
### Description

Greatly simplify `QuestionJsonSampler` by using `QuestionAnswerer` to answer questions.

Details:
- Move `QuestionAnswerer` from `support` to `services.question` directory (originally it was only for tests)
- Call `QuestionAnswerer` in the `addSampleData` method of each `QuestionJsonSampler`.

## Release notes

None.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
   - Existing `api_docs.test.ts` and `QuestionJsonSamplerTest` ensure the change is consistent with previous behavior.
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

None.

#### New Features

None.

### Instructions for manual testing

None.

### Issue(s) this completes

Relates to #5262