### PR TITLE
Create admin GenericOidcClientProvider

### DIFF
--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -100,7 +100,7 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   protected abstract ImmutableList<String> getExtraScopes();
 
   /*
-   * Whether the `state` CSRF parameter should be set in the request.
+   * Whether the `state` CSRF parameter should be set in the requests.
    */
   protected abstract boolean getUseCsrf();
 

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -78,7 +78,7 @@ public class AdfsClientProvider implements Provider<OidcClient> {
     // combined with the name to create the url.
     client.setCallbackUrl(baseUrl + "/callback");
 
-    // This is specific to the implemention using pac4j. pac4j has concept
+    // This is specific to the implementation using pac4j. pac4j has concept
     // of a profile for different identity profiles we have different creators.
     // This is what links the user to the stuff they have access to.
     client.setProfileCreator(

--- a/server/app/auth/oidc/admin/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/admin/GenericOidcClientProvider.java
@@ -1,0 +1,102 @@
+package auth.oidc.admin;
+
+import auth.ProfileFactory;
+import auth.oidc.OidcClientProvider;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.typesafe.config.Config;
+import java.util.Optional;
+import javax.inject.Provider;
+import org.pac4j.core.profile.creator.ProfileCreator;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import repository.UserRepository;
+
+/**
+ * This class implements a `Provider` of a generic `OidcClient` for use in authenticating and
+ * authorizing admins.
+ */
+public class GenericOidcClientProvider extends OidcClientProvider {
+
+  private static final String ATTRIBUTE_PREFIX = "admin_generic_oidc_";
+  private static final ImmutableList<String> DEFAULT_SCOPES =
+      ImmutableList.of("openid", "profile", "email");
+
+  private static final String PROVIDER_NAME_CONFIG_NAME = "provider_name";
+  private static final String CLIENT_ID_CONFIG_NAME = "client_id";
+  private static final String CLIENT_SECRET_CONFIG_NAME = "client_secret";
+  private static final String DISCOVERY_URI_CONFIG_NAME = "discovery_uri";
+  private static final String RESPONSE_MODE_CONFIG_NAME = "response_mode";
+  private static final String RESPONSE_TYPE_CONFIG_NAME = "response_type";
+  private static final String EXTRA_SCOPES_CONFIG_NAME = "additional_scopes";
+  private static final String USE_CSRF = "use_csrf";
+
+  @Inject
+  GenericOidcClientProvider(
+      Config configuration,
+      ProfileFactory profileFactory,
+      Provider<UserRepository> accountRepositoryProvider) {
+    super(configuration, profileFactory, accountRepositoryProvider);
+  }
+
+  @Override
+  @VisibleForTesting
+  public String attributePrefix() {
+    return ATTRIBUTE_PREFIX;
+  }
+
+  @Override
+  protected Optional<String> getProviderName() {
+    return getConfigurationValue(PROVIDER_NAME_CONFIG_NAME);
+  }
+
+  @Override
+  public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
+    return new GenericOidcProfileCreator(
+        config, client, profileFactory, civiformConfig, this.accountRepositoryProvider);
+  }
+
+  @Override
+  protected String getClientID() {
+    return getConfigurationValue(CLIENT_ID_CONFIG_NAME).orElse("");
+  }
+
+  @Override
+  protected Optional<String> getClientSecret() {
+    return Optional.of(getConfigurationValueOrThrow(CLIENT_SECRET_CONFIG_NAME));
+  }
+
+  @Override
+  protected String getDiscoveryURI() {
+    return getConfigurationValueOrThrow(DISCOVERY_URI_CONFIG_NAME);
+  }
+
+  @Override
+  protected String getResponseMode() {
+    return getConfigurationValueOrThrow(RESPONSE_MODE_CONFIG_NAME);
+  }
+
+  @Override
+  protected String getResponseType() {
+    return getConfigurationValueOrThrow(RESPONSE_TYPE_CONFIG_NAME);
+  }
+
+  @Override
+  protected ImmutableList<String> getDefaultScopes() {
+    return DEFAULT_SCOPES;
+  }
+
+  @Override
+  protected ImmutableList<String> getExtraScopes() {
+    Optional<String> extraScopesMaybe = getConfigurationValue(EXTRA_SCOPES_CONFIG_NAME);
+    return extraScopesMaybe
+        .map(s -> ImmutableList.copyOf(s.split(" ")))
+        .orElseGet(ImmutableList::of);
+  }
+
+  @Override
+  protected boolean getUseCsrf() {
+    return Boolean.valueOf(getConfigurationValueOrThrow(USE_CSRF));
+  }
+}

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -1,0 +1,86 @@
+package auth.oidc.admin;
+
+import auth.CiviFormProfile;
+import auth.ProfileFactory;
+import auth.Role;
+import auth.oidc.CiviformOidcProfileCreator;
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import java.util.List;
+import javax.inject.Provider;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.profile.OidcProfile;
+import repository.UserRepository;
+
+/**
+ * This class creates a pac4j `UserProfile` for admins when the identity provider is a generic OIDC
+ * provider.
+ */
+public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
+  private String groupsAttributeName;
+  private String adminGroupName;
+
+  // This config variable holds the name of the profile attribute that lists the groups that apply
+  // to the user.
+  private static String ID_GROUPS_ATTRIBUTE_NAME = "admin_generic_oidc_id_groups_attribute_name";
+  // This config variable holds the name of the group that is used to specify that a user is a
+  // global admin.
+  private static String ADMIN_GROUP_CONFIG_NAME = "admin_generic_oidc_admin_group_name";
+
+  public GenericOidcProfileCreator(
+      OidcConfiguration configuration,
+      OidcClient client,
+      ProfileFactory profileFactory,
+      Config appConfig,
+      Provider<UserRepository> userRepositoryProvider) {
+    super(configuration, client, profileFactory, userRepositoryProvider);
+    this.groupsAttributeName = appConfig.getString(ID_GROUPS_ATTRIBUTE_NAME);
+    this.adminGroupName = appConfig.getString(ADMIN_GROUP_CONFIG_NAME);
+  }
+
+  @Override
+  protected String emailAttributeName() {
+    return "email";
+  }
+
+  @Override
+  protected ImmutableSet<Role> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
+    if (this.isGlobalAdmin(oidcProfile)) {
+      return ImmutableSet.of(Role.ROLE_CIVIFORM_ADMIN);
+    }
+    if (isTrustedIntermediary(profile)) {
+      // Give ROLE_APPLICANT in addition to ROLE_TI so that the TI can perform applicant actions.
+      return ImmutableSet.of(Role.ROLE_APPLICANT, Role.ROLE_TI);
+    }
+    return ImmutableSet.of(Role.ROLE_PROGRAM_ADMIN);
+  }
+
+  private boolean isGlobalAdmin(OidcProfile profile) {
+    @SuppressWarnings("unchecked")
+    List<String> groups = (List) profile.getAttribute(this.groupsAttributeName);
+    return groups.contains(this.adminGroupName);
+  }
+
+  @Override
+  protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Role> roles) {
+    if (roles.contains(Role.ROLE_CIVIFORM_ADMIN)) {
+      profile
+          .getAccount()
+          .thenAccept(
+              account -> {
+                account.setGlobalAdmin(true);
+                account.save();
+              })
+          .join();
+    }
+  }
+
+  @Override
+  public CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile) {
+    if (this.isGlobalAdmin(profile)) {
+      return profileFactory.wrapProfileData(profileFactory.createNewAdmin());
+    }
+    return profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin());
+  }
+}

--- a/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
@@ -1,0 +1,92 @@
+package auth.oidc.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import auth.ProfileFactory;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pac4j.core.profile.creator.ProfileCreator;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import play.api.test.Helpers;
+import repository.ResetPostgres;
+import repository.UserRepository;
+import support.CfTestHelpers;
+
+@RunWith(JUnitParamsRunner.class)
+public class GenericOidcClientProviderTest extends ResetPostgres {
+  private GenericOidcClientProvider genericOidcProvider;
+  private ProfileFactory profileFactory;
+  private static UserRepository accountProvider;
+  private static final String DISCOVERY_URI =
+      "http://dev-oidc:3390/.well-known/openid-configuration";
+  private static final String BASE_URL =
+      String.format("http://localhost:%d", Helpers.testServerPort());
+
+  @Before
+  public void setup() {
+    accountProvider = instanceOf(UserRepository.class);
+    profileFactory = instanceOf(ProfileFactory.class);
+    Config config =
+        ConfigFactory.parseMap(
+            ImmutableMap.<String, String>builder()
+                .put("admin_generic_oidc_provider_name", "Okta")
+                .put("admin_generic_oidc_client_id", "civi")
+                .put("admin_generic_oidc_client_secret", "pass")
+                .put("admin_generic_oidc_response_mode", "form_post")
+                .put("admin_generic_oidc_response_type", "id_token")
+                .put("admin_generic_oidc_additional_scopes", "group")
+                .put("admin_generic_oidc_discovery_uri", DISCOVERY_URI)
+                .put("admin_generic_oidc_id_groups_attribute_name", "groups")
+                .put("admin_generic_oidc_admin_group_name", "admin group")
+                .put("admin_generic_oidc_use_csrf", "true")
+                .put("base_url", BASE_URL)
+                .build());
+
+    // Just need some complete adaptor to access methods.
+    genericOidcProvider =
+        new GenericOidcClientProvider(
+            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountProvider));
+  }
+
+  @Test
+  public void Test_getConfigurationValues() {
+    OidcClient client = genericOidcProvider.get();
+    OidcConfiguration client_config = client.getConfiguration();
+
+    ProfileCreator adaptor = genericOidcProvider.getProfileCreator(client_config, client);
+    assertThat(adaptor.getClass()).isEqualTo(GenericOidcProfileCreator.class);
+
+    String provider = genericOidcProvider.getProviderName().orElse("");
+    assertThat(provider).isEqualTo("Okta");
+
+    String clientId = genericOidcProvider.getClientID();
+    assertThat(clientId).isEqualTo("civi");
+
+    String clientSecret = genericOidcProvider.getClientSecret().get();
+    assertThat(clientSecret).isEqualTo("pass");
+
+    String responseType = genericOidcProvider.getResponseType();
+    assertThat(responseType).isEqualTo("id_token");
+
+    String responseMode = genericOidcProvider.getResponseMode();
+    assertThat(responseMode).isEqualTo("form_post");
+
+    String scope = genericOidcProvider.getScopesAttribute();
+    assertThat(scope).isEqualTo("openid profile email group");
+
+    String discoveryUri = genericOidcProvider.getDiscoveryURI();
+    assertThat(discoveryUri).isEqualTo(DISCOVERY_URI);
+
+    String callbackUrl = client.getCallbackUrl();
+    assertThat(callbackUrl).isEqualTo(BASE_URL + "/callback");
+
+    boolean useCsrf = genericOidcProvider.getUseCsrf();
+    assertThat(useCsrf).isTrue();
+  }
+}

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -1,0 +1,76 @@
+package auth.oidc.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.profile.OidcProfile;
+import repository.ResetPostgres;
+import repository.UserRepository;
+import support.CfTestHelpers;
+
+public class GenericOidcProfileCreatorTest extends ResetPostgres {
+  private GenericOidcProfileCreator genericOidcProfileCreator;
+  private ProfileFactory profileFactory;
+  private static UserRepository accountRepository;
+
+  @Before
+  public void setup() {
+    accountRepository = instanceOf(UserRepository.class);
+    profileFactory = instanceOf(ProfileFactory.class);
+    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
+    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
+    Config serverConfig =
+        ConfigFactory.parseMap(
+            ImmutableMap.<String, String>builder()
+                .put("admin_generic_oidc_id_groups_attribute_name", "groups")
+                .put("admin_generic_oidc_admin_group_name", "CIVIFORM_GLOBAL_ADMIN")
+                .build());
+    genericOidcProfileCreator =
+        new GenericOidcProfileCreator(
+            client_config,
+            client,
+            profileFactory,
+            serverConfig,
+            CfTestHelpers.userRepositoryProvider(accountRepository));
+  }
+
+  @Test
+  public void mergeCiviFormProfile_adminSucceeds() {
+    OidcProfile profile = new OidcProfile();
+    profile.addAttribute("email", "email@example.com");
+    profile.addAttribute("groups", ImmutableList.of("CIVIFORM_GLOBAL_ADMIN"));
+    // Required for OIDC profiles.
+    profile.addAttribute("iss", "issuer");
+    profile.setId("subject");
+
+    CiviFormProfileData profileData =
+        genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile);
+
+    assertThat(profileData.getRoles()).contains("ROLE_CIVIFORM_ADMIN");
+  }
+
+  @Test
+  public void mergeCiviFormProfile_nonAdminSucceeds() {
+    OidcProfile profile = new OidcProfile();
+    profile.addAttribute("email", "email@example.com");
+    profile.addAttribute("groups", ImmutableList.of("NON_ADMIN_GROUP"));
+    // Required for OIDC profiles.
+    profile.addAttribute("iss", "issuer");
+    profile.setId("subject");
+
+    CiviFormProfileData profileData =
+        genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile);
+
+    assertThat(profileData.getRoles()).doesNotContain("ROLE_CIVIFORM_ADMIN");
+  }
+}


### PR DESCRIPTION
### Description

Create a `GenericOidcClientProvider` for admins.

## Release notes

Create a `GenericOidcClientProvider` for admins. At present, it supports authentication and authorization. Support for logout is tracked in #4359.

This PR only creates the new class; wiring the new class into the `SecurityModule` based on new config will come in later PRs.

This class shares quite a bit of logic with the matching version for applicants; a refactoring will follow.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Relates to #5401