### PR TITLE
Update QuestionDefinitions to use option adminNames

### DIFF
--- a/server/app/models/Question.java
+++ b/server/app/models/Question.java
@@ -219,6 +219,7 @@ public class Question extends BaseModel {
                     QuestionOption.create(
                         Long.valueOf(i),
                         Long.valueOf(i),
+                        optionText,
                         LocalizedStrings.of(firstKey, optionText)))
             .collect(toImmutableList());
 

--- a/server/app/services/question/LocalizedQuestionOption.java
+++ b/server/app/services/question/LocalizedQuestionOption.java
@@ -12,8 +12,8 @@ public abstract class LocalizedQuestionOption {
 
   /** Create a LocalizedQuestionOption. */
   public static LocalizedQuestionOption create(
-      long id, long order, String optionText, Locale locale) {
-    return new AutoValue_LocalizedQuestionOption(id, order, optionText, locale);
+      long id, long order, String adminName, String optionText, Locale locale) {
+    return new AutoValue_LocalizedQuestionOption(id, order, adminName, optionText, locale);
   }
 
   /** The id for this option. */
@@ -21,6 +21,9 @@ public abstract class LocalizedQuestionOption {
 
   /** The order of the option. */
   public abstract long order();
+
+  /** The immutable identifier for this option, used to reference it in the API and predicates. */
+  public abstract String adminName();
 
   /** The text strings to display to the user. */
   public abstract String optionText();

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -226,21 +226,33 @@ public abstract class QuestionDefinition {
         errors.add(CiviFormError.of("Multi-option questions must have at least one option"));
       }
 
+      if (multiOptionQuestionDefinition.getOptionsAdminName().stream().anyMatch(String::isEmpty)) {
+        errors.add(CiviFormError.of("Multi-option questions cannot have blank admin names"));
+      }
+
       if (multiOptionQuestionDefinition.getOptions().stream()
           .anyMatch(option -> option.optionText().hasEmptyTranslation())) {
         errors.add(CiviFormError.of("Multi-option questions cannot have blank options"));
       }
 
       int numOptions = multiOptionQuestionDefinition.getOptions().size();
-      int numUniqueOptionDefaultValues =
+      long numUniqueOptionDefaultValues =
           multiOptionQuestionDefinition.getOptions().stream()
               .map(QuestionOption::optionText)
               .map(LocalizedStrings::getDefault)
               .distinct()
-              .mapToInt(s -> 1)
-              .sum();
+              .count();
       if (numUniqueOptionDefaultValues != numOptions) {
         errors.add(CiviFormError.of("Multi-option question options must be unique"));
+      }
+
+      long numUniqueOptionAdminNames =
+          multiOptionQuestionDefinition.getOptions().stream()
+              .map(QuestionOption::adminName)
+              .distinct()
+              .count();
+      if (numUniqueOptionAdminNames != numOptions) {
+        errors.add(CiviFormError.of("Multi-option question admin names must be unique"));
       }
 
       OptionalInt minChoicesRequired =

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -235,6 +235,8 @@ public final class QuestionConfig {
                   LocalizedQuestionOption.create(
                       multiOptionQuestionForm.getOptionIds().get(i),
                       optionIndex,
+                      // TODO(#4862): Use the admin name from the form here
+                      multiOptionQuestionForm.getOptions().get(i),
                       multiOptionQuestionForm.getOptions().get(i),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
@@ -246,7 +248,12 @@ public final class QuestionConfig {
           multiOptionQuestionField(
               Optional.of(
                   LocalizedQuestionOption.create(
-                      -1, optionIndex, newOption, LocalizedStrings.DEFAULT_LOCALE)),
+                      -1,
+                      optionIndex,
+                      // TODO(#4862): Use the admin name from the form here
+                      newOption,
+                      newOption,
+                      LocalizedStrings.DEFAULT_LOCALE)),
               messages,
               /* isForNewOption= */ true));
       optionIndex++;

--- a/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
@@ -27,7 +27,8 @@ public class MultiOptionQuestionTranslationFormTest {
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
             config,
-            ImmutableList.of(QuestionOption.create(1L, LocalizedStrings.withDefaultValue("other"))),
+            ImmutableList.of(
+                QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("other"))),
             MultiOptionQuestionType.RADIO_BUTTON);
 
     MultiOptionQuestionTranslationForm form = new MultiOptionQuestionTranslationForm();
@@ -36,7 +37,7 @@ public class MultiOptionQuestionTranslationFormTest {
         (MultiOptionQuestionDefinition) form.builderWithUpdates(question, Locale.CHINA).build();
 
     assertThat(updated.getOptionsForLocale(Locale.CHINA))
-        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "new", Locale.CHINA));
+        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "opt1", "new", Locale.CHINA));
   }
 
   @Test
@@ -52,7 +53,7 @@ public class MultiOptionQuestionTranslationFormTest {
         new MultiOptionQuestionDefinition(
             config,
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.FRANCE, "existing"))),
+                QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.FRANCE, "existing"))),
             MultiOptionQuestionType.RADIO_BUTTON);
 
     MultiOptionQuestionTranslationForm form = new MultiOptionQuestionTranslationForm();
@@ -61,6 +62,6 @@ public class MultiOptionQuestionTranslationFormTest {
         (MultiOptionQuestionDefinition) form.builderWithUpdates(question, Locale.FRANCE).build();
 
     assertThat(updated.getOptionsForLocale(Locale.FRANCE))
-        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "new", Locale.FRANCE));
+        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "opt1", "new", Locale.FRANCE));
   }
 }

--- a/server/test/models/QuestionTest.java
+++ b/server/test/models/QuestionTest.java
@@ -165,7 +165,7 @@ public class QuestionTest extends ResetPostgres {
             .setQuestionHelpText(LocalizedStrings.empty())
             .setQuestionOptions(
                 ImmutableList.of(
-                    QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option"))))
+                    QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option"))))
             .build();
     Question question = new Question(definition);
 
@@ -179,7 +179,8 @@ public class QuestionTest extends ResetPostgres {
 
     assertThat(multiOption.getOptions())
         .isEqualTo(
-            ImmutableList.of(QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option"))));
+            ImmutableList.of(
+                QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option"))));
     assertThat(multiOption.getEnumeratorId()).hasValue(123L);
   }
 

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -25,10 +25,6 @@ import services.question.types.QuestionDefinitionConfig;
 
 public class MultiSelectQuestionTest {
 
-  // TODO(#4862): Once the admin name is assignable and different then the
-  //  default locale's text, test getSelectedOptionsAdminName() returns it instead
-  //  of the default locale's text.
-
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()
           .setName("name")
@@ -46,10 +42,10 @@ public class MultiSelectQuestionTest {
 
   private static final ImmutableList<QuestionOption> QUESTION_OPTIONS =
       ImmutableList.of(
-          QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "valid")),
-          QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "ok")),
-          QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "third")),
-          QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "fourth")));
+          QuestionOption.create(1L, "uno", LocalizedStrings.of(Locale.US, "valid")),
+          QuestionOption.create(2L, "dos", LocalizedStrings.of(Locale.US, "ok")),
+          QuestionOption.create(3L, "tres", LocalizedStrings.of(Locale.US, "third")),
+          QuestionOption.create(4L, "cuatro", LocalizedStrings.of(Locale.US, "fourth")));
 
   private static final MultiOptionQuestionDefinition CHECKBOX_QUESTION =
       new MultiOptionQuestionDefinition(CONFIG, QUESTION_OPTIONS, MultiOptionQuestionType.CHECKBOX);
@@ -165,6 +161,22 @@ public class MultiSelectQuestionTest {
     MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
 
     assertThat(multiSelectQuestion.getValidationErrors().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void getSelectedOptionsAdminName_getsAdminNames() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(CHECKBOX_QUESTION, applicantData, Optional.empty());
+    QuestionAnswerer.answerMultiSelectQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), 0, 1L);
+    QuestionAnswerer.answerMultiSelectQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), 1, 2L);
+
+    Optional<ImmutableList<String>> adminNames =
+        applicantQuestion.createMultiSelectQuestion().getSelectedOptionsAdminName();
+
+    assertThat(adminNames).isPresent();
+    assertThat(adminNames.get()).containsExactlyInAnyOrder("uno", "dos");
   }
 
   @Test

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -20,10 +20,6 @@ import services.question.types.QuestionDefinitionConfig;
 
 public class SingleSelectQuestionTest {
 
-  // TODO(#4862): Once the admin name is assignable and different then the
-  //  default locale's text, test getSelectedOptionAdminName() returns it instead
-  //  of the default locale's text.
-
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()
           .setName("question name")
@@ -37,9 +33,9 @@ public class SingleSelectQuestionTest {
   private static final ImmutableList<QuestionOption> QUESTION_OPTIONS =
       ImmutableList.of(
           QuestionOption.create(
-              1L, LocalizedStrings.of(Locale.US, "option 1", Locale.FRANCE, "un")),
+              1L, "opt1", LocalizedStrings.of(Locale.US, "option 1", Locale.FRANCE, "un")),
           QuestionOption.create(
-              2L, LocalizedStrings.of(Locale.US, "option 2", Locale.FRANCE, "deux")));
+              2L, "opt2", LocalizedStrings.of(Locale.US, "option 2", Locale.FRANCE, "deux")));
 
   private static final MultiOptionQuestionDefinition dropdownQuestionDefinition =
       new MultiOptionQuestionDefinition(CONFIG, QUESTION_OPTIONS, MultiOptionQuestionType.DROPDOWN);
@@ -62,8 +58,8 @@ public class SingleSelectQuestionTest {
 
     assertThat(singleSelectQuestion.getOptions())
         .containsOnly(
-            LocalizedQuestionOption.create(1L, 1L, "option 1", Locale.US),
-            LocalizedQuestionOption.create(2L, 2L, "option 2", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "opt1", "option 1", Locale.US),
+            LocalizedQuestionOption.create(2L, 2L, "opt2", "option 2", Locale.US));
     assertThat(applicantQuestion.hasErrors()).isFalse();
   }
 
@@ -78,7 +74,7 @@ public class SingleSelectQuestionTest {
 
     assertThat(singleSelectQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue())
-        .hasValue(LocalizedQuestionOption.create(1L, 1L, "option 1", Locale.US));
+        .hasValue(LocalizedQuestionOption.create(1L, 1L, "opt1", "option 1", Locale.US));
   }
 
   @Test
@@ -92,6 +88,20 @@ public class SingleSelectQuestionTest {
 
     assertThat(singleSelectQuestion.getValidationErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue()).isEmpty();
+  }
+
+  @Test
+  public void getSelectedOptionAdminName_getsAdminName() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dropdownQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerSingleSelectQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), 2L);
+
+    Optional<String> adminNames =
+        applicantQuestion.createSingleSelectQuestion().getSelectedOptionAdminName();
+
+    assertThat(adminNames).isPresent();
+    assertThat(adminNames.get()).isEqualTo("opt2");
   }
 
   @Test

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -14,16 +14,12 @@ import services.question.exceptions.UnsupportedQuestionTypeException;
 
 public class MultiOptionQuestionDefinitionTest {
 
-  // TODO(#4862): Once the admin name is assignable and different then the
-  //  default locale's text, test getOptionsAdminName() returns it instead
-  //  of the default locale's text.
-
   @Test
   public void buildMultiSelectQuestion() throws UnsupportedQuestionTypeException {
     ImmutableList<QuestionOption> options =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option 1")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "option 2")));
+            QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option 1")),
+            QuestionOption.create(2L, "opt1", LocalizedStrings.of(Locale.US, "option 2")));
 
     QuestionDefinition definition =
         new QuestionDefinitionBuilder()
@@ -52,7 +48,7 @@ public class MultiOptionQuestionDefinitionTest {
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "test", Locale.FRANCE, "test"))
             .setQuestionOptions(
                 ImmutableList.of(
-                    QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option 1"))))
+                    QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option 1"))))
             .build();
 
     assertThat(definition.getSupportedLocales()).containsExactly(Locale.US);
@@ -74,9 +70,10 @@ public class MultiOptionQuestionDefinitionTest {
                 ImmutableList.of(
                     QuestionOption.create(
                         1L,
+                        "opt1",
                         LocalizedStrings.of(Locale.US, "1", Locale.FRANCE, "1", Locale.UK, "1")),
                     QuestionOption.create(
-                        1L, LocalizedStrings.of(Locale.US, "2", Locale.FRANCE, "2"))))
+                        1L, "opt2", LocalizedStrings.of(Locale.US, "2", Locale.FRANCE, "2"))))
             .build();
 
     assertThat(definition.getSupportedLocales()).containsExactly(Locale.US, Locale.FRANCE);
@@ -93,7 +90,7 @@ public class MultiOptionQuestionDefinitionTest {
             .setQuestionHelpText(LocalizedStrings.empty())
             .setQuestionOptions(
                 ImmutableList.of(
-                    QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option 1"))))
+                    QuestionOption.create(1L, "ay", LocalizedStrings.of(Locale.US, "option 1"))))
             .build();
 
     MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
@@ -107,9 +104,10 @@ public class MultiOptionQuestionDefinitionTest {
   public void getOptionsForLocale_returnsAllTranslations() throws Exception {
     ImmutableList<QuestionOption> options =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "one", Locale.GERMAN, "eins")),
             QuestionOption.create(
-                2L, LocalizedStrings.of(Locale.US, "two", Locale.GERMAN, "zwei")));
+                1L, "ay", LocalizedStrings.of(Locale.US, "one", Locale.GERMAN, "eins")),
+            QuestionOption.create(
+                2L, "bee", LocalizedStrings.of(Locale.US, "two", Locale.GERMAN, "zwei")));
     QuestionDefinition definition =
         new QuestionDefinitionBuilder()
             .setQuestionType(QuestionType.DROPDOWN)
@@ -124,17 +122,19 @@ public class MultiOptionQuestionDefinitionTest {
 
     assertThat(multiOption.getOptionsForLocale(Locale.US))
         .containsExactly(
-            LocalizedQuestionOption.create(1L, 1L, "one", Locale.US),
-            LocalizedQuestionOption.create(2L, 2L, "two", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "ay", "one", Locale.US),
+            LocalizedQuestionOption.create(2L, 2L, "bee", "two", Locale.US));
   }
 
   @Test
   public void getOptionsForLocaleOrDefault_returnsBothLocalizedAndDefault() throws Exception {
     ImmutableList<QuestionOption> options =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "one", Locale.GERMAN, "eins")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "two", Locale.GERMAN, "zwei")),
-            QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "three")));
+            QuestionOption.create(
+                1L, "ay", LocalizedStrings.of(Locale.US, "one", Locale.GERMAN, "eins")),
+            QuestionOption.create(
+                2L, "bee", LocalizedStrings.of(Locale.US, "two", Locale.GERMAN, "zwei")),
+            QuestionOption.create(3L, "see", LocalizedStrings.of(Locale.US, "three")));
     QuestionDefinition definition =
         new QuestionDefinitionBuilder()
             .setQuestionType(QuestionType.DROPDOWN)
@@ -149,8 +149,30 @@ public class MultiOptionQuestionDefinitionTest {
 
     assertThat(multiOption.getOptionsForLocaleOrDefault(Locale.GERMAN))
         .containsExactly(
-            LocalizedQuestionOption.create(1L, 1L, "eins", Locale.GERMAN),
-            LocalizedQuestionOption.create(2L, 2L, "zwei", Locale.GERMAN),
-            LocalizedQuestionOption.create(3L, 3L, "three", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "ay", "eins", Locale.GERMAN),
+            LocalizedQuestionOption.create(2L, 2L, "bee", "zwei", Locale.GERMAN),
+            LocalizedQuestionOption.create(3L, 3L, "see", "three", Locale.US));
+  }
+
+  @Test
+  public void getOptionsAdminName_returnsAdminNames() throws UnsupportedQuestionTypeException {
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option 1")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.of(Locale.US, "option 2")));
+
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setQuestionOptions(options)
+            .build();
+
+    MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
+
+    assertThat(multiOption.getOptionsAdminName()).containsExactly("opt1", "opt2");
   }
 }

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -498,10 +498,29 @@ public class QuestionDefinitionTest {
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
             config,
-            ImmutableList.of(QuestionOption.create(1L, LocalizedStrings.withDefaultValue(""))),
+            ImmutableList.of(
+                QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue(""))),
             MultiOptionQuestionType.CHECKBOX);
     assertThat(question.validate())
         .containsOnly(CiviFormError.of("Multi-option questions cannot have blank options"));
+  }
+
+  @Test
+  public void validate_multiOptionQuestion_withBlankOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config,
+            ImmutableList.of(QuestionOption.create(1L, "", LocalizedStrings.withDefaultValue("a"))),
+            MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option questions cannot have blank admin names"));
   }
 
   @Test
@@ -515,13 +534,52 @@ public class QuestionDefinitionTest {
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.withDefaultValue("a")),
-            QuestionOption.create(2L, LocalizedStrings.withDefaultValue("a")));
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.withDefaultValue("a")));
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.CHECKBOX);
     assertThat(question.validate())
         .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+  }
+
+  @Test
+  public void validate_multiOptionQuestion_withDuplicateOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt1", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option question admin names must be unique"));
+  }
+
+  @Test
+  public void validate_multiOptionQuestion_withUniqueOptionAdminNames_doesNotReturnError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate()).isEmpty();
   }
 
   private static ImmutableList<Object[]> getMultiOptionQuestionValidationTestData() {
@@ -587,8 +645,8 @@ public class QuestionDefinitionTest {
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.withDefaultValue("a")),
-            QuestionOption.create(2L, LocalizedStrings.withDefaultValue("b")));
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.withDefaultValue("b")));
 
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -15,7 +15,7 @@ public class QuestionOptionTest {
   @Test
   public void localize_unsupportedLocale_throws() {
     QuestionOption questionOption =
-        QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option 1"));
+        QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option 1"));
 
     Throwable thrown = catchThrowable(() -> questionOption.localize(Locale.CANADA));
 
@@ -24,26 +24,27 @@ public class QuestionOptionTest {
 
   @Test
   public void localizeOrDefault_returnsDefaultForUnsupportedLocale() {
-    QuestionOption option = QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "default"));
+    QuestionOption option =
+        QuestionOption.create(1L, "default admin", LocalizedStrings.of(Locale.US, "default"));
 
     assertThat(option.localizeOrDefault(Locale.CHINESE))
-        .isEqualTo(LocalizedQuestionOption.create(1L, 1L, "default", Locale.US));
+        .isEqualTo(LocalizedQuestionOption.create(1L, 1L, "default admin", "default", Locale.US));
   }
 
   @Test
-  public void builder_builds() {
+  public void localize_localizes() {
     QuestionOption option =
         QuestionOption.builder()
             .setId(123L)
-            // TODO(#4862): Test the admin name is passed through to the LocalizedQuestionOption
-            .setAdminName("test")
+            .setAdminName("test admin")
             .setOptionText(LocalizedStrings.withDefaultValue("test"))
             .setDisplayOrder(OptionalLong.of(1L))
             .build();
 
     assertThat(option.localize(LocalizedStrings.DEFAULT_LOCALE))
         .isEqualTo(
-            LocalizedQuestionOption.create(123L, 1L, "test", LocalizedStrings.DEFAULT_LOCALE));
+            LocalizedQuestionOption.create(
+                123L, 1L, "test admin", "test", LocalizedStrings.DEFAULT_LOCALE));
   }
 
   @Test


### PR DESCRIPTION
### Description

- Adds new `create()` methods to `QuestionOption` that take an `adminName`
- Updates the QuestionDefinitions and other nearby code to use admin names

We'll update code in phases, see #4862 for the work plan.

## Release notes

n/a - no user facing changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

n/a

#### New Features

n/a

### Instructions for manual testing

n/a

### Issue(s) this completes

Part of #4862
