### PR TITLE
Create filter to record PLAY_SESSION cookie size

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -10,7 +10,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Base64;
 import java.util.Optional;
 import javax.inject.Provider;
 import models.Applicant;
@@ -23,7 +22,6 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
-import org.pac4j.play.store.PlayCookieSessionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.UserRepository;

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -9,6 +9,8 @@ import auth.Role;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+
+import java.util.Base64;
 import java.util.Optional;
 import javax.inject.Provider;
 import models.Applicant;
@@ -21,6 +23,7 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
+import org.pac4j.play.store.PlayCookieSessionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.UserRepository;

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -9,7 +9,6 @@ import auth.Role;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-
 import java.util.Optional;
 import javax.inject.Provider;
 import models.Applicant;

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -2,8 +2,6 @@ package filters;
 
 import akka.stream.Materializer;
 import io.prometheus.client.Histogram;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -14,8 +12,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 public class RecordCookieSizeFilter extends Filter {
-  private static final Logger logger = LoggerFactory.getLogger(RecordCookieSizeFilter.class);
-
   private Histogram PLAY_SESSION_COOKIE_SIZE =
     Histogram.build()
       .name("play_session_cookie_size_bytes")

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -12,10 +12,13 @@ import play.routing.Router;
  * controller method.
  */
 public final class RecordCookieSizeFilter extends EssentialFilter {
+  public static int BUCKET_SIZE = 512;
+  public static int NUM_BUCKETS = 10;
+
   private Histogram PLAY_SESSION_COOKIE_SIZE =
       Histogram.build()
           .name("play_session_cookie_size_bytes")
-          .linearBuckets(0, 512, 10)
+          .linearBuckets(0, BUCKET_SIZE, NUM_BUCKETS)
           .labelNames("controller_method")
           .help("Size of the PLAY_SESSION cookie in bytes")
           .register();
@@ -24,19 +27,21 @@ public final class RecordCookieSizeFilter extends EssentialFilter {
   public EssentialAction apply(EssentialAction next) {
     return EssentialAction.of(
         requestHeader -> {
-          String actionMethod = getControllerMethod(requestHeader);
+          String controllerMethod = getControllerMethod(requestHeader);
           requestHeader
               .getCookie("PLAY_SESSION")
               .ifPresent(
                   cookie -> {
-                    PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
+                    PLAY_SESSION_COOKIE_SIZE
+                        .labels(controllerMethod)
+                        .observe(cookie.value().length());
                   });
           return next.apply(requestHeader);
         });
   }
 
   private String getControllerMethod(Http.RequestHeader requestHeader) {
-    // Not always present in browser tests.
+    // Not always present in tests.
     if (requestHeader.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
       HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
       return String.format("%s.%s", handlerDef.controller(), handlerDef.method());

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -1,17 +1,12 @@
 package filters;
 
-import akka.stream.Materializer;
 import io.prometheus.client.Histogram;
-import play.mvc.Filter;
-import play.mvc.Http;
-import play.mvc.Result;
+import play.mvc.EssentialAction;
+import play.mvc.EssentialFilter;
 import play.routing.HandlerDef;
 import play.routing.Router;
 
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-
-public class RecordCookieSizeFilter extends Filter {
+public class RecordCookieSizeFilter extends EssentialFilter {
   private Histogram PLAY_SESSION_COOKIE_SIZE =
     Histogram.build()
       .name("play_session_cookie_size_bytes")
@@ -20,17 +15,17 @@ public class RecordCookieSizeFilter extends Filter {
       .help("Size of the PLAY_SESSION cookie in bytes")
       .register();
 
-  public RecordCookieSizeFilter(Materializer mat) {
-    super(mat);
-  }
-
   @Override
-  public CompletionStage<Result> apply(Function<Http.RequestHeader, CompletionStage<Result>> next, Http.RequestHeader requestHeader) {
-    HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
-    String actionMethod = handlerDef.controller() + "." + handlerDef.method();
-    requestHeader.getCookie("PLAY_SESSION").ifPresent(cookie -> {
-      PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
-    });
-    return next.apply(requestHeader);
+  public EssentialAction apply(EssentialAction next) {
+    return EssentialAction.of(
+      requestHeader -> {
+        HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
+        String actionMethod = handlerDef.controller() + "." + handlerDef.method();
+        requestHeader.getCookie("PLAY_SESSION").ifPresent(cookie -> {
+          PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
+        });
+        return next.apply(requestHeader);
+      }
+    );
   }
 }

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -8,24 +8,26 @@ import play.routing.Router;
 
 public class RecordCookieSizeFilter extends EssentialFilter {
   private Histogram PLAY_SESSION_COOKIE_SIZE =
-    Histogram.build()
-      .name("play_session_cookie_size_bytes")
-      .linearBuckets(0, 512, 10)
-      .labelNames("action_method")
-      .help("Size of the PLAY_SESSION cookie in bytes")
-      .register();
+      Histogram.build()
+          .name("play_session_cookie_size_bytes")
+          .linearBuckets(0, 512, 10)
+          .labelNames("action_method")
+          .help("Size of the PLAY_SESSION cookie in bytes")
+          .register();
 
   @Override
   public EssentialAction apply(EssentialAction next) {
     return EssentialAction.of(
-      requestHeader -> {
-        HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
-        String actionMethod = handlerDef.controller() + "." + handlerDef.method();
-        requestHeader.getCookie("PLAY_SESSION").ifPresent(cookie -> {
-          PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
+        requestHeader -> {
+          HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
+          String actionMethod = handlerDef.controller() + "." + handlerDef.method();
+          requestHeader
+              .getCookie("PLAY_SESSION")
+              .ifPresent(
+                  cookie -> {
+                    PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
+                  });
+          return next.apply(requestHeader);
         });
-        return next.apply(requestHeader);
-      }
-    );
   }
 }

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -6,6 +6,10 @@ import play.mvc.EssentialFilter;
 import play.routing.HandlerDef;
 import play.routing.Router;
 
+/**
+ * Filter that exports the size of the PLAY_SESSION cookie to prometheus, parameterized by
+ * controller method.
+ */
 public class RecordCookieSizeFilter extends EssentialFilter {
   private Histogram PLAY_SESSION_COOKIE_SIZE =
       Histogram.build()

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -10,7 +10,7 @@ public class RecordCookieSizeFilter extends EssentialFilter {
   private Histogram PLAY_SESSION_COOKIE_SIZE =
     Histogram.build()
       .name("play_session_cookie_size_bytes")
-      .linearBuckets(0, 4096, 512)
+      .linearBuckets(0, 512, 10)
       .labelNames("action_method")
       .help("Size of the PLAY_SESSION cookie in bytes")
       .register();

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -10,7 +10,7 @@ import play.routing.Router;
  * Filter that exports the size of the PLAY_SESSION cookie to prometheus, parameterized by
  * controller method.
  */
-public class RecordCookieSizeFilter extends EssentialFilter {
+public final class RecordCookieSizeFilter extends EssentialFilter {
   private Histogram PLAY_SESSION_COOKIE_SIZE =
       Histogram.build()
           .name("play_session_cookie_size_bytes")

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -1,0 +1,41 @@
+package filters;
+
+import akka.stream.Materializer;
+import io.prometheus.client.Histogram;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.mvc.Filter;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.routing.HandlerDef;
+import play.routing.Router;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class RecordCookieSizeFilter extends Filter {
+  private static final Logger logger = LoggerFactory.getLogger(RecordCookieSizeFilter.class);
+
+  private Histogram PLAY_SESSION_COOKIE_SIZE =
+    Histogram.build()
+      .name("play_session_cookie_size_bytes")
+      .linearBuckets(0, 4096, 512)
+      .labelNames("action_method")
+      .help("Size of the PLAY_SESSION cookie in bytes")
+      .register();
+
+  public RecordCookieSizeFilter(Materializer mat) {
+    super(mat);
+  }
+
+  @Override
+  public CompletionStage<Result> apply(Function<Http.RequestHeader, CompletionStage<Result>> next, Http.RequestHeader requestHeader) {
+    HandlerDef handlerDef = requestHeader.attrs().get(Router.Attrs.HANDLER_DEF);
+    String actionMethod = handlerDef.controller() + "." + handlerDef.method();
+    requestHeader.getCookie("PLAY_SESSION").ifPresent(cookie -> {
+      PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
+      logger.info("XXX action_method = {}, cookie size = {}", actionMethod, cookie.value().length());
+    });
+    return next.apply(requestHeader);
+  }
+}

--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -34,7 +34,6 @@ public class RecordCookieSizeFilter extends Filter {
     String actionMethod = handlerDef.controller() + "." + handlerDef.method();
     requestHeader.getCookie("PLAY_SESSION").ifPresent(cookie -> {
       PLAY_SESSION_COOKIE_SIZE.labels(actionMethod).observe(cookie.value().length());
-      logger.info("XXX action_method = {}, cookie size = {}", actionMethod, cookie.value().length());
     });
     return next.apply(requestHeader);
   }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -339,6 +339,7 @@ play.filters {
   enabled += com.github.stijndehaes.playprometheusfilters.filters.StatusAndRouteLatencyAndCounterFilter
   enabled += filters.DisableCachingFilter
   enabled += filters.HSTSFilter
+  enabled += filters.RecordCookieSizeFilter
   enabled += filters.LoggingFilter
   enabled += filters.ValidAccountFilter
   enabled += play.filters.gzip.GzipFilter

--- a/server/test/filters/RecordCookieSizeFilterTest.java
+++ b/server/test/filters/RecordCookieSizeFilterTest.java
@@ -31,13 +31,13 @@ public class RecordCookieSizeFilterTest {
       assertThat(runFilterWithCookieSize(filter, cookieSize).status()).isEqualTo(200);
     }
 
-    var metricFamilySamples = CollectorRegistry.defaultRegistry.metricFamilySamples();
-    assertThat(metricFamilySamples.hasMoreElements()).isTrue();
-    var mfs = metricFamilySamples.nextElement();
-    assertThat(mfs.name).isEqualTo("play_session_cookie_size_bytes");
+    var metricFamilySamplesEnumeration = CollectorRegistry.defaultRegistry.metricFamilySamples();
+    assertThat(metricFamilySamplesEnumeration.hasMoreElements()).isTrue();
+    var metricFamilySamples = metricFamilySamplesEnumeration.nextElement();
+    assertThat(metricFamilySamples.name).isEqualTo("play_session_cookie_size_bytes");
 
     double upperBoundOfCookieSize = 0;
-    for (var sample : mfs.samples) {
+    for (var sample : metricFamilySamples.samples) {
       if (sample.name.equals("play_session_cookie_size_bytes_count")) {
         // Number of samples.
         assertThat(sample.value).isEqualTo(cookieSizes.size());

--- a/server/test/filters/RecordCookieSizeFilterTest.java
+++ b/server/test/filters/RecordCookieSizeFilterTest.java
@@ -1,0 +1,88 @@
+package filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.test.Helpers.fakeRequest;
+
+import akka.stream.testkit.NoMaterializer$;
+import com.google.common.collect.ImmutableList;
+import io.prometheus.client.CollectorRegistry;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import play.libs.streams.Accumulator;
+import play.mvc.EssentialAction;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.mvc.Results;
+
+public class RecordCookieSizeFilterTest {
+  @Before
+  public void clearRegistry() {
+    CollectorRegistry.defaultRegistry.clear();
+  }
+
+  @Test
+  public void testCookieSizesAreRecorded() throws Exception {
+    // Run filter with several requests with various cookie sizes.
+    RecordCookieSizeFilter filter = new RecordCookieSizeFilter();
+    List<Integer> cookieSizes = ImmutableList.of(1000, 2000, 2000, 3000, 3500, 4000);
+    for (int cookieSize : cookieSizes) {
+      assertThat(runFilterWithCookieSize(filter, cookieSize).status()).isEqualTo(200);
+    }
+
+    var metricFamilySamples = CollectorRegistry.defaultRegistry.metricFamilySamples();
+    assertThat(metricFamilySamples.hasMoreElements()).isTrue();
+    var mfs = metricFamilySamples.nextElement();
+    assertThat(mfs.name).isEqualTo("play_session_cookie_size_bytes");
+
+    double upperBoundOfCookieSize = 0;
+    for (var sample : mfs.samples) {
+      if (sample.name.equals("play_session_cookie_size_bytes_count")) {
+        // Number of samples.
+        assertThat(sample.value).isEqualTo(cookieSizes.size());
+        break;
+      }
+      if (sample.name.equals("play_session_cookie_size_bytes_sum")) {
+        // The value of the sum is the sum of sample values.
+        assertThat(sample.value)
+            .isEqualTo(cookieSizes.stream().collect(Collectors.summingInt(Integer::intValue)));
+        break;
+      }
+      // The remaining samples are histogram buckets.
+      assertThat(sample.name).isEqualTo("play_session_cookie_size_bytes_bucket");
+      // Buckets have a label with name "le" and a value indicating the upper bound of the bucket.
+      assertThat(sample.labelNames).contains("le");
+      if (upperBoundOfCookieSize
+          < RecordCookieSizeFilter.NUM_BUCKETS * RecordCookieSizeFilter.BUCKET_SIZE) {
+        assertThat(sample.labelValues).contains(String.valueOf(upperBoundOfCookieSize));
+        // The value of the sample is the cumulative number of samples in the current bucket or
+        // below.
+        assertThat(sample.value)
+            .isEqualTo(samplesBelowUpperBound(cookieSizes, upperBoundOfCookieSize));
+      } else {
+        // The last bucket has a special label.
+        assertThat(sample.labelValues).contains("+Inf");
+        assertThat(sample.value).isEqualTo(cookieSizes.size());
+      }
+      upperBoundOfCookieSize += RecordCookieSizeFilter.BUCKET_SIZE;
+    }
+  }
+
+  private Result runFilterWithCookieSize(RecordCookieSizeFilter filter, int cookieSize)
+      throws Exception {
+    Http.Cookie playSessionCookie =
+        Http.Cookie.builder("PLAY_SESSION", "*".repeat(cookieSize)).build();
+    Http.Request request = fakeRequest().cookie(playSessionCookie).build();
+    return filter
+        .apply(EssentialAction.of(r -> Accumulator.done(Results.ok("OK"))))
+        .apply(request)
+        .run(NoMaterializer$.MODULE$)
+        .toCompletableFuture()
+        .get();
+  }
+
+  private double samplesBelowUpperBound(List<Integer> sizes, double upperBound) {
+    return sizes.stream().filter(n -> n <= upperBound).count();
+  }
+}


### PR DESCRIPTION
### Description

Create filter to record the size of the `PLAY_SESSION` cookie.

There is an upper limit of 4096 bytes, and we'd like to be able to see where we stand.

Tested on a dev instance and can see recorded metrics.

![image](https://github.com/civiform/civiform/assets/1391583/e1f54acd-c946-477e-88ee-eb9c0c9626a9)

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary