### PR TITLE
Removing log message that says canonical question exists

### DIFF
--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -122,8 +122,6 @@ public final class DatabaseSeedTask {
     ImmutableList.Builder<QuestionDefinition> questionDefinitions = ImmutableList.builder();
     for (QuestionDefinition questionDefinition : CANONICAL_QUESTIONS) {
       if (existingCanonicalQuestions.containsKey(questionDefinition.getName())) {
-        LOGGER.info(
-            "Canonical question \"{}\" exists at server start", questionDefinition.getName());
         questionDefinitions.add(existingCanonicalQuestions.get(questionDefinition.getName()));
       } else {
         inSerializableTransaction(


### PR DESCRIPTION
Remove log message that says canonical question exists at server start. Message saying it exists doesn't provide much use.