### PR TITLE
Allow production sites to set the no index meta tag

### DIFF
--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -47,7 +47,7 @@ public class BaseHtmlLayout {
     this.measurementId = settingsManifest.getMeasurementId();
 
     this.isDevOrStaging = checkNotNull(deploymentType).isDevOrStaging();
-    this.addNoindexMetaTag = this.isDevOrStaging && settingsManifest.getStagingAddNoindexMetaTag();
+    this.addNoindexMetaTag = settingsManifest.getStagingAddNoindexMetaTag();
 
     civiformImageTag = settingsManifest.getCiviformImageTag().get();
   }


### PR DESCRIPTION
### Description

We currently restrict the `STAGING_ADD_NOINDEX_META_TAG` to only work in dev and staging, but we should allow this to work anytime it is set..

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Fixes #5635
