### PR TITLE
Use new function to get questions for a version

### DIFF
--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -99,6 +99,10 @@ public final class Version extends BaseModel {
     return ImmutableList.copyOf(programs);
   }
 
+  /**
+   * Returns all questions of a given version. Instead of calling this function directly,
+   * getQuestionsForVersion should be called, since that will implement caching.
+   */
   public ImmutableList<Question> getQuestions() {
     return ImmutableList.copyOf(questions);
   }

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -48,13 +48,13 @@ public final class ActiveAndDraftQuestions {
 
   private ActiveAndDraftQuestions(Version active, Version draft, Version withDraftEdits) {
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
-        active.getQuestions().stream()
+        VersionRepository.getQuestionsForVersion(active).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.activeQuestions = activeNameToQuestion.values().asList();
 
     ImmutableMap<String, QuestionDefinition> draftNameToQuestion =
-        draft.getQuestions().stream()
+        VersionRepository.getQuestionsForVersion(draft).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.draftQuestions = draftNameToQuestion.values().asList();

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -37,7 +37,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
     ImmutableSet.Builder<QuestionDefinition> upToDateBuilder = ImmutableSet.builder();
     Set<String> namesFoundInDraft = new HashSet<>();
     for (QuestionDefinition qd :
-        draftVersion.getQuestions().stream()
+        repository.getQuestionsForVersion(draftVersion).stream()
             .map(Question::getQuestionDefinition)
             .collect(Collectors.toList())) {
       if (!draftVersion.getTombstonedQuestionNames().contains(qd.getName())) {
@@ -48,7 +48,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
       namesFoundInDraft.add(qd.getName());
     }
     for (QuestionDefinition qd :
-        activeVersion.getQuestions().stream()
+        repository.getQuestionsForVersion(activeVersion).stream()
             .map(Question::getQuestionDefinition)
             .collect(Collectors.toList())) {
 

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -6,6 +6,7 @@ import models.Question;
 import models.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import repository.VersionRepository;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.NullQuestionDefinition;
@@ -25,7 +26,7 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
 
   public ReadOnlyVersionedQuestionServiceImpl(Version version) {
     questionsById =
-        version.getQuestions().stream()
+        VersionRepository.getQuestionsForVersion(version).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
   }


### PR DESCRIPTION
### Description

Refactors places that call `version.getQuestions()` to use a new function `getQuestionsForVersion()`. The new function calls `version.getQuestions()` for now, but in the future we'll set up caching for non-draft versions within that function. For now, no functionality is updated with this change. 

See more information in [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/5724