### PR TITLE
Remove database call to get question data on index page if not needed

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -820,16 +820,16 @@ public final class ApplicantService {
                 applicantId, ImmutableSet.of(LifecycleStage.DRAFT, LifecycleStage.ACTIVE))
             .toCompletableFuture();
     ImmutableList<ProgramDefinition> activeProgramDefinitions =
-            versionRepository.getActiveVersion().getPrograms().stream()
-                .map(Program::getProgramDefinition)
-                .filter(
-                    pdef ->
-                        pdef.displayMode().equals(DisplayMode.PUBLIC)
-                            || (requesterProfile.isTrustedIntermediary()
-                                && pdef.displayMode().equals(DisplayMode.TI_ONLY))
-                            || (pdef.displayMode().equals(DisplayMode.SELECT_TI)
-                                && pdef.acls().hasProgramViewPermission(requesterProfile)))
-                .collect(ImmutableList.toImmutableList());
+        versionRepository.getActiveVersion().getPrograms().stream()
+            .map(Program::getProgramDefinition)
+            .filter(
+                pdef ->
+                    pdef.displayMode().equals(DisplayMode.PUBLIC)
+                        || (requesterProfile.isTrustedIntermediary()
+                            && pdef.displayMode().equals(DisplayMode.TI_ONLY))
+                        || (pdef.displayMode().equals(DisplayMode.SELECT_TI)
+                            && pdef.acls().hasProgramViewPermission(requesterProfile)))
+            .collect(ImmutableList.toImmutableList());
 
     return applicationsFuture
         .thenComposeAsync(
@@ -851,7 +851,7 @@ public final class ApplicantService {
               ImmutableSet<Application> applications = applicationsFuture.join();
               logDuplicateDrafts(applications);
               return relevantProgramsForApplicantInternal(
-                activeProgramDefinitions, applications, allPrograms);
+                  activeProgramDefinitions, applications, allPrograms);
             },
             httpExecutionContext.current());
   }


### PR DESCRIPTION
### Description

We look up question data on the program admin page in order to determine eligibility status, but we don't need to do this if the user hasn't started any applications.

This reduces the number of question calls from 1x per program to 1x total.

There are further improvements we can make, but this is the first step.

This change also removes a call to get applicant info, which doesn't seem to be used.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

#5514
