### PR TITLE
Rename `getDraftVersion` to `getDraftVersionOrCreate`

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -196,7 +196,7 @@ public final class AdminProgramController extends CiviFormController {
       // TODO(#2246): Implement FE staleness detection system to handle this more robustly.
       Optional<Program> existingDraft =
           versionRepository
-              .getDraftVersion()
+              .getDraftVersionOrCreate()
               .getProgramByName(programService.getProgramDefinition(programId).adminName());
       final Long idToEdit;
       if (existingDraft.isPresent()) {

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -106,7 +106,7 @@ public final class DevDatabaseSeedTask {
         questionService.getExistingQuestions(sampleQuestionNames);
     if (existingSampleQuestions.size() < sampleQuestionNames.size()) {
       // Ensure a draft version exists to avoid transaction collisions with getDraftVersion.
-      versionRepository.getDraftVersion();
+      versionRepository.getDraftVersionOrCreate();
     }
 
     ImmutableList.Builder<QuestionDefinition> questionDefinitions = ImmutableList.builder();

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -88,7 +88,7 @@ public final class ProgramRepository {
    * DRAFT if necessary.
    */
   public Program createOrUpdateDraft(Program existingProgram) {
-    Version draftVersion = versionRepository.get().getDraftVersion();
+    Version draftVersion = versionRepository.get().getDraftVersionOrCreate();
     Optional<Program> existingDraftOpt =
         draftVersion.getProgramByName(existingProgram.getProgramDefinition().adminName());
     if (existingDraftOpt.isPresent()) {

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -58,7 +58,7 @@ public final class QuestionRepository {
    * DRAFT if there isn't one.
    */
   public Question createOrUpdateDraft(QuestionDefinition definition) {
-    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
+    Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try (Transaction transaction =
         database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
       Optional<Question> existingDraft = draftVersion.getQuestionByName(definition.getName());
@@ -112,7 +112,7 @@ public final class QuestionRepository {
     // TODO: This seems error prone as a question could be present as a DRAFT and ACTIVE.
     // Investigate further.
     Stream.concat(
-            versionRepositoryProvider.get().getDraftVersion().getQuestions().stream(),
+            versionRepositoryProvider.get().getDraftVersionOrCreate().getQuestions().stream(),
             versionRepositoryProvider.get().getActiveVersion().getQuestions().stream())
         // Find questions that reference the old enumerator ID.
         .filter(

--- a/server/app/services/ProgramBlockValidationFactory.java
+++ b/server/app/services/ProgramBlockValidationFactory.java
@@ -11,7 +11,7 @@ import repository.VersionRepository;
  *
  * <p>Needed because - for every question in the question picker, we will need to check if the
  * question is tombstoned, resulting in n+1 DB queries. To avoid this, we create a factory object
- * injecting a VersionRepository and calling getDraftVersion() only once per request.
+ * injecting a VersionRepository and calling getDraftVersionOrCreate() only once per request.
  */
 public final class ProgramBlockValidationFactory {
 
@@ -23,7 +23,7 @@ public final class ProgramBlockValidationFactory {
   }
   /** Creating a ProgramBlockValidation object with version(DB object) as its member variable */
   public ProgramBlockValidation create() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     return new ProgramBlockValidation(version);
   }
 }

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -33,7 +33,7 @@ public final class ActiveAndDraftPrograms {
   public static ActiveAndDraftPrograms buildFromCurrentVersionsSynced(
       ProgramService service, VersionRepository repository) {
     return new ActiveAndDraftPrograms(
-        repository.getActiveVersion(), repository.getDraftVersion(), Optional.of(service));
+        repository.getActiveVersion(), repository.getDraftVersionOrCreate(), Optional.of(service));
   }
 
   /**
@@ -44,7 +44,7 @@ public final class ActiveAndDraftPrograms {
   public static ActiveAndDraftPrograms buildFromCurrentVersionsUnsynced(
       VersionRepository repository) {
     return new ActiveAndDraftPrograms(
-        repository.getActiveVersion(), repository.getDraftVersion(), Optional.empty());
+        repository.getActiveVersion(), repository.getDraftVersionOrCreate(), Optional.empty());
   }
 
   private ActiveAndDraftPrograms(Version active, Version draft, Optional<ProgramService> service) {

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -182,7 +182,7 @@ public final class ProgramServiceImpl implements ProgramService {
   private boolean isActiveOrDraftProgram(Program program) {
     return Streams.concat(
             versionRepository.getActiveVersion().getPrograms().stream(),
-            versionRepository.getDraftVersion().getPrograms().stream())
+            versionRepository.getDraftVersionOrCreate().getPrograms().stream())
         .anyMatch(p -> p.id.equals(program.id));
   }
 
@@ -236,7 +236,7 @@ public final class ProgramServiceImpl implements ProgramService {
             externalLink,
             displayMode,
             ImmutableList.of(emptyBlock),
-            versionRepository.getDraftVersion(),
+            versionRepository.getDraftVersionOrCreate(),
             programType,
             programAcls);
 

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -42,7 +42,7 @@ public final class ActiveAndDraftQuestions {
   public static ActiveAndDraftQuestions buildFromCurrentVersions(VersionRepository repository) {
     return new ActiveAndDraftQuestions(
         repository.getActiveVersion(),
-        repository.getDraftVersion(),
+        repository.getDraftVersionOrCreate(),
         repository.previewPublishNewSynchronizedVersion());
   }
 

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -64,7 +64,7 @@ public final class QuestionService {
       return ErrorAnd.error(errors);
     }
     Question question = new Question(questionDefinition);
-    question.addVersion(versionRepositoryProvider.get().getDraftVersion());
+    question.addVersion(versionRepositoryProvider.get().getDraftVersionOrCreate());
     questionRepository.insertQuestionSync(question);
     return ErrorAnd.of(question.getQuestionDefinition());
   }
@@ -162,7 +162,7 @@ public final class QuestionService {
         .equals(DeletionStatus.PENDING_DELETION)) {
       throw new InvalidUpdateException("Question is not restorable.");
     }
-    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
+    Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     if (!draftVersion.removeTombstoneForQuestion(question.get())) {
       throw new InvalidUpdateException("Not tombstoned.");
     }
@@ -186,7 +186,7 @@ public final class QuestionService {
 
     Question draftQuestion =
         questionRepository.createOrUpdateDraft(question.get().getQuestionDefinition());
-    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
+    Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try {
       if (!draftVersion.addTombstoneForQuestion(draftQuestion)) {
         throw new InvalidUpdateException("Already tombstoned.");
@@ -224,7 +224,7 @@ public final class QuestionService {
         draftId,
         question.getQuestionDefinition().getName());
 
-    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
+    Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     if (!question.removeVersion(draftVersion)) {
       throw new InvalidUpdateException("Did not find question in draft version.");
     }

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -27,7 +27,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
 
   public ReadOnlyCurrentQuestionServiceImpl(VersionRepository repository) {
     Version activeVersion = repository.getActiveVersion();
-    Version draftVersion = repository.getDraftVersion();
+    Version draftVersion = repository.getDraftVersionOrCreate();
     ImmutableMap.Builder<Long, QuestionDefinition> questionIdMap = ImmutableMap.builder();
     ImmutableSet.Builder<QuestionDefinition> upToDateBuilder = ImmutableSet.builder();
     Set<String> namesFoundInDraft = new HashSet<>();

--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -116,7 +116,7 @@ public final class DatabaseSeedTask {
         questionService.getExistingQuestions(canonicalQuestionNames);
     if (existingCanonicalQuestions.size() < canonicalQuestionNames.size()) {
       // Ensure a draft version exists to avoid transaction collisions with getDraftVersion.
-      versionRepository.getDraftVersion();
+      versionRepository.getDraftVersionOrCreate();
     }
 
     ImmutableList.Builder<QuestionDefinition> questionDefinitions = ImmutableList.builder();

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -117,7 +117,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
-        versionRepository.getDraftVersion().getPrograms().get(0).getProgramDefinition().id();
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
@@ -152,7 +157,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
-        versionRepository.getDraftVersion().getPrograms().get(0).getProgramDefinition().id();
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
 
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
@@ -187,7 +197,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
-        versionRepository.getDraftVersion().getPrograms().get(0).getProgramDefinition().id();
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
@@ -290,7 +305,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
-        versionRepository.getDraftVersion().getPrograms().get(0).getProgramDefinition().id();
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
@@ -334,7 +354,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result result = controller.create(requestBuilder.build());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    Optional<Program> newProgram = versionRepository.getDraftVersion().getProgramByName(adminName);
+    Optional<Program> newProgram =
+        versionRepository.getDraftVersionOrCreate().getProgramByName(adminName);
     assertThat(newProgram).isPresent();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());
@@ -384,7 +405,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
         ProgramBuilder.newActiveProgram(programName, "active description").build();
 
     Result result = controller.newVersionFrom(request, activeProgram.id);
-    Optional<Program> newDraft = versionRepository.getDraftVersion().getProgramByName(programName);
+    Optional<Program> newDraft =
+        versionRepository.getDraftVersionOrCreate().getProgramByName(programName);
 
     // A new draft is made and redirected to.
     assertThat(newDraft).isPresent();
@@ -574,7 +596,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
-        versionRepository.getDraftVersion().getPrograms().get(0).getProgramDefinition().id();
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
@@ -613,7 +640,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     Optional<Program> newProgram =
-        versionRepository.getDraftVersion().getProgramByName("Existing One");
+        versionRepository.getDraftVersionOrCreate().getProgramByName("Existing One");
     assertThat(newProgram).isPresent();
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -46,7 +46,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     controller = instanceOf(AdminQuestionTranslationsController.class);
     // Create a new draft version.
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
-    draftVersion = versionRepository.getDraftVersion();
+    draftVersion = versionRepository.getDraftVersionOrCreate();
   }
 
   @Test

--- a/server/test/models/VersionTest.java
+++ b/server/test/models/VersionTest.java
@@ -25,7 +25,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void addAndRemoveProgram() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     Program program =
         new Program(
             "adminName",
@@ -50,7 +50,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void addAndRemoveQuestion() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     Question question = resourceCreator.insertQuestion("name");
 
     version.addQuestion(question);
@@ -63,7 +63,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getProgramByName_found() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programName = "program";
     resourceCreator.insertDraftProgram(programName);
     version.refresh();
@@ -75,7 +75,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getProgramByName_notFound() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programName = "program";
     resourceCreator.insertDraftProgram(programName);
     version.refresh();
@@ -86,7 +86,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getQuestionByName_found() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionName = "question";
     Question question = resourceCreator.insertQuestion(questionName);
     question.addVersion(version).save();
@@ -99,7 +99,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getQuestionByName_notFound() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionName = "question";
     Question question = resourceCreator.insertQuestion(questionName);
     question.addVersion(version).save();
@@ -111,7 +111,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getProgramNames() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     String programNameTwo = "programtwo";
@@ -130,7 +130,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getQuestionNames() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     String questionTwoName = "two";
@@ -150,7 +150,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getTombstonedProgramNames() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     String tombstonedProgramNameOne = "tombstoneOne";
@@ -172,7 +172,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void getTombstonedQuestionNames() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     String tombstonedQuestionOneName = "tombstoneOne";
@@ -194,7 +194,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void questionIsTombstoned() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     String tombstonedQuestionOneName = "tombstoneOne";
@@ -214,7 +214,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void programIsTombstoned() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     String tombstonedProgramNameOne = "tombstoneOne";
@@ -234,7 +234,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void addTombstoneForQuestion() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -249,7 +249,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void addTombstoneForQuestion_alreadyTombstoned() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -267,7 +267,7 @@ public class VersionTest extends ResetPostgres {
   @Test
   public void addTombstoneForQuestion_questionNotInVersion_throwsException() throws Exception {
     Version activeVersion = versionRepository.getActiveVersion();
-    Version draftVersion = versionRepository.getDraftVersion();
+    Version draftVersion = versionRepository.getDraftVersionOrCreate();
 
     Question question = resourceCreator.insertQuestion("question");
     question.addVersion(activeVersion).save();
@@ -279,7 +279,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void removeTombstoneForQuestion() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -296,7 +296,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void removeTombstoneForQuestion_forNonTombstonedQuestion() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -308,7 +308,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void removeTombstoneForProgram() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
 
@@ -325,7 +325,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void removeTombstoneForProgram_forNonTombstonedProgram() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     version.addProgram(programOne);
@@ -338,7 +338,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void hasAnyChanges_hasTombstonedQuestions() throws Exception {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -349,7 +349,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void hasAnyChanges_hasTombstonedPrograms() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     version.addTombstoneForProgramForTest(programOne);
@@ -359,7 +359,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void hasAnyChanges_hasQuestions() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
@@ -369,7 +369,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void hasAnyChanges_hasPrograms() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";
     Program programOne = resourceCreator.insertDraftProgram(programNameOne);
     version.addProgram(programOne);
@@ -379,7 +379,7 @@ public class VersionTest extends ResetPostgres {
 
   @Test
   public void hasAnyChanges_noChanges() {
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -161,7 +161,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             "",
             DisplayMode.PUBLIC.getValue(),
             ImmutableList.of(),
-            versionRepo.getDraftVersion(),
+            versionRepo.getDraftVersionOrCreate(),
             ProgramType.DEFAULT,
             new ProgramAcls());
     Program withId = repo.insertProgramSync(program);

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -144,7 +144,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void insertingDuplicateDraftQuestions_raisesDatabaseException() throws Exception {
     var versionRepo = instanceOf(VersionRepository.class);
-    var draftVersion = versionRepo.getDraftVersion();
+    var draftVersion = versionRepo.getDraftVersionOrCreate();
     Question activeQuestion = testQuestionBank.applicantName();
     assertThat(activeQuestion.id).isNotNull();
 

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -23,7 +23,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   public void setProgramBlockValidation()
       throws services.question.exceptions.QuestionNotFoundException {
     versionRepository = instanceOf(repository.VersionRepository.class);
-    Version version = versionRepository.getDraftVersion();
+    Version version = versionRepository.getDraftVersionOrCreate();
     String tombstonedQuestionOneName = "tombstoneOne";
     questionForTombstone = resourceCreator.insertQuestion(tombstonedQuestionOneName);
     version.addQuestion(questionForTombstone);

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -42,7 +42,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         versionRepository.getActiveVersion(), tombstonedQuestionFromActiveVersion);
 
     versionRepository
-        .getDraftVersion()
+        .getDraftVersionOrCreate()
         .addQuestion(resourceCreator.insertQuestion("active-and-draft-question"))
         .addQuestion(resourceCreator.insertQuestion("draft-only-question"))
         .save();
@@ -75,7 +75,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         versionRepository.getActiveVersion(), tombstonedQuestionFromActiveVersion);
 
     versionRepository
-        .getDraftVersion()
+        .getDraftVersionOrCreate()
         .addQuestion(activeAndDraftQuestionUpdated)
         .addQuestion(draftOnlyQuestion)
         .save();
@@ -147,7 +147,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     versionRepository.getActiveVersion().addQuestion(activeVersionQuestion).save();
 
     Question draftVersionQuestion = resourceCreator.insertQuestion("draft-version-question");
-    versionRepository.getDraftVersion().addQuestion(draftVersionQuestion).save();
+    versionRepository.getDraftVersionOrCreate().addQuestion(draftVersionQuestion).save();
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.DELETABLE);
@@ -160,10 +160,10 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(question).save();
     versionRepository
-        .getDraftVersion()
+        .getDraftVersionOrCreate()
         .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
         .save();
-    addTombstoneToVersion(versionRepository.getDraftVersion(), question);
+    addTombstoneToVersion(versionRepository.getDraftVersionOrCreate(), question);
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
@@ -172,8 +172,8 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
   @Test
   public void getDeletionStatus_createdAndTombstonedInDraftVersion() throws Exception {
     Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
-    versionRepository.getDraftVersion().addQuestion(question).save();
-    addTombstoneToVersion(versionRepository.getDraftVersion(), question);
+    versionRepository.getDraftVersionOrCreate().addQuestion(question).save();
+    addTombstoneToVersion(versionRepository.getDraftVersionOrCreate(), question);
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.PENDING_DELETION);
@@ -229,7 +229,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
     // Adding a draft edit of the question continues to be considered deletable.
     Question questionDraft = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
-    versionRepository.getDraftVersion().addQuestion(questionDraft).save();
+    versionRepository.getDraftVersionOrCreate().addQuestion(questionDraft).save();
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
         .isEqualTo(DeletionStatus.DELETABLE);
@@ -244,7 +244,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
         .save();
     versionRepository
-        .getDraftVersion()
+        .getDraftVersionOrCreate()
         .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
         .save();
 
@@ -270,7 +270,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
     // Make an edit of the question in the draft version and leave it unreferenced.
     versionRepository
-        .getDraftVersion()
+        .getDraftVersionOrCreate()
         .addQuestion(resourceCreator.insertQuestion(TEST_QUESTION_NAME))
         .save();
     result = newActiveAndDraftQuestions().getReferencingPrograms(TEST_QUESTION_NAME);
@@ -318,7 +318,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
             .withBlock("Screen 1")
             .withRequiredQuestion(question)
             .build();
-    versionRepository.getDraftVersion().addQuestion(question).save();
+    versionRepository.getDraftVersionOrCreate().addQuestion(question).save();
 
     ActiveAndDraftQuestions.ReferencingPrograms result =
         newActiveAndDraftQuestions().getReferencingPrograms(TEST_QUESTION_NAME);
@@ -352,7 +352,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
     // No longer reference the question from the first program.
     Question draftQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
-    versionRepository.getDraftVersion().addQuestion(draftQuestion).save();
+    versionRepository.getDraftVersionOrCreate().addQuestion(draftQuestion).save();
     ProgramBuilder.newDraftProgram("first-program").withBlock("Screen 1").build();
     Program secondProgramDraft =
         ProgramBuilder.newDraftProgram("second-program")

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -83,7 +83,7 @@ public class ProgramBuilder {
             "https://usa.gov",
             DisplayMode.PUBLIC.getValue(),
             ImmutableList.of(EMPTY_FIRST_BLOCK),
-            versionRepository.getDraftVersion(),
+            versionRepository.getDraftVersionOrCreate(),
             ProgramType.DEFAULT,
             new ProgramAcls());
     program.save();
@@ -95,7 +95,7 @@ public class ProgramBuilder {
   /** Creates a {@link ProgramBuilder} with a new {@link Program} in draft state. */
   public static ProgramBuilder newDraftProgram(ProgramDefinition programDefinition) {
     VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
-    Program program = new Program(programDefinition, versionRepository.getDraftVersion());
+    Program program = new Program(programDefinition, versionRepository.getDraftVersionOrCreate());
     program.save();
     ProgramDefinition.Builder builder =
         program.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of());


### PR DESCRIPTION
### Description

Renames `VersionRepository`'s `getDraftVersion` to `getDraftVersionOrCreate` as the method creates a global draft version if one doesn't already exist. 

Separating out this PR from a [child PR](https://github.com/civiform/civiform/pull/5310) because it is large (though simple) and relatively unrelated, and necessary for the child one.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

