### PR TITLE
Redirect to home if user is not authorized in ApplicantProgramsController

### DIFF
--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -4,25 +4,6 @@ import {BASE_URL} from './support/config'
 describe('applicant security', () => {
   const ctx = createTestContext()
 
-  it('applicant cannot access another applicant data', async () => {
-    const {page} = ctx
-    // this test visits page that returns 401 which triggers BrowserErrorWatcher.
-    // Silencing error on that page.
-    ctx.browserErrorWatcher.ignoreErrorsFromUrl(/applicants\/1234\/programs/)
-    const response = await gotoEndpoint(page, '/applicants/1234/programs')
-    expect(response!.status()).toBe(401)
-  })
-
-  it('admin cannot access applicant pages', async () => {
-    const {page} = ctx
-    // this test visits page that returns 401 which triggers BrowserErrorWatcher.
-    // Silencing error on that page.
-    ctx.browserErrorWatcher.ignoreErrorsFromUrl(/applicants\/1234567\/programs/)
-    await loginAsAdmin(page)
-    const response = await gotoEndpoint(page, '/applicants/1234567/programs')
-    expect(response!.status()).toBe(401)
-  })
-
   it('applicant cannot access admin pages', async () => {
     const {page} = ctx
     // this test visits page that returns 401 which triggers BrowserErrorWatcher.

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -145,6 +145,8 @@ public final class ApplicantProgramsController extends CiviFormController {
             ex -> {
               if (ex instanceof CompletionException) {
                 if (ex.getCause() instanceof SecurityException) {
+                  // If the applicant id in the URL does not correspond to the current user, start
+                  // from scratch. This could happen if a user bookmarks a URL.
                   return redirectToHome();
                 }
               }
@@ -197,6 +199,8 @@ public final class ApplicantProgramsController extends CiviFormController {
               if (ex instanceof CompletionException) {
                 Throwable cause = ex.getCause();
                 if (cause instanceof SecurityException) {
+                  // If the applicant id in the URL does not correspond to the current user, start
+                  // from scratch. This could happen if a user bookmarks a URL.
                   return redirectToHome();
                 }
                 if (cause instanceof ProgramNotFoundException) {

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -7,7 +7,6 @@ import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
 import static support.CfTestHelpers.requestBuilderWithSettings;
@@ -30,7 +29,6 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.VersionRepository;
-import scala.App;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.question.QuestionAnswerer;
@@ -63,7 +61,8 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void index_applicantWithoutProfile_redirectsToHome() {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    Result result = controller.index(request, applicantWithoutProfile.id).toCompletableFuture().join();
+    Result result =
+        controller.index(request, applicantWithoutProfile.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -218,21 +217,47 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void edit_differentApplicant_returnsUnauthorizedResult() {
+  public void view_applicantWithoutProfile_redirectsToHome() {
+    Program program = resourceCreator().insertActiveProgram("program");
+
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id + 1, 1L).toCompletableFuture().join();
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+        controller
+            .view(request, applicantWithoutProfile.id, program.id)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test
-  public void edit_applicantAccessToDraftProgram_returnsUnauthorized() {
+  public void edit_differentApplicant_redirectsToHome() {
+    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Result result =
+        controller.edit(request, currentApplicant.id + 1, 1L).toCompletableFuture().join();
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
+  public void edit_applicantWithoutProfile_redirectsToHome() {
+    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Result result =
+        controller.edit(request, applicantWithoutProfile.id, 1L).toCompletableFuture().join();
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
+  public void edit_applicantAccessToDraftProgram_redirectsToHome() {
     Program draftProgram = ProgramBuilder.newDraftProgram().build();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
         controller.edit(request, currentApplicant.id, draftProgram.id).toCompletableFuture().join();
 
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -30,6 +30,7 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.VersionRepository;
+import scala.App;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.question.QuestionAnswerer;
@@ -39,6 +40,7 @@ import support.ProgramBuilder;
 public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   private Applicant currentApplicant;
+  private Applicant applicantWithoutProfile;
   private ApplicantProgramsController controller;
   private VersionRepository versionRepository;
 
@@ -47,13 +49,23 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     resetDatabase();
     controller = instanceOf(ApplicantProgramsController.class);
     currentApplicant = createApplicantWithMockedProfile();
+    applicantWithoutProfile = createApplicant();
   }
 
   @Test
-  public void index_differentApplicant_returnsUnauthorizedResult() {
+  public void index_differentApplicant_redirectsToHome() {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result = controller.index(request, currentApplicant.id + 1).toCompletableFuture().join();
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
+  public void index_applicantWithoutProfile_redirectsToHome() {
+    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Result result = controller.index(request, applicantWithoutProfile.id).toCompletableFuture().join();
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
   }
 
   @Test


### PR DESCRIPTION
### Description

Revised the behavior of `ApplicantProgramsController` to redirect user to home page if authorization fails. Getting a 401 response is not helping anyone.

I removed the browser tests, because the browser just shows the home page, and the test cannot tell if this is for an old session or the new one. The new behavior is covered by controller tests and has also been tested manually.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

1. Go to CiviForm address (any environment)
1. Copy URL
1. Click end session
1. Create new tab
1. Paste the URL copied in step 2
1. Verify user is redirected to home page with a different numeric value in the URL

### Issue(s) this completes

Fixes #5528 
