### PR TITLE
Revert APPLICANT_REGISTER_URI to optional

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1006,7 +1006,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "APPLICANT_REGISTER_URI",
                               "URI to create a new account in the applicant identity provider.",
-                              /* isRequired= */ true,
+                              /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -49,8 +49,7 @@
           "APPLICANT_REGISTER_URI": {
             "mode": "ADMIN_READABLE",
             "description": "URI to create a new account in the applicant identity provider.",
-            "type": "string",
-            "required": true
+            "type": "string"
           },
           "APPLICANT_PORTAL_NAME": {
             "mode": "ADMIN_WRITEABLE",


### PR DESCRIPTION
This was optional previously, setting it to required caused problems for deployments that do not have it set yet.