### PR TITLE
Add admin names to QuestionOptions

### DIFF
--- a/server/app/services/question/QuestionOption.java
+++ b/server/app/services/question/QuestionOption.java
@@ -21,6 +21,10 @@ public abstract class QuestionOption {
   @JsonProperty("id")
   public abstract long id();
 
+  /** The immutable admin name for this option. */
+  @JsonProperty("adminName")
+  public abstract String adminName();
+
   /** The text strings to display to the user, keyed by locale. */
   @JsonProperty("localizedOptionText")
   public abstract LocalizedStrings optionText();
@@ -51,8 +55,13 @@ public abstract class QuestionOption {
 
   /** Create a QuestionOption. */
   public static QuestionOption create(long id, long displayOrder, LocalizedStrings optionText) {
+    // TODO(#4862): Get the adminName from the user, instead of defaulting it to the default
+    // locale's option text.
+    String adminName = optionText.maybeGet(Locale.getDefault()).orElse(String.valueOf(id));
+
     return QuestionOption.builder()
         .setId(id)
+        .setAdminName(adminName)
         .setOptionText(optionText)
         .setDisplayOrder(OptionalLong.of(displayOrder))
         .build();
@@ -60,8 +69,13 @@ public abstract class QuestionOption {
 
   /** Create a QuestionOption. */
   public static QuestionOption create(long id, LocalizedStrings optionText) {
+    // TODO(#4862): Get the adminName from the user, instead of defaulting it to the default
+    // locale's option text.
+    String adminName = optionText.maybeGet(Locale.getDefault()).orElse(String.valueOf(id));
+
     return QuestionOption.builder()
         .setId(id)
+        .setAdminName(adminName)
         .setOptionText(optionText)
         .setDisplayOrder(OptionalLong.empty())
         .build();
@@ -105,6 +119,9 @@ public abstract class QuestionOption {
 
     @JsonProperty("id")
     public abstract Builder setId(long id);
+
+    @JsonProperty("adminName")
+    public abstract Builder setAdminName(String adminName);
 
     @JsonProperty("localizedOptionText")
     public abstract Builder setOptionText(LocalizedStrings optionText);

--- a/server/conf/evolutions/default/57.sql
+++ b/server/conf/evolutions/default/57.sql
@@ -1,0 +1,32 @@
+-- These assume a default locale of en_US, which is true for all deployments as of 2023-09-05.
+
+# --- !Ups
+UPDATE ONLY questions
+SET question_options = (
+  SELECT jsonb_agg(
+           jsonb_set(
+             question_option,
+             '{adminName}',
+             CASE
+               WHEN question_option->'localizedOptionText'->'translations' ? 'en_US'
+                 AND jsonb_typeof(question_option->'localizedOptionText'->'translations'->'en_US') = 'string'
+                 AND question_option->'localizedOptionText'->'translations'->>'en_US' <> ''
+               THEN
+                 to_jsonb(question_option->'localizedOptionText'->'translations'->'en_US')
+               ELSE
+                 to_jsonb(question_option->>'id')
+               END,
+             true
+             )
+           )
+  FROM jsonb_array_elements(question_options) AS question_option
+)
+WHERE question_options IS NOT NULL AND jsonb_array_length(question_options) <> 0;
+
+# --- !Downs
+UPDATE ONLY questions
+SET question_options = (
+  SELECT jsonb_agg((question_option - 'adminName'))
+  FROM jsonb_array_elements(question_options) AS question_option
+)
+WHERE question_options IS NOT NULL;

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -35,6 +35,8 @@ public class QuestionOptionTest {
     QuestionOption option =
         QuestionOption.builder()
             .setId(123L)
+            // TODO(#4862): Test the admin name is passed through to the LocalizedQuestionOption
+            .setAdminName("test")
             .setOptionText(LocalizedStrings.withDefaultValue("test"))
             .setDisplayOrder(OptionalLong.of(1L))
             .build();
@@ -42,5 +44,19 @@ public class QuestionOptionTest {
     assertThat(option.localize(LocalizedStrings.DEFAULT_LOCALE))
         .isEqualTo(
             LocalizedQuestionOption.create(123L, 1L, "test", LocalizedStrings.DEFAULT_LOCALE));
+  }
+
+  @Test
+  public void create_withNoDefaultLocaleText_usesIdAsAdminName() {
+    QuestionOption questionOption =
+        QuestionOption.create(1L, LocalizedStrings.of(Locale.FRANCE, "option 1"));
+
+    assertThat(questionOption)
+        .isEqualTo(
+            QuestionOption.builder()
+                .setOptionText(LocalizedStrings.of(Locale.FRANCE, "option 1"))
+                .setAdminName("1")
+                .setId(1L)
+                .build());
   }
 }


### PR DESCRIPTION
### Description

Migrates the `question_options` fields of `questions` to have an admin name, which will be used when the answer is exported via the API. If an option doesn't have an `en_US` translation, the option id is used.

Previously, `question_options` field was a JSON array of options, each of which look like:
```js
  {
    "id": 1,
    "displayOrder": 1,
    "localizedOptionText": {
      "isRequired": true,
      "translations": {
        "en_US": "SMEG blue retro toaster"
      }
    }
  },
```

With this migration, each now has an additional `adminName` field that is set from the default locale's option text:
```js
  {
    "id": 1,
    "adminName": "SMEG blue retro toaster",
    "displayOrder": 1,
    "localizedOptionText": {
      "isRequired": true,
      "translations": {
        "en_US": "SMEG blue retro toaster"
      }
    }
  },
```

For now, this is not exposed to the user; we just assign the default locale's option text as the admin name. In a future PR, we will add an admin name field to the option creation UI, so the admin name can be different then the option text:
```js
  {
    "id": 1,
    "adminName": "toaster",
    "displayOrder": 1,
    "localizedOptionText": {
      "isRequired": true,
      "translations": {
        "en_US": "SMEG blue retro toaster"
      }
    }
  },
```

If there is no `en_US` translation or it's blank, we have:
```js
  {
    "id": 1,
    "adminName": "1",
    "displayOrder": 1,
    "localizedOptionText": {
      "isRequired": true,
      "translations": {
        "fr_FR": "SMEG blue retro toaster"
      }
    }
  },
```

See #4862 for details and the work plan.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [n/a] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary (See #5350)

#### User visible changes

n/a

#### New Features

n/a

### Instructions for manual testing

- With a database that contains question options, start the app and ensure everything loads correclty.
- Create a new question option and ensure that the database includes an "adminName" field.

### Issue(s) this completes

Part of #4862
