### PR TITLE
Generalize attribute prefix

### DIFF
--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -48,7 +48,9 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   }
 
   /*
-   * The prefix used in the application.conf for retriving oidc options.
+   * The prefix used in the application.conf for retrieving oidc options.
+   *
+   * If a '.' is intended to be included in the attribute name, it must be included at the end of the prefix.
    */
   protected abstract String attributePrefix();
 
@@ -103,27 +105,26 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   protected abstract boolean getUseCsrf();
 
   /*
-   * Helper function for retriving values from the application.conf,
-   * prepended with "<attributePrefix>."
+   * Helper function for retrieving values from the application.conf,
+   * prepended with <attributePrefix>
    */
   protected final Optional<String> getConfigurationValue(String suffix) {
-    String name = attributePrefix() + "." + suffix;
+    String name = attributePrefix() + suffix;
     return getBaseConfigurationValue(name);
   }
 
   /*
-   * Helper function for retriving values from the application.conf,
-   * prepended with "<attributePrefix>."
+   * Helper function for retrieving values from the application.conf,
+   * prepended with <attributePrefix>
    */
   protected final String getConfigurationValueOrThrow(String suffix) {
-    String name = attributePrefix() + "." + suffix;
+    String name = attributePrefix() + suffix;
     return getBaseConfigurationValue(name)
         .orElseThrow(() -> new RuntimeException(name + " must be set"));
   }
 
   /*
-   * Helper function for retriving values from the application.conf,
-   * prepended with "<attributePrefix>."
+   * Helper function for retrieving values from the application.conf.
    */
   protected final Optional<String> getBaseConfigurationValue(String name) {
     if (civiformConfig.hasPath(name)) {

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -15,7 +15,7 @@ import repository.UserRepository;
 
 public class GenericOidcClientProvider extends OidcClientProvider {
 
-  private static final String ATTRIBUTE_PREFIX = "applicant_generic_oidc";
+  private static final String ATTRIBUTE_PREFIX = "applicant_generic_oidc.";
   private static final ImmutableList<String> DEFAULT_SCOPES =
       ImmutableList.of("openid", "profile", "email");
 

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -15,7 +15,7 @@ import repository.UserRepository;
 /** This class customized the OIDC provider to a specific provider, allowing overrides to be set. */
 public final class IdcsClientProvider extends OidcClientProvider {
 
-  private static final String ATTRIBUTE_PREFIX = "idcs";
+  private static final String ATTRIBUTE_PREFIX = "idcs.";
   private static final String CLIENT_ID_CONFIG_NAME = "client_id";
   private static final String CLIENT_SECRET_CONFIG_NAME = "secret";
   private static final String DISCOVERY_URI_CONFIG_NAME = "discovery_uri";

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -33,7 +33,7 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
   @Override
   @VisibleForTesting
   public String attributePrefix() {
-    return "login_gov";
+    return "login_gov.";
   }
 
   @Override


### PR DESCRIPTION
### Description

Generalize attribute prefix so that a '.' is not required in the config var name.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Relates to #5401
