### PR TITLE
Update env-var-docs markdown generation for containerization

### DIFF
--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -36,10 +36,6 @@ jobs:
           ref: ${{ inputs.release_number }}
           path: civiform-main/civiform-release
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
       - name: Run bin/env-var-docs-generate-markdown
         env:
           LOCAL_OUTPUT: false


### PR DESCRIPTION
Now that the script to generate the markdown runs inside a container, we need to change how this action works. This now clones into the civiform-release directory inside of the civiform-main directory, since the civiform-main directory is volume mounted into the container. It also changes the ENV_VAR_DOCS_PATH to point to the relative location rather than the path on the action runner.

This additionally removes the step of setting up Python. Since it is containerized, the action runner doesn't need to have it installed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
