### PR TITLE
Revert tests.yaml change

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,12 +90,8 @@ jobs:
           DOCKER_HUB_USERNAME: civiform
         run: bin/build-mock-web-services
       - name: Bring up test env with Localstack
-        env:
-          CI: true
         run: bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
-        env:
-          CI: true
         run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Verify no new image snapshots added
         # jest-image-snapshots automatically adds snapshot if it's missing.
@@ -161,12 +157,8 @@ jobs:
           DOCKER_HUB_USERNAME: civiform
         run: bin/build-mock-web-services
       - name: Bring up test env with Azurite
-        env:
-          CI: true
         run: bin/run-browser-test-env --azure --ci
       - name: Run browser tests with Azurite
-        env:
-          CI: true
         run: bin/run-browser-tests-azure
       - name: Upload image diff outputs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Description

Seems like https://github.com/civiform/civiform/pull/5708 might have caused some issues, so reverting.

Tests were skipped here: https://github.com/civiform/civiform/actions/runs/6398372897/job/17368379114?pr=5712 

Some weird behavior here: https://github.com/civiform/civiform/actions/runs/6398355831/job/17368327527?pr=5711 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

