### PR TITLE
Adding applicant enabled language support

### DIFF
--- a/server/app/controllers/LanguageUtils.java
+++ b/server/app/controllers/LanguageUtils.java
@@ -29,7 +29,7 @@ public final class LanguageUtils {
       UserRepository userRepository, Langs langs, SettingsManifest settingsManifest) {
     this.userRepository = checkNotNull(userRepository);
     this.langs = checkNotNull(langs);
-    this.settingsManifest = settingsManifest;
+    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   public Applicant maybeSetDefaultLocale(Applicant applicant) {
@@ -76,7 +76,7 @@ public final class LanguageUtils {
 
     // Filter list
     return allLanguages.stream()
-        .filter(x -> applicantLanguages.contains(x.code()))
+        .filter(lang -> applicantLanguages.contains(lang.code()))
         .collect(ImmutableList.toImmutableList());
   }
 }

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -637,11 +637,23 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * The languages that applicants can choose from when specifying their language preference and
-   * that admins can choose from when adding translations for programs and applications.
+   * The full list of languages available to CiviForm. These are the language that admins can choose
+   * from when adding translations for programs and applications, as well as the default list that
+   * applicants can choose from when specifying their language preference. See
+   * CIVIFORM_APPLICANT_ENABLED_LANGUAGES for further control over languages available to
+   * applicants.
    */
   public Optional<ImmutableList<String>> getCiviformSupportedLanguages() {
     return getListOfStrings("CIVIFORM_SUPPORTED_LANGUAGES");
+  }
+
+  /**
+   * If populated, this filters the languages that are visible to the applicant to just those in the
+   * list. This allows program admins to develop languages support for programs and questions, but
+   * not let the applicant use a language that is not yet ready.
+   */
+  public Optional<ImmutableList<String>> getCiviformApplicantEnabledLanguages() {
+    return getListOfStrings("CIVIFORM_APPLICANT_ENABLED_LANGUAGES");
   }
 
   /**
@@ -1725,9 +1737,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       Pattern.compile("^(?!http://|https://).+")),
                   SettingDescription.create(
                       "CIVIFORM_SUPPORTED_LANGUAGES",
-                      "The languages that applicants can choose from when specifying their"
-                          + " language preference and that admins can choose from when adding"
-                          + " translations for programs and applications.",
+                      "The full list of languages available to CiviForm. These are the language"
+                          + " that admins can choose from when adding translations for programs"
+                          + " and applications, as well as the default list that applicants can"
+                          + " choose from when specifying their language preference. See"
+                          + " CIVIFORM_APPLICANT_ENABLED_LANGUAGES for further control over"
+                          + " languages available to applicants.",
+                      /* isRequired= */ false,
+                      SettingType.LIST_OF_STRINGS,
+                      SettingMode.HIDDEN),
+                  SettingDescription.create(
+                      "CIVIFORM_APPLICANT_ENABLED_LANGUAGES",
+                      "If populated, this filters the languages that are visible to the applicant"
+                          + " to just those in the list. This allows program admins to develop"
+                          + " languages support for programs and questions, but not let the"
+                          + " applicant use a language that is not yet ready.",
                       /* isRequired= */ false,
                       SettingType.LIST_OF_STRINGS,
                       SettingMode.HIDDEN),

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -54,7 +54,7 @@ public final class LanguageSelector {
 
     var preferredLanguage =
         languageUtils.getApplicantEnabledLanguages().stream()
-            .filter(x -> x.code().equals(preferredLanguageCode))
+            .filter(lang -> lang.code().equals(preferredLanguageCode))
             .findFirst();
 
     return preferredLanguage.orElse(Lang.defaultLang());

--- a/server/app/views/LanguageSelector.java
+++ b/server/app/views/LanguageSelector.java
@@ -1,5 +1,6 @@
 package views;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
@@ -8,6 +9,7 @@ import static j2html.TagCreator.option;
 import static j2html.TagCreator.select;
 
 import com.google.common.collect.ImmutableList;
+import controllers.LanguageUtils;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.LabelTag;
 import j2html.tags.specialized.OptionTag;
@@ -15,7 +17,6 @@ import j2html.tags.specialized.SelectTag;
 import java.util.Locale;
 import javax.inject.Inject;
 import play.i18n.Lang;
-import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
 import views.style.BaseStyles;
@@ -29,17 +30,34 @@ import views.style.StyleUtils;
 public final class LanguageSelector {
 
   public final ImmutableList<Locale> supportedLanguages;
+  private final LanguageUtils languageUtils;
   private final MessagesApi messagesApi;
 
   @Inject
-  public LanguageSelector(Langs langs, MessagesApi messagesApi) {
-    this.messagesApi = messagesApi;
+  public LanguageSelector(LanguageUtils languageUtils, MessagesApi messagesApi) {
+    this.languageUtils = checkNotNull(languageUtils);
+    this.messagesApi = checkNotNull(messagesApi);
+
     this.supportedLanguages =
-        langs.availables().stream().map(Lang::toLocale).collect(toImmutableList());
+        languageUtils.getApplicantEnabledLanguages().stream()
+            .map(Lang::toLocale)
+            .collect(toImmutableList());
   }
 
+  /**
+   * Returns the selected preferred language based on the applicant's browser settings. If the
+   * current browser settings are for a language that is not supported/enabled for applicants it
+   * returns the default system language.
+   */
   public Lang getPreferredLangage(Http.RequestHeader request) {
-    return messagesApi.preferred(request).lang();
+    var preferredLanguageCode = messagesApi.preferred(request).lang().code();
+
+    var preferredLanguage =
+        languageUtils.getApplicantEnabledLanguages().stream()
+            .filter(x -> x.code().equals(preferredLanguageCode))
+            .findFirst();
+
+    return preferredLanguage.orElse(Lang.defaultLang());
   }
 
   public SelectTag renderDropdown(String preferredLanguage) {

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -568,3 +568,13 @@ civiform_api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST
 
 # deterministic reporting stats for browser tests
 reporting_use_deterministic_stats = false
+
+# The languages an applicant is allowed to select. If this list is empty
+# all enabled languages in play.i18n.langs will be used. This allows for
+# the system to have access to the language for program admins, but not to
+# allow applicants to use ones that are not ready
+#   CIVIFORM_APPLICANT_ENABLED_LANGUAGES.0="en-US"
+#   CIVIFORM_APPLICANT_ENABLED_LANGUAGES.1="ko"
+#   CIVIFORM_APPLICANT_ENABLED_LANGUAGES.2="es-US"
+civiform_applicant_enabled_languages = []
+civiform_applicant_enabled_languages = ${?CIVIFORM_APPLICANT_ENABLED_LANGUAGES}

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -555,7 +555,12 @@
   },
   "CIVIFORM_SUPPORTED_LANGUAGES": {
     "mode": "HIDDEN",
-    "description": "The languages that applicants can choose from when specifying their language preference and that admins can choose from when adding translations for programs and applications.",
+    "description": "The full list of languages available to CiviForm. These are the language that admins can choose from when adding translations for programs and applications, as well as the default list that applicants can choose from when specifying their language preference. See CIVIFORM_APPLICANT_ENABLED_LANGUAGES for further control over languages available to applicants.",
+    "type": "index-list"
+  },
+  "CIVIFORM_APPLICANT_ENABLED_LANGUAGES": {
+    "mode": "HIDDEN",
+    "description": "If populated, this filters the languages that are visible to the applicant to just those in the list. This allows program admins to develop languages support for programs and questions, but not let the applicant use a language that is not yet ready.",
     "type": "index-list"
   },
   "CIVIFORM_TIME_ZONE_ID": {

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -17,6 +17,7 @@ import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Result;
 import repository.UserRepository;
+import services.settings.SettingsManifest;
 
 public class HomeControllerWithProfileTest extends WithMockedProfiles {
 
@@ -42,7 +43,9 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
     Applicant applicant = createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
-    LanguageUtils languageUtils = new LanguageUtils(instanceOf(UserRepository.class), mockLangs);
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    LanguageUtils languageUtils =
+        new LanguageUtils(instanceOf(UserRepository.class), mockLangs, mockSettingsManifest);
 
     HomeController controller =
         new HomeController(

--- a/server/test/controllers/applicant/DeepLinkControllerTest.java
+++ b/server/test/controllers/applicant/DeepLinkControllerTest.java
@@ -26,6 +26,7 @@ import repository.VersionRepository;
 import services.applicant.ApplicantService;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
+import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 
 public class DeepLinkControllerTest extends WithMockedProfiles {
@@ -135,7 +136,9 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     Applicant applicant = createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
-    LanguageUtils languageUtils = new LanguageUtils(instanceOf(UserRepository.class), mockLangs);
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    LanguageUtils languageUtils =
+        new LanguageUtils(instanceOf(UserRepository.class), mockLangs, mockSettingsManifest);
 
     DeepLinkController controller =
         new DeepLinkController(
@@ -165,7 +168,9 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     Applicant applicant = createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of());
-    LanguageUtils languageUtils = new LanguageUtils(instanceOf(UserRepository.class), mockLangs);
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    LanguageUtils languageUtils =
+        new LanguageUtils(instanceOf(UserRepository.class), mockLangs, mockSettingsManifest);
 
     DeepLinkController controller =
         new DeepLinkController(


### PR DESCRIPTION
### Description

This adds a new (optional) setting named `CIVIFORM_APPLICANT_ENABLED_LANGUAGES`. It is an array that takes a list of language codes that same way `CIVIFORM_SUPPORTED_LANGUAGES` does. Whereas `CIVIFORM_SUPPORTED_LANGUAGES` is the system-wide list of languages the platform can use `CIVIFORM_APPLICANT_ENABLED_LANGUAGES` represents the subset of the system-wide languages that are available for applicants to select.

This allows us to add new languages to the system and for program admins to start configuring `programs` and `questions` with new language strings, but not allow applicants to select them until the business deems them to be ready.

Settings are set upon deployment.

Additionally, the auto-selection of the language based on the browser preference has been updated to only allow for values allowable to the applicant.

## Release notes

Allow Civiform Admins to specify which languages are available for applicants to select from the broader list of languages available in the system.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5688