### PR TITLE
Modify env-var-docs for Python 3.7

### DIFF
--- a/env-var-docs/check_vars_documented.py
+++ b/env-var-docs/check_vars_documented.py
@@ -15,7 +15,10 @@ import pprint
 import re
 import sys
 import typing
+# Needed for <3.10
 from typing import Union
+# Needed for <3.9
+from typing import Dict, Tuple, List
 
 
 def errorexit(msg):
@@ -63,7 +66,7 @@ def make_config() -> Config:
 
 def main():
     config = make_config()
-    server_vars: dict[str, ServerVar] = vars_from_application_conf(
+    server_vars: Dict[str, ServerVar] = vars_from_application_conf(
         config.app_conf_path)
     with open(config.docs_path) as f:
         documented_vars, parse_errors = vars_from_docs(f)
@@ -102,7 +105,7 @@ def main():
         errorexit(msg)
 
 
-def vars_from_application_conf(app_conf_path: str) -> dict[str, ServerVar]:
+def vars_from_application_conf(app_conf_path: str) -> Dict[str, ServerVar]:
     """Parses an application.conf file and returns the set of referenced environment variables.
 
     If the application.conf file includes other conf files, those files will
@@ -158,8 +161,8 @@ def vars_from_application_conf(app_conf_path: str) -> dict[str, ServerVar]:
 
 def vars_from_docs(
     docs_file: typing.TextIO
-) -> tuple[Union[dict[str, env_var_docs.parser.Variable], None],
-           list[env_var_docs.parser.NodeParseError]]:
+) -> Tuple[Union[Dict[str, env_var_docs.parser.Variable], None],
+           List[env_var_docs.parser.NodeParseError]]:
     """If docs_file has no parsing errors, returns the set of defined
     environment variables in an environment variable documentation file.
     Otherwise returns the parsing errors.

--- a/env-var-docs/generate_markdown.py
+++ b/env-var-docs/generate_markdown.py
@@ -20,7 +20,10 @@ import github
 import os
 import sys
 import typing
+# Needed for <3.10
 from typing import Union
+# Needed for <3.9
+from typing import List, Tuple
 
 
 def error_exit(msg):
@@ -94,7 +97,7 @@ def main():
     path = f"{config.repo_path}/{config.version}.md"
     try:
         file = repo.get_contents(path)
-        if isinstance(file, list):
+        if isinstance(file, List):
             error_exit(f"{path} returns multiple files in the repo, aborting")
 
         if file.decoded_content.decode() == markdown:
@@ -140,7 +143,7 @@ def main():
 
 def generate_markdown(
     docs_file: typing.TextIO
-) -> tuple[Union[str, None], list[env_var_docs.parser.NodeParseError]]:
+) -> Tuple[Union[str, None], List[env_var_docs.parser.NodeParseError]]:
     out = ""
 
     def append_node_to_out(node: env_var_docs.parser.Node):
@@ -196,21 +199,30 @@ def generate_markdown(
     return out, []
 
 
-def new_summary(current_summary: str, docs_paths: list[str]) -> str:
+# These are added to support Python <3.9
+def removesuffix(text, suffix):
+    return text[:-len(suffix)] if text.endswith(suffix) else text
+
+
+def removeprefix(text, prefix):
+    return text[len(prefix):] if text.startswith(prefix) else text
+
+
+def new_summary(current_summary: str, docs_paths: List[str]) -> str:
     """In SUMMARY.md we have a '[CiviForm server environment variables]' list
     item that has sublist items for each versioned environment variable
     documentation markdown files. This function updates the sublist items to
     match docs_file_paths.
     """
 
-    def format_docs_links(indent_level: int, docs_paths: list[str]) -> str:
+    def format_docs_links(indent_level: int, docs_paths: List[str]) -> str:
         docs_paths.sort()
         out = ""
         for p in docs_paths:
             indent = " " * indent_level
-            name = os.path.basename(p).removesuffix(".md")
-            link = p.removeprefix(
-                "docs/"
+            name = removesuffix(os.path.basename(p), ".md")
+            link = removeprefix(
+                p, "docs/"
             )  # gitbook root is in docs/ directory of civiform/docs repo.
             out += f"{indent}  * [{name}]({link})\n"
         return out

--- a/env-var-docs/parser-package/pyproject.toml
+++ b/env-var-docs/parser-package/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "env_var_docs"
 version = "1.0.0"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
     "jinja2==3.1.2"
 ]

--- a/env-var-docs/parser-package/src/env_var_docs/errors_formatter.py
+++ b/env-var-docs/parser-package/src/env_var_docs/errors_formatter.py
@@ -1,7 +1,9 @@
 import env_var_docs.parser
+# Needed for <3.9
+from typing import List
 
 
-def format(errors: list[env_var_docs.parser.NodeParseError]) -> str:
+def format(errors: List[env_var_docs.parser.NodeParseError]) -> str:
     """Formats a list of NodeParseErrors returned from
     env_var_docs.parser.visit as a human-readable string.
 

--- a/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
+++ b/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
@@ -13,15 +13,18 @@ import env_var_docs.errors_formatter
 from jinja2 import Environment, PackageLoader, select_autoescape
 from env_var_docs.parser import Variable, Mode, Node, Group, NodeParseError, visit
 from io import StringIO
+# Needed for <3.10
 from typing import Union
+# Needed for <3.9
+from typing import Dict, List, Tuple
 
 
 @dataclasses.dataclass
 class ParsedGroup:
     group_name: str
     group_description: str
-    sub_groups: list['ParsedGroup'] = dataclasses.field(default_factory=list)
-    variables: dict[str, Variable] = dataclasses.field(default_factory=dict)
+    sub_groups: List['ParsedGroup'] = dataclasses.field(default_factory=list)
+    variables: Dict[str, Variable] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass
@@ -184,10 +187,10 @@ class GetterMethodSpec:
 
 def generate_manifest(
         docs_file: typing.TextIO
-) -> tuple[Union[str, None], list[NodeParseError]]:
+) -> Tuple[Union[str, None], List[NodeParseError]]:
     root_group = ParsedGroup("Miscellaneous", "Miscellaneous")
-    docs: dict[str, Union[ParsedGroup, Variable]] = {"file": root_group}
-    getter_method_specs: list[GetterMethodSpec] = []
+    docs: Dict[str, Union[ParsedGroup, Variable]] = {"file": root_group}
+    getter_method_specs: List[GetterMethodSpec] = []
 
     def visitor(node: Node):
         nonlocal docs

--- a/env-var-docs/parser-package/tests/parser_test.py
+++ b/env-var-docs/parser-package/tests/parser_test.py
@@ -1,6 +1,8 @@
 from env_var_docs.parser import Mode, Group, Variable, RegexTest, ParseError, NodeParseError, Node, visit, _path, _ensure_no_extra_fields, _parse_field, _try_parse_group, _try_parse_variable
 import unittest
 import io
+# Needed for Python <3.9
+from typing import Dict, List
 
 
 def donothing(_: Node):
@@ -663,10 +665,10 @@ class TestParseField(unittest.TestCase):
             _parse_field(
                 parent_path="root",
                 key="key",
-                json_type=list,
+                json_type=List,
                 required=False,
                 obj={"key": []},
-                return_type=list[str])
+                return_type=List[str])
         self.assertIn(
             "'extract_fn' must be provided if 'return_type' is provided",
             str(e.exception))
@@ -676,7 +678,7 @@ class TestParseField(unittest.TestCase):
             _parse_field(
                 parent_path="root",
                 key="key",
-                json_type=list,
+                json_type=List,
                 required=False,
                 obj={"key": []},
                 extract_fn=lambda o: [])
@@ -689,7 +691,7 @@ class TestParseField(unittest.TestCase):
             _parse_field(
                 parent_path="root",
                 key="key",
-                json_type=list,
+                json_type=List,
                 required=True,
                 obj={"keyz": []},
                 default=["Default"])
@@ -792,7 +794,7 @@ class TestParseField(unittest.TestCase):
         got, gotErrors = _parse_field(
             parent_path="root",
             key="key",
-            json_type=dict,
+            json_type=Dict,
             required=False,
             obj={"key": "true"})
         self.assertEqual(
@@ -803,7 +805,7 @@ class TestParseField(unittest.TestCase):
         got, gotErrors = _parse_field(
             parent_path="root",
             key="key",
-            json_type=dict,
+            json_type=Dict,
             required=False,
             obj={"key": {
                 "subkey": "hello there"
@@ -815,7 +817,7 @@ class TestParseField(unittest.TestCase):
         got, gotErrors = _parse_field(
             parent_path="root",
             key="key",
-            json_type=list,
+            json_type=List,
             required=False,
             obj={"key": "true"})
         self.assertEqual(gotErrors, [ParseError("root.key", "must be a list")])
@@ -825,7 +827,7 @@ class TestParseField(unittest.TestCase):
         got, gotErrors = _parse_field(
             parent_path="root",
             key="key",
-            json_type=list,
+            json_type=List,
             required=False,
             obj={"key": [1, 2, 3]})
         self.assertEqual(gotErrors, [])

--- a/env-var-docs/run_regex_tests.py
+++ b/env-var-docs/run_regex_tests.py
@@ -13,7 +13,10 @@ import os
 import re
 import sys
 import typing
+# Needed for <3.10
 from typing import Union
+# Needed for <3.9
+from typing import Tuple, List
 
 
 def errorexit(msg):
@@ -53,7 +56,7 @@ def main():
 
 def run_tests(
     docs_file: typing.TextIO
-) -> tuple[Union[list[str], None], list[env_var_docs.parser.NodeParseError]]:
+) -> Tuple[Union[List[str], None], List[env_var_docs.parser.NodeParseError]]:
     """Runs any provided regex tests in an environment variable documentation file.
 
     Returns a list of environment variable names that failed their tests. Test
@@ -97,7 +100,7 @@ class Test:
     variable: str
     regex: str
     regex_error: str
-    matches: list[Match]
+    matches: List[Match]
     failing_matches: bool
 
     def __str__(self) -> str:
@@ -128,7 +131,7 @@ class Test:
 
 def _run_test(
         node_name: str, regex_text: str,
-        tests: list[env_var_docs.parser.RegexTest]) -> Test:
+        tests: List[env_var_docs.parser.RegexTest]) -> Test:
     try:
         regex = re.compile(regex_text)
     except re.error as e:


### PR DESCRIPTION
This uses dict, list, and tuple explicitly from 'typing', as these built-ins were not added until Python 3.9. This will allow us to use this with Python 3.7, as used on AWS CloudShell. This also adds removeprefix and removesuffix functions, as these also don't exist in 3.7.

This has been tested with Python 3.7.16.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)