### PR TITLE
Remove mutation in `getActiveProgramFromSlug`

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -157,10 +157,6 @@ public final class ProgramRepository {
   public CompletableFuture<Program> getActiveProgramFromSlug(String slug) {
     return supplyAsync(
         () -> {
-          for (Program program : database.find(Program.class).where().isNull("slug").findList()) {
-            program.getSlug();
-            program.save();
-          }
           ImmutableList<Program> activePrograms =
               versionRepository.get().getActiveVersion().getPrograms();
           List<Program> programsMatchingSlug =

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -123,25 +123,6 @@ public class ProgramRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void getForSlug_withOldSchema() {
-    DB.sqlUpdate(
-            "insert into programs (name, description, block_definitions, legacy_localized_name,"
-                + " legacy_localized_description, program_type) values ('Old Schema Entry',"
-                + " 'Description', '[]', '{\"en_us\": \"a\"}', '{\"en_us\": \"b\"}', 'default');")
-        .execute();
-    DB.sqlUpdate(
-            "insert into versions_programs (versions_id, programs_id) values ("
-                + "(select id from versions where lifecycle_stage = 'active'),"
-                + "(select id from programs where name = 'Old Schema Entry'));")
-        .execute();
-
-    Program found = repo.getActiveProgramFromSlug("old-schema-entry").toCompletableFuture().join();
-
-    assertThat(found.getProgramDefinition().adminName()).isEqualTo("Old Schema Entry");
-    assertThat(found.getProgramDefinition().adminDescription()).isEqualTo("Description");
-  }
-
-  @Test
   public void getForSlug_findsCorrectProgram() {
     Program program = resourceCreator.insertActiveProgram("Something With A Name");
 


### PR DESCRIPTION
### Description

This mutation was intended for an old schema, this PR removes it. Mutations in getX methods are bad practice.


#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

None.