### PR TITLE
Update JSON to use admin names

### DIFF
--- a/server/app/services/applicant/question/MultiSelectQuestion.java
+++ b/server/app/services/applicant/question/MultiSelectQuestion.java
@@ -12,6 +12,7 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
+import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 
 /**
@@ -95,6 +96,22 @@ public final class MultiSelectQuestion extends Question {
     return Optional.of(
         getOptions(locale).stream()
             .filter(option -> optionIds.contains(option.id()))
+            .collect(toImmutableList()));
+  }
+
+  public Optional<ImmutableList<String>> getSelectedOptionsAdminName() {
+    Optional<ImmutableList<Long>> maybeSelectedOptionIds =
+        applicantQuestion.getApplicantData().readLongList(getSelectionPath());
+
+    if (maybeSelectedOptionIds.isEmpty()) {
+      return Optional.empty();
+    }
+
+    ImmutableList<Long> selectedOptionIds = maybeSelectedOptionIds.get();
+    return Optional.of(
+        getQuestionDefinition().getOptions().stream()
+            .filter(option -> selectedOptionIds.contains(option.id()))
+            .map(QuestionOption::adminName)
             .collect(toImmutableList()));
   }
 

--- a/server/app/services/applicant/question/SingleSelectQuestion.java
+++ b/server/app/services/applicant/question/SingleSelectQuestion.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
+import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 
 /**
@@ -68,6 +69,19 @@ public final class SingleSelectQuestion extends Question {
     return getOptions(locale).stream()
         .filter(option -> selectedOptionId == option.id())
         .findFirst();
+  }
+
+  public Optional<String> getSelectedOptionAdminName() {
+    Optional<Long> maybeSelectedOptionId = getSelectedOptionId();
+    if (maybeSelectedOptionId.isEmpty()) {
+      return Optional.empty();
+    }
+
+    Long selectedOptionId = maybeSelectedOptionId.get();
+    return getQuestionDefinition().getOptions().stream()
+        .filter(option -> selectedOptionId == option.id())
+        .findFirst()
+        .map(QuestionOption::adminName);
   }
 
   public MultiOptionQuestionDefinition getQuestionDefinition() {

--- a/server/app/services/export/QuestionJsonPresenter.java
+++ b/server/app/services/export/QuestionJsonPresenter.java
@@ -12,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import javax.inject.Inject;
-import services.LocalizedStrings;
 import services.Path;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
@@ -26,7 +25,6 @@ import services.applicant.question.Scalar;
 import services.applicant.question.SingleSelectQuestion;
 import services.export.enums.ApiPathSegment;
 import services.export.enums.QuestionTypeExternal;
-import services.question.LocalizedQuestionOption;
 import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
 
@@ -198,9 +196,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
       Path path = question.getSelectionPath().asNestedEntitiesPath();
 
       ImmutableList<String> selectedOptions =
-          question.getSelectedOptionsValue().orElse(ImmutableList.of()).stream()
-              .map(LocalizedQuestionOption::optionText)
-              .collect(ImmutableList.toImmutableList());
+          question.getSelectedOptionsAdminName().orElse(ImmutableList.of());
 
       return ImmutableMap.of(path, Optional.of(selectedOptions));
     }
@@ -329,8 +325,7 @@ public interface QuestionJsonPresenter<Q extends Question> {
           question
               .getApplicantQuestion()
               .createSingleSelectQuestion()
-              .getSelectedOptionValue(LocalizedStrings.DEFAULT_LOCALE)
-              .map(LocalizedQuestionOption::optionText));
+              .getSelectedOptionAdminName());
     }
   }
 }

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -106,6 +106,15 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   /**
+   * Get the admin names of the question's options.
+   *
+   * @return a list of option admin names.
+   */
+  public ImmutableList<String> getOptionsAdminName() {
+    return this.questionOptions.stream().map(QuestionOption::adminName).collect(toImmutableList());
+  }
+
+  /**
    * Attempt to get question options for the given locale. If there aren't options for the given
    * locale, it will return the options for the default locale.
    */

--- a/server/app/views/api/ApiDocsView.java
+++ b/server/app/views/api/ApiDocsView.java
@@ -19,7 +19,6 @@ import static services.export.JsonPrettifier.asPrettyJsonString;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.OptionTag;
@@ -35,7 +34,6 @@ import play.twirl.api.Content;
 import services.TranslationNotFoundException;
 import services.export.ProgramJsonSampler;
 import services.program.ProgramDefinition;
-import services.question.LocalizedQuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import views.BaseHtmlLayout;
@@ -234,12 +232,7 @@ public class ApiDocsView extends BaseHtmlView {
   }
 
   private static String getOptionsString(MultiOptionQuestionDefinition questionDefinition) {
-    ImmutableList<LocalizedQuestionOption> options =
-        questionDefinition.getOptionsForDefaultLocale();
-    ImmutableList<String> optionsText =
-        options.stream().map(LocalizedQuestionOption::optionText).collect(toImmutableList());
-
-    return "\"" + String.join("\", \"", optionsText) + "\"";
+    return "\"" + String.join("\", \"", questionDefinition.getOptionsAdminName()) + "\"";
   }
 
   private boolean isAuthenticatedAdmin(Http.Request request) {

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -25,6 +25,10 @@ import services.question.types.QuestionDefinitionConfig;
 
 public class MultiSelectQuestionTest {
 
+  // TODO(#4862): Once the admin name is assignable and different then the
+  //  default locale's text, test getSelectedOptionsAdminName() returns it instead
+  //  of the default locale's text.
+
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()
           .setName("name")

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -20,6 +20,10 @@ import services.question.types.QuestionDefinitionConfig;
 
 public class SingleSelectQuestionTest {
 
+  // TODO(#4862): Once the admin name is assignable and different then the
+  //  default locale's text, test getSelectedOptionAdminName() returns it instead
+  //  of the default locale's text.
+
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()
           .setName("question name")

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -642,6 +642,32 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
+    public FakeApplicationFiller answerDropdownQuestion(Long optionId) {
+      Path answerPath =
+          testQuestionBank
+              .applicantIceCream()
+              .getQuestionDefinition()
+              .getContextualizedPath(
+                  /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
+      ApplicantData applicantData = applicant.getApplicantData();
+      QuestionAnswerer.answerSingleSelectQuestion(applicantData, answerPath, optionId);
+      applicant.save();
+      return this;
+    }
+
+    public FakeApplicationFiller answerRadioButtonQuestion(Long optionId) {
+      Path answerPath =
+          testQuestionBank
+              .applicantSeason()
+              .getQuestionDefinition()
+              .getContextualizedPath(
+                  /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
+      ApplicantData applicantData = applicant.getApplicantData();
+      QuestionAnswerer.answerSingleSelectQuestion(applicantData, answerPath, optionId);
+      applicant.save();
+      return this;
+    }
+
     public FakeApplicationFiller answerEmailQuestion(String answer) {
       Path answerPath =
           testQuestionBank

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -415,6 +415,54 @@ public class JsonExporterTest extends AbstractExporterTest {
   }
 
   @Test
+  public void export_whenDropdownQuestionIsAnswered_valueIsInResponse() {
+    createFakeQuestions();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
+    new FakeApplicationFiller(fakeProgram).answerDropdownQuestion(2L /* strawberry */).submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_ice_cream",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
+            + "  \"selection\" : \"strawberry\"\n"
+            + "}");
+  }
+
+  @Test
+  public void export_whenDropdownQuestionIsNotAnswered_valueInResponseIsNull() {
+    createFakeQuestions();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_ice_cream",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
+            + "  \"selection\" : null\n"
+            + "}");
+  }
+
+  @Test
   public void export_whenEmailQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
@@ -557,6 +605,54 @@ public class JsonExporterTest extends AbstractExporterTest {
         "{\n" // comment to prevent fmt wrapping
             + "  \"phone_number\" : null,\n"
             + "  \"question_type\" : \"PHONE\"\n"
+            + "}");
+  }
+
+  @Test
+  public void export_whenRadioButtonQuestionIsAnswered_valueIsInResponse() {
+    createFakeQuestions();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
+    new FakeApplicationFiller(fakeProgram).answerRadioButtonQuestion(3L /* summer */).submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_favorite_season",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
+            + "  \"selection\" : \"summer\"\n"
+            + "}");
+  }
+
+  @Test
+  public void export_whenRadioButtonQuestionIsNotAnswered_valueInResponseIsNull() {
+    createFakeQuestions();
+    var fakeProgram =
+        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
+    new FakeApplicationFiller(fakeProgram).submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_favorite_season",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
+            + "  \"selection\" : null\n"
             + "}");
   }
 

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -14,6 +14,10 @@ import services.question.exceptions.UnsupportedQuestionTypeException;
 
 public class MultiOptionQuestionDefinitionTest {
 
+  // TODO(#4862): Once the admin name is assignable and different then the
+  //  default locale's text, test getOptionsAdminName() returns it instead
+  //  of the default locale's text.
+
   @Test
   public void buildMultiSelectQuestion() throws UnsupportedQuestionTypeException {
     ImmutableList<QuestionOption> options =


### PR DESCRIPTION
### Description

Updates the JSON API to use the new `adminName` field on QuestionOptions, instead of retrieving the localized user-facing text.

This is not a user facing change, as the `QuestionOption` still just sets the admin name to the default locale's text for now.

## Release notes

n/a - This is not a user-facing change.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary

#### User visible changes

n/a

#### New Features

n/a

### Instructions for manual testing

n/a

### Issue(s) this completes

This is part of #4862
