### PR TITLE
Refactor version.getPrograms to be called from versionRepository

### DIFF
--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -123,8 +123,7 @@ public final class ProfileFactory {
             account -> {
               versionRepositoryProvider
                   .get()
-                  .getActiveVersion()
-                  .getPrograms()
+                  .getProgramsForVersion(versionRepositoryProvider.get().getActiveVersion())
                   .forEach(
                       program -> account.addAdministeredProgram(program.getProgramDefinition()));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
@@ -149,8 +148,7 @@ public final class ProfileFactory {
               account.setAuthorityId(generateFakeAdminAuthorityId());
               versionRepositoryProvider
                   .get()
-                  .getActiveVersion()
-                  .getPrograms()
+                  .getProgramsForVersion(versionRepositoryProvider.get().getActiveVersion())
                   .forEach(
                       program -> account.addAdministeredProgram(program.getProgramDefinition()));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -13,6 +13,7 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
+import repository.VersionRepository;
 import services.program.ProgramDefinition;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
@@ -95,6 +96,10 @@ public final class Version extends BaseModel {
     return this.questions.remove(question);
   }
 
+  /**
+   * Returns all programs of a given version. Instead of calling this function directly,
+   * getProgramsForVersion should be called, since that will implement caching.
+   */
   public ImmutableList<Program> getPrograms() {
     return ImmutableList.copyOf(programs);
   }
@@ -112,7 +117,7 @@ public final class Version extends BaseModel {
    * exist in a version.
    */
   public Optional<Program> getProgramByName(String name) {
-    return getPrograms().stream()
+    return VersionRepository.getProgramsForVersion(this).stream()
         .filter(p -> p.getProgramDefinition().adminName().equals(name))
         .findAny();
   }
@@ -129,7 +134,7 @@ public final class Version extends BaseModel {
 
   /** Returns the names of all the programs. */
   public ImmutableSet<String> getProgramNames() {
-    return getPrograms().stream()
+    return VersionRepository.getProgramsForVersion(this).stream()
         .map(Program::getProgramDefinition)
         .map(ProgramDefinition::adminName)
         .collect(ImmutableSet.toImmutableSet());

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -121,7 +121,7 @@ public final class ProgramRepository {
       newDraft = insertProgramSync(newDraft);
       draftVersion.refresh();
       Preconditions.checkState(
-          draftVersion.getPrograms().contains(newDraft),
+          versionRepository.get().getProgramsForVersion(draftVersion).contains(newDraft),
           "Must have successfully added draft version.");
       Preconditions.checkState(
           draftVersion.getLifecycleStage().equals(LifecycleStage.DRAFT),
@@ -129,7 +129,7 @@ public final class ProgramRepository {
       // Ensure we didn't add a duplicate with other code running at the same time.
       String programName = existingProgram.getProgramDefinition().adminName();
       Preconditions.checkState(
-          draftVersion.getPrograms().stream()
+          versionRepository.get().getProgramsForVersion(draftVersion).stream()
                   .map(Program::getProgramDefinition)
                   .map(ProgramDefinition::adminName)
                   .filter(programName::equals)
@@ -159,7 +159,9 @@ public final class ProgramRepository {
     return supplyAsync(
         () -> {
           ImmutableList<Program> activePrograms =
-              versionRepository.get().getActiveVersion().getPrograms();
+              versionRepository
+                  .get()
+                  .getProgramsForVersion(versionRepository.get().getActiveVersion());
           return activePrograms.stream()
               .filter(activeProgram -> activeProgram.getSlug().equals(slug))
               .findFirst()
@@ -177,7 +179,8 @@ public final class ProgramRepository {
       throw new ProgramDraftNotFoundException(slug);
     }
 
-    ImmutableList<Program> draftPrograms = version.get().getPrograms();
+    ImmutableList<Program> draftPrograms =
+        versionRepository.get().getProgramsForVersion(version.get());
 
     return draftPrograms.stream()
         .filter(draftProgram -> draftProgram.getSlug().equals(slug))

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -109,7 +109,7 @@ public final class VersionRepository {
           question -> draft.questionIsTombstoned(question.getQuestionDefinition().getName());
 
       // Associate any active programs that aren't present in the draft with the draft.
-      active.getPrograms().stream()
+      getProgramsForVersion(active).stream()
           // Exclude programs deleted in the draft.
           .filter(not(programIsDeletedInDraft))
           // Exclude programs that are in the draft already.
@@ -148,7 +148,7 @@ public final class VersionRepository {
                 draft.removeTombstoneForQuestion(questionToDelete);
                 draft.removeQuestion(questionToDelete);
               });
-      draft.getPrograms().stream()
+      getProgramsForVersion(draft).stream()
           .filter(programIsDeletedInDraft)
           .forEach(
               programToDelete -> {
@@ -163,7 +163,7 @@ public final class VersionRepository {
       switch (publishMode) {
         case PUBLISH_CHANGES:
           Preconditions.checkState(
-              !draft.getPrograms().isEmpty() || !getQuestionsForVersion(draft).isEmpty(),
+              !getProgramsForVersion(draft).isEmpty() || !getQuestionsForVersion(draft).isEmpty(),
               "Must have at least 1 program or question in the draft version.");
           draft.save();
           active.save();
@@ -222,7 +222,7 @@ public final class VersionRepository {
       }
 
       // Move everything we're not publishing right now to the new draft.
-      existingDraft.getPrograms().stream()
+      getProgramsForVersion(existingDraft).stream()
           .filter(
               program ->
                   !program.getProgramDefinition().adminName().equals(programToPublishAdminName))
@@ -243,7 +243,7 @@ public final class VersionRepository {
 
       // Associate any active programs and questions that aren't present in the draft with the
       // draft.
-      active.getPrograms().stream()
+      getProgramsForVersion(active).stream()
           .filter(
               activeProgram ->
                   !programToPublishAdminName.equals(
@@ -384,6 +384,16 @@ public final class VersionRepository {
   }
 
   /**
+   * Returns the programs for a version.
+   *
+   * <p>This replaces all calls for version.getPrograms() and will eventually be where
+   * version-programs caching is implemented.
+   */
+  public static ImmutableList<Program> getProgramsForVersion(Version version) {
+    return version.getPrograms();
+  }
+
+  /**
    * Given any revision of a question, return the most recent conceptual version of it. Will return
    * the current DRAFT version if present then the current ACTIVE version.
    */
@@ -430,7 +440,7 @@ public final class VersionRepository {
   }
 
   public boolean isInactive(Program program) {
-    return !getActiveVersion().getPrograms().stream()
+    return !getProgramsForVersion(getActiveVersion()).stream()
         .anyMatch(activeProgram -> activeProgram.id.equals(program.id));
   }
 
@@ -446,7 +456,7 @@ public final class VersionRepository {
 
   /** Returns true if the program with the provided id is a member of the current draft version. */
   public boolean isDraftProgram(Long programId) {
-    return getDraftVersionOrCreate().getPrograms().stream()
+    return getProgramsForVersion(getDraftVersionOrCreate()).stream()
         .anyMatch(draftProgram -> draftProgram.id.equals(programId));
   }
 
@@ -457,7 +467,7 @@ public final class VersionRepository {
 
   /** Returns true if the program with the provided id is a member of the current active version. */
   public boolean isActiveProgram(Long programId) {
-    return getActiveVersion().getPrograms().stream()
+    return getProgramsForVersion(getActiveVersion()).stream()
         .anyMatch(activeProgram -> activeProgram.id.equals(programId));
   }
 
@@ -471,7 +481,7 @@ public final class VersionRepository {
     // Check there aren't any duplicate questions in the new active version
     validateNoDuplicateQuestions(newActiveQuestions);
     ImmutableSet<Long> missingQuestionIds =
-        activeVersion.getPrograms().stream()
+        getProgramsForVersion(activeVersion).stream()
             .map(program -> program.getProgramDefinition().getQuestionIdsInProgram())
             .flatMap(Collection::stream)
             .filter(
@@ -483,7 +493,7 @@ public final class VersionRepository {
             .collect(ImmutableSet.toImmutableSet());
     if (!missingQuestionIds.isEmpty()) {
       ImmutableSet<Long> programIdsMissingQuestions =
-          activeVersion.getPrograms().stream()
+          getProgramsForVersion(activeVersion).stream()
               .filter(
                   program ->
                       program.getProgramDefinition().getQuestionIdsInProgram().stream()
@@ -598,13 +608,13 @@ public final class VersionRepository {
    */
   public void updateProgramsThatReferenceQuestion(long oldQuestionId) {
     // Update all DRAFT program revisions that reference the question.
-    getDraftVersionOrCreate().getPrograms().stream()
+    getProgramsForVersion(getDraftVersionOrCreate()).stream()
         .filter(program -> program.getProgramDefinition().hasQuestion(oldQuestionId))
         .forEach(this::updateQuestionVersions);
 
     // Update any ACTIVE program without a DRAFT that references the question, a new DRAFT is
     // created.
-    getActiveVersion().getPrograms().stream()
+    getProgramsForVersion(getActiveVersion()).stream()
         .filter(program -> program.getProgramDefinition().hasQuestion(oldQuestionId))
         .filter(
             program ->
@@ -622,7 +632,7 @@ public final class VersionRepository {
       Version version) {
     ImmutableMap<Long, String> questionIdToNameLookup = getQuestionIdToNameMap(version);
     Map<String, Set<ProgramDefinition>> result = Maps.newHashMap();
-    for (Program program : version.getPrograms()) {
+    for (Program program : getProgramsForVersion(version)) {
       ImmutableSet<String> programQuestionNames =
           getProgramQuestionNames(program.getProgramDefinition(), questionIdToNameLookup);
       for (String questionName : programQuestionNames) {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -832,7 +832,7 @@ public final class ApplicantService {
                 applicantId, ImmutableSet.of(LifecycleStage.DRAFT, LifecycleStage.ACTIVE))
             .toCompletableFuture();
     ImmutableList<ProgramDefinition> activeProgramDefinitions =
-        versionRepository.getActiveVersion().getPrograms().stream()
+        versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream()
             .map(Program::getProgramDefinition)
             .filter(
                 pdef ->

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -52,7 +52,7 @@ public final class ActiveAndDraftPrograms {
     // an additional database lookup in order to sync the set of questions associated with the
     // program.
     ImmutableMap<String, ProgramDefinition> activeNameToProgram =
-        checkNotNull(active).getPrograms().stream()
+        VersionRepository.getProgramsForVersion(checkNotNull(active)).stream()
             .map(
                 program ->
                     service.isPresent()
@@ -62,7 +62,7 @@ public final class ActiveAndDraftPrograms {
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
 
     ImmutableMap<String, ProgramDefinition> draftNameToProgram =
-        checkNotNull(draft).getPrograms().stream()
+        VersionRepository.getProgramsForVersion(checkNotNull(draft)).stream()
             .map(
                 program ->
                     service.isPresent()

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -191,8 +191,10 @@ public final class ProgramServiceImpl implements ProgramService {
 
   private boolean isActiveOrDraftProgram(Program program) {
     return Streams.concat(
-            versionRepository.getActiveVersion().getPrograms().stream(),
-            versionRepository.getDraftVersionOrCreate().getPrograms().stream())
+            versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream(),
+            versionRepository
+                .getProgramsForVersion(versionRepository.getDraftVersionOrCreate())
+                .stream())
         .anyMatch(p -> p.id.equals(program.id));
   }
 


### PR DESCRIPTION
### Description

Refactors places that call `version.getPrograms()` to use a new function `getProgramsForVersion()`. The new function calls `version.getPrograms()` for now, but in the future we'll set up caching for non-draft versions within that function. For now, no functionality is updated with this change. 

This is very similar to https://github.com/civiform/civiform/pull/5711

See more information in [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/5724
