### PR TITLE
Allow admin view/edit to load with question definition errors

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -6,6 +6,7 @@ import static views.ViewUtils.ProgramDisplayType.DRAFT;
 
 import auth.Authorizers;
 import auth.ProfileUtils;
+import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import forms.BlockForm;
 import java.util.Optional;
@@ -249,7 +250,12 @@ public final class AdminProgramBlocksController extends CiviFormController {
 
     return ok(
         editView.render(
-            request, program, block, message, roQuestionService.getUpToDateQuestions()));
+            request,
+            program,
+            block,
+            message,
+            roQuestionService.getUpToDateQuestions(),
+            ImmutableList.of()));
   }
 
   private Result renderReadOnlyViewWithMessage(
@@ -257,9 +263,13 @@ public final class AdminProgramBlocksController extends CiviFormController {
     ReadOnlyQuestionService roQuestionService =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join();
 
+    var allQuestions = roQuestionService.getUpToDateQuestions();
+    var allPreviousVersionQuestions =
+        questionService.getAllPreviousVersionQuestions(versionRepository.getActiveVersion());
+
     return ok(
         readOnlyView.render(
-            request, program, block, Optional.empty(), roQuestionService.getUpToDateQuestions()));
+            request, program, block, Optional.empty(), allQuestions, allPreviousVersionQuestions));
   }
 
   private Result renderEditViewWithMessage(
@@ -282,7 +292,8 @@ public final class AdminProgramBlocksController extends CiviFormController {
               blockDefinition,
               blockDefinition.programQuestionDefinitions(),
               message,
-              roQuestionService.getUpToDateQuestions()));
+              roQuestionService.getUpToDateQuestions(),
+              ImmutableList.of()));
     } catch (ProgramBlockDefinitionNotFoundException e) {
       return notFound(e.toString());
     }

--- a/server/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/server/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -166,6 +166,7 @@ public class AdminQuestionTranslationsController extends CiviFormController {
       case CURRENCY: // fallthrough intended
       case FILEUPLOAD: // fallthrough intended
       case NAME: // fallthrough intended
+      case NULL_QUESTION: // fallthrough intended
       case NUMBER: // fallthrough intended
       case TEXT: // fallthrough intended
       case PHONE: // fallthrough intended

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -348,8 +348,7 @@ public final class VersionRepository {
    * Returns the previous version to the one passed in. If there is only one version there isn't a
    * previous version so the Optional result will be empty.
    *
-   * <p>This can return draft, active, or obsolete versions. Versions flagged as deleted are
-   * excluded.
+   * <p>This can return active or obsolete versions. Versions flagged as deleted are excluded.
    */
   public Optional<Version> getPreviousVersion(Version version) {
     Version previousVersion =

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -345,6 +345,29 @@ public final class VersionRepository {
   }
 
   /**
+   * Returns the previous version to the one passed in. If there is only one version there isn't a
+   * previous version so the Optional result will be empty.
+   *
+   * <p>This can return draft, active, or obsolete versions. Versions flagged as deleted are
+   * excluded.
+   */
+  public Optional<Version> getPreviousVersion(Version version) {
+    Version previousVersion =
+        database
+            .find(Version.class)
+            .where()
+            .lt("id", version.id)
+            .not()
+            .eq("lifecycle_stage", LifecycleStage.DELETED)
+            .orderBy()
+            .desc("id")
+            .setMaxRows(1)
+            .findOne();
+
+    return Optional.ofNullable(previousVersion);
+  }
+
+  /**
    * Given any revision of a question, return the most recent conceptual version of it. Will return
    * the current DRAFT version if present then the current ACTIVE version.
    */

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -164,6 +164,7 @@ public abstract class AnswerData {
         return applicantQuestion().createSingleSelectQuestion();
       case FILEUPLOAD:
         return applicantQuestion().createFileUploadQuestion();
+      case NULL_QUESTION: // fallthrough intended
       default:
         throw new RuntimeException(
             String.format("Unknown QuestionType %s", questionDefinition().getQuestionType()));

--- a/server/app/services/applicant/question/ApplicantQuestion.java
+++ b/server/app/services/applicant/question/ApplicantQuestion.java
@@ -311,7 +311,7 @@ public final class ApplicantQuestion {
       case PHONE:
         return createPhoneQuestion();
       case NULL_QUESTION:
-        throw new RuntimeException(
+        throw new IllegalStateException(
             String.format(
                 "Question type %s should not be rendered. Question ID: %s. Active program question"
                     + " definition is possibly pointing to an old question ID",

--- a/server/app/services/applicant/question/ApplicantQuestion.java
+++ b/server/app/services/applicant/question/ApplicantQuestion.java
@@ -310,6 +310,12 @@ public final class ApplicantQuestion {
         return createStaticContentQuestion();
       case PHONE:
         return createPhoneQuestion();
+      case NULL_QUESTION:
+        throw new RuntimeException(
+            String.format(
+                "Question type %s should not be rendered. Question ID: %s. Active program question"
+                    + " definition is possibly pointing to an old question ID",
+                getType(), getQuestionDefinition().getId()));
       default:
         throw new RuntimeException("Unrecognized question type: " + getType());
     }

--- a/server/app/services/applicant/question/NullQuestion.java
+++ b/server/app/services/applicant/question/NullQuestion.java
@@ -6,6 +6,13 @@ import com.google.common.collect.ImmutableSet;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 
+/**
+ * This represents a missing questions and acts as a placeholder. This question does not get
+ * surfaced to the user or stored in the database
+ *
+ * <p>In normal operation this shouldn't ever be reached, but an occasional gremlin has resulted in
+ * the rare instance of a program pointing at an old version of a question.
+ */
 public class NullQuestion extends Question {
   NullQuestion(ApplicantQuestion applicantQuestion) {
     super(applicantQuestion);

--- a/server/app/services/applicant/question/NullQuestion.java
+++ b/server/app/services/applicant/question/NullQuestion.java
@@ -1,0 +1,40 @@
+package services.applicant.question;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
+
+public class NullQuestion extends Question {
+  NullQuestion(ApplicantQuestion applicantQuestion) {
+    super(applicantQuestion);
+  }
+
+  /**
+   * Question-type specific implementation of {@link Question}. Note that keys with an empty set of
+   * errors will be filtered out by {@link Question} so that calls to isEmpty on the
+   * getvalidationErrors result are sufficient to indicate if there any errors.
+   */
+  @Override
+  protected ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> getValidationErrorsInternal() {
+    return ImmutableMap.of();
+  }
+
+  /**
+   * Returns the answer as a text string.
+   *
+   * <p>This is the canonical representation to users in static contexts such as the review page and
+   * data export.
+   */
+  @Override
+  public String getAnswerString() {
+    return "";
+  }
+
+  /** Return every path used by this question. */
+  @Override
+  public ImmutableList<Path> getAllPaths() {
+    return ImmutableList.of();
+  }
+}

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -160,6 +160,7 @@ public enum Scalar {
         // do.
         throw new InvalidQuestionTypeException("Enumeration questions are handled separately.");
 
+      case NULL_QUESTION: // Fallthrough intended
       default:
         throw new UnsupportedQuestionTypeException(questionType);
     }

--- a/server/app/services/program/BlockDefinition.java
+++ b/server/app/services/program/BlockDefinition.java
@@ -225,6 +225,18 @@ public abstract class BlockDefinition {
     return programQuestionDefinitions().size();
   }
 
+  /**
+   * Returns true if any of the question definitions in this block are QuestionType.NULL_QUESTION
+   */
+  @JsonIgnore
+  @Memoized
+  public boolean hasNullQuestion() {
+    return programQuestionDefinitions().stream()
+        .map(ProgramQuestionDefinition::getQuestionDefinition)
+        .map(QuestionDefinition::getQuestionType)
+        .anyMatch(questionType -> questionType.equals(QuestionType.NULL_QUESTION));
+  }
+
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -373,4 +373,27 @@ public final class QuestionService {
     }
     return errors.build();
   }
+
+  /**
+   * Returns all questions for the specified version. For example passing in version of id 2, would
+   * return questions for version of id 1. Will return a list for draft, active, or obsolete
+   * versions.
+   *
+   * <p>If there is no previous version an empty list is returned.
+   *
+   * @param version The version used to lookup the previous version
+   * @return Populated list of Question Definitions or an empty list
+   */
+  public ImmutableList<QuestionDefinition> getAllPreviousVersionQuestions(Version version) {
+    Optional<Version> optionalPreviousVersion =
+        versionRepositoryProvider.get().getPreviousVersion(version);
+
+    // This should only happen if we only have one version in the system
+    // such as in a fresh install
+    if (optionalPreviousVersion.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    return getReadOnlyVersionedQuestionService(optionalPreviousVersion.get()).getAllQuestions();
+  }
 }

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -8,9 +8,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import models.Question;
 import models.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import repository.VersionRepository;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
 /**
@@ -24,6 +27,8 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
   private final ImmutableMap<Long, QuestionDefinition> questionsById;
   private final ImmutableSet<QuestionDefinition> upToDateQuestions;
   private final ActiveAndDraftQuestions activeAndDraftQuestions;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ReadOnlyCurrentQuestionServiceImpl.class);
 
   public ReadOnlyCurrentQuestionServiceImpl(VersionRepository repository) {
     Version activeVersion = repository.getActiveVersion();
@@ -94,6 +99,8 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
     if (questionsById.containsKey(id)) {
       return questionsById.get(id);
     }
-    throw new QuestionNotFoundException(id);
+
+    LOGGER.error("Question not found for ID: {}", id);
+    return new NullQuestionDefinition(id);
   }
 }

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -4,8 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import models.Question;
 import models.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
 /**
@@ -17,6 +20,8 @@ import services.question.types.QuestionDefinition;
 public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuestionService {
 
   private final ImmutableMap<Long, QuestionDefinition> questionsById;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ReadOnlyVersionedQuestionServiceImpl.class);
 
   public ReadOnlyVersionedQuestionServiceImpl(Version version) {
     questionsById =
@@ -61,6 +66,8 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
     if (questionsById.containsKey(id)) {
       return questionsById.get(id);
     }
-    throw new QuestionNotFoundException(id);
+
+    LOGGER.error("Question not found for ID: {}", id);
+    return new NullQuestionDefinition(id);
   }
 }

--- a/server/app/services/question/types/NullQuestionDefinition.java
+++ b/server/app/services/question/types/NullQuestionDefinition.java
@@ -1,0 +1,52 @@
+package services.question.types;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * This is an empty QuestionDefinition that is used when the system can't find the question. It
+ * works with the NullQuestionDefinitionConfig class to provide a placeholder object that assists in
+ * letting the application to continue loading in the event of an error.
+ *
+ * <p>In normal operation this shouldn't ever be reached, but an occasional gremlin has resulted in
+ * the rare instance of a program pointing at an old version of a question.
+ */
+public class NullQuestionDefinition extends QuestionDefinition {
+
+  @AutoValue
+  public static class NullValidationPredicates extends ValidationPredicates {
+
+    public static NullQuestionDefinition.NullValidationPredicates parse(String jsonString) {
+      return new NullValidationPredicates() {
+        @Override
+        public String serializeAsString() {
+          return "";
+        }
+      };
+    }
+
+    public static NullQuestionDefinition.NullValidationPredicates create() {
+      return new NullValidationPredicates() {
+        @Override
+        public String serializeAsString() {
+          return "";
+        }
+      };
+    }
+  }
+
+  public NullQuestionDefinition(long id) {
+    super(new NullQuestionDefinitionConfig(id));
+  }
+
+  /** Get the type of this question. */
+  @Override
+  public QuestionType getQuestionType() {
+    return QuestionType.NULL_QUESTION;
+  }
+
+  /** Get the default validation predicates for this question type. */
+  @Override
+  ValidationPredicates getDefaultValidationPredicates() {
+    return new NullQuestionDefinition.NullValidationPredicates();
+  }
+}

--- a/server/app/services/question/types/NullQuestionDefinitionConfig.java
+++ b/server/app/services/question/types/NullQuestionDefinitionConfig.java
@@ -1,0 +1,145 @@
+package services.question.types;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalLong;
+import services.LocalizedStrings;
+
+/**
+ * This is an empty QuestionDefinitionConfig that is used when the system can't find the question.
+ * It works with the NullQuestionDefinition class to provide a placeholder object that assists in
+ * letting the application to continue loading in the event of an error.
+ *
+ * <p>In normal operation this shouldn't ever be reached, but an occasional gremlin has resulted in
+ * the rare instance of a program pointing at an old version of a question.
+ */
+public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
+  private final long _id;
+
+  public NullQuestionDefinitionConfig(long id) {
+    _id = id;
+  }
+
+  @Override
+  String name() {
+    return "null-name-" + _id;
+  }
+
+  @Override
+  String description() {
+    return "null-description-" + _id;
+  }
+
+  /**
+   * Note: you must check prefixes anytime you are doing a locale lookup see {@link
+   * QuestionDefinition#getQuestionText} body comment for explanation.
+   */
+  @Override
+  LocalizedStrings questionText() {
+    return LocalizedStrings.of(Locale.US, "en-US");
+  }
+
+  @Override
+  Optional<LocalizedStrings> questionHelpTextInternal() {
+    return Optional.empty();
+  }
+
+  @Override
+  Optional<QuestionDefinition.ValidationPredicates> validationPredicates() {
+    return Optional.empty();
+  }
+
+  @Override
+  OptionalLong id() {
+    return OptionalLong.of(_id);
+  }
+
+  @Override
+  Optional<Long> enumeratorId() {
+    return Optional.empty();
+  }
+
+  @Override
+  Optional<Instant> lastModifiedTime() {
+    return Optional.empty();
+  }
+
+  /** Used to create a new {@link Builder} based on an existing one. */
+  public static class Builder extends QuestionDefinitionConfig.Builder {
+
+    private final NullQuestionDefinitionConfig _nullQuestionDefinitionConfig;
+
+    public Builder(NullQuestionDefinitionConfig nullQuestionDefinitionConfig) {
+      _nullQuestionDefinitionConfig = nullQuestionDefinitionConfig;
+    }
+
+    @Override
+    public RequiredDescription setName(String name) {
+      return description -> questionText -> this;
+    }
+
+    @Override
+    public RequiredQuestionText setDescription(String description) {
+      return questionText -> this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setQuestionText(LocalizedStrings questionText) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setId(long id) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setId(OptionalLong id) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setEnumeratorId(long enumeratorId) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setEnumeratorId(Optional<Long> enumeratorId) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setLastModifiedTime(Instant lastModifiedTime) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setLastModifiedTime(
+        Optional<Instant> lastModifiedTime) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setValidationPredicates(
+        QuestionDefinition.ValidationPredicates validationPredicates) {
+      return this;
+    }
+
+    @Override
+    QuestionDefinitionConfig.Builder setQuestionHelpTextInternal(
+        LocalizedStrings questionHelpText) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig build() {
+      return _nullQuestionDefinitionConfig;
+    }
+  }
+
+  @Override
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+}

--- a/server/app/services/question/types/NullQuestionDefinitionConfig.java
+++ b/server/app/services/question/types/NullQuestionDefinitionConfig.java
@@ -15,20 +15,20 @@ import services.LocalizedStrings;
  * the rare instance of a program pointing at an old version of a question.
  */
 public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
-  private final long _id;
+  private final long id;
 
   public NullQuestionDefinitionConfig(long id) {
-    _id = id;
+    this.id = id;
   }
 
   @Override
   String name() {
-    return "null-name-" + _id;
+    return "null-name-" + id;
   }
 
   @Override
   String description() {
-    return "null-description-" + _id;
+    return "null-description-" + id;
   }
 
   /**
@@ -52,7 +52,7 @@ public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
 
   @Override
   OptionalLong id() {
-    return OptionalLong.of(_id);
+    return OptionalLong.of(id);
   }
 
   @Override

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -10,6 +10,7 @@ import services.applicant.question.FileUploadQuestion;
 import services.applicant.question.IdQuestion;
 import services.applicant.question.MultiSelectQuestion;
 import services.applicant.question.NameQuestion;
+import services.applicant.question.NullQuestion;
 import services.applicant.question.NumberQuestion;
 import services.applicant.question.PhoneQuestion;
 import services.applicant.question.Question;
@@ -34,7 +35,8 @@ public enum QuestionType {
   RADIO_BUTTON("Radio Button", SingleSelectQuestion.class),
   STATIC("Static Text", StaticContentQuestion.class),
   TEXT("Text Field", TextQuestion.class),
-  PHONE("Phone Field", PhoneQuestion.class);
+  PHONE("Phone Field", PhoneQuestion.class),
+  NULL_QUESTION("Null Field", NullQuestion.class);
 
   private final String label;
   private final Class<? extends Question> supportedQuestion;

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -36,7 +36,7 @@ public enum QuestionType {
   STATIC("Static Text", StaticContentQuestion.class),
   TEXT("Text Field", TextQuestion.class),
   PHONE("Phone Field", PhoneQuestion.class),
-  NULL_QUESTION("Null Field", NullQuestion.class);
+  NULL_QUESTION("Missing Question", NullQuestion.class);
 
   private final String label;
   private final Class<? extends Question> supportedQuestion;

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -6,6 +6,8 @@ import static j2html.TagCreator.b;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
+import static j2html.TagCreator.iff;
+import static j2html.TagCreator.iffElse;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.join;
 import static j2html.TagCreator.p;
@@ -38,6 +40,7 @@ import services.program.ProgramDefinition.Direction;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramType;
 import services.program.predicate.PredicateDefinition;
+import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.StaticContentQuestionDefinition;
 import services.settings.SettingsManifest;
@@ -107,7 +110,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       ProgramDefinition program,
       BlockDefinition blockDefinition,
       Optional<ToastMessage> message,
-      ImmutableList<QuestionDefinition> questions) {
+      ImmutableList<QuestionDefinition> questions,
+      ImmutableList<QuestionDefinition> allPreviousVersionQuestions) {
     return render(
         request,
         program,
@@ -116,7 +120,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
         blockDefinition,
         blockDefinition.programQuestionDefinitions(),
         message,
-        questions);
+        questions,
+        allPreviousVersionQuestions);
   }
 
   public Content render(
@@ -127,7 +132,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       BlockDefinition blockDefinition,
       ImmutableList<ProgramQuestionDefinition> blockQuestions,
       Optional<ToastMessage> message,
-      ImmutableList<QuestionDefinition> questions) {
+      ImmutableList<QuestionDefinition> questions,
+      ImmutableList<QuestionDefinition> allPreviousVersionQuestions) {
     InputTag csrfTag = makeCsrfTokenInputTag(request);
 
     String title =
@@ -145,6 +151,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
         controllers.admin.routes.AdminProgramBlocksController.destroy(programId, blockId).url();
     Modal blockDeleteScreenModal =
         renderBlockDeleteModal(csrfTag, blockDeleteAction, blockDefinition);
+
+    boolean malformedQuestionDefinition =
+        programDefinition.getNonRepeatedBlockDefinitions().stream()
+            .anyMatch(BlockDefinition::hasNullQuestion);
 
     HtmlBundle htmlBundle =
         layout
@@ -164,7 +174,14 @@ public final class ProgramBlocksView extends ProgramBaseView {
                                 div()
                                     .withClasses("flex")
                                     .with(renderEditButton(request, programDefinition))
-                                    .with(renderPreviewButton(programDefinition))),
+                                    .with(renderPreviewButton(programDefinition)))
+                            .with(
+                                iff(
+                                    malformedQuestionDefinition,
+                                    div(
+                                        p("Some questions are not pointing at the latest version."
+                                                + " Edit the program and try republishing.")
+                                            .withClasses("text-center", "text-red-500")))),
                         div()
                             .withClasses("flex", "flex-grow", "-mx-2")
                             .with(renderBlockOrderPanel(request, programDefinition, blockId))
@@ -175,6 +192,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                                     blockForm,
                                     blockQuestions,
                                     questions,
+                                    allPreviousVersionQuestions,
                                     blockDefinition.isEnumerator(),
                                     csrfTag,
                                     blockDescriptionEditModal.getButton(),
@@ -309,7 +327,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
           .with(
               a().withClasses("flex-grow", "overflow-hidden")
                   .withHref(switchBlockLink)
-                  .with(p(blockName), p(questionCountText).withClasses("text-sm")));
+                  .with(
+                      p(blockName)
+                          .withClass(iff(blockDefinition.hasNullQuestion(), "text-red-500")),
+                      p(questionCountText).withClasses("text-sm")));
       if (viewAllowsEditingProgram()) {
         DivTag moveButtons =
             renderBlockMoveButtons(
@@ -387,6 +408,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
       BlockForm blockForm,
       ImmutableList<ProgramQuestionDefinition> blockQuestions,
       ImmutableList<QuestionDefinition> allQuestions,
+      ImmutableList<QuestionDefinition> allPreviousVersionQuestions,
       boolean blockDefinitionIsEnumerator,
       InputTag csrfTag,
       ButtonTag blockDescriptionModalButton,
@@ -435,18 +457,22 @@ public final class ProgramBlocksView extends ProgramBaseView {
     IntStream.range(0, blockQuestions.size())
         .forEach(
             index -> {
-              var question = blockQuestions.get(index);
+              ProgramQuestionDefinition question = blockQuestions.get(index);
+              QuestionDefinition questionDefinition =
+                  findQuestionDefinition(question, allPreviousVersionQuestions);
+
               programQuestions.with(
                   renderQuestion(
                       csrfTag,
                       program,
                       blockDefinition,
-                      question.getQuestionDefinition(),
+                      questionDefinition,
                       canDelete,
                       question.optional(),
                       question.addressCorrectionEnabled(),
                       index,
                       blockQuestions.size(),
+                      question.getQuestionDefinition() instanceof NullQuestionDefinition,
                       request));
             });
 
@@ -476,6 +502,28 @@ public final class ProgramBlocksView extends ProgramBaseView {
       maybeEligibilityPredicateDisplay.ifPresent(div::with);
       return div.with(programQuestions);
     }
+  }
+
+  /**
+   * Returns the QuestionDefinition to display. If we find a NullQuestionDefinition we will attempt
+   * to find it in the list of previous version questions.
+   *
+   * <p>If we still don't find the details we'll return the NullQuestionDefinition. The screen will
+   * render a box indicating there's an error, but won't have details to show
+   */
+  private QuestionDefinition findQuestionDefinition(
+      ProgramQuestionDefinition question,
+      ImmutableList<QuestionDefinition> allPreviousVersionQuestions) {
+    QuestionDefinition questionDefinition = question.getQuestionDefinition();
+
+    if (!(questionDefinition instanceof NullQuestionDefinition)) {
+      return questionDefinition;
+    }
+
+    var foundMissingQuestionDefinition =
+        allPreviousVersionQuestions.stream().filter(x -> x.getId() == question.id()).findFirst();
+
+    return foundMissingQuestionDefinition.orElse(questionDefinition);
   }
 
   private DivTag renderBlockPanelButtons(
@@ -617,14 +665,15 @@ public final class ProgramBlocksView extends ProgramBaseView {
       boolean addressCorrectionEnabled,
       int questionIndex,
       int questionsCount,
+      boolean malformedQuestionDefinition,
       Request request) {
     DivTag ret =
         div()
             .withClasses(
                 ReferenceClasses.PROGRAM_QUESTION,
                 "my-2",
-                "border",
-                "border-gray-200",
+                iffElse(malformedQuestionDefinition, "border-2", "border"),
+                iffElse(malformedQuestionDefinition, "border-red-500", "border-gray-200"),
                 "px-4",
                 "py-2",
                 "flex",
@@ -639,10 +688,18 @@ public final class ProgramBlocksView extends ProgramBaseView {
         questionDefinition.getQuestionHelpText().isEmpty()
             ? ""
             : questionDefinition.getQuestionHelpText().getDefault();
+
     DivTag content =
         div()
             .withClass("flex-grow")
             .with(
+                iff(
+                    malformedQuestionDefinition,
+                    p("This is not pointing at the latest version")
+                        .withClasses("text-red-500", "font-bold")),
+                iff(
+                    malformedQuestionDefinition,
+                    p("Edit the program and try republishing").withClass("text-red-500")),
                 p(questionDefinition.getQuestionText().getDefault()),
                 p(questionHelpText).withClasses("mt-1", "text-sm"),
                 p(String.format("Admin ID: %s", questionDefinition.getName()))

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -179,8 +179,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
                                 iff(
                                     malformedQuestionDefinition,
                                     div(
-                                        p("Some questions are not pointing at the latest version."
-                                                + " Edit the program and try republishing.")
+                                        p("If you see this file a bug with the CiviForm"
+                                              + " development team. Some questions are not"
+                                              + " pointing at the latest version. Edit the program"
+                                              + " and try republishing. ")
                                             .withClasses("text-center", "text-red-500")))),
                         div()
                             .withClasses("flex", "flex-grow", "-mx-2")

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -50,6 +50,12 @@ public final class CreateQuestionButton {
       if (!phoneQuestionTypeEnabled && QuestionType.PHONE.equals(type)) {
         continue;
       }
+
+      // Do not attempt to render a null question
+      if (type == QuestionType.NULL_QUESTION) {
+        continue;
+      }
+
       String typeString = type.toString().toLowerCase(Locale.ROOT);
       String link =
           controllers.admin.routes.AdminQuestionController.newOne(

--- a/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -67,6 +67,12 @@ public final class ApplicantQuestionRendererFactory {
         return new TextQuestionRenderer(question);
       case PHONE:
         return new PhoneQuestionRenderer(question);
+      case NULL_QUESTION:
+        throw new RuntimeException(
+            String.format(
+                "Question type %s should not be rendered. Question ID: %s. Active program question"
+                    + " definition is possibly pointing to an old question ID",
+                question.getType(), question.getQuestionDefinition().getId()));
       default:
         throw new UnsupportedOperationException(
             "Unrecognized question type: " + question.getType());

--- a/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -68,7 +68,7 @@ public final class ApplicantQuestionRendererFactory {
       case PHONE:
         return new PhoneQuestionRenderer(question);
       case NULL_QUESTION:
-        throw new RuntimeException(
+        throw new IllegalStateException(
             String.format(
                 "Question type %s should not be rendered. Question ID: %s. Active program question"
                     + " definition is possibly pointing to an old question ID",

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import io.ebean.DB;
 import io.ebean.Transaction;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import models.LifecycleStage;
 import models.Program;
@@ -871,5 +872,22 @@ public class VersionRepositoryTest extends ResetPostgres {
         .containsExactlyInAnyOrder(
             secondQuestionUpdated.getQuestionDefinition().getName(),
             thirdQuestion.getQuestionDefinition().getName());
+  }
+
+  @Test
+  public void previousVersion_isFound() {
+    // Create first version
+    Version version1 = versionRepository.getDraftVersionOrCreate();
+    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    firstQuestion.addVersion(version1).save();
+    version1.save();
+    versionRepository.publishNewSynchronizedVersion();
+    version1.refresh();
+
+    // Test finding previous version
+    Version activeVersion = versionRepository.getActiveVersion();
+    Optional<Version> previousVersion = versionRepository.getPreviousVersion(activeVersion);
+
+    assertThat(previousVersion.isPresent()).isTrue();
   }
 }

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -65,6 +65,12 @@ public class ApplicantQuestionTest {
   @Test
   @Parameters(source = QuestionType.class)
   public void errorsPresenterExtendedForAllTypes(QuestionType questionType) {
+    // Null question type is used to handle backend missing questions and
+    // does not get surfaced to applicants
+    if (questionType == QuestionType.NULL_QUESTION) {
+      return;
+    }
+
     QuestionDefinition definition =
         testQuestionBank.getSampleQuestionsForAllTypes().get(questionType).getQuestionDefinition();
     ApplicantQuestion applicantQuestion =

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -143,6 +143,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       case STATIC:
         // Do nothing.
         break;
+      case NULL_QUESTION:
+        // Do nothing.
     }
   }
 

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -208,4 +208,19 @@ public class BlockDefinitionTest {
 
     assertThat(blockDefinition.hasNullQuestion()).isTrue();
   }
+
+  @Test
+  public void hasNullQuestion_isFalse() {
+    QuestionDefinition nullQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(9999L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .addQuestion(ProgramQuestionDefinition.create(nullQuestion, Optional.empty()))
+            .build();
+
+    assertThat(blockDefinition.hasNullQuestion()).isFalse();
+  }
 }

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -193,4 +193,19 @@ public class BlockDefinitionTest {
             .build();
     return block;
   }
+
+  @Test
+  public void hasNullQuestion_isTrue() {
+    QuestionDefinition nullQuestion = testQuestionBank.nullQuestion().getQuestionDefinition();
+
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(9999L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .addQuestion(ProgramQuestionDefinition.create(nullQuestion, Optional.empty()))
+            .build();
+
+    assertThat(blockDefinition.hasNullQuestion()).isTrue();
+  }
 }

--- a/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
 import services.question.exceptions.QuestionNotFoundException;
+import services.question.types.QuestionType;
 import support.TestQuestionBank;
 
 public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
@@ -90,8 +91,9 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
 
   @Test
   public void getQuestionDefinition_notFound() throws QuestionNotFoundException {
-    assertThatThrownBy(() -> service.getQuestionDefinition(9999L))
-        .isInstanceOf(QuestionNotFoundException.class);
+    var questionDefinition = service.getQuestionDefinition(9999L);
+
+    assertThat(questionDefinition.getQuestionType()).isEqualTo(QuestionType.NULL_QUESTION);
   }
 
   private static void addQuestionsToVersion(Version version, ImmutableList<Question> questions) {

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -24,6 +24,7 @@ import services.question.types.IdQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.NameQuestionDefinition;
+import services.question.types.NullQuestionDefinition;
 import services.question.types.NumberQuestionDefinition;
 import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -160,6 +161,11 @@ public class TestQuestionBank {
   // Name
   public Question applicantName() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_NAME, this::applicantName);
+  }
+
+  // Name
+  public Question nullQuestion() {
+    return questionCache.computeIfAbsent(QuestionEnum.NULL_QUESTION, this::nullQuestion);
   }
 
   // Repeated name
@@ -374,6 +380,11 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private Question nullQuestion(QuestionEnum ignore) {
+    QuestionDefinition definition = new NullQuestionDefinition(9999L);
+    return new Question(definition);
+  }
+
   // Repeated name
   private Question applicantHouseholdMemberName(QuestionEnum ignore) {
     Question householdMembers = applicantHouseholdMembers();
@@ -571,5 +582,6 @@ public class TestQuestionBank {
     APPLICANT_EMAIL,
     STATIC_CONTENT,
     APPLICANT_PHONE,
+    NULL_QUESTION
   }
 }

--- a/server/test/support/TestQuestionBankTest.java
+++ b/server/test/support/TestQuestionBankTest.java
@@ -38,6 +38,11 @@ public class TestQuestionBankTest {
   @Test
   @Parameters(source = QuestionType.class)
   public void getSampleQuestionForAllTypes_hasASampleForEachType(QuestionType questionType) {
+    // A null question type is not allowed to be created and won't show in the list
+    if (questionType == QuestionType.NULL_QUESTION) {
+      return;
+    }
+
     assertThat(testQuestionBank.getSampleQuestionsForAllTypes().get(questionType)).isNotNull();
   }
 }

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -29,6 +29,11 @@ public class QuestionConfigTest {
   @Test
   @Parameters(source = QuestionType.class)
   public void resultForAllQuestions(QuestionType questionType) throws Exception {
+    // A null question type is not allowed to be created and won't show in the list
+    if (questionType == QuestionType.NULL_QUESTION) {
+      return;
+    }
+
     QuestionForm questionForm = QuestionFormBuilder.create(questionType);
     Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(questionForm, messages);
     switch (questionType) {

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -32,6 +32,11 @@ public class ApplicantQuestionRendererFactoryTest {
   @Test
   @Parameters(source = QuestionType.class)
   public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
+    // A null question type is not allowed to be created and won't show in the list
+    if (type == QuestionType.NULL_QUESTION) {
+      return;
+    }
+
     ApplicantQuestionRendererFactory factory =
         new ApplicantQuestionRendererFactory(new AwsFileUploadViewStrategy());
 
@@ -47,6 +52,11 @@ public class ApplicantQuestionRendererFactoryTest {
   @Parameters(source = QuestionType.class)
   public void compositeQuestionsUseFieldset(QuestionType type)
       throws UnsupportedQuestionTypeException {
+    // A null question type is not allowed to be created and won't show in the list
+    if (type == QuestionType.NULL_QUESTION) {
+      return;
+    }
+
     // Multi-input questions should be wrapped in fieldsets for screen reader users.
     ApplicantQuestionRendererFactory factory =
         new ApplicantQuestionRendererFactory(new AwsFileUploadViewStrategy());
@@ -74,6 +84,9 @@ public class ApplicantQuestionRendererFactoryTest {
       case PHONE:
       case TEXT:
         assertThat(renderedContent).doesNotContain("fieldset");
+        break;
+        // This is here because errorprone doesn't like that it was missing
+      case NULL_QUESTION:
         break;
     }
   }


### PR DESCRIPTION
### Description

This allows the admin program view/edit screens to continue to load in the event the program question definition is pointing at a "missing" question. "Missing" questions so far have occurred because the active program is pointing at previous version (and now obsolete) questions.

Here is an example of what the civiform admin would see when viewing a program.

![image](https://github.com/civiform/civiform/assets/195162/84dce723-f4cb-414f-b6ed-3672553753d3)

When creating a new draft of a program the system is able to find the correct active version and the draft ends up in the correct state. Publishing then fixes the problem.

Ideally no one should ever see these errors show on the screen, but at least now the screen will load.

## Release notes


### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Manually tested at 200% size
- [x] Manually evaluated tab order


### Instructions for manual testing

Tester needs to be running a copy of the database attached to #5278 or somehow has managed to get into a bad state. If this is true you can view program 1495 to see the errors render.

### Issue(s) this completes

Helps fix #5278
