### PR TITLE
Run server tests on dockerfile update

### DIFF
--- a/.github/workflows/pr_server.yaml
+++ b/.github/workflows/pr_server.yaml
@@ -16,7 +16,7 @@ on:
       - 'browser-test/**'
       - 'test-support/**'
       - 'mock-web-services/**'
-      - 'prod.Dockerfile'
+      - '**.Dockerfile'
       - '.github/workflows/**'
 
 permissions: read-all

--- a/.github/workflows/pr_server.yaml
+++ b/.github/workflows/pr_server.yaml
@@ -16,7 +16,6 @@ on:
       - 'browser-test/**'
       - 'test-support/**'
       - 'mock-web-services/**'
-      - 'Dockerfile'
       - 'prod.Dockerfile'
       - '.github/workflows/**'
 

--- a/.github/workflows/pr_server_skip.yaml
+++ b/.github/workflows/pr_server_skip.yaml
@@ -15,7 +15,7 @@ on:
       - 'browser-test/**'
       - 'test-support/**'
       - 'mock-web-services/**'
-      - 'prod.Dockerfile'
+      - '**.Dockerfile'
       - '.github/workflows/**'
 
 permissions: read-all


### PR DESCRIPTION
### Description

This ensures we don't introduce breaking changes by upgrading one of our docker image versions. It turns out https://github.com/civiform/civiform/pull/5715 wasn't the right file to change. That file will skip any path that isn't part of the list, so we do want Dockerfile in there, but we need "**" before in order for it to not skip any file that ends with Dockerfile. Removed 'prod.Dockerfile', since that's included in '**.Dockerfile'


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5705
