### PR TITLE
Radio button list now selects the item anywhere on the line

### DIFF
--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -71,10 +71,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
       ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode,
       Optional<String> questionName) {
     String id = RandomStringUtils.randomAlphabetic(8);
-    LabelTag labelTag =
-        label()
-            .withFor(id)
-            .with(span(option.optionText()).withClasses(ReferenceClasses.MULTI_OPTION_VALUE));
+
     InputTag inputTag =
         input()
             .withId(id)
@@ -92,6 +89,13 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
             .condAttr(!isOptional, "aria-required", "true")
             .withClasses(StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO));
 
+    LabelTag labelTag =
+        label()
+            .withFor(id)
+            .withClasses("inline-block", "w-full", "h-full")
+            .with(inputTag)
+            .with(span(option.optionText()).withClasses(ReferenceClasses.MULTI_OPTION_VALUE));
+
     return div()
         .withClasses(
             "my-2",
@@ -100,7 +104,6 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
             ReferenceClasses.RADIO_OPTION,
             BaseStyles.RADIO_LABEL,
             checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
-        .with(inputTag)
         .with(labelTag);
   }
 }


### PR DESCRIPTION
### Description

Radio button list will now select the item no matter where on the item you click. Now works like the checkbox question

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features


### Instructions for manual testing

Click on the radio button itself, click on the text next to the radio button, or click on the whitespace in the box. These will all select the button now.
