### PR TITLE
"Return" should trigger an action in Applications Search form

### DIFF
--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -262,8 +262,15 @@ function attachStopPropogationListenerOnFormButtons() {
 /**
  * Disables default browser behavior where pressing Enter on any input in a form
  * triggers form submission. See https://github.com/civiform/civiform/issues/3872
+ * Except when the ignore element is present, the default form action would work
+ * See https://github.com/civiform/civiform/issues/5464
  */
 function disableEnterToSubmitBehaviorOnForms() {
+  const ignoreElement = document.getElementById('cf-search-applications')
+  if (ignoreElement) {
+    return
+  }
+
   addEventListenerToElements('form', 'keydown', (e: KeyboardEvent) => {
     const target = (e.target as HTMLElement).tagName.toLowerCase()
     // If event originated from a button, link, or textarea, it should proceed with the default action.

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -262,19 +262,20 @@ function attachStopPropogationListenerOnFormButtons() {
 /**
  * Disables default browser behavior where pressing Enter on any input in a form
  * triggers form submission. See https://github.com/civiform/civiform/issues/3872
- * Except when the ignore element is present, the default form action would work
+ * Except when the overrideDisableSubmitOnEnter attribute is present for the form, the default form action would work
  * See https://github.com/civiform/civiform/issues/5464
  */
 function disableEnterToSubmitBehaviorOnForms() {
-  const ignoreElement = document.getElementById('cf-search-applications')
-  if (ignoreElement) {
-    return
-  }
-
   addEventListenerToElements('form', 'keydown', (e: KeyboardEvent) => {
     const target = (e.target as HTMLElement).tagName.toLowerCase()
-    // If event originated from a button, link, or textarea, it should proceed with the default action.
+    const overrideDisableSubmitOnEnter = document
+      .getElementById((e.target as HTMLElement).id)
+      ?.closest('form')
+      ?.hasAttribute('data-override-disable-submit-on-enter')
+    // If event originated from a button, link, or textarea, or if overrideDisableSubmitOnEnter is enabled,
+    // it should proceed with the default action.
     if (
+      overrideDisableSubmitOnEnter === false &&
       target !== 'button' &&
       target !== 'a' &&
       target !== 'textarea' &&

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -262,7 +262,7 @@ function attachStopPropogationListenerOnFormButtons() {
 /**
  * Disables default browser behavior where pressing Enter on any input in a form
  * triggers form submission. See https://github.com/civiform/civiform/issues/3872
- * Except when the overrideDisableSubmitOnEnter attribute is present for the form, the default form action would work
+ * Except when the data-override-disable-submit-on-enter attribute is present for the form, the default form action would work
  * See https://github.com/civiform/civiform/issues/5464
  */
 function disableEnterToSubmitBehaviorOnForms() {

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -178,6 +178,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
             .url();
     return form()
         .withClasses("mt-6")
+        .attr("data-override-disable-submit-on-enter")
         .withMethod("GET")
         .withAction(
             routes.AdminApplicationController.index(
@@ -211,7 +212,6 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                 .withClasses("flex"))),
             FieldWithLabel.input()
                 .setFieldName(SEARCH_PARAM)
-                .setId("cf-search-applications")
                 .setValue(filterParams.search().orElse(""))
                 .setLabelText("Search by name, email, or application ID")
                 .getInputTag()

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -211,6 +211,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                                 .withClasses("flex"))),
             FieldWithLabel.input()
                 .setFieldName(SEARCH_PARAM)
+                .setId("cf-search-applications")
                 .setValue(filterParams.search().orElse(""))
                 .setLabelText("Search by name, email, or application ID")
                 .getInputTag()


### PR DESCRIPTION
### Description

"Return" should trigger an action in Applications Search form

## Release notes

"Return" should trigger an action in Applications Search form

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Fixes #5464 
