### PR TITLE
Rename applicantRepositoryProvider to accountRepositoryProvider

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -36,19 +36,19 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
   private static final Logger logger = LoggerFactory.getLogger(CiviformOidcProfileCreator.class);
   protected final ProfileFactory profileFactory;
-  protected final Provider<UserRepository> applicantRepositoryProvider;
+  protected final Provider<UserRepository> accountRepositoryProvider;
   protected final CiviFormProfileMerger civiFormProfileMerger;
 
   public CiviformOidcProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
+      Provider<UserRepository> accountRepositoryProvider) {
     super(Preconditions.checkNotNull(configuration), Preconditions.checkNotNull(client));
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
-    this.applicantRepositoryProvider = Preconditions.checkNotNull(applicantRepositoryProvider);
+    this.accountRepositoryProvider = Preconditions.checkNotNull(accountRepositoryProvider);
     this.civiFormProfileMerger =
-        new CiviFormProfileMerger(profileFactory, applicantRepositoryProvider);
+        new CiviFormProfileMerger(profileFactory, accountRepositoryProvider);
   }
 
   protected abstract String emailAttributeName();
@@ -179,7 +179,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
                 () -> new InvalidOidcProfileException("Unable to get authority ID from profile."));
 
     Optional<Applicant> applicantOpt =
-        applicantRepositoryProvider
+        accountRepositoryProvider
             .get()
             .lookupApplicantByAuthorityId(authorityId)
             .toCompletableFuture()
@@ -193,7 +193,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
     // authority ID and will be keyed on their email.
     String userEmail = profile.getAttribute(emailAttributeName(), String.class);
     logger.debug("Looking up user using email {}", userEmail);
-    return applicantRepositoryProvider
+    return accountRepositoryProvider
         .get()
         .lookupApplicantByEmail(userEmail)
         .toCompletableFuture()

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
 /**
- * This class provides the base applicant OIDC implementation. It's abstract because AD and other
+ * This class provides the base user OIDC implementation. It's abstract because AD and other
  * providers need slightly different implementations and profile creators, and use different config
  * values.
  */
@@ -31,16 +31,16 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   private static final Logger logger = LoggerFactory.getLogger(OidcClientProvider.class);
   protected final Config civiformConfig;
   protected final ProfileFactory profileFactory;
-  protected final Provider<UserRepository> applicantRepositoryProvider;
+  protected final Provider<UserRepository> accountRepositoryProvider;
   protected final String baseUrl;
 
   public OidcClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
+      Provider<UserRepository> accountRepositoryProvider) {
     this.civiformConfig = checkNotNull(configuration);
     this.profileFactory = checkNotNull(profileFactory);
-    this.applicantRepositoryProvider = checkNotNull(applicantRepositoryProvider);
+    this.accountRepositoryProvider = checkNotNull(accountRepositoryProvider);
 
     this.baseUrl =
         getBaseConfigurationValue("base_url")

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -19,17 +19,17 @@ public class AdfsClientProvider implements Provider<OidcClient> {
   private final Config configuration;
   private final String baseUrl;
   private final ProfileFactory profileFactory;
-  private final Provider<UserRepository> applicantRepositoryProvider;
+  private final Provider<UserRepository> userRepositoryProvider;
 
   @Inject
   public AdfsClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
+      Provider<UserRepository> userRepositoryProvider) {
     this.configuration = checkNotNull(configuration);
     this.baseUrl = configuration.getString("base_url");
     this.profileFactory = profileFactory;
-    this.applicantRepositoryProvider = applicantRepositoryProvider;
+    this.userRepositoryProvider = userRepositoryProvider;
   }
 
   @Override
@@ -83,7 +83,7 @@ public class AdfsClientProvider implements Provider<OidcClient> {
     // This is what links the user to the stuff they have access to.
     client.setProfileCreator(
         new AdfsProfileCreator(
-            config, client, profileFactory, configuration, applicantRepositoryProvider));
+            config, client, profileFactory, configuration, userRepositoryProvider));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.init();
     return client;

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -27,8 +27,8 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
       OidcClient client,
       ProfileFactory profileFactory,
       Config appConfig,
-      Provider<UserRepository> applicantRepositoryProvider) {
-    super(configuration, client, profileFactory, applicantRepositoryProvider);
+      Provider<UserRepository> accountRepositoryProvider) {
+    super(configuration, client, profileFactory, accountRepositoryProvider);
     this.adminGroupName = appConfig.getString("adfs.admin_group");
     this.ad_groups_attribute_name = appConfig.getString("adfs.ad_groups_attribute_name");
   }

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -39,11 +39,11 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider,
+      Provider<UserRepository> accountRepositoryProvider,
       String emailAttributeName,
       @Nullable String localeAttributeName,
       ImmutableList<String> nameAttributeNames) {
-    super(configuration, client, profileFactory, applicantRepositoryProvider);
+    super(configuration, client, profileFactory, accountRepositoryProvider);
     this.emailAttributeName = Preconditions.checkNotNull(emailAttributeName);
     this.localeAttributeName = Optional.ofNullable(localeAttributeName);
     this.nameAttributeNames = Preconditions.checkNotNull(nameAttributeNames);

--- a/server/app/auth/oidc/applicant/Auth0ClientProvider.java
+++ b/server/app/auth/oidc/applicant/Auth0ClientProvider.java
@@ -24,8 +24,8 @@ public class Auth0ClientProvider extends GenericOidcClientProvider {
   public Auth0ClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
-    super(configuration, profileFactory, applicantRepositoryProvider);
+      Provider<UserRepository> accountRepositoryProvider) {
+    super(configuration, profileFactory, accountRepositoryProvider);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
@@ -17,7 +17,7 @@ public class GenericApplicantProfileCreator extends ApplicantProfileCreator {
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider,
+      Provider<UserRepository> accountRepositoryProvider,
       String emailAttributeName,
       String localeAttributeName,
       ImmutableList<String> nameAttributeNames) {
@@ -25,7 +25,7 @@ public class GenericApplicantProfileCreator extends ApplicantProfileCreator {
         configuration,
         client,
         profileFactory,
-        applicantRepositoryProvider,
+        accountRepositoryProvider,
         emailAttributeName,
         localeAttributeName,
         nameAttributeNames);

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -65,7 +65,7 @@ public class GenericOidcClientProvider extends OidcClientProvider {
         config,
         client,
         profileFactory,
-        applicantRepositoryProvider,
+        accountRepositoryProvider,
         emailAttr,
         localeAttr.orElse(null),
         nameAttrsBuilder.build());

--- a/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
@@ -40,12 +40,12 @@ public final class IdcsApplicantProfileCreator extends ApplicantProfileCreator {
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
+      Provider<UserRepository> userRepositoryProvider) {
     super(
         configuration,
         client,
         profileFactory,
-        applicantRepositoryProvider,
+        userRepositoryProvider,
         EMAIL_ATTRIBUTE_NAME,
         LOCALE_ATTRIBUTE_NAME,
         ImmutableList.of(NAME_ATTRIBUTE_NAME));

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -27,8 +27,8 @@ public final class IdcsClientProvider extends OidcClientProvider {
   public IdcsClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
-    super(configuration, profileFactory, applicantRepositoryProvider);
+      Provider<UserRepository> accountRepositoryProvider) {
+    super(configuration, profileFactory, accountRepositoryProvider);
   }
 
   @Override
@@ -44,7 +44,7 @@ public final class IdcsClientProvider extends OidcClientProvider {
   @Override
   public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
     return new IdcsApplicantProfileCreator(
-        config, client, profileFactory, applicantRepositoryProvider);
+        config, client, profileFactory, accountRepositoryProvider);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -26,8 +26,8 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
   public LoginGovClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
-    super(configuration, profileFactory, applicantRepositoryProvider);
+      Provider<UserRepository> accountRepositoryProvider) {
+    super(configuration, profileFactory, accountRepositoryProvider);
   }
 
   @Override
@@ -44,7 +44,7 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
         config,
         client,
         profileFactory,
-        applicantRepositoryProvider,
+        accountRepositoryProvider,
         "email",
         /*localeAttributeName*/ null,
         nameAttrs);


### PR DESCRIPTION
### Description

Rename applicantRepositoryProvider to accountRepositoryProvider, as it is used for admins as well as applicants.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Supports #5401 
