### PR TITLE
Redirect user to home on APRC failures

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -1,13 +1,10 @@
 package controllers.applicant;
 
-import static auth.DefaultToGuestRedirector.createGuestSessionAndRedirect;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
-import static views.components.Modal.RepeatOpenBehavior;
 import static views.components.Modal.RepeatOpenBehavior.Group.PROGRAM_SLUG_LOGIN_PROMPT;
 
 import auth.CiviFormProfile;
-import auth.GuestClient;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -86,7 +83,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
     // If the user isn't already logged in within their browser session, send them home.
     if (submittingProfile.isEmpty()) {
-      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+      return CompletableFuture.completedFuture(redirectToHome());
     }
 
     boolean isTrustedIntermediary = submittingProfile.get().isTrustedIntermediary();
@@ -163,7 +160,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return redirect(controllers.routes.HomeController.index().url());
+                  return redirectToHome();
                 }
                 if (cause instanceof ProgramNotFoundException) {
                   return notFound(cause.toString());
@@ -184,7 +181,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
     // If the user isn't already logged in within their browser session, send them home.
     if (submittingProfile.isEmpty()) {
-      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+      return CompletableFuture.completedFuture(redirectToHome());
     }
 
     if (submittingProfile.get().isCiviFormAdmin()) {
@@ -201,7 +198,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return redirect(controllers.routes.HomeController.index().url());
+                  return redirectToHome();
                 }
                 throw new RuntimeException(cause);
               }
@@ -306,5 +303,9 @@ public class ApplicantProgramReviewController extends CiviFormController {
               }
               throw new RuntimeException(ex);
             });
+  }
+
+  private static Result redirectToHome() {
+    return redirect(controllers.routes.HomeController.index().url());
   }
 }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -1,11 +1,13 @@
 package controllers.applicant;
 
+import static auth.DefaultToGuestRedirector.createGuestSessionAndRedirect;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.components.Modal.RepeatOpenBehavior;
 import static views.components.Modal.RepeatOpenBehavior.Group.PROGRAM_SLUG_LOGIN_PROMPT;
 
 import auth.CiviFormProfile;
+import auth.GuestClient;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -80,8 +82,14 @@ public class ApplicantProgramReviewController extends CiviFormController {
   }
 
   public CompletionStage<Result> review(Request request, long applicantId, long programId) {
-    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
-    boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
+    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+
+    // If the user isn't already logged in within their browser session, send them home.
+    if (submittingProfile.isEmpty()) {
+      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+    }
+
+    boolean isTrustedIntermediary = submittingProfile.get().isTrustedIntermediary();
     Optional<ToastMessage> flashBanner =
         request.flash().get("banner").map(m -> ToastMessage.alert(m));
     Optional<ToastMessage> flashSuccessBanner =
@@ -155,7 +163,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return unauthorized();
+                  return redirect(controllers.routes.HomeController.index().url());
                 }
                 if (cause instanceof ProgramNotFoundException) {
                   return notFound(cause.toString());
@@ -172,7 +180,14 @@ public class ApplicantProgramReviewController extends CiviFormController {
    */
   @Secure
   public CompletionStage<Result> submit(Request request, long applicantId, long programId) {
-    if (profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+
+    // If the user isn't already logged in within their browser session, send them home.
+    if (submittingProfile.isEmpty()) {
+      return CompletableFuture.completedFuture(redirect(controllers.routes.HomeController.index().url()));
+    }
+
+    if (submittingProfile.get().isCiviFormAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.AdminProgramPreviewController.back(programId).url()));
     }
@@ -186,7 +201,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
-                  return unauthorized();
+                  return redirect(controllers.routes.HomeController.index().url());
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
+++ b/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
@@ -1,0 +1,27 @@
+package controllers;
+
+import org.mockito.ArgumentMatcher;
+import play.mvc.Http;
+
+/**
+ * ArgumentMatcher that matches an Http.Request containing a specified header
+ * whose value is "true".
+ */
+public class HasBooleanHeaderArgumentMatcher implements ArgumentMatcher<Http.Request> {
+  private final String headerName;
+
+  HasBooleanHeaderArgumentMatcher(String headerName) {
+    this.headerName = headerName;
+  }
+
+  @Override
+  public boolean matches(Http.Request argument) {
+    if (argument == null || !argument.hasHeader(headerName)) return false;
+    return Boolean.parseBoolean(argument.header(headerName).get());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[HTTP Request has header %s containing \"true\"]", headerName);
+  }
+}

--- a/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
+++ b/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
@@ -15,7 +15,9 @@ public class HasBooleanHeaderArgumentMatcher implements ArgumentMatcher<Http.Req
 
   @Override
   public boolean matches(Http.Request argument) {
-    if (argument == null || !argument.hasHeader(headerName)) return false;
+    if (argument == null || !argument.hasHeader(headerName)) {
+      return false;
+    }
     return Boolean.parseBoolean(argument.header(headerName).get());
   }
 

--- a/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
+++ b/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
@@ -6,7 +6,7 @@ import play.mvc.Http;
 /**
  * ArgumentMatcher that matches an Http.Request containing a specified header whose value is "true".
  */
-public class HasBooleanHeaderArgumentMatcher implements ArgumentMatcher<Http.Request> {
+public final class HasBooleanHeaderArgumentMatcher implements ArgumentMatcher<Http.Request> {
   private final String headerName;
 
   HasBooleanHeaderArgumentMatcher(String headerName) {

--- a/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
+++ b/server/test/controllers/HasBooleanHeaderArgumentMatcher.java
@@ -4,8 +4,7 @@ import org.mockito.ArgumentMatcher;
 import play.mvc.Http;
 
 /**
- * ArgumentMatcher that matches an Http.Request containing a specified header
- * whose value is "true".
+ * ArgumentMatcher that matches an Http.Request containing a specified header whose value is "true".
  */
 public class HasBooleanHeaderArgumentMatcher implements ArgumentMatcher<Http.Request> {
   private final String headerName;

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -1,6 +1,7 @@
 package controllers;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static play.inject.Bindings.bind;
 
@@ -16,6 +17,7 @@ import models.TrustedIntermediaryGroup;
 import models.Version;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import play.Application;
 import play.inject.Injector;
@@ -31,6 +33,8 @@ public class WithMockedProfiles {
   private static final ProfileUtils MOCK_UTILS = Mockito.mock(ProfileUtils.class);
 
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(true);
+
+  protected static final String skipUserProfile = "skipUserProfile";
 
   private static Injector injector;
   private static ProfileFactory profileFactory;
@@ -132,7 +136,11 @@ public class WithMockedProfiles {
     return adminAccount;
   }
 
+  private ArgumentMatcher<Http.Request> skipUserProfile() {
+    return new HasBooleanHeaderArgumentMatcher(skipUserProfile);
+  }
+
   private void mockProfile(CiviFormProfile profile) {
-    when(MOCK_UTILS.currentUserProfile(any(Http.Request.class))).thenReturn(Optional.of(profile));
+    when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile())))).thenReturn(Optional.of(profile));
   }
 }

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -141,6 +141,7 @@ public class WithMockedProfiles {
   }
 
   private void mockProfile(CiviFormProfile profile) {
-    when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile())))).thenReturn(Optional.of(profile));
+    when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile()))))
+        .thenReturn(Optional.of(profile));
   }
 }

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -6,13 +6,11 @@ import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static play.mvc.Http.Status.UNAUTHORIZED;
 import static support.CfTestHelpers.requestBuilderWithSettings;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.WithMockedProfiles;
-import java.util.Optional;
 import models.Account;
 import models.Applicant;
 import models.Application;
@@ -28,8 +26,6 @@ import services.Path;
 import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
-
-import javax.swing.text.html.Option;
 
 public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -33,9 +33,10 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   private ApplicantProgramBlocksController blockController;
   private Program activeProgram;
   public Applicant applicant;
+  public Applicant applicantWithoutProfile;
 
   @Before
-  public void setUpWithFreshApplicant() {
+  public void setUpWithFreshApplicants() {
     resetDatabase();
 
     subject = instanceOf(ApplicantProgramReviewController.class);
@@ -46,12 +47,20 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     applicant = createApplicantWithMockedProfile();
+    applicantWithoutProfile = createApplicant();
   }
 
   @Test
   public void review_invalidApplicant_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.review(badApplicantId, activeProgram.id);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
+  public void review_applicantWithoutProfile_redirectsToHome() {
+    Result result = this.review(applicantWithoutProfile.id, activeProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -105,6 +114,13 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   public void submit_invalid_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.submit(badApplicantId, activeProgram.id);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
+  public void submit_applicantWithoutProfile_redirectsToHome() {
+    Result result = this.submit(applicantWithoutProfile.id, activeProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -241,25 +241,28 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   public Result review(long applicantId, long programId) {
+    Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramReviewController.review(applicantId, programId)))
+                        routes.ApplicantProgramReviewController.review(applicantId, programId))
+                    .header(skipUserProfile, shouldSkipUserProfile.toString()))
             .build();
     return subject.review(request, applicantId, programId).toCompletableFuture().join();
   }
 
   public Result submit(long applicantId, long programId) {
+    Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramReviewController.submit(applicantId, programId)))
+                        routes.ApplicantProgramReviewController.submit(applicantId, programId))
+                    .header(skipUserProfile, shouldSkipUserProfile.toString()))
             .build();
     return subject.submit(request, applicantId, programId).toCompletableFuture().join();
   }
 
   private void answer(long programId) {
-
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -12,6 +12,7 @@ import static support.CfTestHelpers.requestBuilderWithSettings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.WithMockedProfiles;
+import java.util.Optional;
 import models.Account;
 import models.Applicant;
 import models.Application;
@@ -27,6 +28,8 @@ import services.Path;
 import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
+
+import javax.swing.text.html.Option;
 
 public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
@@ -50,21 +53,23 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void review_invalidApplicant_returnsUnauthorized() {
+  public void review_invalidApplicant_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.review(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
-  public void review_applicantAccessToDraftProgram_returnsUnauthorized() {
+  public void review_applicantAccessToDraftProgram_redirectsToHome() {
     Program draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Result result = this.review(applicant.id, draftProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
@@ -101,21 +106,23 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void submit_invalid_returnsUnauthorized() {
+  public void submit_invalid_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.submit(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
-  public void submit_applicantAccessToDraftProgram_returnsUnauthorized() {
+  public void submit_applicantAccessToDraftProgram_redirectsToHome() {
     Program draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Result result = this.submit(applicant.id, draftProgram.id);
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test


### PR DESCRIPTION
### Description

In cases where the `ApplicantProgramReviewController` cannot fetch the user profile, or the user is unauthorized, redirect the user to the home page.

## Release notes

In cases where the user profile cannot be fetched, or the user is unauthorized, redirect the user to the home page. This case could occur if a tab is left open overnight and the browser session expires.

If a user profile is not available, then it doesn't make sense to create a guest browser session and try the action again, since the new account will not be authorized to see the application for the existing account. Sending the user to the homepage seems reasonable for this case.

Similarly, if the user fails authorization for any reason, we currently just return 401 and nothing shows in the browser. Redirecting to the home page also makes sense here.

This addresses two out of three stack traces reported in #4944.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

