### PR TITLE
Inject SettingsService into SettingsFilter via provider

### DIFF
--- a/server/app/filters/SettingsFilter.java
+++ b/server/app/filters/SettingsFilter.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import akka.stream.Materializer;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import play.libs.streams.Accumulator;
 import play.mvc.EssentialAction;
 import play.mvc.EssentialFilter;
@@ -17,13 +18,13 @@ import services.settings.SettingsService;
  */
 public final class SettingsFilter extends EssentialFilter {
 
-  private final SettingsService settingsService;
+  private final Provider<SettingsService> settingsService;
   private final Materializer materializer;
   private final SettingsManifest settingsManifest;
 
   @Inject
   public SettingsFilter(
-      SettingsService settingsService,
+      Provider<SettingsService> settingsService,
       Materializer materializer,
       SettingsManifest settingsManifest) {
     this.settingsService = checkNotNull(settingsService);
@@ -41,6 +42,7 @@ public final class SettingsFilter extends EssentialFilter {
         (Http.RequestHeader request) ->
             Accumulator.flatten(
                 settingsService
+                    .get()
                     .applySettingsToRequest(request)
                     .thenApply(modifiedRequest -> next.apply(modifiedRequest)),
                 materializer));


### PR DESCRIPTION
### Description

Play Framework initializes instances of filters when the server starts. Since EBean initializes independently of the Play server, there may be a race condition between the database being available and Play attempting to create an instance of `SettingsFilter`. Since that the constructor dependency tree for that filter eventually calls `DB.getDefautl()` in `SettingsGroupRepository`, this may be the cause of recent crash-loop deployment failures.

By instead injecting a `Provider`, we delay the time that the constructor for `SettingsService` gets called until after the server boots and begins receiving requests, hopefully avoiding the race condition with EBean initialization.

I tested this fix by building a prod image (`SNAPSHOT-3e5665f-1691445630`) and deploying it to AWS eight times with several different variables set.

See also: https://github.com/playframework/play-ebean/issues/51#issuecomment-157475737

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5378