### PR TITLE
Allow CSRF behavior to be specified by subclasses of OidcClientProvider

### DIFF
--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -98,6 +98,11 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   protected abstract ImmutableList<String> getExtraScopes();
 
   /*
+   * Whether the `state` CSRF parameter should be set in the request.
+   */
+  protected abstract boolean getUseCsrf();
+
+  /*
    * Helper function for retriving values from the application.conf,
    * prepended with "<attributePrefix>."
    */
@@ -194,7 +199,7 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
     config.setResponseType(responseType);
 
     config.setUseNonce(true);
-    config.setWithState(false);
+    config.setWithState(getUseCsrf());
 
     config.setScope(scope);
     return config;

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -109,4 +109,10 @@ public class GenericOidcClientProvider extends OidcClientProvider {
     }
     return ImmutableList.copyOf(extraScopesMaybe.get().split(" "));
   }
+
+  @Override
+  protected boolean getUseCsrf() {
+    // In the future, we may wish to make this configurable, since this is a generic provider.
+    return false;
+  }
 }

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -90,4 +90,9 @@ public final class IdcsClientProvider extends OidcClientProvider {
   protected ImmutableList<String> getExtraScopes() {
     return ImmutableList.of();
   }
+
+  @Override
+  protected boolean getUseCsrf() {
+    return false;
+  }
 }


### PR DESCRIPTION
### Description

Allow CSRF behavior to be specified by subclasses of OidcClientProvider.

## Release notes

Allow CSRF behavior to be specified by subclasses of OidcClientProvider. This PR does not affect current behavior, but allows future subclasses to specify a value other than `false`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Supports #5401
