### PR TITLE
In cases where the user profile cannot be fetched, or the user is unauthorized, redirect the user to the home page.

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -1,11 +1,13 @@
 package controllers.applicant;
 
+import static auth.DefaultToGuestRedirector.createGuestSessionAndRedirect;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.components.Modal.RepeatOpenBehavior;
 import static views.components.Modal.RepeatOpenBehavior.Group.PROGRAM_SLUG_LOGIN_PROMPT;
 
 import auth.CiviFormProfile;
+import auth.GuestClient;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -80,8 +82,14 @@ public class ApplicantProgramReviewController extends CiviFormController {
   }
 
   public CompletionStage<Result> review(Request request, long applicantId, long programId) {
-    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
-    boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
+    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+
+    // If the user isn't already logged in within their browser session, send them home.
+    if (submittingProfile.isEmpty()) {
+      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+    }
+
+    boolean isTrustedIntermediary = submittingProfile.get().isTrustedIntermediary();
     Optional<ToastMessage> flashBanner =
         request.flash().get("banner").map(m -> ToastMessage.alert(m));
     Optional<ToastMessage> flashSuccessBanner =
@@ -155,7 +163,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return unauthorized();
+                  return redirect(controllers.routes.HomeController.index().url());
                 }
                 if (cause instanceof ProgramNotFoundException) {
                   return notFound(cause.toString());
@@ -172,7 +180,14 @@ public class ApplicantProgramReviewController extends CiviFormController {
    */
   @Secure
   public CompletionStage<Result> submit(Request request, long applicantId, long programId) {
-    if (profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+
+    // If the user isn't already logged in within their browser session, send them home.
+    if (submittingProfile.isEmpty()) {
+      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+    }
+
+    if (submittingProfile.get().isCiviFormAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.AdminProgramPreviewController.back(programId).url()));
     }
@@ -186,7 +201,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return unauthorized();
+                  return redirect(controllers.routes.HomeController.index().url());
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -12,6 +12,7 @@ import static support.CfTestHelpers.requestBuilderWithSettings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.WithMockedProfiles;
+import java.util.Optional;
 import models.Account;
 import models.Applicant;
 import models.Application;
@@ -27,6 +28,8 @@ import services.Path;
 import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
+
+import javax.swing.text.html.Option;
 
 public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
@@ -50,21 +53,23 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void review_invalidApplicant_returnsUnauthorized() {
+  public void review_invalidApplicant_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.review(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
-  public void review_applicantAccessToDraftProgram_returnsUnauthorized() {
+  public void review_applicantAccessToDraftProgram_redirectsToHome() {
     Program draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Result result = this.review(applicant.id, draftProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
@@ -101,21 +106,23 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void submit_invalid_returnsUnauthorized() {
+  public void submit_invalid_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.submit(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
-  public void submit_applicantAccessToDraftProgram_returnsUnauthorized() {
+  public void submit_applicantAccessToDraftProgram_redirectsToHome() {
     Program draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Result result = this.submit(applicant.id, draftProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test


### PR DESCRIPTION
### Description

In cases where the user profile cannot be extracted from the session or the user is not authorized to access a resource, redirect user to the home page.

## Release notes

In cases where the user profile cannot be extracted from the session or the user is not authorized to access a resource, redirect user to the home page.

This can happen if the browser session expires (say, a tab is left open overnight).

Before this PR, we return HTTP error codes to the browser that give no information to the user. It doesn't make sense to create a guest session at this point, because the new account would not be able to access applications of a previous applicant. There is really no reasonable action we can take under these circumstances, so we redirect the user to the home page.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://docs.civiform.us/contributor-guide/developer-guide/internationalization-i18n#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://docs.civiform.us/contributor-guide/developer-guide/feature-flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #4944
