### PR TITLE
Add tests and overloads for JsonPrettifier and CfJsonDocumentContext

### DIFF
--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -25,6 +25,7 @@ import services.applicant.JsonPathProvider;
 import services.applicant.exception.JsonPathTypeMismatchException;
 import services.applicant.predicate.JsonPathPredicate;
 import services.applicant.question.Scalar;
+import services.export.JsonPrettifier;
 
 // NON_ABSTRACT_CLASS_ALLOWS_SUBCLASSING CfJsonDocumentContext
 
@@ -595,6 +596,20 @@ public class CfJsonDocumentContext {
 
   public String asJsonString() {
     return jsonData.jsonString();
+  }
+
+  /**
+   * Pretty-print the JSON document, below the specified {@link Path}.
+   *
+   * <p>If the document is only a {@code null} value (for example, if the path points to a {@code
+   * null} leaf node), then this returns the String "null".
+   *
+   * @param path the path to the subtree that should be pretty-printed
+   * @return the pretty-printed document
+   */
+  public String asPrettyJsonString(Path path) {
+    Object subtreeAtPath = jsonData.read(path.toString());
+    return JsonPrettifier.asPrettyJsonString(subtreeAtPath);
   }
 
   @Override

--- a/server/app/services/export/JsonPrettifier.java
+++ b/server/app/services/export/JsonPrettifier.java
@@ -6,14 +6,35 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 /** Provides methods related to "prettifying" (formatting) JSON strings. */
 public final class JsonPrettifier {
-  public static String asPrettyJsonString(String original) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-    objectMapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .enable(SerializationFeature.INDENT_OUTPUT)
+          .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 
+  /**
+   * Pretty-print the JSON document
+   *
+   * @param jsonObject the JSON document as an {@link Object}
+   * @return the pretty-printed document
+   */
+  public static String asPrettyJsonString(Object jsonObject) {
     try {
-      Object jsonObject = objectMapper.readValue(original, Object.class);
-      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+      return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+    } catch (JsonProcessingException e) {
+      return "Error parsing json";
+    }
+  }
+
+  /**
+   * Pretty-print the JSON document
+   *
+   * @param jsonString the JSON document as a {@link String}
+   * @return the pretty-printed document
+   */
+  public static String asPrettyJsonString(String jsonString) {
+    try {
+      Object jsonObject = OBJECT_MAPPER.readValue(jsonString, Object.class);
+      return asPrettyJsonString(jsonObject);
     } catch (JsonProcessingException e) {
       return "Error parsing json";
     }

--- a/server/test/services/CfJsonDocumentContextTest.java
+++ b/server/test/services/CfJsonDocumentContextTest.java
@@ -615,6 +615,46 @@ public class CfJsonDocumentContextTest {
   }
 
   @Test
+  public void asPrettyJsonString_prettyPrintsDocumentAtPath() {
+    String testData =
+        "{ \"deeply\": { \"nested\": { \"value\": \"long text to stop formatter de-wrapping\" } }"
+            + " }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply"));
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"nested\" : {\n"
+                + "    \"value\" : \"long text to stop formatter de-wrapping\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullString() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": \"null\" } } }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply.nested.age"));
+
+    // If the leaf node is the String "null", then pretty-print it as a JSON string.
+    assertThat(prettyJson).isEqualTo("\"null\"");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullValue() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": null } } }";
+    CfJsonDocumentContext data = new CfJsonDocumentContext(testData);
+
+    String prettyJson = data.asPrettyJsonString(Path.create("$.deeply.nested.age"));
+
+    // If the leaf node is the value "null", then pretty-print it as the null value.
+    assertThat(prettyJson).isEqualTo("null");
+  }
+
+  @Test
   public void locked_makesCfJsonDocumentContextImmutable() {
     CfJsonDocumentContext data = new CfJsonDocumentContext();
     // Can mutate before CfJsonDocumentContext is locked.

--- a/server/test/services/export/JsonPrettifierTest.java
+++ b/server/test/services/export/JsonPrettifierTest.java
@@ -1,0 +1,62 @@
+package services.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static services.export.JsonPrettifier.asPrettyJsonString;
+
+import org.junit.Test;
+import services.applicant.JsonPathProvider;
+
+public class JsonPrettifierTest {
+  @Test
+  public void asPrettyJsonString_prettyPrintsJsonString() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": 12 } } }";
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"deeply\" : {\n"
+                + "    \"nested\" : {\n"
+                + "      \"age\" : 12\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullString() {
+    String testData = "\"null\""; // A JSON document that is the string "null"
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson).isEqualTo("\"null\"");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsJsonObject() {
+    String testData = "{ \"deeply\": { \"nested\": { \"age\": 12 } } }";
+    Object jsonObject = JsonPathProvider.getJsonPath().parse(testData).json();
+
+    String prettyJson = asPrettyJsonString(jsonObject);
+
+    assertThat(prettyJson)
+        .isEqualTo(
+            "{\n"
+                + "  \"deeply\" : {\n"
+                + "    \"nested\" : {\n"
+                + "      \"age\" : 12\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void asPrettyJsonString_prettyPrintsNullValue() {
+    Object testData = null; // A JSON document that is the value `null`
+
+    String prettyJson = asPrettyJsonString(testData);
+
+    assertThat(prettyJson).isEqualTo("null");
+  }
+}


### PR DESCRIPTION
### Description

Adds tests for JsonPrettifier and an `asPrettyJsonString()` to the CfJsonDocumentContext that prints the document below the specified path.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

n/a

### Issue(s) this completes

Part of #5277 
