### PR TITLE
add more details about required vars in env-var-docs

### DIFF
--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -51,8 +51,9 @@ Variables have the following fields:
   set in the environment and not visible to admins, `ADMIN_READABLE` vars are set
   in the environment and displayed to the admin in the Settings UI, `ADMIN_WRITEABLE`
   vars are set by CiviForm admins in the CiviForm UI.
-- `required`: If the environment variable is required to be set. If the
-  `required` field is not set, the environment variable is not required.
+- `required`: If the environment variable is required to be set in the
+  [config.sh file](https://github.com/civiform/civiform-deploy/blob/957a90fc27b5816de464231d92dc5886dac26b93/civiform_config.example.sh).    Attempting to deploy while missing variables marked "required" will throw an error.
+  If the `required` field is not set, the environment variable is not required.
 - `values`: If `type` is string, a list of valid strings can be provided. If
   `values` is defined, `regex` and `regex_tests` can not be defined.
 - `regex`: If `type` is string, a regular expression using [python re

--- a/env-var-docs/parser-package/README.md
+++ b/env-var-docs/parser-package/README.md
@@ -52,7 +52,7 @@ Variables have the following fields:
   in the environment and displayed to the admin in the Settings UI, `ADMIN_WRITEABLE`
   vars are set by CiviForm admins in the CiviForm UI.
 - `required`: If the environment variable is required to be set in the
-  [config.sh file](https://github.com/civiform/civiform-deploy/blob/957a90fc27b5816de464231d92dc5886dac26b93/civiform_config.example.sh).    Attempting to deploy while missing variables marked "required" will throw an error.
+  [config.sh file](https://github.com/civiform/civiform-deploy/blob/957a90fc27b5816de464231d92dc5886dac26b93/civiform_config.example.sh). Attempting to deploy while missing variables marked "required" will throw an error.
   If the `required` field is not set, the environment variable is not required.
 - `values`: If `type` is string, a list of valid strings can be provided. If
   `values` is defined, `regex` and `regex_tests` can not be defined.


### PR DESCRIPTION
### Description

Added more details about "required" vars in the env-var-docs parser package.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Extended the README / documentation, if necessary
