### PR TITLE
Program Translations Save button will load the same view on success

### DIFF
--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -17,7 +17,6 @@ import play.mvc.Result;
 import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
-import services.LocalizedStrings;
 import services.TranslationLocales;
 import services.program.OutOfDateStatusesException;
 import services.program.ProgramDefinition;
@@ -146,11 +145,8 @@ public class AdminProgramTranslationsController extends CiviFormController {
           translationView.render(
               request, localeToUpdate, program, translationForm, Optional.of(errorMessage)));
     }
-    return redirect(routes.AdminProgramController.index().url())
-        .flashing(
-            "success",
-            String.format(
-                "Program translations updated for %s",
-                localeToUpdate.getDisplayLanguage(LocalizedStrings.DEFAULT_LOCALE)));
+    return ok(
+        translationView.render(
+            request, localeToUpdate, program, translationForm, Optional.empty()));
   }
 }

--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -147,6 +147,6 @@ public class AdminProgramTranslationsController extends CiviFormController {
     }
     return ok(
         translationView.render(
-            request, localeToUpdate, program, translationForm, Optional.empty()));
+            request, localeToUpdate, program, translationForm, /*message=*/ Optional.empty()));
   }
 }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -165,12 +165,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
             addCSRFToken(requestBuilder).build(),
             program.getProgramDefinition().adminName(),
             "es-US");
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation().orElse(""))
-        .isEqualTo(controllers.admin.routes.AdminProgramController.index().url());
-    assertThat(result.flash().get("success").get())
-        .isEqualTo("Program translations updated for Spanish");
+    assertThat(result.status()).isEqualTo(OK);
 
     ProgramDefinition updatedProgram =
         programRepository


### PR DESCRIPTION
### Description

Program Translations "Save" button will load the same translation program view on success. This was a bug from the previous work, where every click to the "Save" button will re-route the CiviForm admins back to the program list view. This fix will keep the admins on the same view. They can use "Back" button to go back to the list view. 

## Release notes

Program Translations Save button will load the same view on success

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #5377
