### PR TITLE
Continue refactoring code to make getQuestionsForVersion an instance method

### DIFF
--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -13,6 +13,7 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
+import repository.VersionRepository;
 import services.program.ProgramDefinition;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
@@ -122,7 +123,7 @@ public final class Version extends BaseModel {
    * can exist in a version.
    */
   public Optional<Question> getQuestionByName(String name) {
-    return getQuestions().stream()
+    return VersionRepository.getQuestionsForVersion(this).stream()
         .filter(q -> q.getQuestionDefinition().getName().equals(name))
         .findAny();
   }
@@ -137,7 +138,7 @@ public final class Version extends BaseModel {
 
   /** Returns the names of all the questions. */
   public ImmutableSet<String> getQuestionNames() {
-    return getQuestions().stream()
+    return VersionRepository.getQuestionsForVersion(this).stream()
         .map(Question::getQuestionDefinition)
         .map(QuestionDefinition::getName)
         .collect(ImmutableSet.toImmutableSet());

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -15,6 +15,7 @@ import javax.persistence.Table;
 import play.data.validation.Constraints;
 import services.program.ProgramDefinition;
 import services.question.exceptions.QuestionNotFoundException;
+import services.question.types.QuestionDefinition;
 
 /**
  * An EBean mapped class that stores a reference object for coordinating the CiviForm data model.
@@ -156,7 +157,11 @@ public final class Version extends BaseModel {
    */
   public boolean addTombstoneForQuestion(Question question) throws QuestionNotFoundException {
     String name = question.getQuestionDefinition().getName();
-    if (!this.getQuestionNames().contains(name)) {
+    if (!this.getQuestions().stream()
+        .map(Question::getQuestionDefinition)
+        .map(QuestionDefinition::getName)
+        .collect(ImmutableSet.toImmutableSet())
+        .contains(name)) {
       throw new QuestionNotFoundException(question.getQuestionDefinition().getId());
     }
     if (this.tombstonedQuestionNames == null) {

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -15,7 +15,6 @@ import javax.persistence.Table;
 import play.data.validation.Constraints;
 import services.program.ProgramDefinition;
 import services.question.exceptions.QuestionNotFoundException;
-import services.question.types.QuestionDefinition;
 
 /**
  * An EBean mapped class that stores a reference object for coordinating the CiviForm data model.
@@ -153,24 +152,15 @@ public final class Version extends BaseModel {
    * Attempts to mark the provided question as not eligible for copying to the next version.
    *
    * @return true if the question was successfully marked as tombstoned, false otherwise.
-   * @throws QuestionNotFoundException if the question cannot be found in this version.
    */
-  public boolean addTombstoneForQuestion(Question question) throws QuestionNotFoundException {
-    String name = question.getQuestionDefinition().getName();
-    if (!this.getQuestions().stream()
-        .map(Question::getQuestionDefinition)
-        .map(QuestionDefinition::getName)
-        .collect(ImmutableSet.toImmutableSet())
-        .contains(name)) {
-      throw new QuestionNotFoundException(question.getQuestionDefinition().getId());
-    }
+  public boolean addTombstoneForQuestion(String questionName) {
     if (this.tombstonedQuestionNames == null) {
       this.tombstonedQuestionNames = new ArrayList<>();
     }
-    if (this.questionIsTombstoned(name)) {
+    if (this.questionIsTombstoned(questionName)) {
       return false;
     }
-    return this.tombstonedQuestionNames.add(name);
+    return this.tombstonedQuestionNames.add(questionName);
   }
 
   /**

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -13,10 +13,8 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
-import repository.VersionRepository;
 import services.program.ProgramDefinition;
 import services.question.exceptions.QuestionNotFoundException;
-import services.question.types.QuestionDefinition;
 
 /**
  * An EBean mapped class that stores a reference object for coordinating the CiviForm data model.

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -14,7 +14,6 @@ import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
 import services.program.ProgramDefinition;
-import services.question.exceptions.QuestionNotFoundException;
 
 /**
  * An EBean mapped class that stores a reference object for coordinating the CiviForm data model.

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -118,29 +118,11 @@ public final class Version extends BaseModel {
         .findAny();
   }
 
-  /**
-   * If a question by the given name exists, return it. A maximum of one question by a given name
-   * can exist in a version.
-   */
-  public Optional<Question> getQuestionByName(String name) {
-    return VersionRepository.getQuestionsForVersion(this).stream()
-        .filter(q -> q.getQuestionDefinition().getName().equals(name))
-        .findAny();
-  }
-
   /** Returns the names of all the programs. */
   public ImmutableSet<String> getProgramNames() {
     return getPrograms().stream()
         .map(Program::getProgramDefinition)
         .map(ProgramDefinition::adminName)
-        .collect(ImmutableSet.toImmutableSet());
-  }
-
-  /** Returns the names of all the questions. */
-  public ImmutableSet<String> getQuestionNames() {
-    return VersionRepository.getQuestionsForVersion(this).stream()
-        .map(Question::getQuestionDefinition)
-        .map(QuestionDefinition::getName)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -61,7 +61,10 @@ public final class QuestionRepository {
     Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try (Transaction transaction =
         database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
-      Optional<Question> existingDraft = versionRepositoryProvider.get().getQuestionByNameForVersion(definition.getName(), draftVersion);
+      Optional<Question> existingDraft =
+          versionRepositoryProvider
+              .get()
+              .getQuestionByNameForVersion(definition.getName(), draftVersion);
       try {
         if (existingDraft.isPresent()) {
           Question updatedDraft =

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -61,7 +61,7 @@ public final class QuestionRepository {
     Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try (Transaction transaction =
         database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
-      Optional<Question> existingDraft = draftVersion.getQuestionByName(definition.getName());
+      Optional<Question> existingDraft = versionRepositoryProvider.get().getQuestionByNameForVersion(definition.getName(), draftVersion);
       try {
         if (existingDraft.isPresent()) {
           Question updatedDraft =

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -656,7 +656,7 @@ public final class VersionRepository {
   }
 
   /** Returns the names of questions referenced by the program that are in the specified version. */
-  public static ImmutableSet<String> getProgramQuestionNamesInVersion(
+  public ImmutableSet<String> getProgramQuestionNamesInVersion(
       ProgramDefinition program, Version version) {
     ImmutableMap<Long, String> questionIdToNameLookup = getQuestionIdToNameMap(version);
     return getProgramQuestionNames(program, questionIdToNameLookup);

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -99,7 +99,7 @@ public final class VersionRepository {
       Version active = getActiveVersion();
 
       ImmutableSet<String> draftProgramsNames = draft.getProgramNames();
-      ImmutableSet<String> draftQuestionNames = draft.getQuestionNames();
+      ImmutableSet<String> draftQuestionNames = getQuestionNamesForVersion(draft);
 
       // Is a program being deleted in the draft version?
       Predicate<Program> programIsDeletedInDraft =

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -666,7 +666,7 @@ public final class VersionRepository {
    * Returns true if any questions in the provided set are referenced by multiple programs in the
    * specified version.
    */
-  private static boolean anyQuestionIsShared(Version version, ImmutableSet<String> questions) {
+  private boolean anyQuestionIsShared(Version version, ImmutableSet<String> questions) {
     ImmutableMap<String, ImmutableSet<ProgramDefinition>> referencingProgramsByQuestionName =
         buildReferencingProgramsMap(version);
     return questions.stream()

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -47,6 +47,7 @@ import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.OrNode;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
+import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
 
 /** A repository object for dealing with versioning of questions and programs. */
@@ -371,6 +372,22 @@ public final class VersionRepository {
             .findOne();
 
     return Optional.ofNullable(previousVersion);
+  }
+
+  /**
+   * Attempts to mark the provided question of a particular version as not eligible for copying to
+   * the next version.
+   *
+   * @return true if the question was successfully marked as tombstoned, false otherwise.
+   * @throws QuestionNotFoundException if the question cannot be found in this version.
+   */
+  public boolean addTombstoneForQuestionInVersion(Question question, Version version)
+      throws QuestionNotFoundException {
+    String name = question.getQuestionDefinition().getName();
+    if (!getQuestionNamesForVersion(version).contains(name)) {
+      throw new QuestionNotFoundException(question.getQuestionDefinition().getId());
+    }
+    return version.addTombstoneForQuestion(name);
   }
 
   /** Returns the names of all the questions for a particular version. */

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -373,15 +373,13 @@ public final class VersionRepository {
     return Optional.ofNullable(previousVersion);
   }
 
-
   /** Returns the names of all the questions for a particular version. */
   public ImmutableSet<String> getQuestionNamesForVersion(Version version) {
     return getQuestionsForVersion(version).stream()
-      .map(Question::getQuestionDefinition)
-      .map(QuestionDefinition::getName)
-      .collect(ImmutableSet.toImmutableSet());
+        .map(Question::getQuestionDefinition)
+        .map(QuestionDefinition::getName)
+        .collect(ImmutableSet.toImmutableSet());
   }
-
 
   /**
    * If a question by the given name exists, return it. A maximum of one question by a given name
@@ -389,8 +387,8 @@ public final class VersionRepository {
    */
   public Optional<Question> getQuestionByNameForVersion(String name, Version version) {
     return getQuestionsForVersion(version).stream()
-      .filter(q -> q.getQuestionDefinition().getName().equals(name))
-      .findAny();
+        .filter(q -> q.getQuestionDefinition().getName().equals(name))
+        .findAny();
   }
 
   /**

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -373,13 +373,33 @@ public final class VersionRepository {
     return Optional.ofNullable(previousVersion);
   }
 
+
+  /** Returns the names of all the questions for a particular version. */
+  public ImmutableSet<String> getQuestionNamesForVersion(Version version) {
+    return getQuestionsForVersion(version).stream()
+      .map(Question::getQuestionDefinition)
+      .map(QuestionDefinition::getName)
+      .collect(ImmutableSet.toImmutableSet());
+  }
+
+
+  /**
+   * If a question by the given name exists, return it. A maximum of one question by a given name
+   * can exist in a version.
+   */
+  public Optional<Question> getQuestionByNameForVersion(String name, Version version) {
+    return getQuestionsForVersion(version).stream()
+      .filter(q -> q.getQuestionDefinition().getName().equals(name))
+      .findAny();
+  }
+
   /**
    * Returns the questions for a version.
    *
    * <p>This replaces all calls for version.getQuestions() and will eventually be where
    * version-questions caching is implemented.
    */
-  public static ImmutableList<Question> getQuestionsForVersion(Version version) {
+  public ImmutableList<Question> getQuestionsForVersion(Version version) {
     return version.getQuestions();
   }
 
@@ -618,7 +638,7 @@ public final class VersionRepository {
    * Inspects the provided version and returns a map where the key is the question name and the
    * value is a set of programs that reference the given question in this version.
    */
-  public static ImmutableMap<String, ImmutableSet<ProgramDefinition>> buildReferencingProgramsMap(
+  public ImmutableMap<String, ImmutableSet<ProgramDefinition>> buildReferencingProgramsMap(
       Version version) {
     ImmutableMap<Long, String> questionIdToNameLookup = getQuestionIdToNameMap(version);
     Map<String, Set<ProgramDefinition>> result = Maps.newHashMap();
@@ -663,7 +683,7 @@ public final class VersionRepository {
    * Different versions of a question can have distinct IDs. The name is an ID that is constant
    * across versions.
    */
-  private static ImmutableMap<Long, String> getQuestionIdToNameMap(Version version) {
+  private ImmutableMap<Long, String> getQuestionIdToNameMap(Version version) {
     return getQuestionsForVersion(version).stream()
         .map(Question::getQuestionDefinition)
         .collect(

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -1028,7 +1028,8 @@ public final class ProgramServiceImpl implements ProgramService {
         Version v = p.getVersions().stream().findAny().orElseThrow();
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
         if (questionServiceForVersion == null) {
-          questionServiceForVersion = questionService.getReadOnlyVersionedQuestionService(v, versionRepository);
+          questionServiceForVersion =
+              questionService.getReadOnlyVersionedQuestionService(v, versionRepository);
           versionToQuestionService.put(v.id, questionServiceForVersion);
         }
         programToQuestionService.put(programDef.id(), questionServiceForVersion);
@@ -1260,7 +1261,8 @@ public final class ProgramServiceImpl implements ProgramService {
       ProgramDefinition programDefinition, Version version) {
     try {
       return syncProgramDefinitionQuestions(
-          programDefinition, questionService.getReadOnlyVersionedQuestionService(version, versionRepository));
+          programDefinition,
+          questionService.getReadOnlyVersionedQuestionService(version, versionRepository));
     } catch (QuestionNotFoundException e) {
       throw new RuntimeException(
           String.format(

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -1028,7 +1028,7 @@ public final class ProgramServiceImpl implements ProgramService {
         Version v = p.getVersions().stream().findAny().orElseThrow();
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
         if (questionServiceForVersion == null) {
-          questionServiceForVersion = questionService.getReadOnlyVersionedQuestionService(v);
+          questionServiceForVersion = questionService.getReadOnlyVersionedQuestionService(v, versionRepository);
           versionToQuestionService.put(v.id, questionServiceForVersion);
         }
         programToQuestionService.put(programDef.id(), questionServiceForVersion);
@@ -1260,7 +1260,7 @@ public final class ProgramServiceImpl implements ProgramService {
       ProgramDefinition programDefinition, Version version) {
     try {
       return syncProgramDefinitionQuestions(
-          programDefinition, questionService.getReadOnlyVersionedQuestionService(version));
+          programDefinition, questionService.getReadOnlyVersionedQuestionService(version, versionRepository));
     } catch (QuestionNotFoundException e) {
       throw new RuntimeException(
           String.format(

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -43,18 +43,18 @@ public final class ActiveAndDraftQuestions {
     return new ActiveAndDraftQuestions(
         repository.getActiveVersion(),
         repository.getDraftVersionOrCreate(),
-        repository.previewPublishNewSynchronizedVersion());
+        repository.previewPublishNewSynchronizedVersion(), repository);
   }
 
-  private ActiveAndDraftQuestions(Version active, Version draft, Version withDraftEdits) {
+  private ActiveAndDraftQuestions(Version active, Version draft, Version withDraftEdits, VersionRepository repository) {
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
-        VersionRepository.getQuestionsForVersion(active).stream()
+        repository.getQuestionsForVersion(active).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.activeQuestions = activeNameToQuestion.values().asList();
 
     ImmutableMap<String, QuestionDefinition> draftNameToQuestion =
-        VersionRepository.getQuestionsForVersion(draft).stream()
+        repository.getQuestionsForVersion(draft).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.draftQuestions = draftNameToQuestion.values().asList();
@@ -71,9 +71,9 @@ public final class ActiveAndDraftQuestions {
                     }));
 
     this.draftVersionHasAnyEdits = draft.hasAnyChanges();
-    this.referencingActiveProgramsByName = VersionRepository.buildReferencingProgramsMap(active);
+    this.referencingActiveProgramsByName = repository.buildReferencingProgramsMap(active);
     this.referencingDraftProgramsByName =
-        VersionRepository.buildReferencingProgramsMap(withDraftEdits);
+        repository.buildReferencingProgramsMap(withDraftEdits);
 
     ImmutableSet<String> tombstonedQuestionNames =
         ImmutableSet.copyOf(

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -40,13 +40,13 @@ public final class ActiveAndDraftQuestions {
    * state.
    */
   public static ActiveAndDraftQuestions buildFromCurrentVersions(VersionRepository repository) {
-    return new ActiveAndDraftQuestions(
-        repository.getActiveVersion(),
-        repository.getDraftVersionOrCreate(),
-        repository.previewPublishNewSynchronizedVersion(), repository);
+    return new ActiveAndDraftQuestions(repository);
   }
 
-  private ActiveAndDraftQuestions(Version active, Version draft, Version withDraftEdits, VersionRepository repository) {
+  private ActiveAndDraftQuestions(VersionRepository repository) {
+    Version active = repository.getActiveVersion();
+    Version draft = repository.getDraftVersionOrCreate();
+    Version withDraftEdits = repository.previewPublishNewSynchronizedVersion();
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
         repository.getQuestionsForVersion(active).stream()
             .map(Question::getQuestionDefinition)
@@ -72,8 +72,7 @@ public final class ActiveAndDraftQuestions {
 
     this.draftVersionHasAnyEdits = draft.hasAnyChanges();
     this.referencingActiveProgramsByName = repository.buildReferencingProgramsMap(active);
-    this.referencingDraftProgramsByName =
-        repository.buildReferencingProgramsMap(withDraftEdits);
+    this.referencingDraftProgramsByName = repository.buildReferencingProgramsMap(withDraftEdits);
 
     ImmutableSet<String> tombstonedQuestionNames =
         ImmutableSet.copyOf(

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -189,7 +189,9 @@ public final class QuestionService {
         questionRepository.createOrUpdateDraft(question.get().getQuestionDefinition());
     Version draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try {
-      if (!draftVersion.addTombstoneForQuestion(draftQuestion)) {
+      if (!versionRepositoryProvider
+          .get()
+          .addTombstoneForQuestionInVersion(draftQuestion, draftVersion)) {
         throw new InvalidUpdateException("Already tombstoned.");
       }
     } catch (QuestionNotFoundException e) {

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -396,6 +396,8 @@ public final class QuestionService {
       return ImmutableList.of();
     }
 
-    return getReadOnlyVersionedQuestionService(optionalPreviousVersion.get()).getAllQuestions();
+    return getReadOnlyVersionedQuestionService(
+            optionalPreviousVersion.get(), versionRepositoryProvider.get())
+        .getAllQuestions();
   }
 }

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -103,7 +103,8 @@ public final class QuestionService {
    * Get a {@link ReadOnlyQuestionService} which implements synchronous, in-memory read behavior for
    * questions in a particular version.
    */
-  public ReadOnlyQuestionService getReadOnlyVersionedQuestionService(Version version, VersionRepository versionRepository) {
+  public ReadOnlyQuestionService getReadOnlyVersionedQuestionService(
+      Version version, VersionRepository versionRepository) {
     return new ReadOnlyVersionedQuestionServiceImpl(version, versionRepository);
   }
 
@@ -210,7 +211,8 @@ public final class QuestionService {
     // Find the Active version.
     Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
     Long activeId =
-        versionRepositoryProvider.get()
+        versionRepositoryProvider
+            .get()
             .getQuestionByNameForVersion(question.getQuestionDefinition().getName(), activeVersion)
             // TODO: If nothing depends on this question then it could be removed.
             .orElseThrow(

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -103,8 +103,8 @@ public final class QuestionService {
    * Get a {@link ReadOnlyQuestionService} which implements synchronous, in-memory read behavior for
    * questions in a particular version.
    */
-  public ReadOnlyQuestionService getReadOnlyVersionedQuestionService(Version version) {
-    return new ReadOnlyVersionedQuestionServiceImpl(version);
+  public ReadOnlyQuestionService getReadOnlyVersionedQuestionService(Version version, VersionRepository versionRepository) {
+    return new ReadOnlyVersionedQuestionServiceImpl(version, versionRepository);
   }
 
   /**
@@ -210,8 +210,8 @@ public final class QuestionService {
     // Find the Active version.
     Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
     Long activeId =
-        activeVersion
-            .getQuestionByName(question.getQuestionDefinition().getName())
+        versionRepositoryProvider.get()
+            .getQuestionByNameForVersion(question.getQuestionDefinition().getName(), activeVersion)
             // TODO: If nothing depends on this question then it could be removed.
             .orElseThrow(
                 () ->

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -2,6 +2,7 @@ package services.question;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Provider;
 import models.Question;
 import models.Version;
 import org.slf4j.Logger;
@@ -24,9 +25,9 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ReadOnlyVersionedQuestionServiceImpl.class);
 
-  public ReadOnlyVersionedQuestionServiceImpl(Version version) {
+  public ReadOnlyVersionedQuestionServiceImpl(Version version, VersionRepository versionRepository) {
     questionsById =
-        VersionRepository.getQuestionsForVersion(version).stream()
+        versionRepository.getQuestionsForVersion(version).stream()
             .map(Question::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
   }

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Provider;
 import models.Question;
 import models.Version;
 import org.slf4j.Logger;
@@ -25,7 +24,8 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ReadOnlyVersionedQuestionServiceImpl.class);
 
-  public ReadOnlyVersionedQuestionServiceImpl(Version version, VersionRepository versionRepository) {
+  public ReadOnlyVersionedQuestionServiceImpl(
+      Version version, VersionRepository versionRepository) {
     questionsById =
         versionRepository.getQuestionsForVersion(version).stream()
             .map(Question::getQuestionDefinition)

--- a/server/conf/i18n/README.md
+++ b/server/conf/i18n/README.md
@@ -6,7 +6,7 @@ The `server/conf/i18n` directory contains localization files for the CiviForm se
 
 Developers are free to add to and update `messages` with English strings as needed. When they do, the [Transifex CiviForm project](https://app.transifex.com/civiform/civiform/dashboard) will update with their changes upon merging to `main`. However, they should **not** modify the foreign language files. These files are managed by Transifex when translations are added.
 
-Please see the [internationalization docs](https://github.com/civiform/civiform/wiki/Internationalization-(i18n)) for more information on how translations are retrieved and updated in CiviForm.
+Please see the [internationalization docs](<https://github.com/civiform/civiform/wiki/Internationalization-(i18n)>) for more information on how translations are retrieved and updated in CiviForm.
 
 ## Updating the `messages` file
 

--- a/server/test/models/VersionTest.java
+++ b/server/test/models/VersionTest.java
@@ -116,10 +116,10 @@ public class VersionTest extends ResetPostgres {
     version.addQuestion(questionOne);
     version.addQuestion(questionTwo);
     version.addQuestion(tombstonedQuestionOne);
-    version.addTombstoneForQuestion(tombstonedQuestionOne);
+    versionRepository.addTombstoneForQuestionInVersion(tombstonedQuestionOne, version);
 
-    assertThat(version.getQuestionNames()).hasSize(3);
-    assertThat(version.getQuestionNames())
+    assertThat(versionRepository.getQuestionNamesForVersion(version)).hasSize(3);
+    assertThat(versionRepository.getQuestionNamesForVersion(version))
         .containsExactlyInAnyOrder(questionOneName, questionTwoName, tombstonedQuestionOneName);
   }
 
@@ -159,8 +159,8 @@ public class VersionTest extends ResetPostgres {
     version.addQuestion(tombstonedQuestionOne);
     version.addQuestion(tombstonedQuestionTwo);
 
-    version.addTombstoneForQuestion(tombstonedQuestionOne);
-    version.addTombstoneForQuestion(tombstonedQuestionTwo);
+    versionRepository.addTombstoneForQuestionInVersion(tombstonedQuestionOne, version);
+    versionRepository.addTombstoneForQuestionInVersion(tombstonedQuestionTwo, version);
 
     assertThat(version.getTombstonedQuestionNames()).hasSize(2);
     assertThat(version.getTombstonedQuestionNames())
@@ -178,7 +178,7 @@ public class VersionTest extends ResetPostgres {
     version.addQuestion(questionOne);
     version.addQuestion(tombstonedQuestionOne);
 
-    version.addTombstoneForQuestion(tombstonedQuestionOne);
+    versionRepository.addTombstoneForQuestionInVersion(tombstonedQuestionOne, version);
 
     assertThat(version.questionIsTombstoned(tombstonedQuestionOneName)).isTrue();
     assertThat(version.questionIsTombstoned(questionOneName)).isFalse();
@@ -214,7 +214,7 @@ public class VersionTest extends ResetPostgres {
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
-    boolean succeeded = version.addTombstoneForQuestion(questionOne);
+    boolean succeeded = versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
 
     assertThat(succeeded).isTrue();
     assertThat(version.questionIsTombstoned(questionOneName)).isTrue();
@@ -229,12 +229,12 @@ public class VersionTest extends ResetPostgres {
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
-    boolean succeeded = version.addTombstoneForQuestion(questionOne);
+    boolean succeeded = versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
 
     assertThat(succeeded).isTrue();
     assertThat(version.questionIsTombstoned(questionOneName)).isTrue();
 
-    succeeded = version.addTombstoneForQuestion(questionOne);
+    succeeded = versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
     assertThat(succeeded).isFalse();
     assertThat(version.questionIsTombstoned(questionOneName)).isTrue();
   }
@@ -248,7 +248,8 @@ public class VersionTest extends ResetPostgres {
     question.addVersion(activeVersion).save();
     activeVersion.refresh();
 
-    assertThatThrownBy(() -> draftVersion.addTombstoneForQuestion(question))
+    assertThatThrownBy(
+            () -> versionRepository.addTombstoneForQuestionInVersion(question, draftVersion))
         .isInstanceOf(QuestionNotFoundException.class);
   }
 
@@ -259,7 +260,7 @@ public class VersionTest extends ResetPostgres {
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
-    version.addTombstoneForQuestion(questionOne);
+    versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
     assertThat(version.questionIsTombstoned(questionOneName)).isTrue();
 
     boolean succeeded = version.removeTombstoneForQuestion(questionOne);
@@ -317,7 +318,7 @@ public class VersionTest extends ResetPostgres {
     String questionOneName = "one";
     Question questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
-    version.addTombstoneForQuestion(questionOne);
+    versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
 
     assertThat(version.hasAnyChanges()).isTrue();
   }

--- a/server/test/models/VersionTest.java
+++ b/server/test/models/VersionTest.java
@@ -85,31 +85,6 @@ public class VersionTest extends ResetPostgres {
   }
 
   @Test
-  public void getQuestionByName_found() {
-    Version version = versionRepository.getDraftVersionOrCreate();
-    String questionName = "question";
-    Question question = resourceCreator.insertQuestion(questionName);
-    question.addVersion(version).save();
-    version.refresh();
-
-    Optional<Question> result = version.getQuestionByName(questionName);
-    assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getQuestionDefinition().getName()).isEqualTo(questionName);
-  }
-
-  @Test
-  public void getQuestionByName_notFound() {
-    Version version = versionRepository.getDraftVersionOrCreate();
-    String questionName = "question";
-    Question question = resourceCreator.insertQuestion(questionName);
-    question.addVersion(version).save();
-    version.refresh();
-
-    Optional<Question> result = version.getQuestionByName(questionName + "other");
-    assertThat(result.isPresent()).isFalse();
-  }
-
-  @Test
   public void getProgramNames() {
     Version version = versionRepository.getDraftVersionOrCreate();
     String programNameOne = "programone";

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -52,7 +52,10 @@ public class VersionRepositoryTest extends ResetPostgres {
         ProgramBuilder.newDraftProgram("draft-only-program").withBlock("Screen 1").build();
 
     Version draftForTombstoning = versionRepository.getDraftVersionOrCreate();
-    assertThat(draftForTombstoning.addTombstoneForQuestion(draftOnlyQuestion)).isTrue();
+    assertThat(
+            versionRepository.addTombstoneForQuestionInVersion(
+                draftOnlyQuestion, draftForTombstoning))
+        .isTrue();
     assertThat(draftForTombstoning.addTombstoneForProgramForTest(draftOnlyProgram)).isTrue();
     draftForTombstoning.save();
 
@@ -189,7 +192,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     Version draftForTombstoning = versionRepository.getDraftVersionOrCreate();
     draftForTombstoning.addQuestion(firstQuestion).save();
-    assertThat(draftForTombstoning.addTombstoneForQuestion(firstQuestion)).isTrue();
+    assertThat(
+            versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
+        .isTrue();
     Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
@@ -226,7 +231,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     Version draftForTombstoning = versionRepository.getDraftVersionOrCreate();
     draftForTombstoning.addQuestion(firstQuestion).save();
-    assertThat(draftForTombstoning.addTombstoneForQuestion(firstQuestion)).isTrue();
+    assertThat(
+            versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
+        .isTrue();
     Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     versionRepository.updateProgramsThatReferenceQuestion(secondQuestion.id);
@@ -275,7 +282,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     Version draftForTombstoning = versionRepository.getDraftVersionOrCreate();
     draftForTombstoning.addQuestion(firstQuestion).save();
-    assertThat(draftForTombstoning.addTombstoneForQuestion(firstQuestion)).isTrue();
+    assertThat(
+            versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
+        .isTrue();
     Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -930,7 +930,8 @@ public class VersionRepositoryTest extends ResetPostgres {
     question.addVersion(version).save();
     version.refresh();
 
-    Optional<Question> result = versionRepository.getQuestionByNameForVersion(questionName, version);
+    Optional<Question> result =
+        versionRepository.getQuestionByNameForVersion(questionName, version);
     assertThat(result.isPresent()).isTrue();
     assertThat(result.get().getQuestionDefinition().getName()).isEqualTo(questionName);
   }
@@ -943,7 +944,8 @@ public class VersionRepositoryTest extends ResetPostgres {
     question.addVersion(version).save();
     version.refresh();
 
-    Optional<Question> result = versionRepository.getQuestionByNameForVersion(questionName + "other", version);
+    Optional<Question> result =
+        versionRepository.getQuestionByNameForVersion(questionName + "other", version);
     assertThat(result.isPresent()).isFalse();
   }
 }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -921,4 +921,29 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     assertThat(previousVersion.isPresent()).isTrue();
   }
+
+  @Test
+  public void getQuestionByNameForVersion_found() {
+    Version version = versionRepository.getDraftVersionOrCreate();
+    String questionName = "question";
+    Question question = resourceCreator.insertQuestion(questionName);
+    question.addVersion(version).save();
+    version.refresh();
+
+    Optional<Question> result = versionRepository.getQuestionByNameForVersion(questionName, version);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getQuestionDefinition().getName()).isEqualTo(questionName);
+  }
+
+  @Test
+  public void getQuestionByNameForVersion_notFound() {
+    Version version = versionRepository.getDraftVersionOrCreate();
+    String questionName = "question";
+    Question question = resourceCreator.insertQuestion(questionName);
+    question.addVersion(version).save();
+    version.refresh();
+
+    Optional<Question> result = versionRepository.getQuestionByNameForVersion(questionName + "other", version);
+    assertThat(result.isPresent()).isFalse();
+  }
 }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -885,20 +885,20 @@ public class VersionRepositoryTest extends ResetPostgres {
     Version active = versionRepository.getActiveVersion();
 
     assertThat(
-            VersionRepository.getProgramQuestionNamesInVersion(
+            versionRepository.getProgramQuestionNamesInVersion(
                 firstProgramActive.getProgramDefinition(), active))
         .containsExactlyInAnyOrder(firstQuestion.getQuestionDefinition().getName());
     assertThat(
-            VersionRepository.getProgramQuestionNamesInVersion(
+            versionRepository.getProgramQuestionNamesInVersion(
                 firstProgramActive.getProgramDefinition(), draft))
         .isEmpty();
 
     assertThat(
-            VersionRepository.getProgramQuestionNamesInVersion(
+            versionRepository.getProgramQuestionNamesInVersion(
                 secondProgramActive.getProgramDefinition(), active))
         .containsExactlyInAnyOrder(secondQuestion.getQuestionDefinition().getName());
     assertThat(
-            VersionRepository.getProgramQuestionNamesInVersion(
+            versionRepository.getProgramQuestionNamesInVersion(
                 secondProgramDraft.getProgramDefinition(), draft))
         .containsExactlyInAnyOrder(
             secondQuestionUpdated.getQuestionDefinition().getName(),

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -34,7 +34,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
     String tombstonedQuestionOneName = "tombstoneOne";
     questionForTombstone = resourceCreator.insertQuestion(tombstonedQuestionOneName);
     version.addQuestion(questionForTombstone);
-    version.addTombstoneForQuestion(questionForTombstone);
+    versionRepository.addTombstoneForQuestionInVersion(questionForTombstone, version);
     version.save();
     questionForEligible = resourceCreator.insertQuestion("eligible question");
     version.addQuestion(questionForEligible);

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -392,7 +392,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
   }
 
   private void addTombstoneToVersion(Version version, Question question) throws Exception {
-    assertThat(version.addTombstoneForQuestion(question)).isTrue();
+    assertThat(versionRepository.addTombstoneForQuestionInVersion(question, version)).isTrue();
     version.save();
   }
 }

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -182,7 +182,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify the draft is there.
     Optional<Question> draftQuestion =
-        versionRepository.getDraftVersionOrCreate().getQuestionByName(nameQuestion.getName());
+        versionRepository.getQuestionByNameForVersion(nameQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(draftQuestion).isPresent();
     assertThat(draftQuestion.get().getQuestionDefinition().getQuestionText())
         .isEqualTo(toUpdate.getQuestionText());
@@ -192,7 +192,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify.
     assertThat(
-            versionRepository.getDraftVersionOrCreate().getQuestionByName(nameQuestion.getName()))
+      versionRepository.getQuestionByNameForVersion(nameQuestion.getName(), versionRepository.getDraftVersionOrCreate()))
         .isNotPresent();
   }
 
@@ -222,7 +222,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify.
     Optional<Question> dependentDraft =
-        versionRepository.getDraftVersionOrCreate().getQuestionByName(dependentQuestion.getName());
+        versionRepository.getQuestionByNameForVersion(dependentQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(dependentDraft).isPresent();
     assertThat(dependentDraft.get().getQuestionDefinition().getEnumeratorId().get())
         .isEqualTo(enumeratorActiveId);

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -182,7 +182,8 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify the draft is there.
     Optional<Question> draftQuestion =
-        versionRepository.getQuestionByNameForVersion(nameQuestion.getName(), versionRepository.getDraftVersionOrCreate());
+        versionRepository.getQuestionByNameForVersion(
+            nameQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(draftQuestion).isPresent();
     assertThat(draftQuestion.get().getQuestionDefinition().getQuestionText())
         .isEqualTo(toUpdate.getQuestionText());
@@ -192,7 +193,8 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify.
     assertThat(
-      versionRepository.getQuestionByNameForVersion(nameQuestion.getName(), versionRepository.getDraftVersionOrCreate()))
+            versionRepository.getQuestionByNameForVersion(
+                nameQuestion.getName(), versionRepository.getDraftVersionOrCreate()))
         .isNotPresent();
   }
 
@@ -222,7 +224,8 @@ public class QuestionServiceTest extends ResetPostgres {
 
     // Verify.
     Optional<Question> dependentDraft =
-        versionRepository.getQuestionByNameForVersion(dependentQuestion.getName(), versionRepository.getDraftVersionOrCreate());
+        versionRepository.getQuestionByNameForVersion(
+            dependentQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(dependentDraft).isPresent();
     assertThat(dependentDraft.get().getQuestionDefinition().getEnumeratorId().get())
         .isEqualTo(enumeratorActiveId);

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -285,14 +285,18 @@ public class QuestionServiceTest extends ResetPostgres {
   public void archiveQuestion_createsDraftIfNoneExists() throws Exception {
     Question addressQuestion = testQuestionBank.applicantAddress();
 
-    assertThat(versionRepository.getDraftVersionOrCreate().getQuestionNames())
+    assertThat(
+            versionRepository.getQuestionNamesForVersion(
+                versionRepository.getDraftVersionOrCreate()))
         .doesNotContain(addressQuestion.getQuestionDefinition().getName());
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
         .doesNotContain(addressQuestion.getQuestionDefinition().getName());
 
     questionService.archiveQuestion(addressQuestion.id);
 
-    assertThat(versionRepository.getDraftVersionOrCreate().getQuestionNames())
+    assertThat(
+            versionRepository.getQuestionNamesForVersion(
+                versionRepository.getDraftVersionOrCreate()))
         .contains(addressQuestion.getQuestionDefinition().getName());
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
         .contains(addressQuestion.getQuestionDefinition().getName());

--- a/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -18,7 +18,8 @@ import support.TestQuestionBank;
 public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
   private VersionRepository versionRepository;
   private final ReadOnlyQuestionService emptyService =
-      new ReadOnlyVersionedQuestionServiceImpl(new Version(LifecycleStage.OBSOLETE), instanceOf(VersionRepository.class));
+      new ReadOnlyVersionedQuestionServiceImpl(
+          new Version(LifecycleStage.OBSOLETE), instanceOf(VersionRepository.class));
   private TestQuestionBank testQuestionBank;
   private Question nameQuestion;
   private Question addressQuestion;

--- a/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -10,14 +10,15 @@ import models.Version;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
+import repository.VersionRepository;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionType;
 import support.TestQuestionBank;
 
 public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
-
+  private VersionRepository versionRepository;
   private final ReadOnlyQuestionService emptyService =
-      new ReadOnlyVersionedQuestionServiceImpl(new Version(LifecycleStage.OBSOLETE));
+      new ReadOnlyVersionedQuestionServiceImpl(new Version(LifecycleStage.OBSOLETE), instanceOf(VersionRepository.class));
   private TestQuestionBank testQuestionBank;
   private Question nameQuestion;
   private Question addressQuestion;
@@ -33,9 +34,10 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
     addressQuestion = testQuestionBank.applicantAddress();
     basicQuestion = testQuestionBank.applicantFavoriteColor();
     questions = ImmutableList.of(nameQuestion, addressQuestion, basicQuestion);
+    versionRepository = instanceOf(VersionRepository.class);
     Version version = new Version(LifecycleStage.OBSOLETE);
     addQuestionsToVersion(version, questions);
-    service = new ReadOnlyVersionedQuestionServiceImpl(version);
+    service = new ReadOnlyVersionedQuestionServiceImpl(version, versionRepository);
   }
 
   @Test
@@ -76,7 +78,7 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
     Version version = new Version(LifecycleStage.OBSOLETE);
     addQuestionsToVersion(version, questions);
     addQuestionsToVersion(version, ImmutableList.of(enumeratorQuestion));
-    var service = new ReadOnlyVersionedQuestionServiceImpl(version);
+    var service = new ReadOnlyVersionedQuestionServiceImpl(version, versionRepository);
     assertThat(service.getAllEnumeratorQuestions().size()).isEqualTo(1);
     assertThat(service.getAllEnumeratorQuestions().get(0))
         .isEqualTo(enumeratorQuestion.getQuestionDefinition());


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/5711 refactored places that call `version.getQuestions()` to use a new function `getQuestionsForVersion()`. We'll want to do this in the version class as well and make the method an instance method, which is handled in this PR. By changing it into an instance method, we had to refactor and move some other functions as well. 

See more information in [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/5724