### PR TITLE
Update frontend related code to use admin names

### DIFF
--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -49,17 +49,18 @@ describe('create dropdown question with options', () => {
       '#question-settings div.flex-row:nth-of-type(3) input',
       'strawberry',
     )
+    await page.pause()
 
     // Assert there are three options present
     let questionSettingsDiv = await page.innerHTML('#question-settings')
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(3)
+    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(6) // 2 inputs each for 3 options
 
     // Remove first option - use :visible to not select the hidden template
     await page.click('button:has-text("Delete"):visible')
 
     // Assert there are only two options now
     questionSettingsDiv = await page.innerHTML('#question-settings')
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(2)
+    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(4) // 2 inputs each for 2 options
 
     // Verify question preview text has changed based on user input.
     expect(await page.innerText('.cf-applicant-question-text')).toContain(
@@ -76,6 +77,7 @@ describe('create dropdown question with options', () => {
     // Edit the question
     await adminQuestions.gotoQuestionEditPage(questionName)
     questionSettingsDiv = await page.innerHTML('#question-settings')
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(4)
+    // 3 inputs each for 2 options (option, optionAdminName, and optionId)
+    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(6)
   })
 })

--- a/server/app/forms/MultiOptionQuestionForm.java
+++ b/server/app/forms/MultiOptionQuestionForm.java
@@ -25,6 +25,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   private List<String> newOptions;
   // The IDs of each option are not expected to be in any particular order.
   private List<Long> optionIds;
+  private List<String> optionAdminNames;
+  private List<String> newOptionAdminNames;
   // This value is the max existing ID + 1. The max ID will not necessarily be the last one in the
   // optionIds list, we do not store options by order of their IDs.
   private OptionalLong nextAvailableId;
@@ -36,6 +38,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.options = new ArrayList<>();
     this.newOptions = new ArrayList<>();
     this.optionIds = new ArrayList<>();
+    this.optionAdminNames = new ArrayList<>();
+    this.newOptionAdminNames = new ArrayList<>();
     this.minChoicesRequired = OptionalInt.empty();
     this.maxChoicesAllowed = OptionalInt.empty();
     this.nextAvailableId = OptionalLong.empty();
@@ -49,6 +53,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.options = new ArrayList<>();
     this.newOptions = new ArrayList<>();
     this.optionIds = new ArrayList<>();
+    this.optionAdminNames = new ArrayList<>();
+    this.newOptionAdminNames = new ArrayList<>();
 
     try {
       // The first time a question is created, we only create for the default locale. The admin can
@@ -60,6 +66,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
                 option -> {
                   options.add(option.optionText());
                   optionIds.add(option.id());
+                  optionAdminNames.add(option.adminName());
                 });
         this.nextAvailableId =
             OptionalLong.of(
@@ -96,6 +103,22 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   public void setOptionIds(List<Long> optionIds) {
     this.optionIds = optionIds;
+  }
+
+  public List<String> getOptionAdminNames() {
+    return this.optionAdminNames;
+  }
+
+  public void setOptionAdminNames(List<String> optionAdminNames) {
+    this.optionAdminNames = optionAdminNames;
+  }
+
+  public List<String> getNewOptionAdminNames() {
+    return this.newOptionAdminNames;
+  }
+
+  public void setNewOptionAdminNames(List<String> newOptionAdminNames) {
+    this.newOptionAdminNames = newOptionAdminNames;
   }
 
   public OptionalInt getMinChoicesRequired() {
@@ -151,12 +174,18 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     Preconditions.checkState(
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
+    Preconditions.checkState(
+        this.optionAdminNames.size() == this.options.size(),
+        "Option admin names and options are not the same size.");
 
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptionsBuilder.add(
           QuestionOption.create(
-              optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
+              optionIds.get(i),
+              i,
+              optionAdminNames.get(i),
+              LocalizedStrings.withDefaultValue(options.get(i))));
     }
 
     // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
@@ -169,6 +198,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
           QuestionOption.create(
               nextAvailableId.getAsLong() + i,
               options.size() + i,
+              // TODO(#4862): Use the admin name from the form here, once the UI allows setting the
+              // admin name
+              newOptions.get(i),
               LocalizedStrings.withDefaultValue(newOptions.get(i))));
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();

--- a/server/app/services/question/QuestionOption.java
+++ b/server/app/services/question/QuestionOption.java
@@ -91,38 +91,6 @@ public abstract class QuestionOption {
         .build();
   }
 
-  /**
-   * Create a QuestionOption.
-   *
-   * <p>TODO(#4862): Deprecate this method.
-   */
-  public static QuestionOption create(long id, long displayOrder, LocalizedStrings optionText) {
-    String adminName = optionText.maybeGet(Locale.getDefault()).orElse(String.valueOf(id));
-
-    return QuestionOption.builder()
-        .setId(id)
-        .setAdminName(adminName)
-        .setOptionText(optionText)
-        .setDisplayOrder(OptionalLong.of(displayOrder))
-        .build();
-  }
-
-  /**
-   * Create a QuestionOption.
-   *
-   * <p>TODO(#4862): Deprecate this method.
-   */
-  public static QuestionOption create(long id, LocalizedStrings optionText) {
-    String adminName = optionText.maybeGet(Locale.getDefault()).orElse(String.valueOf(id));
-
-    return QuestionOption.builder()
-        .setId(id)
-        .setAdminName(adminName)
-        .setOptionText(optionText)
-        .setDisplayOrder(OptionalLong.empty())
-        .build();
-  }
-
   public LocalizedQuestionOption localize(Locale locale) {
     if (!optionText().hasTranslationFor(locale)) {
       throw new RuntimeException(

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -180,6 +180,15 @@ public final class QuestionConfig {
             .showFieldErrors(false)
             .getInputTag()
             .withClasses("flex", "ml-2", "gap-x-3", ReferenceClasses.MULTI_OPTION_INPUT);
+    DivTag optionAdminName =
+        FieldWithLabel.input()
+            .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
+            .setLabelText("Admin Name")
+            .setRequired(true)
+            .setValue(existingOption.map(LocalizedQuestionOption::adminName))
+            .getInputTag()
+            // TODO(#4862): Update the form to allow setting option admin names
+            .withClasses("hidden");
     DivTag optionIndexInput =
         isForNewOption
             ? div()
@@ -217,7 +226,13 @@ public final class QuestionConfig {
             "flex-row",
             "mb-4",
             "items-center")
-        .with(optionInput, optionIndexInput, moveUpButton, moveDownButton, removeOptionButton);
+        .with(
+            optionInput,
+            optionIndexInput,
+            optionAdminName,
+            moveUpButton,
+            moveDownButton,
+            removeOptionButton);
   }
 
   private QuestionConfig addMultiOptionQuestionFields(
@@ -235,14 +250,15 @@ public final class QuestionConfig {
                   LocalizedQuestionOption.create(
                       multiOptionQuestionForm.getOptionIds().get(i),
                       optionIndex,
-                      // TODO(#4862): Use the admin name from the form here
-                      multiOptionQuestionForm.getOptions().get(i),
+                      multiOptionQuestionForm.getOptionAdminNames().get(i),
                       multiOptionQuestionForm.getOptions().get(i),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
               /* isForNewOption= */ false));
       optionIndex++;
     }
+
+    //
     for (String newOption : multiOptionQuestionForm.getNewOptions()) {
       optionsBuilder.add(
           multiOptionQuestionField(
@@ -250,7 +266,8 @@ public final class QuestionConfig {
                   LocalizedQuestionOption.create(
                       -1,
                       optionIndex,
-                      // TODO(#4862): Use the admin name from the form here
+                      // TODO(#4862): Use the admin name from the form here, once the UI allows
+                      // setting the admin name
                       newOption,
                       newOption,
                       LocalizedStrings.DEFAULT_LOCALE)),

--- a/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -93,7 +93,10 @@ public final class ApplicantQuestionRendererFactory {
       builder.setQuestionOptions(
           ImmutableList.of(
               QuestionOption.create(
-                  1L, 1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
+                  1L,
+                  1L,
+                  "sample option admin name",
+                  LocalizedStrings.of(Locale.US, "Sample question option"))));
     }
 
     if (questionType.equals(QuestionType.ENUMERATOR)) {

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -367,13 +367,21 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
             QuestionOption.create(
-                1L, LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+                1L,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
             QuestionOption.create(
-                2L, LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")),
+                2L,
+                "strawberry admin",
+                LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")),
             QuestionOption.create(
-                3L, LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
+                3L,
+                "vanilla admin",
+                LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
             QuestionOption.create(
-                4L, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")));
+                4L,
+                "coffee admin",
+                LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")));
     MultiOptionQuestionDefinition definition =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
@@ -408,13 +416,21 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
             QuestionOption.create(
-                1L, LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+                /* id= */ 1L,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
             QuestionOption.create(
-                2L, LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")),
+                /* id= */ 2L,
+                "strawberry admin",
+                LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")),
             QuestionOption.create(
-                3L, LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
+                /* id= */ 3L,
+                "vanilla admin",
+                LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
             QuestionOption.create(
-                4L, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")));
+                /* id= */ 4L,
+                "coffee admin",
+                LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")));
 
     QuestionDefinition definition =
         new MultiOptionQuestionDefinition(
@@ -435,6 +451,9 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("newOptions[0]", "lavender") // New flavor
             .put("optionIds[0]", "4")
             .put("optionIds[1]", "3")
+            .put("optionAdminNames[0]", "coffee admin")
+            .put("optionAdminNames[1]", "vanilla admin")
+            .put("newOptionAdminNames[2]", "lavender admin")
             .put("nextAvailableId", "5")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             // Has one fewer than the original question
@@ -458,10 +477,19 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableList<QuestionOption> expectedOptions =
         ImmutableList.of(
             QuestionOption.create(
-                4, 0, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")),
+                /* id= */ 4,
+                /* displayOrder= */ 0,
+                "coffee admin",
+                LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")),
             QuestionOption.create(
-                3, 1, LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
-            QuestionOption.create(5, 2, LocalizedStrings.withDefaultValue("lavender")));
+                /* id= */ 3,
+                /* displayOrder= */ 1,
+                "vanilla admin",
+                LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
+            // TODO(#4862): For new options, the form processing code currently ignores the
+            // adminName field and sets it to the option text. This test should be updated
+            // once the form is updated to support admin names.
+            QuestionOption.create(5, 2, "lavender", LocalizedStrings.withDefaultValue("lavender")));
     assertThat(((MultiOptionQuestionDefinition) found.getQuestionDefinition()).getOptions())
         .isEqualTo(expectedOptions);
 
@@ -471,6 +499,138 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
     assertThat(questionForm.getNextAvailableId()).isPresent();
     assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(5L);
+  }
+
+  @Test
+  public void update_ignoresChangedAdminNameForExistingOptions() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("applicant ice cream")
+            .setDescription("Select your favorite ice cream flavor")
+            .setQuestionText(
+                LocalizedStrings.of(Locale.US, "Ice cream?", Locale.FRENCH, "crème glacée?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help", Locale.FRENCH, "aider"))
+            .build();
+
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+            QuestionOption.create(
+                /* id= */ 2L,
+                "strawberry admin",
+                LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")));
+
+    QuestionDefinition definition =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.DROPDOWN);
+
+    // We can only update draft questions, so save this in the DRAFT version.
+    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate admin")
+            .put("optionAdminNames[1]", "strawberry new admin name") // updated admin name
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .build();
+    RequestBuilder requestBuilder = addCSRFToken(requestBuilderWithSettings().bodyForm(formData));
+
+    controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
+    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+
+    ImmutableList<QuestionOption> expectedOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1,
+                /* displayOrder= */ 0,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+            QuestionOption.create(
+                /* id= */ 2,
+                /* displayOrder= */ 1,
+                "strawberry admin", // ignore changed admin name
+                LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")));
+    assertThat(((MultiOptionQuestionDefinition) found.getQuestionDefinition()).getOptions())
+        .isEqualTo(expectedOptions);
+  }
+
+  @Test
+  public void update_clearsTranslationsAndKeepsAdminName_ifDefaultTextIsChanged() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("applicant ice cream")
+            .setDescription("Select your favorite ice cream flavor")
+            .setQuestionText(
+                LocalizedStrings.of(Locale.US, "Ice cream?", Locale.FRENCH, "crème glacée?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help", Locale.FRENCH, "aider"))
+            .build();
+
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+            QuestionOption.create(
+                /* id= */ 2L,
+                "strawberry admin",
+                LocalizedStrings.of(Locale.US, "strawberry", Locale.FRENCH, "fraise")));
+
+    QuestionDefinition definition =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.DROPDOWN);
+
+    // We can only update draft questions, so save this in the DRAFT version.
+    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "new ice cream name")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate admin")
+            .put("optionAdminNames[1]", "new admin name") // updated admin name
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .build();
+    RequestBuilder requestBuilder = addCSRFToken(requestBuilderWithSettings().bodyForm(formData));
+
+    controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
+    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+
+    ImmutableList<QuestionOption> expectedOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1,
+                /* displayOrder= */ 0,
+                "chocolate admin",
+                LocalizedStrings.of(Locale.US, "chocolate", Locale.FRENCH, "chocolat")),
+            QuestionOption.create(
+                /* id= */ 2,
+                /* displayOrder= */ 1,
+                "strawberry admin", // ignore changed admin name
+                LocalizedStrings.of(Locale.US, "new ice cream name"))); // clear other locales
+    assertThat(((MultiOptionQuestionDefinition) found.getQuestionDefinition()).getOptions())
+        .isEqualTo(expectedOptions);
   }
 
   @Test

--- a/server/test/forms/CheckboxQuestionFormTest.java
+++ b/server/test/forms/CheckboxQuestionFormTest.java
@@ -24,6 +24,7 @@ public class CheckboxQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
     form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -37,9 +38,9 @@ public class CheckboxQuestionFormTest {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "cat")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "dog")),
-            QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "rabbit")));
+            QuestionOption.create(1L, "cat admin", LocalizedStrings.of(Locale.US, "cat")),
+            QuestionOption.create(2L, "dog admin", LocalizedStrings.of(Locale.US, "dog")),
+            QuestionOption.create(3L, "rabbit admin", LocalizedStrings.of(Locale.US, "rabbit")));
     MultiOptionQuestionDefinition expected =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.CHECKBOX);
@@ -59,8 +60,8 @@ public class CheckboxQuestionFormTest {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "hello")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "world")));
+            QuestionOption.create(1L, "hello admin", LocalizedStrings.of(Locale.US, "hello")),
+            QuestionOption.create(2L, "world admin", LocalizedStrings.of(Locale.US, "world")));
 
     MultiOptionQuestionDefinition originalQd =
         new MultiOptionQuestionDefinition(

--- a/server/test/forms/DropdownQuestionFormTest.java
+++ b/server/test/forms/DropdownQuestionFormTest.java
@@ -24,6 +24,7 @@ public class DropdownQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
     form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -37,9 +38,9 @@ public class DropdownQuestionFormTest {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "cat")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "dog")),
-            QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "rabbit")));
+            QuestionOption.create(1L, "cat admin", LocalizedStrings.of(Locale.US, "cat")),
+            QuestionOption.create(2L, "dog admin", LocalizedStrings.of(Locale.US, "dog")),
+            QuestionOption.create(3L, "rabbit admin", LocalizedStrings.of(Locale.US, "rabbit")));
     MultiOptionQuestionDefinition expected =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
@@ -58,8 +59,8 @@ public class DropdownQuestionFormTest {
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "hello")),
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "world")));
+            QuestionOption.create(1L, "hello admin", LocalizedStrings.of(Locale.US, "hello")),
+            QuestionOption.create(1L, "world admin", LocalizedStrings.of(Locale.US, "world")));
 
     MultiOptionQuestionDefinition originalQd =
         new MultiOptionQuestionDefinition(

--- a/server/test/forms/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/MultiOptionQuestionFormTest.java
@@ -27,6 +27,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("1");
     form.setMaxChoicesAllowed("10");
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
     form.setOptionIds(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -42,7 +43,8 @@ public class MultiOptionQuestionFormTest {
         new MultiOptionQuestionDefinition(
             config,
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option one"))),
+                QuestionOption.create(
+                    1L, "opt1 admin", LocalizedStrings.of(Locale.US, "option one"))),
             MultiOptionQuestionType.CHECKBOX);
 
     QuestionDefinition actual = builder.build();
@@ -63,7 +65,8 @@ public class MultiOptionQuestionFormTest {
     MultiOptionQuestionDefinition originalQd =
         new MultiOptionQuestionDefinition(
             config,
-            ImmutableList.of(QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option 1"))),
+            ImmutableList.of(
+                QuestionOption.create(1L, "one admin", LocalizedStrings.of(Locale.US, "option 1"))),
             MultiOptionQuestionType.CHECKBOX);
 
     MultiOptionQuestionForm form = new CheckboxQuestionForm(originalQd);
@@ -84,6 +87,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
     form.setOptionIds(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -98,7 +102,8 @@ public class MultiOptionQuestionFormTest {
         new MultiOptionQuestionDefinition(
             config,
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "option one"))),
+                QuestionOption.create(
+                    1L, "one admin", LocalizedStrings.of(Locale.US, "option one"))),
             MultiOptionQuestionType.CHECKBOX);
 
     QuestionDefinition actual = builder.build();
@@ -116,6 +121,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
     form.setOptionIds(ImmutableList.of(4L, 1L));
 
     form.getBuilder();
@@ -134,11 +140,42 @@ public class MultiOptionQuestionFormTest {
     form.setMaxChoicesAllowed("");
     // Add two existing options with IDs 1 and 2
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
     form.setOptionIds(ImmutableList.of(1L, 2L));
     form.setNewOptions(ImmutableList.of("three", "four"));
+    form.setNewOptionAdminNames(ImmutableList.of("three admin", "four admin"));
 
     form.getBuilder();
 
     assertThat(form.getNextAvailableId()).isEqualTo(OptionalLong.of(5));
+  }
+
+  @Test
+  public void getBuilder_addNewOptions_setsAdminNameCorrectly() throws Exception {
+    MultiOptionQuestionForm form = new DropdownQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    // Add two existing options with IDs 1 and 2
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setNewOptions(ImmutableList.of("three", "four"));
+    form.setNewOptionAdminNames(ImmutableList.of("three admin", "four admin"));
+
+    MultiOptionQuestionDefinition questionDefinition =
+        (MultiOptionQuestionDefinition) form.getBuilder().build();
+
+    assertThat(questionDefinition.getOptionsAdminName())
+        .containsExactly(
+            "one admin",
+            "two admin",
+            // TODO(#4862): Currently the admin name is set to the user-facing text. Once the form
+            // view is updated to support admin names, this test should be updated.
+            "three",
+            "four");
   }
 }

--- a/server/test/forms/RadioButtonQuestionFormTest.java
+++ b/server/test/forms/RadioButtonQuestionFormTest.java
@@ -24,6 +24,7 @@ public class RadioButtonQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
     form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -37,9 +38,9 @@ public class RadioButtonQuestionFormTest {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "cat")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "dog")),
-            QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "rabbit")));
+            QuestionOption.create(1L, "cat admin", LocalizedStrings.of(Locale.US, "cat")),
+            QuestionOption.create(2L, "dog admin", LocalizedStrings.of(Locale.US, "dog")),
+            QuestionOption.create(3L, "rabbit admin", LocalizedStrings.of(Locale.US, "rabbit")));
     MultiOptionQuestionDefinition expected =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.RADIO_BUTTON);
@@ -59,8 +60,8 @@ public class RadioButtonQuestionFormTest {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "hello")),
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "world")));
+            QuestionOption.create(1L, "hello admin", LocalizedStrings.of(Locale.US, "hello")),
+            QuestionOption.create(1L, "world admin", LocalizedStrings.of(Locale.US, "world")));
 
     MultiOptionQuestionDefinition originalQd =
         new MultiOptionQuestionDefinition(

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -512,9 +512,9 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "cat")),
-            QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "dog")),
-            QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "horse")));
+            QuestionOption.create(1L, "cat admin", LocalizedStrings.of(Locale.US, "cat")),
+            QuestionOption.create(2L, "dog admin", LocalizedStrings.of(Locale.US, "dog")),
+            QuestionOption.create(3L, "horse admin", LocalizedStrings.of(Locale.US, "horse")));
     QuestionDefinition multiSelectQuestion =
         questionService
             .create(

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -46,18 +46,4 @@ public class QuestionOptionTest {
             LocalizedQuestionOption.create(
                 123L, 1L, "test admin", "test", LocalizedStrings.DEFAULT_LOCALE));
   }
-
-  @Test
-  public void create_withNoDefaultLocaleText_usesIdAsAdminName() {
-    QuestionOption questionOption =
-        QuestionOption.create(1L, LocalizedStrings.of(Locale.FRANCE, "option 1"));
-
-    assertThat(questionOption)
-        .isEqualTo(
-            QuestionOption.builder()
-                .setOptionText(LocalizedStrings.of(Locale.FRANCE, "option 1"))
-                .setAdminName("1")
-                .setId(1L)
-                .build());
-  }
 }

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -109,8 +109,11 @@ public class QuestionConfigTest {
   public void checkboxForm_preservesNewOptions() {
     CheckboxQuestionForm form = new CheckboxQuestionForm();
     form.setOptions(ImmutableList.of("existing-option-a", "existing-option-b"));
+    form.setOptionAdminNames(
+        ImmutableList.of("existing-option-admin-a", "existing-option-admin-b"));
     form.setOptionIds(ImmutableList.of(1L, 2L));
     form.setNewOptions(ImmutableList.of("new-option-c", "new-option-d"));
+    form.setNewOptionAdminNames(ImmutableList.of("new-option-admin-c", "new-option-admin-d"));
 
     Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(form, messages);
     assertThat(maybeConfig).isPresent();
@@ -120,5 +123,9 @@ public class QuestionConfigTest {
     assertThat(result).contains("existing-option-b");
     assertThat(result).contains("new-option-c");
     assertThat(result).contains("new-option-d");
+    assertThat(result).contains("existing-option-admin-a");
+    assertThat(result).contains("existing-option-admin-b");
+    // TODO(#4862): When the form is updated to allow setting admin names, add
+    // the new option admin names to this test.
   }
 }

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -39,9 +39,9 @@ public class CheckboxQuestionRendererTest extends ResetPostgres {
           .build();
   private static final ImmutableList<QuestionOption> QUESTION_OPTIONS =
       ImmutableList.of(
-          QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "hello")),
-          QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "happy")),
-          QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "world")));
+          QuestionOption.create(1L, "hello admin", LocalizedStrings.of(Locale.US, "hello")),
+          QuestionOption.create(2L, "happy admin", LocalizedStrings.of(Locale.US, "happy")),
+          QuestionOption.create(3L, "world admin", LocalizedStrings.of(Locale.US, "world")));
   private static final MultiOptionQuestionDefinition CHECKBOX_QUESTION =
       new MultiOptionQuestionDefinition(CONFIG, QUESTION_OPTIONS, MultiOptionQuestionType.CHECKBOX);
   private final ApplicantData applicantData = new ApplicantData();

--- a/server/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -38,10 +38,12 @@ public class DropdownQuestionRendererTest extends ResetPostgres {
           .build();
   private static final ImmutableList<QuestionOption> QUESTION_OPTIONS =
       ImmutableList.of(
-          QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "chocolate")),
-          QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "peanut butter")),
-          QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "vanilla")),
-          QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "raspberry")));
+          QuestionOption.create(1L, "chocolate admin", LocalizedStrings.of(Locale.US, "chocolate")),
+          QuestionOption.create(
+              2L, "peanut butter admin", LocalizedStrings.of(Locale.US, "peanut butter")),
+          QuestionOption.create(3L, "vanilla admin", LocalizedStrings.of(Locale.US, "vanilla")),
+          QuestionOption.create(
+              4L, "raspberry admin", LocalizedStrings.of(Locale.US, "raspberry")));
   private static final MultiOptionQuestionDefinition QUESTION =
       new MultiOptionQuestionDefinition(CONFIG, QUESTION_OPTIONS, MultiOptionQuestionType.DROPDOWN);
 

--- a/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/server/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -37,10 +37,12 @@ public class RadioButtonQuestionRendererTest {
           .build();
   private static final ImmutableList<QuestionOption> QUESTION_OPTIONS =
       ImmutableList.of(
-          QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "chocolate")),
-          QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "peanut butter")),
-          QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "vanilla")),
-          QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "raspberry")));
+          QuestionOption.create(1L, "chocolate admin", LocalizedStrings.of(Locale.US, "chocolate")),
+          QuestionOption.create(
+              2L, "peanut butter admin", LocalizedStrings.of(Locale.US, "peanut butter")),
+          QuestionOption.create(3L, "vanilla admin", LocalizedStrings.of(Locale.US, "vanilla")),
+          QuestionOption.create(
+              4L, "raspberry admin", LocalizedStrings.of(Locale.US, "raspberry")));
   private static final MultiOptionQuestionDefinition QUESTION =
       new MultiOptionQuestionDefinition(
           CONFIG, QUESTION_OPTIONS, MultiOptionQuestionType.RADIO_BUTTON);


### PR DESCRIPTION
### Description

Updates question form processing logic to support admin names, and removes final uses of the deprecated `QuestionOption::create()` overloads that don't have `adminName` as a parameter.

Notes on the logic:
- The MultiOptionQuestionForm validates that it's provided a a form that can be turned into a valid `QuestionDefinition`, but not that the `QuestionDefinition` is one we'd want to save.
- The `AdminQuestionController` is responsible for merging the new `QuestionDefinition` with the existing one.

Also:
- Option admin names are included in the form itself, but the input is hidden. The next PR will be to update the form and all the browser tests support a user actually providing an option admin name.
- Because the admin name input box is hidden, when processing new options in the form we still set the admin name to the user-facing text the admin set. Any existing admin names are preserved, however. There are TODOs throughout to updates tests once the input is unhidden.
- Unhiding the new input currently makes the form cramped and hard to use, so in the next PR we will reorganize it.

We're updating code in phases, see https://github.com/civiform/civiform/issues/4862 for the work plan and additional context.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://docs.civiform.us/contributor-guide/developer-guide/technical-contribution-guide#guidelines-for-pull-requests)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

n/a

#### New Features

n/a

### Instructions for manual testing

- Ensure that adding or removing options in the question edit form doesn't result in any errors

### Issue(s) this completes

This is part of #4862
