### PR TITLE
Detect applications that are duplicates (modulo timestamps).

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -127,13 +127,15 @@ public final class ApplicationRepository {
             || app.getLifecycleStage().equals(LifecycleStage.OBSOLETE)) {
           continue;
         }
+        boolean isDuplicate = applicant.getApplicantData().isDuplicateOf(app.getApplicantData());
         LOGGER.warn(
             "Multiple applications found at submit time for applicant {} to program {} {}:"
-                + " application {}",
+                + " application {}, duplicate = {}",
             applicant.id,
             program.id,
             program.getProgramDefinition().adminName(),
-            app.id);
+            app.id,
+            isDuplicate);
 
         app.setSubmitTimeToNow();
         app.setLifecycleStage(LifecycleStage.OBSOLETE);

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -173,6 +173,7 @@ public class ApplicantData extends CfJsonDocumentContext {
     // The `updated_at` timestamp for an answer should not be considered when
     // comparing answers.
     try {
+      // The ".." in the path scans the entire document.
       applicantData.getDocumentContext().set("$..updated_at", 0);
     } catch (PathNotFoundException unused) {
       // Metadata may be missing in unit tests. No harm, no foul.

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -156,7 +156,7 @@ public class ApplicantData extends CfJsonDocumentContext {
 
   /**
    * Returns `true` if the answers in `other` match the answers in the current object. Ignores
-   * certain metadata (such as timestamps) when comparing answers.
+   * `updated_at` timestamps when comparing answers.
    */
   public boolean isDuplicateOf(ApplicantData other) {
     // Copy data and clear fields not required for comparison.

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.jayway.jsonpath.PathNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
@@ -151,5 +152,30 @@ public class ApplicantData extends CfJsonDocumentContext {
 
   public void setDateOfBirth(String dateOfBirth) {
     putDate(WellKnownPaths.APPLICANT_DOB, dateOfBirth);
+  }
+
+  /**
+   * Returns `true` if the answers in `other` match the answers in the current object. Ignores
+   * certain metadata (such as timestamps) when comparing answers.
+   */
+  public boolean isDuplicateOf(ApplicantData other) {
+    // Copy data and clear fields not required for comparison.
+    ApplicantData thisApplicantData = new ApplicantData(this.preferredLocale, this.asJsonString());
+    clearFieldsNotRequiredForComparison(thisApplicantData);
+    ApplicantData otherApplicantData =
+        new ApplicantData(other.preferredLocale, other.asJsonString());
+    clearFieldsNotRequiredForComparison(otherApplicantData);
+
+    return thisApplicantData.asJsonString().equals(otherApplicantData.asJsonString());
+  }
+
+  private static void clearFieldsNotRequiredForComparison(ApplicantData applicantData) {
+    // The `updated_at` timestamp for an answer should not be considered when
+    // comparing answers.
+    try {
+      applicantData.getDocumentContext().set("$..updated_at", 0);
+    } catch (PathNotFoundException unused) {
+      // Metadata may be missing in unit tests. No harm, no foul.
+    }
   }
 }

--- a/server/test/services/applicant/ApplicantDataTest.java
+++ b/server/test/services/applicant/ApplicantDataTest.java
@@ -79,4 +79,56 @@ public class ApplicantDataTest {
     ApplicantData applicantData = new ApplicantData();
     assertThat(applicantData.getDateOfBirth()).isEqualTo(Optional.empty());
   }
+
+  @Test
+  public void isDuplicate_returnsTrue() {
+    String userName = "First Last";
+    String dob = "2022-01-05";
+
+    ApplicantData data1 = new ApplicantData();
+    data1.setUserName(userName);
+    data1.setDateOfBirth(dob);
+
+    ApplicantData data2 = new ApplicantData();
+    data2.setUserName(userName);
+    data2.setDateOfBirth(dob);
+
+    assertThat(data1.isDuplicateOf(data2)).isTrue();
+    assertThat(data2.isDuplicateOf(data1)).isTrue();
+  }
+
+  @Test
+  public void isDuplicate_returnsFalse() {
+    String userName1 = "First Last";
+    String userName2 = "User Name";
+    String dob = "2022-01-05";
+
+    ApplicantData data1 = new ApplicantData();
+    data1.setUserName(userName1);
+    data1.setDateOfBirth(dob);
+
+    ApplicantData data2 = new ApplicantData();
+    data2.setUserName(userName2);
+    data2.setDateOfBirth(dob);
+
+    assertThat(data1.isDuplicateOf(data2)).isFalse();
+    assertThat(data2.isDuplicateOf(data1)).isFalse();
+  }
+
+  @Test
+  public void isDuplicateWithMetadata_returnsTrue() {
+    // The only difference is the timestamp in the `updated_at` field.
+    //
+    // Since this field is not settable by any API, we use the JSON representation to specify the
+    // applicant data.
+    ApplicantData data1 =
+        new ApplicantData(
+            "{\"applicant\":{\"name\":{\"first_name\":\"First\",\"last_name\":\"Last\",\"program_updated_in\":2,\"updated_at\":1690288712068}}}");
+    ApplicantData data2 =
+        new ApplicantData(
+            "{\"applicant\":{\"name\":{\"first_name\":\"First\",\"last_name\":\"Last\",\"program_updated_in\":2,\"updated_at\":1690293297676}}}");
+
+    assertThat(data1.isDuplicateOf(data2)).isTrue();
+    assertThat(data2.isDuplicateOf(data1)).isTrue();
+  }
 }


### PR DESCRIPTION
### Description

Detect applications that are duplicates (modulo timestamps).

## Release notes

This PR adds code to detect that a draft application being submitted contains identical answers to the currently-active application for this applicant and program. The scope of this PR is to log the condition; future PRs may affect the UX.

Though it would be cleanest to compare answers via their Java representations, these are not available at this point in the flow; only the JSON representation is available. Thus we compare the JSON representations of the applicant data, after clearing some timestamp metadata.

See [Design: Detecting Unintentional Duplicate Applications](https://docs.google.com/document/d/1nUGatPTxcL0bCuGY3e2hTajPAYufQJpXXnbpgXi4Xs4/edit?usp=sharing).

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

As a logged-in user, edit an existing application. Do not change any answers before re-submitting.

As a guest user, complete an application. Then use the browser back button and re-submit.

In either case, check the server logs for `warn`-level messages that contain the string `"duplicate = true"`.
