### PR TITLE
Create change that breaks bin/run-dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - LOGIN_RADIUS_KEYSTORE_PASS
       - LOGIN_RADIUS_KEYSTORE_NAME
       - CIVIFORM_APPLICANT_IDP=generic-oidc
-      - CIVIFORM_ADMIN_IDP=adfs
+      - CIVIFORM_ADMIN_IDP=typo
       # Hard coded in test-support/test_oidc_provider.js
       - IDCS_CLIENT_ID=idcs-fake-oidc-client
       - IDCS_SECRET=idcs-fake-oidc-secret


### PR DESCRIPTION
This is a change that passes GH checks but breaks `bin/run-dev`.

The checks that were run for this PR didn't run the junit or browser tests, so I triggered them [manually](https://github.com/civiform/civiform/actions/runs/5967985213). They all passed as well.

