### PR TITLE
Rockyfine/pare down azure ci tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Bring up test env with Azurite
         run: bin/run-browser-test-env --azure --ci
       - name: Run browser tests with Azurite
-        run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+        run: bin/run-browser-tests-azure
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,8 +122,6 @@ jobs:
   run_browser_tests_azure:
     strategy:
       fail-fast: false
-      matrix:
-        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - name: check out ${{ env.GITHUB_REF }}

--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -29,9 +29,6 @@ jobs:
       - run: 'echo "skipping"'
 
   run_browser_tests_azure:
-    strategy:
-      matrix:
-        batch_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'

--- a/bin/run-browser-tests-azure
+++ b/bin/run-browser-tests-azure
@@ -4,7 +4,6 @@
 
 import subprocess
 
-# Select test files we specifically want to test in Azurite
 def get_test_files():
     test_files = ['src/file.test.ts'] # file upload tests
     test_files.sort()

--- a/bin/run-browser-tests-azure
+++ b/bin/run-browser-tests-azure
@@ -4,9 +4,9 @@
 
 import subprocess
 
-# Gets a list of all the test files in the browser-test directory.
+# Select test files we specifically want to test in Azurite
 def get_test_files():
-    test_files = ['src/file.test.ts']
+    test_files = ['src/file.test.ts'] # file upload tests
     test_files.sort()
     return test_files
 

--- a/bin/run-browser-tests-azure
+++ b/bin/run-browser-tests-azure
@@ -7,7 +7,6 @@ import subprocess
 
 def get_test_files():
     test_files = ['src/file.test.ts']  # file upload tests
-    test_files.sort()
     return test_files
 
 

--- a/bin/run-browser-tests-azure
+++ b/bin/run-browser-tests-azure
@@ -1,0 +1,14 @@
+#! /usr/bin/env python3
+
+# DOC: Run a subset of browser tests that we want to specifically test in Azure in CI mode. 
+
+import subprocess
+
+# Gets a list of all the test files in the browser-test directory.
+def get_test_files():
+    test_files = ['src/file.test.ts']
+    test_files.sort()
+    return test_files
+
+shell_command = ["./bin/run-browser-tests-ci"] + get_test_files()
+subprocess.run(shell_command, check=True)

--- a/bin/run-browser-tests-azure
+++ b/bin/run-browser-tests-azure
@@ -1,13 +1,15 @@
 #! /usr/bin/env python3
 
-# DOC: Run a subset of browser tests that we want to specifically test in Azure in CI mode. 
+# DOC: Run a subset of browser tests that we want to specifically test in Azure in CI mode.
 
 import subprocess
 
+
 def get_test_files():
-    test_files = ['src/file.test.ts'] # file upload tests
+    test_files = ['src/file.test.ts']  # file upload tests
     test_files.sort()
     return test_files
+
 
 shell_command = ["./bin/run-browser-tests-ci"] + get_test_files()
 subprocess.run(shell_command, check=True)


### PR DESCRIPTION
### Description

As a part of the work to [deprecate active Azure support](https://github.com/civiform/civiform/issues/5299), this PR adds a script to only run the Azure tests we think are most likely to break (in this case, file upload) and adds that script to `.github/workflows/tests.yaml` instead of running the full suite of browser tests.

Note: after PR is approved I'll remove the require `run_browser_tests_azure` tests from [here](https://github.com/civiform/civiform/settings/branch_protection_rules/18907456) to allow tests to complete.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (ran script locally)
