### PR TITLE
Add additional formatting for use in confirmation screen

### DIFF
--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -258,4 +258,68 @@ public class TextFormatterTest {
     assertThat(nonPreservedContent[2])
         .isEqualTo("<div>This is the third (or sixth) line of content.</div>");
   }
+
+  @Test
+  public void addsBoldFormattingToText() {
+    String stringWithBoldedText = "hello this **b(text should be bold) and this text is not";
+    DomContent formattedText =
+        TextFormatter.maybeAddAdditionalFormatting(
+            stringWithBoldedText, new ImmutableList.Builder<DomContent>());
+    assertThat(formattedText.render())
+        .isEqualTo("<span>hello this <b>text should be bold</b> and this text is not</span>");
+  }
+
+  @Test
+  public void addsItalicizedFormattingToText() {
+    String stringWithBoldedText = "hello this **i(text should be italicized) and this text is not";
+    DomContent formattedText =
+        TextFormatter.maybeAddAdditionalFormatting(
+            stringWithBoldedText, new ImmutableList.Builder<DomContent>());
+    assertThat(formattedText.render())
+        .isEqualTo("<span>hello this <i>text should be italicized</i> and this text is not</span>");
+  }
+
+  @Test
+  public void addsFontSizeToText() {
+    String stringWithBoldedAndItalicizedText =
+        "hello this **s(font should be smaller) and this **l(font should be even larger) and this"
+            + " **x(font should be the largest!)";
+    DomContent formattedText =
+        TextFormatter.maybeAddAdditionalFormatting(
+            stringWithBoldedAndItalicizedText, new ImmutableList.Builder<DomContent>());
+    assertThat(formattedText.render())
+        .isEqualTo(
+            "<span>hello this <span class=\"text-sm\">font should be smaller</span> and this <span"
+                + " class=\"text-lg\">font should be even larger</span> and this <span"
+                + " class=\"text-xl\">font should be the largest!</span></span>");
+  }
+
+  @Test
+  public void handlesMultipleFormattingRules() {
+    String stringWithBoldedAndItalicizedText =
+        "hello this **i(text should be italicized) and this **b(text is bold) and this **l(text"
+            + " should be large)!";
+    DomContent formattedText =
+        TextFormatter.maybeAddAdditionalFormatting(
+            stringWithBoldedAndItalicizedText, new ImmutableList.Builder<DomContent>());
+    assertThat(formattedText.render())
+        .isEqualTo(
+            "<span>hello this <i>text should be italicized</i> and this <b>text is bold</b> and"
+                + " this <span class=\"text-lg\">text should be large</span>!</span>");
+  }
+
+  @Test
+  public void handlesNestedFormattingRules() {
+    String stringWithBoldedAndItalicizedText =
+        "hello this **i(text should be italicized, **b(this text should be italicized and bolded,"
+            + " and **s(this text should be italicized, bolded, and small)))!";
+    DomContent formattedText =
+        TextFormatter.maybeAddAdditionalFormatting(
+            stringWithBoldedAndItalicizedText, new ImmutableList.Builder<DomContent>());
+    assertThat(formattedText.render())
+        .isEqualTo(
+            "<span>hello this <i><span>text should be italicized, <b><span>this text should be"
+                + " italicized and bolded, and <span class=\"text-sm\">this text should be"
+                + " italicized, bolded, and small</span></span></b></span></i>!</span>");
+  }
 }


### PR DESCRIPTION
### Description

Adds the ability to add additional formatting to text fields, specifically bolding or italiczing text and changing the font size. I would be introducing these changes as a part of [this issue](https://github.com/civiform/civiform/issues/5434), but I'm seeking feedback on the approach before fully implementing it.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes) -- still need to test in Chrome
- [ ] Extended the README / documentation, if necessary -- probably need to add documentation about how to use this... how do admins know how to use current formatting?

#### User visible changes -- still need to test

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)

### Instructions for manual testing

1. Create a program
2. Edit the program details to include a custom confirmation screen message with formatting applied (the text below "A custom message that will be shown on the confirmation page after an application has been submitted.")
3. Publish the program
4. As an applicant, apply to the program and submit your application
5. On the confirmation screen, you should see the custom confirmation screen message with the correct formatting applied

### Issue(s) this completes
Eventually https://github.com/civiform/civiform/issues/5434
