### PR TITLE
Add play http thread pool variables

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -430,6 +430,55 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * Determines which kind of ExecutorService to use for the default dispatcher. The default is
+   * 'fork-join-executor'
+   */
+  public Optional<String> getAkkaDefaultExecutor() {
+    return getString("AKKA_DEFAULT_EXECUTOR");
+  }
+
+  /**
+   * Min number of threads to cap factor-based parallelism number to for the 'fork-join-executor'
+   */
+  public Optional<Integer> getForkJoinParallelismMin() {
+    return getInt("FORK_JOIN_PARALLELISM_MIN");
+  }
+
+  /**
+   * Max number of threads to cap factor-based parallelism number to for the 'fork-join-executor'
+   */
+  public Optional<Integer> getForkJoinParallelismMax() {
+    return getInt("FORK_JOIN_PARALLELISM_MAX");
+  }
+
+  /**
+   * The parallelism factor is used to determine thread pool size for the 'fork-join-executor' using
+   * the following formula: ceil(available processors * factor). Resulting size is then bounded by
+   * the parallelism-min and parallelism-max values.
+   */
+  public Optional<Integer> getForkJoinParallelismFactor() {
+    return getInt("FORK_JOIN_PARALLELISM_FACTOR");
+  }
+
+  /**
+   * The size of the thread pool for the 'thread-pool-executor' type. If not defined, this will use
+   * the
+   * [default](https://github.com/akka/akka/blob/main/akka-actor/src/main/resources/reference.conf#L492)
+   * core and max pool sizes.
+   */
+  public Optional<Integer> getThreadPoolExecutorFixedPoolSize() {
+    return getInt("THREAD_POOL_EXECUTOR_FIXED_POOL_SIZE");
+  }
+
+  /**
+   * The number of messages that are processed in a batch before the thread is returned to the pool.
+   * Set to 1 for as fair as possible.
+   */
+  public Optional<Integer> getAkkaThroughput() {
+    return getInt("AKKA_THROUGHPUT");
+  }
+
+  /**
    * Region where the AWS SES service exists. If STORAGE_SERVICE_NAME is set to 'aws', it is also
    * the region where the AWS s3 service exists.
    */
@@ -1262,6 +1311,59 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.SECRET))),
+                  SettingsSection.create(
+                      "Thread pools",
+                      "Configures the Play framework [thread"
+                          + " pools](https://www.playframework.com/documentation/2.8.x/ThreadPools).",
+                      ImmutableList.of(),
+                      ImmutableList.of(
+                          SettingDescription.create(
+                              "AKKA_DEFAULT_EXECUTOR",
+                              "Determines which kind of ExecutorService to use for the default"
+                                  + " dispatcher. The default is 'fork-join-executor'",
+                              /* isRequired= */ false,
+                              SettingType.STRING,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "FORK_JOIN_PARALLELISM_MIN",
+                              "Min number of threads to cap factor-based parallelism number to for"
+                                  + " the 'fork-join-executor'",
+                              /* isRequired= */ false,
+                              SettingType.INT,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "FORK_JOIN_PARALLELISM_MAX",
+                              "Max number of threads to cap factor-based parallelism number to for"
+                                  + " the 'fork-join-executor'",
+                              /* isRequired= */ false,
+                              SettingType.INT,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "FORK_JOIN_PARALLELISM_FACTOR",
+                              "The parallelism factor is used to determine thread pool size for"
+                                  + " the 'fork-join-executor' using the following formula:"
+                                  + " ceil(available processors * factor). Resulting size is then"
+                                  + " bounded by the parallelism-min and parallelism-max values.",
+                              /* isRequired= */ false,
+                              SettingType.INT,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "THREAD_POOL_EXECUTOR_FIXED_POOL_SIZE",
+                              "The size of the thread pool for the 'thread-pool-executor' type. If"
+                                  + " not defined, this will use the"
+                                  + " [default](https://github.com/akka/akka/blob/main/akka-actor/src/main/resources/reference.conf#L492)"
+                                  + " core and max pool sizes.",
+                              /* isRequired= */ false,
+                              SettingType.INT,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "AKKA_THROUGHPUT",
+                              "The number of messages that are processed in a batch before the"
+                                  + " thread is returned to the pool. Set to 1 for as fair as"
+                                  + " possible.",
+                              /* isRequired= */ false,
+                              SettingType.INT,
+                              SettingMode.HIDDEN))),
                   SettingsSection.create(
                       "Application File Upload Storage",
                       "Configuration options for the application file upload storage provider",

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -46,6 +46,43 @@ akka {
   #
   #log-config-on-start = true
   logger-startup-timeout = 30s
+
+  actor {
+    default-dispatcher {
+      # What kind of ExecutionService to use
+      executor = "fork-join-executor"
+      executor = ${?AKKA_DEFAULT_EXECUTOR}
+      # Configuration for the fork join pool if that is the executor type
+      fork-join-executor {
+        # Min number of threads to cap factor-based parallelism number to
+        parallelism-min = 8
+        parallelism-min = ${?FORK_JOIN_PARALLELISM_MIN}
+        # Parallelism (threads) ... ceil(available processors * factor)
+        parallelism-factor = 1.0
+        parallelism-factor = ${?FORK_JOIN_PARALLELISM_FACTOR}
+        # Max number of threads to cap factor-based parallelism number to
+        parallelism-max = 64
+        parallelism-max = ${?FORK_JOIN_PARALLELISM_MAX}
+      }
+      # This will be used if you have set "executor = "thread-pool-executor""
+      # Underlying thread pool implementation is java.util.concurrent.ThreadPoolExecutor
+      thread-pool-executor {
+        # Define a fixed thread pool size with this property. The corePoolSize
+        # and the maximumPoolSize of the ThreadPoolExecutor will be set to this
+        # value, if it is defined. Then the other pool-size properties will not
+        # be used.
+        #
+        # Valid values are: `off` or a positive integer.
+        fixed-pool-size = off
+        fixed-pool-size = ${?THREAD_POOL_EXECUTOR_FIXED_POOL_SIZE}
+      }
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 5
+      throughput = ${?AKKA_THROUGHPUT}
+    }
+  }
 }
 
 ## Secret key

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -355,6 +355,41 @@
           }
         }
       },
+      "Thread pools": {
+        "group_description": "Configures the Play framework [thread pools](https://www.playframework.com/documentation/2.8.x/ThreadPools).",
+        "members": {
+          "AKKA_DEFAULT_EXECUTOR": {
+            "mode": "HIDDEN",
+            "description": "Determines which kind of ExecutorService to use for the default dispatcher. The default is 'fork-join-executor'",
+            "type": "string"
+          },
+          "FORK_JOIN_PARALLELISM_MIN": {
+            "mode": "HIDDEN",
+            "description": "Min number of threads to cap factor-based parallelism number to for the 'fork-join-executor'",
+            "type": "int"
+          },
+          "FORK_JOIN_PARALLELISM_MAX": {
+            "mode": "HIDDEN",
+            "description": "Max number of threads to cap factor-based parallelism number to for the 'fork-join-executor'",
+            "type": "int"
+          },
+          "FORK_JOIN_PARALLELISM_FACTOR": {
+            "mode": "HIDDEN",
+            "description": "The parallelism factor is used to determine thread pool size for the 'fork-join-executor' using the following formula: ceil(available processors * factor). Resulting size is then bounded by the parallelism-min and parallelism-max values.",
+            "type": "int"
+          },
+          "THREAD_POOL_EXECUTOR_FIXED_POOL_SIZE": {
+            "mode": "HIDDEN",
+            "description": "The size of the thread pool for the 'thread-pool-executor' type. If not defined, this will use the [default](https://github.com/akka/akka/blob/main/akka-actor/src/main/resources/reference.conf#L492) core and max pool sizes.",
+            "type": "int"
+          },
+          "AKKA_THROUGHPUT": {
+            "mode": "HIDDEN",
+            "description": "The number of messages that are processed in a batch before the thread is returned to the pool. Set to 1 for as fair as possible.",
+            "type": "int"
+          }
+        }
+      },
       "AWS_REGION": {
         "mode": "HIDDEN",
         "description": "Region where the AWS SES service exists. If STORAGE_SERVICE_NAME is set to 'aws', it is also the region where the AWS s3 service exists.",


### PR DESCRIPTION
### Description

We currently use play's default HTTP thread count. We should make this configurable to optimize resource utilization. 

If unset, we use the akka defaults https://github.com/akka/akka/blob/main/akka-actor/src/main/resources/reference.conf#L357-L572

## Release notes

Allow for configurability of HTTP thread count settings

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Related to [#4722
](https://github.com/civiform/civiform/issues/4722)
