### PR TITLE
Don't load settings for assets requests

### DIFF
--- a/server/app/filters/SettingsFilter.java
+++ b/server/app/filters/SettingsFilter.java
@@ -39,12 +39,14 @@ public final class SettingsFilter extends EssentialFilter {
     }
 
     return EssentialAction.of(
-        (Http.RequestHeader request) ->
-            Accumulator.flatten(
-                settingsService
-                    .get()
-                    .applySettingsToRequest(request)
-                    .thenApply(modifiedRequest -> next.apply(modifiedRequest)),
-                materializer));
+        (Http.RequestHeader request) -> {
+          if (request.path().startsWith("/assets")) {
+            return next.apply(request);
+          }
+
+          return Accumulator.flatten(
+              settingsService.get().applySettingsToRequest(request).thenApply(next::apply),
+              materializer);
+        });
   }
 }


### PR DESCRIPTION
### Description

Requests to `/assets/` are handled by the Play Framework assets controller. Since that controller doesn't consume any of our code we can safely skip loading settings which saves a database query per request.