### PR TITLE
Bug fix Part-2 :Adding tombstoned questions to a program creates invalid state

### DIFF
--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -7,6 +7,7 @@ import models.Version;
 import services.program.BlockDefinition;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
+import services.question.ActiveAndDraftQuestions;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
@@ -14,9 +15,12 @@ import services.question.types.QuestionDefinition;
 public final class ProgramBlockValidation {
 
   private final Version version;
+  private final ActiveAndDraftQuestions activeAndDraftQuestions;
 
-  public ProgramBlockValidation(Version version) {
+  public ProgramBlockValidation(
+      models.Version version, ActiveAndDraftQuestions activeAndDraftQuestions) {
     this.version = checkNotNull(version);
+    this.activeAndDraftQuestions = checkNotNull(activeAndDraftQuestions);
   }
   /**
    * Result of checking whether a question can be added to a specific block. Only ELIGIBLE means
@@ -44,7 +48,8 @@ public final class ProgramBlockValidation {
     // provided question is not; or the provided question is a child of an enumerator question while
     // the block is a regular block.
     ENUMERATOR_MISMATCH,
-    QUESTION_TOMBSTONED
+    QUESTION_TOMBSTONED,
+    QUESTION_NOT_IN_ACTIVE_OR_DRAFT_STATE
   }
 
   /**
@@ -72,6 +77,11 @@ public final class ProgramBlockValidation {
     }
     if (!question.getEnumeratorId().equals(getEnumeratorQuestionId(program, block))) {
       return AddQuestionResult.ENUMERATOR_MISMATCH;
+    }
+    if (!activeAndDraftQuestions.getActiveQuestions().contains(question)
+        && !activeAndDraftQuestions.getDraftQuestions().contains(question)) {
+      return services.ProgramBlockValidation.AddQuestionResult
+          .QUESTION_NOT_IN_ACTIVE_OR_DRAFT_STATE;
     }
     return AddQuestionResult.ELIGIBLE;
   }

--- a/server/app/services/ProgramBlockValidationFactory.java
+++ b/server/app/services/ProgramBlockValidationFactory.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import javax.inject.Inject;
 import models.Version;
 import repository.VersionRepository;
+import services.question.QuestionService;
 
 /**
  * Factory for creating `ProgramBlockValidation` instances.
@@ -16,14 +17,19 @@ import repository.VersionRepository;
 public final class ProgramBlockValidationFactory {
 
   private final VersionRepository versionRepository;
+  private final QuestionService questionService;
 
   @Inject
-  public ProgramBlockValidationFactory(VersionRepository versionRepository) {
+  public ProgramBlockValidationFactory(
+      VersionRepository versionRepository, QuestionService questionService) {
     this.versionRepository = checkNotNull(versionRepository);
+    this.questionService = checkNotNull(questionService);
   }
   /** Creating a ProgramBlockValidation object with version(DB object) as its member variable */
   public ProgramBlockValidation create() {
     Version version = versionRepository.getDraftVersionOrCreate();
-    return new ProgramBlockValidation(version);
+    services.question.ActiveAndDraftQuestions activeAndDraftQuestions =
+        questionService.getReadOnlyQuestionServiceSync().getActiveAndDraftQuestions();
+    return new ProgramBlockValidation(version, activeAndDraftQuestions);
   }
 }

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -75,6 +75,37 @@ public class ResourceCreator {
     return question;
   }
 
+  public Question insertEnum(String name) {
+    QuestionDefinition enumDefinition =
+        new services.question.types.EnumeratorQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setDescription("The applicant's household members")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "Who are your household members?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build(),
+            LocalizedStrings.empty());
+    Question enumQuestion = new Question(enumDefinition);
+    enumQuestion.save();
+    return enumQuestion;
+  }
+
+  public Question insertEnumQuestion(String enumName, Question question) {
+    QuestionDefinition enumDefinition =
+        new services.question.types.EnumeratorQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(enumName)
+                .setDescription("The applicant's household member's jobs")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What are the $this's jobs?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "Where does $this work?"))
+                .setEnumeratorId(Optional.of(question.id))
+                .build(),
+            LocalizedStrings.empty());
+    Question enumQuestion = new Question(enumDefinition);
+    enumQuestion.save();
+    return enumQuestion;
+  }
+
   public Question insertQuestion() {
     String name = UUID.randomUUID().toString();
     QuestionDefinition definition =


### PR DESCRIPTION
### Description

This is the second part of the bugfix. This PR ensures that every question displayed in the QuestionListView is always in Draft or Active State.

## Release notes

This is the second part of the bugfix for #5281. This PR ensures that every question displayed in the QuestionListView is always in Draft or Active State.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)



### Issue(s) this completes

Fixes #5281
