### PR TITLE
Upate PredicateValue logic to use question option admin names

### DIFF
--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -131,7 +131,7 @@ public abstract class PredicateValue {
   private static String parseMultiOptionIdToText(
       MultiOptionQuestionDefinition question, String id) {
     return question
-        .getDefaultLocaleOptionForId(Long.parseLong(id.substring(1, id.length() - 1)))
+        .getOptionAdminNameForId(Long.parseLong(id.substring(1, id.length() - 1)))
         .orElse("<obsolete>");
   }
 

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -162,11 +162,11 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
     }
   }
 
-  /** Get the default locale representation of the option with the given ID. */
-  public Optional<String> getDefaultLocaleOptionForId(long id) {
-    return getOptionsForDefaultLocale().stream()
+  /** Get the admin name representation of the option with the given ID. */
+  public Optional<String> getOptionAdminNameForId(long id) {
+    return getOptions().stream()
         .filter(o -> o.id() == id)
-        .map(LocalizedQuestionOption::optionText)
+        .map(QuestionOption::adminName)
         .findFirst();
   }
 

--- a/server/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/server/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -144,7 +144,7 @@ public class PredicateExpressionNodeTest {
     assertThat(node.toDisplayString(ImmutableList.of(multiOption, date)))
         .isEqualTo(
             String.format(
-                "\"%s\" selection is one of [Chocolate, Strawberry]"
+                "\"%s\" selection is one of [chocolate, strawberry]"
                     + " or \"%s\" date is earlier than 2021-01-01",
                 multiOption.getName(), date.getName()));
   }

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -78,7 +78,7 @@ public class PredicateValueTest {
 
     PredicateValue value = PredicateValue.listOfStrings(ImmutableList.of("1", "2"));
 
-    assertThat(value.toDisplayString(multiOption)).isEqualTo("[Chocolate, Strawberry]");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("[chocolate, strawberry]");
   }
 
   @Test
@@ -88,7 +88,7 @@ public class PredicateValueTest {
 
     PredicateValue value = PredicateValue.of("1");
 
-    assertThat(value.toDisplayString(multiOption)).isEqualTo("Toaster");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("toaster");
   }
 
   @Test
@@ -98,7 +98,7 @@ public class PredicateValueTest {
     PredicateValue value =
         PredicateValue.listOfStrings(ImmutableList.of("1", "100")); // 100 is not a valid ID
 
-    assertThat(value.toDisplayString(multiOption)).isEqualTo("[Chocolate, <obsolete>]");
+    assertThat(value.toDisplayString(multiOption)).isEqualTo("[chocolate, <obsolete>]");
   }
 
   @Test


### PR DESCRIPTION
### Description

Updates the PredicateValue logic to use immutable question option admin names, instead of the user-facing text.

Changes tests back to using admin names (they were updated to use the user-facing text in #5573)

We're updating code in phases, see https://github.com/civiform/civiform/issues/4862 for the work plan and additional context.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

n/a

#### New Features

n/a

### Instructions for manual testing

n/a

### Issue(s) this completes

This is part of #4862
