### PR TITLE
Localstack v2.3.x returning 500s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 
 services:
   localstack:
-    image: localstack/localstack:2.3.1
+    image: localstack/localstack:2.2.0
     profiles: ['aws', 'emulator']
     expose:
       - '4566'

--- a/localstack/localstack.Dockerfile
+++ b/localstack/localstack.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM localstack/localstack:2.3.1
+FROM localstack/localstack:2.2.0
 
 # Localstack tries to connect to the host specified
 # by success_redirect_url upon successful upload of


### PR DESCRIPTION
Localstack was updated last Friday from v2.2.0 to [v2.3.0](https://github.com/civiform/civiform/pull/5690)/[v2.3.1](https://github.com/civiform/civiform/pull/5693); it is now returning 500 error codes. 

Tried switching to using their new S3 engine with env var `PROVIDER_OVERRIDE_S3=v3` no luck. Even using the our current settings `PROVIDER_OVERRIDE_S3=legacy` fails. 

We can get more details setting env vars `LS_LOG=trace` and `DEBUG=1` in the `docker-compose` file

Rollback back for now.

### Checklist

#### General

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
