### PR TITLE
Do not require CIVIFORM_ADMIN_IDP to be set

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1221,7 +1221,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "CIVIFORM_ADMIN_IDP",
                               "What identity provider to use for admins.",
-                              /* isRequired= */ true,
+                              /* isRequired= */ false,
                               SettingType.ENUM,
                               SettingMode.ADMIN_READABLE,
                               ImmutableList.of("adfs", "generic-oidc-admin")))),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -231,7 +231,7 @@
             "description": "What identity provider to use for admins.",
             "type": "string",
             "values": ["adfs", "generic-oidc-admin"],
-            "required": true
+            "required": false
           },
           "Active Directory Federation Services": {
             "group_description": "Configuration options for the [ADFS](https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#azure-a-d-and-adfs-oidc) provider.",


### PR DESCRIPTION
### Description

Do not require env var `CIVIFORM_ADMIN_IDP` to be set, as this breaks existing deployments. Instead, rely on the [default value](https://github.com/civiform/civiform/blob/602b568e51b1dd039e78f988848f1ead2b0e1fb6/server/conf/helper/auth.conf#L4) of `"adfs"` if not set.

### Issue(s) this completes

Relates to #5401 
