### PR TITLE
Prohibit catching `Exception` or `throws`-ing `RuntimeException`

### DIFF
--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -222,7 +222,7 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
 
     try {
       client.init();
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       logger.error("Error while initilizing OIDC provider", e);
       throw e;
     }

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -168,7 +168,7 @@ public final class AdminProgramController extends CiviFormController {
     try {
       versionRepository.publishNewSynchronizedVersion();
       return redirect(routes.AdminProgramController.index());
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       return badRequest(e.toString());
     }
   }
@@ -208,7 +208,7 @@ public final class AdminProgramController extends CiviFormController {
       return redirect(controllers.admin.routes.AdminProgramBlocksController.index(idToEdit).url());
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       return badRequest(e.toString());
     }
   }

--- a/server/app/controllers/api/ApiDocsController.java
+++ b/server/app/controllers/api/ApiDocsController.java
@@ -52,7 +52,7 @@ public final class ApiDocsController {
     try {
       programDefinition =
           programService.getActiveProgramDefinitionAsync(programSlug).toCompletableFuture().join();
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       return notFound(
           String.format(
               "No active programs found for %s. Please create and publish a program with this slug"

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -175,7 +175,9 @@ public final class DevDatabaseSeedTask {
       programService.setProgramQuestionDefinitionOptionality(
           programId, blockId, nameQuestionId, true);
 
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("CatchingUnchecked")
+        Exception e) {
       throw new RuntimeException(e);
     }
   }
@@ -321,7 +323,9 @@ public final class DevDatabaseSeedTask {
       programService.setProgramQuestionDefinitionOptionality(
           programId, blockId, fileQuestionId, true);
 
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("CatchingUnchecked")
+        Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -44,7 +44,13 @@ import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
 import services.applicant.question.Scalar;
+import services.program.CantAddQuestionToBlockException;
+import services.program.DuplicateStatusException;
+import services.program.IllegalPredicateOrderingException;
+import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
+import services.program.ProgramNotFoundException;
+import services.program.ProgramQuestionDefinitionNotFoundException;
 import services.program.ProgramService;
 import services.program.ProgramType;
 import services.program.StatusDefinitions;
@@ -55,6 +61,7 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionService;
+import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
 
 /**
@@ -159,7 +166,7 @@ public final class DevDatabaseSeedTask {
               /* isIntakeFormFeatureEnabled= */ false,
               ImmutableList.copyOf(new ArrayList<>()));
       if (programDefinitionResult.isError()) {
-        throw new Exception(programDefinitionResult.getErrors().toString());
+        throw new RuntimeException(programDefinitionResult.getErrors().toString());
       }
       ProgramDefinition programDefinition = programDefinitionResult.getResult();
       long programId = programDefinition.id();
@@ -175,9 +182,11 @@ public final class DevDatabaseSeedTask {
       programService.setProgramQuestionDefinitionOptionality(
           programId, blockId, nameQuestionId, true);
 
-    } catch (
-        @SuppressWarnings("CatchingUnchecked")
-        Exception e) {
+    } catch (ProgramNotFoundException
+        | ProgramBlockDefinitionNotFoundException
+        | QuestionNotFoundException
+        | CantAddQuestionToBlockException
+        | ProgramQuestionDefinitionNotFoundException e) {
       throw new RuntimeException(e);
     }
   }
@@ -198,7 +207,7 @@ public final class DevDatabaseSeedTask {
               /* isIntakeFormFeatureEnabled= */ false,
               ImmutableList.copyOf(new ArrayList<>()));
       if (programDefinitionResult.isError()) {
-        throw new Exception(programDefinitionResult.getErrors().toString());
+        throw new RuntimeException(programDefinitionResult.getErrors().toString());
       }
       ProgramDefinition programDefinition = programDefinitionResult.getResult();
       long programId = programDefinition.id();
@@ -213,7 +222,7 @@ public final class DevDatabaseSeedTask {
                   .setLocalizedEmailBodyText(Optional.empty())
                   .build());
       if (appendStatusResult.isError()) {
-        throw new Exception(appendStatusResult.getErrors().toString());
+        throw new RuntimeException(appendStatusResult.getErrors().toString());
       }
 
       long blockId = 1L;
@@ -323,9 +332,13 @@ public final class DevDatabaseSeedTask {
       programService.setProgramQuestionDefinitionOptionality(
           programId, blockId, fileQuestionId, true);
 
-    } catch (
-        @SuppressWarnings("CatchingUnchecked")
-        Exception e) {
+    } catch (ProgramNotFoundException
+        | ProgramBlockDefinitionNotFoundException
+        | IllegalPredicateOrderingException
+        | QuestionNotFoundException
+        | CantAddQuestionToBlockException
+        | ProgramQuestionDefinitionNotFoundException
+        | DuplicateStatusException e) {
       throw new RuntimeException(e);
     }
   }

--- a/server/app/repository/UserRepository.java
+++ b/server/app/repository/UserRepository.java
@@ -158,7 +158,7 @@ public final class UserRepository {
     return tiGroup;
   }
 
-  public void deleteTrustedIntermediaryGroup(long id) throws NoSuchTrustedIntermediaryGroupError {
+  public void deleteTrustedIntermediaryGroup(long id) {
     Optional<TrustedIntermediaryGroup> tiGroup = getTrustedIntermediaryGroup(id);
     if (tiGroup.isEmpty()) {
       throw new NoSuchTrustedIntermediaryGroupError();
@@ -175,8 +175,7 @@ public final class UserRepository {
    * existing account, then create an account and associate it, so it will be ready when the TI
    * signs in for the first time.
    */
-  public void addTrustedIntermediaryToGroup(long id, String emailAddress)
-      throws NoSuchTrustedIntermediaryGroupError, NotEligibleToBecomeTiError {
+  public void addTrustedIntermediaryToGroup(long id, String emailAddress) {
     Optional<TrustedIntermediaryGroup> tiGroup = getTrustedIntermediaryGroup(id);
     if (tiGroup.isEmpty()) {
       throw new NoSuchTrustedIntermediaryGroupError();
@@ -199,8 +198,7 @@ public final class UserRepository {
     account.save();
   }
 
-  public void removeTrustedIntermediaryFromGroup(long id, long accountId)
-      throws NoSuchTrustedIntermediaryGroupError, NoSuchTrustedIntermediaryError {
+  public void removeTrustedIntermediaryFromGroup(long id, long accountId) {
     Optional<TrustedIntermediaryGroup> tiGroup = getTrustedIntermediaryGroup(id);
     if (tiGroup.isEmpty()) {
       throw new NoSuchTrustedIntermediaryGroupError();
@@ -236,8 +234,7 @@ public final class UserRepository {
    * @throws EmailAddressExistsException if the provided email address already exists.
    */
   public void createNewApplicantForTrustedIntermediaryGroup(
-      AddApplicantToTrustedIntermediaryGroupForm form, TrustedIntermediaryGroup tiGroup)
-      throws EmailAddressExistsException {
+      AddApplicantToTrustedIntermediaryGroupForm form, TrustedIntermediaryGroup tiGroup) {
     Account newAccount = new Account();
     if (!Strings.isNullOrEmpty(form.getEmailAddress())) {
       if (lookupAccountByEmail(form.getEmailAddress()).isPresent()) {

--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -100,7 +100,7 @@ public class CfJsonDocumentContext {
    * @param path the {@link Path} to check
    * @return true if there is a null value at the given path; false otherwise.
    */
-  public boolean hasNullValueAtPath(Path path) throws PathNotFoundException {
+  public boolean hasNullValueAtPath(Path path) {
     return jsonData.read(path.toString()) == null;
   }
 

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -389,7 +389,7 @@ public class FieldWithLabel {
     return checkboxApplyAttrsAndGenLabel(inputFieldTag);
   }
 
-  private DivTag getNonNumberInputTag() throws RuntimeException {
+  private DivTag getNonNumberInputTag() {
     InputTag inputFieldTag = TagCreator.input();
     inputFieldTag.withType(getFieldType());
     applyAttributesFromSet(inputFieldTag);
@@ -402,7 +402,7 @@ public class FieldWithLabel {
   }
 
   /** Public final tag getters * */
-  public DivTag getTextareaTag() throws RuntimeException {
+  public DivTag getTextareaTag() {
     if (isTagTypeTextarea()) {
       TextareaTag textareaFieldTag = TagCreator.textarea();
       applyAttributesFromSet(textareaFieldTag);
@@ -431,7 +431,7 @@ public class FieldWithLabel {
     return getNonNumberInputTag();
   }
 
-  public DivTag getNumberTag() throws RuntimeException {
+  public DivTag getNumberTag() {
     InputTag inputFieldTag = TagCreator.input();
     inputFieldTag.withType(getFieldType());
     applyAttributesFromSet(inputFieldTag);
@@ -582,7 +582,7 @@ public class FieldWithLabel {
   }
 
   protected <T extends EmptyTag<T> & IChecked<T> & IName<T> & IDisabled<T>>
-      LabelTag checkboxApplyAttrsAndGenLabel(T fieldTag) throws RuntimeException {
+      LabelTag checkboxApplyAttrsAndGenLabel(T fieldTag) {
     genRandIdIfEmpty();
     // Apply attributes
     applyAttrsGenFieldErrorsInfo(fieldTag);

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -116,7 +116,7 @@ lazy val root = (project in file("."))
       "-XDcompilePolicy=simple",
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
-      "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR",
+      "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR",
       "-implicit:class",
       "-Werror",
       // The compile option below is a hack that preserves generated files. Normally,

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -116,7 +116,7 @@ lazy val root = (project in file("."))
       "-XDcompilePolicy=simple",
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
-      "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR",
+      "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR -Xep:ThrowsUncheckedException:ERROR",
       "-implicit:class",
       "-Werror",
       // The compile option below is a hack that preserves generated files. Normally,


### PR DESCRIPTION
## Description

### `CatchingUnchecked`

This PR enables ErrorProne's `CatchingUnchecked` bug pattern, which prevents us from having a `catch (Exception e)` style block. We do so by enabling `-Xep:CatchingUnchecked:ERROR` in `build.sbt`.

https://errorprone.info/bugpattern/CatchingUnchecked

> This catch block catches `Exception`, but can only catch unchecked exceptions. Consider catching RuntimeException (or something more specific) instead so it is more apparent that no checked exceptions are being handled.

### `ThrowsUncheckedException`

While we're here, I also enabled `ThrowsUncheckedException`, which is less pressing but also enfoces better practice. It prevents us from declaring `throws RuntimeException` (and subclasses of it), which may misleadingly imply that callers will need to handle these exceptions at compile-time.

https://errorprone.info/bugpattern/ThrowsUncheckedException

> Use the Javadoc @throws tag to document each exception that a method can throw, but do not use the throws keyword on unchecked exceptions.

### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

None.