### PR TITLE
Mark variables required for deployment as "required" in env-var-docs

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -821,7 +821,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                   SettingDescription.create(
                       "CIVIC_ENTITY_SMALL_LOGO_URL",
                       "Small logo for the civic entity used on the login page.",
-                      /* isRequired= */ false,
+                      /* isRequired= */ true,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
@@ -1469,7 +1469,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "SENDER_EMAIL_ADDRESS",
                       "The email address used for the 'from' email header for emails sent by"
                           + " CiviForm.",
-                      /* isRequired= */ false,
+                      /* isRequired= */ true,
                       SettingType.STRING,
                       SettingMode.HIDDEN))),
           "Email Addresses",
@@ -1498,7 +1498,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the program administrator's email"
                           + " address.",
-                      /* isRequired= */ false,
+                      /* isRequired= */ true,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
@@ -1506,14 +1506,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the trusted intermediary's email"
                           + " address.",
-                      /* isRequired= */ false,
+                      /* isRequired= */ true,
                       SettingType.STRING,
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "STAGING_APPLICANT_NOTIFICATION_MAILING_LIST",
                       "If this is a staging deployment, the application notification email is sent"
                           + " to this email address instead of the applicant's email address.",
-                      /* isRequired= */ false,
+                      /* isRequired= */ true,
                       SettingType.STRING,
                       SettingMode.HIDDEN))),
           "Custom Text",

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -5,7 +5,8 @@
       "CIVIC_ENTITY_SMALL_LOGO_URL": {
         "mode": "ADMIN_READABLE",
         "description": "Small logo for the civic entity used on the login page.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "WHITELABEL_CIVIC_ENTITY_SHORT_NAME": {
         "mode": "ADMIN_WRITEABLE",
@@ -398,7 +399,8 @@
       "SENDER_EMAIL_ADDRESS": {
         "mode": "HIDDEN",
         "description": "The email address used for the 'from' email header for emails sent by CiviForm.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "Application File Upload Storage": {
         "group_description": "Configuration options for the application file upload storage provider",
@@ -490,17 +492,20 @@
       "STAGING_PROGRAM_ADMIN_NOTIFICATION_MAILING_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the program administrator's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "STAGING_TI_NOTIFICATION_MAILING_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the trusted intermediary's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       },
       "STAGING_APPLICANT_NOTIFICATION_MAILING_LIST": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment, the application notification email is sent to this email address instead of the applicant's email address.",
-        "type": "string"
+        "type": "string",
+        "required": true
       }
     }
   },


### PR DESCRIPTION
### Description

This PR marks variables "required" in `env-var-docs.json` if they are required as a part of deployment. If a variable is marked as "required" here and is not present in the `civiform-config.sh` file, the deployment will exit with [an error](https://github.com/civiform/cloud-deploy-infra/blob/40c339725e080607a22708279e320ce656ff3cab/cloud/shared/bin/lib/config_loader.py#L293). 

The list of "required" vars is pulled from the shared [`variable_definitions.json`](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/shared/variable_definitions.json) file in `cloud-deploy-infra`. Variables that are listed in `env-var-docs.json` will be deleted from `variable_definitions.json` as a part of cleanup work.

Note: Marking vars as "required" was unblocked by the work to [sync variable names](https://github.com/civiform/civiform/pull/5615) between `env-var-docs.json` and `civiform-config.sh`.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (I ran `bin/setup` with all vars listed in the [example config](https://github.com/civiform/civiform-deploy/blob/main/civiform_config.example.sh) without my changes and then `bin/deploy` with my changes and confirmed there were no errors and deployment succeeded)

### Issue(s) this completes

Fixes #5247 
