### PR TITLE
Populate OIDC id token in logout request

### DIFF
--- a/browser-test/src/auth.test.ts
+++ b/browser-test/src/auth.test.ts
@@ -7,6 +7,7 @@ import {
   logout,
   loginAsAdmin,
   validateAccessibility,
+  enableFeatureFlag,
 } from './support'
 import {TEST_USER_AUTH_STRATEGY} from './support/config'
 
@@ -49,10 +50,46 @@ describe('applicant auth', () => {
         'Do you want to sign-out from',
       )
     })
+
+    it('applicant can confirm central provider logout, enhanced version', async () => {
+      const {page} = ctx
+      await enableFeatureFlag(page, 'applicant_oidc_enhanced_logout_enabled')
+      await loginAsTestUser(page)
+      expect(await ctx.page.textContent('html')).toContain(
+        `Logged in as ${testUserDisplayName()}`,
+      )
+
+      await page.click('text=Logout')
+
+      await validateScreenshot(page, 'central-provider-logout')
+      expect(await ctx.page.textContent('html')).toContain(
+        'Do you want to sign-out from',
+      )
+    })
   }
 
   it('applicant can logout', async () => {
     const {page} = ctx
+    await loginAsTestUser(page)
+    expect(await ctx.page.textContent('html')).toContain(
+      `Logged in as ${testUserDisplayName()}`,
+    )
+
+    await logout(page)
+
+    expect(await ctx.page.textContent('html')).toContain('Get benefits')
+
+    // Try login again, ensuring that full login process is followed. If login
+    // page doesn't ask for username/password - the method will fail.
+    await loginAsTestUser(page)
+    expect(await ctx.page.textContent('html')).toContain(
+      `Logged in as ${testUserDisplayName()}`,
+    )
+  })
+
+  it('applicant can logout, enhanced version', async () => {
+    const {page} = ctx
+    await enableFeatureFlag(page, 'applicant_oidc_enhanced_logout_enabled')
     await loginAsTestUser(page)
     expect(await ctx.page.textContent('html')).toContain(
       `Logged in as ${testUserDisplayName()}`,

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -5,6 +5,7 @@ import java.util.function.BiFunction;
 import javax.inject.Provider;
 import models.AccountModel;
 import models.Applicant;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.UserProfile;
 import repository.AccountRepository;
 
@@ -25,17 +26,51 @@ public final class CiviFormProfileMerger {
    * session storage, and an external profile from an external authentication provider
    *
    * @param applicantInDatabase a potentially existing applicant in the database
-   * @param guestProfile a guest profile from the browser session
+   * @param existingProfile a guest profile from the browser session
    * @param authProviderProfile profile data from an external auth provider, such as OIDC
    * @param mergeFunction a function that merges an external profile into a Civiform profile, or
    *     provides one if it doesn't exist
    */
   public <T> Optional<UserProfile> mergeProfiles(
       Optional<Applicant> applicantInDatabase,
-      Optional<CiviFormProfile> guestProfile,
+      Optional<CiviFormProfile> existingProfile,
       T authProviderProfile,
       BiFunction<Optional<CiviFormProfile>, T, UserProfile> mergeFunction) {
+    existingProfile = mergeApplicantAndGuestProfile(applicantInDatabase, existingProfile);
 
+    // Merge externalProfile into existingProfile.
+    // Merge function will create a new CiviFormProfile if it doesn't exist,
+    // or otherwise handle it
+    return Optional.of(mergeFunction.apply(existingProfile, authProviderProfile));
+  }
+
+  /**
+   * Performs a three way merge between an existing applicant in the database, a guest profile in
+   * session storage, and an external profile from an external authentication provider
+   *
+   * @param applicantInDatabase a potentially existing applicant in the database
+   * @param existingProfile a guest profile from the browser session
+   * @param authProviderProfile profile data from an external auth provider, such as OIDC
+   * @param context WebContext of current request
+   * @param mergeFunction a function that merges an external profile into a Civiform profile, or
+   *     provides one if it doesn't exist
+   */
+  public <T> Optional<UserProfile> mergeProfiles(
+      Optional<Applicant> applicantInDatabase,
+      Optional<CiviFormProfile> existingProfile,
+      T authProviderProfile,
+      WebContext context,
+      TriFunction<Optional<CiviFormProfile>, T, WebContext, UserProfile> mergeFunction) {
+    existingProfile = mergeApplicantAndGuestProfile(applicantInDatabase, existingProfile);
+
+    // Merge externalProfile into existingProfile.
+    // Merge function will create a new CiviFormProfile if it doesn't exist,
+    // or otherwise handle it
+    return Optional.of(mergeFunction.apply(existingProfile, authProviderProfile, context));
+  }
+
+  private Optional<CiviFormProfile> mergeApplicantAndGuestProfile(
+      Optional<Applicant> applicantInDatabase, Optional<CiviFormProfile> guestProfile) {
     if (applicantInDatabase.isPresent()) {
       if (guestProfile.isEmpty()
           || guestProfile.get().getApplicant().join().getApplications().isEmpty()) {
@@ -47,11 +82,7 @@ public final class CiviFormProfileMerger {
         guestProfile = Optional.of(mergeProfiles(applicantInDatabase.get(), guestProfile.get()));
       }
     }
-
-    // Merge externalProfile into existingProfile.
-    // Merge function will create a new CiviFormProfile if it doesn't exist,
-    // or otherwise handle it
-    return Optional.of(mergeFunction.apply(guestProfile, authProviderProfile));
+    return guestProfile;
   }
 
   private CiviFormProfile mergeProfiles(

--- a/server/app/auth/TriFunction.java
+++ b/server/app/auth/TriFunction.java
@@ -1,0 +1,6 @@
+package auth;
+
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+  R apply(A a, B b, C c);
+}

--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -3,12 +3,18 @@ package auth.oidc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfileData;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import com.typesafe.config.Config;
+import filters.SessionIdFilter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.ParseException;
 import java.util.Optional;
+import javax.inject.Provider;
+import models.AccountModel;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
@@ -18,6 +24,10 @@ import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
+import org.pac4j.play.PlayWebContext;
+import play.mvc.Http;
+import repository.AccountRepository;
+import services.settings.SettingsManifest;
 
 /**
  * Custom OidcLogoutActionBuilder for CiviFormProfileData (since it extends CommonProfile, not
@@ -37,17 +47,29 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
 
   private String postLogoutRedirectParam;
   private final String clientId;
+  private Provider<AccountRepository> accountRepositoryProvider;
+  private final IdTokensFactory idTokensFactory;
+  private boolean isAdmin;
+  private SettingsManifest settingsManifest;
 
   public CiviformOidcLogoutActionBuilder(
-      Config civiformConfiguration, OidcConfiguration oidcConfiguration, String clientId) {
+      OidcConfiguration oidcConfiguration,
+      String clientId,
+      OidcClientProviderParams params,
+      boolean isAdmin) {
     super(oidcConfiguration);
-    checkNotNull(civiformConfiguration);
+
+    checkNotNull(params.configuration());
     // Use `post_logout_redirect_uri` by default according OIDC spec.
     this.postLogoutRedirectParam =
-        getConfigurationValue(civiformConfiguration, "auth.oidc_post_logout_param")
+        getConfigurationValue(params.configuration(), "auth.oidc_post_logout_param")
             .orElse("post_logout_redirect_uri");
 
     this.clientId = clientId;
+    this.accountRepositoryProvider = params.accountRepositoryProvider();
+    this.idTokensFactory = checkNotNull(params.idTokensFactory());
+    this.isAdmin = isAdmin;
+    this.settingsManifest = new SettingsManifest(params.configuration());
   }
 
   /** Helper function for retriving values from the application.conf, */
@@ -66,6 +88,35 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
   public CiviformOidcLogoutActionBuilder setPostLogoutRedirectParam(String param) {
     this.postLogoutRedirectParam = param;
     return this;
+  }
+
+  private JWT getIdTokenForAccount(long accountId, WebContext context) {
+    PlayWebContext playWebContext = (PlayWebContext) context;
+    if (!enhancedLogoutEnabled(context)) {
+      return null;
+    }
+    Optional<String> sessionId = playWebContext.getNativeSession().get(SessionIdFilter.SESSION_ID);
+    if (sessionId.isEmpty()) {
+      // The session id is only populated if the feature flag is enabled.
+      return null;
+    }
+    Optional<AccountModel> account = accountRepositoryProvider.get().lookupAccount(accountId);
+    if (account.isEmpty()) {
+      return null;
+    }
+    SerializedIdTokens serializedIdTokens = account.get().getSerializedIdTokens();
+    IdTokens idTokens = idTokensFactory.create(serializedIdTokens);
+    // When we build the logout action, we do not remove the id token. We leave it in place in case
+    // of transient logout failures. Expired tokens are purged at login time instead.
+    Optional<String> idToken = idTokens.getIdToken(sessionId.get());
+    if (idToken.isEmpty()) {
+      return null;
+    }
+    try {
+      return JWTParser.parse(idToken.get());
+    } catch (ParseException e) {
+      return null;
+    }
   }
 
   /**
@@ -88,13 +139,17 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
         State state =
             new State(configuration.getStateGenerator().generateValue(context, sessionStore));
 
+        long accountId = Long.parseLong(currentProfile.getId());
+        JWT idToken = getIdTokenForAccount(accountId, context);
+
         LogoutRequest logoutRequest =
             new CustomOidcLogoutRequest(
                 endSessionEndpoint,
                 postLogoutRedirectParam,
                 new URI(targetUrl),
                 Optional.of(clientId),
-                state);
+                state,
+                idToken);
 
         return Optional.of(
             HttpActionHelper.buildRedirectUrlAction(context, logoutRequest.toURI().toString()));
@@ -104,5 +159,15 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     }
 
     return Optional.empty();
+  }
+
+  private boolean enhancedLogoutEnabled(WebContext context) {
+    PlayWebContext playWebContext = (PlayWebContext) context;
+    Http.RequestHeader request = playWebContext.getNativeJavaRequest();
+    if (isAdmin) {
+      return settingsManifest.getAdminOidcEnhancedLogoutEnabled(request);
+    } else {
+      return settingsManifest.getApplicantOidcEnhancedLogoutEnabled(request);
+    }
   }
 }

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -10,20 +10,27 @@ import auth.Role;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import filters.SessionIdFilter;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import javax.inject.Provider;
 import models.Applicant;
+import org.apache.commons.lang3.NotImplementedException;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
+import org.pac4j.play.PlayWebContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.mvc.Http;
 import repository.AccountRepository;
+import services.settings.SettingsManifest;
 
 /**
  * This class ensures that the OidcProfileCreator that both the AD and IDCS clients use will
@@ -36,16 +43,21 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CiviformOidcProfileCreator.class);
   protected final ProfileFactory profileFactory;
+  protected final IdTokensFactory idTokensFactory;
   protected final Provider<AccountRepository> accountRepositoryProvider;
   protected final CiviFormProfileMerger civiFormProfileMerger;
+  protected final SettingsManifest settingsManifest;
 
   public CiviformOidcProfileCreator(
       OidcConfiguration configuration, OidcClient client, OidcClientProviderParams params) {
     super(Preconditions.checkNotNull(configuration), Preconditions.checkNotNull(client));
     this.profileFactory = Preconditions.checkNotNull(params.profileFactory());
     this.accountRepositoryProvider = Preconditions.checkNotNull(params.accountRepositoryProvider());
+    this.idTokensFactory = Preconditions.checkNotNull(params.idTokensFactory());
     this.civiFormProfileMerger =
         new CiviFormProfileMerger(profileFactory, accountRepositoryProvider);
+    this.settingsManifest =
+        new SettingsManifest(Preconditions.checkNotNull(params.configuration()));
   }
 
   protected abstract String emailAttributeName();
@@ -97,19 +109,19 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
    */
   @VisibleForTesting
   public CiviFormProfileData mergeCiviFormProfile(
-      Optional<CiviFormProfile> maybeCiviFormProfile, OidcProfile oidcProfile) {
+      Optional<CiviFormProfile> maybeCiviFormProfile, OidcProfile oidcProfile, WebContext context) {
     var civiformProfile =
         maybeCiviFormProfile.orElseGet(
             () -> {
               LOGGER.debug("Found no existing profile in session cookie.");
               return createEmptyCiviFormProfile(oidcProfile);
             });
-    return mergeCiviFormProfile(civiformProfile, oidcProfile);
+    return mergeCiviFormProfile(civiformProfile, oidcProfile, context);
   }
 
   /** Merge the two provided profiles into a new CiviFormProfileData. */
   protected CiviFormProfileData mergeCiviFormProfile(
-      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
+      CiviFormProfile civiformProfile, OidcProfile oidcProfile, WebContext context) {
 
     // Meaning: whatever you signed in with most recently is the role you have.
     ImmutableSet<Role> roles = roles(civiformProfile, oidcProfile);
@@ -141,7 +153,35 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
     civiformProfile.setAuthorityId(authorityId).join();
 
+    civiformProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
+
+    Optional<String> sessionId = getSessionId(context);
+    if (sessionId.isPresent() && enhancedLogoutEnabled(context)) {
+      // Save the id_token from the returned OidcProfile in the account so that it can be
+      // retrieved at logout time.
+      civiformProfile
+          .getAccount()
+          .thenAccept(
+              account -> {
+                SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
+                if (serializedIdTokens == null) {
+                  serializedIdTokens = new SerializedIdTokens();
+                  account.setSerializedIdTokens(serializedIdTokens);
+                }
+                IdTokens idTokens = idTokensFactory.create(serializedIdTokens);
+                idTokens.purgeExpiredIdTokens();
+                idTokens.storeIdToken(sessionId.get(), oidcProfile.getIdTokenString());
+                account.save();
+              })
+          .join();
+    }
+
     return civiformProfile.getProfileData();
+  }
+
+  private Optional<String> getSessionId(WebContext context) {
+    PlayWebContext playWebContext = (PlayWebContext) context;
+    return playWebContext.getNativeSession().get(SessionIdFilter.SESSION_ID);
   }
 
   @Override
@@ -166,8 +206,12 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> guestProfile = profileUtils.currentUserProfile(context);
 
+    // The merge function signature specifies the two profiles as parameters.
+    // We need to supply an extra parameter (context), so bind it here.
+    BiFunction<Optional<CiviFormProfile>, OidcProfile, UserProfile> mergeFunction =
+        (cProfile, oProfile) -> this.mergeCiviFormProfile(cProfile, oProfile, context);
     return civiFormProfileMerger.mergeProfiles(
-        existingApplicant, guestProfile, profile, this::mergeCiviFormProfile);
+        existingApplicant, guestProfile, profile, mergeFunction);
   }
 
   @VisibleForTesting
@@ -206,5 +250,19 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
   protected final boolean isTrustedIntermediary(CiviFormProfile profile) {
     return profile.getAccount().join().getMemberOfGroup().isPresent();
+  }
+
+  private boolean enhancedLogoutEnabled(WebContext context) {
+    PlayWebContext playWebContext = (PlayWebContext) context;
+    Http.RequestHeader request = playWebContext.getNativeJavaRequest();
+    switch (identityProviderType()) {
+      case ADMIN_IDENTITY_PROVIDER:
+        return settingsManifest.getAdminOidcEnhancedLogoutEnabled(request);
+      case APPLICANT_IDENTITY_PROVIDER:
+        return settingsManifest.getApplicantOidcEnhancedLogoutEnabled(request);
+      default:
+        throw new NotImplementedException(
+          "Identity provider type not handled: " + identityProviderType());
+    }
   }
 }

--- a/server/app/auth/oidc/CustomOidcLogoutRequest.java
+++ b/server/app/auth/oidc/CustomOidcLogoutRequest.java
@@ -1,5 +1,6 @@
 package auth.oidc;
 
+import com.nimbusds.jwt.JWT;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
@@ -43,11 +44,12 @@ public final class CustomOidcLogoutRequest extends LogoutRequest {
       final String postLogoutRedirectParam,
       final URI postLogoutRedirectURI,
       final Optional<String> clientId,
-      final State state) {
+      final State state,
+      final JWT idTokenHint) {
 
     super(
         uri,
-        /* idTokenHint = */ null,
+        idTokenHint,
         /* logoutHint = */ null,
         /* clientID = */ clientId.map(ClientID::new).orElse(null),
         postLogoutRedirectURI,

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -19,7 +19,6 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import play.mvc.Http;
 import repository.AccountRepository;
 import services.settings.SettingsManifest;
 
@@ -34,6 +33,7 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   protected final OidcClientProviderParams params;
   protected final Config civiformConfig;
   protected final ProfileFactory profileFactory;
+  protected final IdTokensFactory idTokensFactory;
   protected final Provider<AccountRepository> accountRepositoryProvider;
   protected final String baseUrl;
   protected final SettingsManifest settingsManifest;
@@ -42,6 +42,7 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
     this.params = params;
     this.civiformConfig = checkNotNull(params.configuration());
     this.profileFactory = checkNotNull(params.profileFactory());
+    this.idTokensFactory = checkNotNull(params.idTokensFactory());
     this.accountRepositoryProvider = checkNotNull(params.accountRepositoryProvider());
 
     this.baseUrl =
@@ -145,11 +146,6 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
   }
 
   /*
-   * Returns true if this client provider should provide enhanced logout capabilities (populate `id_token_hint` in logout request).
-   */
-  protected abstract boolean enhancedLogoutEnabled(Http.RequestHeader requestHeader);
-
-  /*
    * Helper function for combining the default and additional scopes,
    * and return them in the space-separated string required by OIDC.
    */
@@ -229,10 +225,11 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
       client.setName(providerName.get());
     }
     client.setCallbackUrl(callbackURL);
-    client.setProfileCreator(getProfileCreator(config, client));
+    ProfileCreator profileCreator = getProfileCreator(config, client);
+    client.setProfileCreator(profileCreator);
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setLogoutActionBuilder(
-        new CiviformOidcLogoutActionBuilder(civiformConfig, config, config.getClientId()));
+        new CiviformOidcLogoutActionBuilder(config, config.getClientId(), params, isAdmin));
 
     try {
       client.init();

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -2,6 +2,7 @@ package auth.oidc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.IdentityProviderType;
 import auth.ProfileFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -226,10 +227,13 @@ public abstract class OidcClientProvider implements Provider<OidcClient> {
     }
     client.setCallbackUrl(callbackURL);
     ProfileCreator profileCreator = getProfileCreator(config, client);
+    IdentityProviderType identityProviderType =
+        ((CiviformOidcProfileCreator) profileCreator).identityProviderType();
     client.setProfileCreator(profileCreator);
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setLogoutActionBuilder(
-        new CiviformOidcLogoutActionBuilder(config, config.getClientId(), params, isAdmin));
+        new CiviformOidcLogoutActionBuilder(
+            config, config.getClientId(), params, identityProviderType));
 
     try {
       client.init();

--- a/server/app/auth/oidc/OidcClientProviderParams.java
+++ b/server/app/auth/oidc/OidcClientProviderParams.java
@@ -14,22 +14,28 @@ public abstract class OidcClientProviderParams {
   public static OidcClientProviderParams create(
       Config configuration,
       ProfileFactory profileFactory,
+      IdTokensFactory idTokensFactory,
       Provider<AccountRepository> accountRepositoryProvider) {
     return new AutoValue_OidcClientProviderParams(
-        configuration, profileFactory, accountRepositoryProvider);
+        configuration, profileFactory, idTokensFactory, accountRepositoryProvider);
   }
 
   // Our tests have paths like:
   //   /usr/src/server/test/auth/ProfileMergeTest.java
   @RestrictedApi(explanation = "Only allow for tests", allowedOnPath = ".*/test/.*")
   public static OidcClientProviderParams create(
-      ProfileFactory profileFactory, Provider<AccountRepository> accountRepositoryProvider) {
-    return create(ConfigFactory.empty(), profileFactory, accountRepositoryProvider);
+      ProfileFactory profileFactory,
+      IdTokensFactory idTokensFactory,
+      Provider<AccountRepository> accountRepositoryProvider) {
+    return create(
+        ConfigFactory.empty(), profileFactory, idTokensFactory, accountRepositoryProvider);
   }
 
   public abstract Config configuration();
 
   abstract ProfileFactory profileFactory();
+
+  abstract IdTokensFactory idTokensFactory();
 
   abstract Provider<AccountRepository> accountRepositoryProvider();
 }

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -3,6 +3,7 @@ package auth.oidc.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -20,17 +21,20 @@ public class AdfsClientProvider implements Provider<OidcClient> {
   private final Config configuration;
   private final String baseUrl;
   private final ProfileFactory profileFactory;
-  private final Provider<AccountRepository> userRepositoryProvider;
+  private final IdTokensFactory idTokensFactory;
+  private final Provider<AccountRepository> accountRepositoryProvider;
 
   @Inject
   public AdfsClientProvider(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<AccountRepository> userRepositoryProvider) {
+      IdTokensFactory idTokensFactory,
+      Provider<AccountRepository> accountRepositoryProvider) {
     this.configuration = checkNotNull(configuration);
     this.baseUrl = configuration.getString("base_url");
     this.profileFactory = profileFactory;
-    this.userRepositoryProvider = userRepositoryProvider;
+    this.idTokensFactory = idTokensFactory;
+    this.accountRepositoryProvider = accountRepositoryProvider;
   }
 
   @Override
@@ -87,7 +91,8 @@ public class AdfsClientProvider implements Provider<OidcClient> {
             config,
             client,
             OidcClientProviderParams.create(
-                configuration, profileFactory, userRepositoryProvider)));
+                configuration, profileFactory, idTokensFactory, accountRepositoryProvider)));
+
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.init();
     return client;

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -32,9 +32,9 @@ public class AdfsClientProvider implements Provider<OidcClient> {
       Provider<AccountRepository> accountRepositoryProvider) {
     this.configuration = checkNotNull(configuration);
     this.baseUrl = configuration.getString("base_url");
-    this.profileFactory = profileFactory;
-    this.idTokensFactory = idTokensFactory;
-    this.accountRepositoryProvider = accountRepositoryProvider;
+    this.profileFactory = checkNotNull(profileFactory);
+    this.idTokensFactory = checkNotNull(idTokensFactory);
+    this.accountRepositoryProvider = checkNotNull(accountRepositoryProvider);
   }
 
   @Override

--- a/server/app/auth/oidc/admin/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/admin/GenericOidcClientProvider.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import play.mvc.Http;
 
 /**
  * This class implements a `Provider` of a generic `OidcClient` for use in authenticating and
@@ -92,10 +91,5 @@ public class GenericOidcClientProvider extends OidcClientProvider {
   @Override
   protected boolean getUseCsrf() {
     return Boolean.valueOf(getConfigurationValueOrThrow(USE_CSRF));
-  }
-
-  @Override
-  protected boolean enhancedLogoutEnabled(Http.RequestHeader requestHeader) {
-    return settingsManifest.getAdminOidcEnhancedLogoutEnabled(requestHeader);
   }
 }

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -93,7 +94,7 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
   /** Merge the two provided profiles into a new CiviFormProfileData. */
   @Override
   protected final CiviFormProfileData mergeCiviFormProfile(
-      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
+      CiviFormProfile civiformProfile, OidcProfile oidcProfile, WebContext context) {
     final Optional<String> maybeLocale = getLocale(oidcProfile);
     final Optional<String> maybeName = getName(oidcProfile);
 
@@ -117,7 +118,7 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
           .join();
     }
 
-    return super.mergeCiviFormProfile(civiformProfile, oidcProfile);
+    return super.mergeCiviFormProfile(civiformProfile, oidcProfile, context);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import play.mvc.Http;
 
 public class GenericOidcClientProvider extends OidcClientProvider {
 
@@ -103,10 +102,5 @@ public class GenericOidcClientProvider extends OidcClientProvider {
   protected boolean getUseCsrf() {
     // In the future, we may wish to make this configurable, since this is a generic provider.
     return false;
-  }
-
-  @Override
-  protected boolean enhancedLogoutEnabled(Http.RequestHeader requestHeader) {
-    return settingsManifest.getApplicantOidcEnhancedLogoutEnabled(requestHeader);
   }
 }

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import play.mvc.Http;
 
 /** This class customized the OIDC provider to a specific provider, allowing overrides to be set. */
 public final class IdcsClientProvider extends OidcClientProvider {
@@ -88,10 +87,5 @@ public final class IdcsClientProvider extends OidcClientProvider {
   @Override
   protected boolean getUseCsrf() {
     return false;
-  }
-
-  @Override
-  protected boolean enhancedLogoutEnabled(Http.RequestHeader requestHeader) {
-    return settingsManifest.getApplicantOidcEnhancedLogoutEnabled(requestHeader);
   }
 }

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -79,7 +79,9 @@ public class MainModule extends AbstractModule {
   public OidcClientProviderParams provideOidcClientProviderParams(
       Config config,
       ProfileFactory profileFactory,
+      IdTokensFactory idTokensFactory,
       Provider<AccountRepository> accountRepositoryProvider) {
-    return OidcClientProviderParams.create(config, profileFactory, accountRepositoryProvider);
+    return OidcClientProviderParams.create(
+        config, profileFactory, idTokensFactory, accountRepositoryProvider);
   }
 }

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -265,7 +265,7 @@ public final class AccountRepository {
     }
   }
 
-  private Optional<AccountModel> lookupAccount(long accountId) {
+  public Optional<AccountModel> lookupAccount(long accountId) {
     return database
         .find(AccountModel.class)
         .setId(accountId)

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -5,6 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
+import auth.oidc.IdTokens;
+import auth.oidc.IdTokensFactory;
+import auth.oidc.SerializedIdTokens;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -21,6 +24,7 @@ import javax.inject.Inject;
 import models.AccountModel;
 import models.Applicant;
 import models.TrustedIntermediaryGroup;
+import org.pac4j.oidc.profile.OidcProfile;
 import services.CiviFormError;
 import services.applicant.ApplicantData;
 import services.program.ProgramDefinition;
@@ -38,11 +42,14 @@ public final class AccountRepository {
 
   private final Database database;
   private final DatabaseExecutionContext executionContext;
+  private final IdTokensFactory idTokensFactory;
 
   @Inject
-  public AccountRepository(DatabaseExecutionContext executionContext) {
+  public AccountRepository(
+      DatabaseExecutionContext executionContext, IdTokensFactory idTokensFactory) {
     this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);
+    this.idTokensFactory = checkNotNull(idTokensFactory);
   }
 
   public CompletionStage<Set<Applicant>> listApplicants() {
@@ -396,5 +403,24 @@ public final class AccountRepository {
             + "WHERE accounts.id IN (SELECT account_id FROM unused_accounts);";
 
     return database.sqlUpdate(sql).execute();
+  }
+
+  /**
+   * Associates the ID token from the profile with the provided session id and persists this
+   * association to the provided account.
+   *
+   * <p>Also purges any expired ID tokens as a side effect.
+   */
+  public void updateSerializedIdTokens(
+      AccountModel account, String sessionId, OidcProfile oidcProfile) {
+    SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
+    if (serializedIdTokens == null) {
+      serializedIdTokens = new SerializedIdTokens();
+      account.setSerializedIdTokens(serializedIdTokens);
+    }
+    IdTokens idTokens = idTokensFactory.create(serializedIdTokens);
+    idTokens.purgeExpiredIdTokens();
+    idTokens.storeIdToken(sessionId, oidcProfile.getIdTokenString());
+    account.save();
   }
 }

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -79,7 +79,7 @@ public class CiviFormProfileMergerTest {
     var merged =
         civiFormProfileMerger.mergeProfiles(
             /* applicantInDatabase = */ Optional.empty(),
-            /* guestProfile = */ Optional.empty(),
+            /* existingProfile = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
@@ -94,7 +94,7 @@ public class CiviFormProfileMergerTest {
     var merged =
         civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
-            /* guestProfile = */ Optional.empty(),
+            /* existingProfile = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -111,9 +111,6 @@ public class ProfileMergeTest extends ResetPostgres {
             /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
     AccountModel account =
         database.find(AccountModel.class).where().eq("email_address", "foo@example.com").findOne();
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
-    Account account =
-        database.find(Account.class).where().eq("email_address", "foo@example.com").findOne();
     account.setAuthorityId(null);
     account.save();
 

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -2,7 +2,9 @@ package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static play.test.Helpers.fakeRequest;
 
+import auth.oidc.IdTokensFactory;
 import auth.oidc.InvalidOidcProfileException;
 import auth.oidc.OidcClientProviderParams;
 import auth.oidc.applicant.IdcsApplicantProfileCreator;
@@ -16,10 +18,12 @@ import java.util.concurrent.ExecutionException;
 import models.AccountModel;
 import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
+import org.pac4j.play.PlayWebContext;
 import org.pac4j.saml.profile.SAML2Profile;
 import repository.AccountRepository;
 import repository.ResetPostgres;
@@ -30,8 +34,10 @@ public class ProfileMergeTest extends ResetPostgres {
   private IdcsApplicantProfileCreator idcsApplicantProfileCreator;
   private SamlProfileCreator samlProfileCreator;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountRepository;
   private Database database;
+  private WebContext context;
 
   @Before
   public void setupDatabase() {
@@ -41,6 +47,7 @@ public class ProfileMergeTest extends ResetPostgres {
   @Before
   public void setupFactory() {
     profileFactory = instanceOf(ProfileFactory.class);
+    idTokensFactory = instanceOf(IdTokensFactory.class);
     accountRepository = instanceOf(AccountRepository.class);
     OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
@@ -50,13 +57,16 @@ public class ProfileMergeTest extends ResetPostgres {
             client_config,
             client,
             OidcClientProviderParams.create(
-                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
     samlProfileCreator =
         new SamlProfileCreator(
             /* configuration = */ null,
             /* client = */ null,
             profileFactory,
             CfTestHelpers.userRepositoryProvider(accountRepository));
+    context = new PlayWebContext(fakeRequest().build());
   }
 
   private OidcProfile createOidcProfile(String email, String issuer, String subject) {
@@ -81,7 +91,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -98,9 +108,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData existingProfileWithoutAuthority =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
     AccountModel account =
         database.find(AccountModel.class).where().eq("email_address", "foo@example.com").findOne();
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+    Account account =
+        database.find(Account.class).where().eq("email_address", "foo@example.com").findOne();
     account.setAuthorityId(null);
     account.save();
 
@@ -112,7 +125,8 @@ public class ProfileMergeTest extends ResetPostgres {
         profileFactory.wrapProfileData(
             idcsApplicantProfileCreator.mergeCiviFormProfile(
                 Optional.of(profileFactory.wrapProfileData(existingProfileWithoutAuthority)),
-                oidcProfileWithAuthority));
+                oidcProfileWithAuthority,
+                context));
     assertThat(mergedProfile.getEmailAddress().get()).isEqualTo("foo@example.com");
     assertThat(mergedProfile.getAuthorityId().get()).isEqualTo("iss: issuer sub: subject");
   }
@@ -123,12 +137,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThat(
             idcsApplicantProfileCreator
                 .mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), oidcProfile)
+                    Optional.of(profileFactory.wrapProfileData(profileData)), oidcProfile, context)
                 .getEmail())
         .isEqualTo("foo@example.com");
   }
@@ -143,12 +157,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile, context))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -162,12 +176,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile, context))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -181,12 +195,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)), newProfile, context))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -197,12 +211,14 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), conflictingProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)),
+                    conflictingProfile,
+                    context))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -214,12 +230,14 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), conflictingProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)),
+                    conflictingProfile,
+                    context))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -231,12 +249,14 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
                 idcsApplicantProfileCreator.mergeCiviFormProfile(
-                    Optional.of(profileFactory.wrapProfileData(profileData)), conflictingProfile))
+                    Optional.of(profileFactory.wrapProfileData(profileData)),
+                    conflictingProfile,
+                    context))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfileData;
+import auth.IdentityProviderType;
 import auth.ProfileFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Provider;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import models.Account;
 import models.AccountModel;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -118,7 +118,8 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
         OidcClientProviderParams.create(
             civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
-        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ false);
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.APPLICANT_IDENTITY_PROVIDER);
 
     WebContext context = getWebContext(Optional.of(sessionId));
 
@@ -158,7 +159,8 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
         OidcClientProviderParams.create(
             civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
-        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ true);
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
 
     WebContext context = getWebContext(Optional.of(sessionId));
 
@@ -202,7 +204,8 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
         OidcClientProviderParams.create(
             civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
-        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ false);
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.APPLICANT_IDENTITY_PROVIDER);
 
     WebContext context = getWebContext(Optional.of(sessionId));
 

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -1,0 +1,227 @@
+package auth.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+import static play.test.Helpers.fakeRequest;
+
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Provider;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.PlainJWT;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import filters.SessionIdFilter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import models.Account;
+import models.AccountModel;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.play.PlayWebContext;
+import repository.AccountRepository;
+import repository.ResetPostgres;
+import support.CfTestHelpers;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
+  private static final String oidcHost = "dev-oidc";
+  private static final int oidcPort = 3390;
+  private static final String clientId = "test-client-id";
+  private static final String targetUrl = "http://example.com/target";
+  private static final String sessionId = "test-session-id";
+  private static final long accountId = 1L;
+
+  private IdTokensFactory idTokensFactory;
+  private OidcConfiguration oidcConfig;
+  private CiviFormProfileData civiFormProfileData;
+  private String idToken;
+  @Mock private AccountRepository accountRepository;
+  @Mock private ProfileFactory profileFactory;
+  @Mock private SessionStore sessionStore;
+
+  @Before
+  public void setup() {
+    idTokensFactory = instanceOf(IdTokensFactory.class);
+    oidcConfig = CfTestHelpers.getOidcConfiguration(oidcHost, oidcPort);
+    civiFormProfileData = new CiviFormProfileData(accountId);
+
+    // Build and serialize a minimal JWT as an id token.
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().build();
+    JWT jwt = new PlainJWT(claimsSet);
+    idToken = jwt.serialize();
+  }
+
+  private Optional<String> getRedirectLocation(RedirectionAction action) {
+    // Unfortunately, the RedirectionAction has almost no useful accessor methods, so we have to use
+    // the `toString()` representation, which looks like:
+    //
+    // #FoundAction# | code: 302 | location: http://dev-oidc:3390/session/end?... |
+    Pattern pattern = Pattern.compile("location: (https?://[^ ]+)");
+    Matcher matcher = pattern.matcher(action.toString());
+    if (matcher.find()) {
+      return Optional.of(matcher.group(1));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  Optional<String> queryParamValue(URI uri, String paramName) {
+    List<NameValuePair> queryParams = URLEncodedUtils.parse(uri, Charset.defaultCharset());
+    // This assumes that parameter names are not repeated.
+    for (NameValuePair nvp : queryParams) {
+      if (nvp.getName().equals(paramName)) {
+        return Optional.of(nvp.getValue());
+      }
+    }
+    return Optional.empty();
+  }
+
+  WebContext getWebContext(Optional<String> sessionId) {
+    if (sessionId.isPresent()) {
+      return new PlayWebContext(
+          fakeRequest().session(SessionIdFilter.SESSION_ID, sessionId.get()).build());
+    } else {
+      return new PlayWebContext(fakeRequest().build());
+    }
+  }
+
+  @Test
+  public void testBuilder() throws URISyntaxException {
+    Config civiformConfig = ConfigFactory.parseMap(ImmutableMap.of());
+
+    AccountModel account = new AccountModel();
+    SerializedIdTokens serializedIdTokens =
+        new SerializedIdTokens(ImmutableMap.of(sessionId, idToken));
+    account.setSerializedIdTokens(serializedIdTokens);
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(
+            civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ false);
+
+    WebContext context = getWebContext(Optional.of(sessionId));
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(context, sessionStore, civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    Optional<String> location = getRedirectLocation(logoutAction.get());
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location.get());
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    assertThat(queryParamValue(locationUri, "post_logout_redirect_uri")).hasValue(targetUrl);
+  }
+
+  @Test
+  public void testBuilderWithEnhancedLogoutEnabled() throws URISyntaxException {
+    // Enable enhanced logout for admins.
+    Config civiformConfig =
+        ConfigFactory.parseMap(ImmutableMap.of("admin_oidc_enhanced_logout_enabled", "true"));
+
+    // Set up an admin account.
+    AccountModel account = new AccountModel();
+    account.setGlobalAdmin(true);
+    SerializedIdTokens serializedIdTokens =
+        new SerializedIdTokens(ImmutableMap.of(sessionId, idToken));
+    account.setSerializedIdTokens(serializedIdTokens);
+    when(accountRepository.lookupAccount(accountId)).thenReturn(Optional.of(account));
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(
+            civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ true);
+
+    WebContext context = getWebContext(Optional.of(sessionId));
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(context, sessionStore, civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    Optional<String> location = getRedirectLocation(logoutAction.get());
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location.get());
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    assertThat(queryParamValue(locationUri, "post_logout_redirect_uri")).hasValue(targetUrl);
+
+    // Additional validations for enhanced logout behavior.
+    Optional<String> serializedToken = queryParamValue(locationUri, "id_token_hint");
+    assertThat(serializedToken).isNotEmpty();
+    assertThatCode(() -> JWTParser.parse(serializedToken.get())).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testBuilderWithAlternateTargetUrlParameterName() throws URISyntaxException {
+    // By default, the `post_logout_redirect_url` is parameter is set. In this case, we want to use
+    // a custom parameter name.
+    Config civiformConfig =
+        ConfigFactory.parseMap(
+            ImmutableMap.of("auth.oidc_post_logout_param", "custom_target_url_parameter_name"));
+
+    AccountModel account = new AccountModel();
+    SerializedIdTokens serializedIdTokens =
+        new SerializedIdTokens(ImmutableMap.of(sessionId, idToken));
+    account.setSerializedIdTokens(serializedIdTokens);
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(
+            civiformConfig, profileFactory, idTokensFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(oidcConfig, clientId, params, /* isAdmin= */ false);
+
+    WebContext context = getWebContext(Optional.of(sessionId));
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(context, sessionStore, civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    Optional<String> location = getRedirectLocation(logoutAction.get());
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location.get());
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    // Check the value of the custom parameter.
+    assertThat(queryParamValue(locationUri, "custom_target_url_parameter_name"))
+        .hasValue(targetUrl);
+  }
+}

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -195,7 +195,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     assertThat(l).isEqualTo(Locale.FRENCH);
 
     // Additional validations for enhanced logout behavior.
-    Account account = maybeApplicant.get().getAccount();
+    AccountModel account = maybeApplicant.get().getAccount();
     SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
     assertThat(serializedIdTokens).isNotNull();
     assertThat(serializedIdTokens.containsKey(SESSION_ID)).isTrue();

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -3,12 +3,17 @@ package auth.oidc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.oidc.applicant.IdcsApplicantProfileCreator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import filters.SessionIdFilter;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -20,6 +25,7 @@ import org.junit.Test;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
+import org.pac4j.play.PlayWebContext;
 import repository.AccountRepository;
 import repository.ResetPostgres;
 import services.applicant.ApplicantData;
@@ -31,26 +37,19 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
   private static final String ISSUER = "issuer";
   private static final String SUBJECT = "subject";
   private static final String AUTHORITY_ID = "iss: issuer sub: subject";
+  private static final String SESSION_ID = "session_id";
 
   private static OidcProfile profile;
 
-  private CiviformOidcProfileCreator oidcProfileAdapter;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountRepository;
 
   @Before
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
-    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
-    OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
-    // Just need some complete adaptor to access methods.
-    oidcProfileAdapter =
-        new IdcsApplicantProfileCreator(
-            client_config,
-            client,
-            OidcClientProviderParams.create(
-                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+    idTokensFactory = instanceOf(IdTokensFactory.class);
 
     profile = new OidcProfile();
     profile.addAttribute("user_emailid", EMAIL);
@@ -58,6 +57,31 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("user_locale", "fr");
     profile.addAttribute("iss", ISSUER);
     profile.setId(SUBJECT);
+  }
+
+  private CiviformOidcProfileCreator getOidcProfileCreator(boolean enhancedLogoutEnabled) {
+    Config civiformConfig =
+        ConfigFactory.parseMap(
+            ImmutableMap.of(
+                "applicant_oidc_enhanced_logout_enabled", String.valueOf(enhancedLogoutEnabled)));
+    OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
+    OidcConfiguration oidcConfig = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
+    return new IdcsApplicantProfileCreator(
+        oidcConfig,
+        client,
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            idTokensFactory,
+            CfTestHelpers.userRepositoryProvider(accountRepository)));
+  }
+
+  private CiviformOidcProfileCreator getOidcProfileCreator() {
+    return getOidcProfileCreator(false);
+  }
+
+  private CiviformOidcProfileCreator getOidcProfileCreatorWithEnhancedLogoutEnabled() {
+    return getOidcProfileCreator(true);
   }
 
   @Test
@@ -72,6 +96,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
         .setEmailAddress(EMAIL)
         .setApplicants(ImmutableList.of(resourceCreator.insertApplicant()))
         .save();
+    CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
 
     // Execute.
     Optional<Applicant> applicant = oidcProfileAdapter.getExistingApplicant(profile);
@@ -99,6 +124,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
         .setAuthorityId(AUTHORITY_ID)
         .setApplicants(ImmutableList.of(resourceCreator.insertApplicant()))
         .save();
+    CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
 
     // Execute.
     Optional<Applicant> applicant = oidcProfileAdapter.getExistingApplicant(profile);
@@ -115,9 +141,11 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
 
   @Test
   public void mergeCiviFormProfile_succeeds_new_user() {
+    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
     // Execute.
     CiviFormProfileData profileData =
-        oidcProfileAdapter.mergeCiviFormProfile(Optional.empty(), profile);
+        oidcProfileAdapter.mergeCiviFormProfile(Optional.empty(), profile, context);
 
     // Verify.
     assertThat(profileData).isNotNull();
@@ -138,6 +166,42 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
   }
 
   @Test
+  public void mergeCiviFormProfile_succeeds_new_user_with_enhanced_logout() {
+    // Create a web context containing a session id.
+    PlayWebContext context =
+        new PlayWebContext(fakeRequest().session(SessionIdFilter.SESSION_ID, SESSION_ID).build());
+    CiviformOidcProfileCreator oidcProfileAdapter =
+        getOidcProfileCreatorWithEnhancedLogoutEnabled();
+
+    // Execute.
+    CiviFormProfileData profileData =
+        oidcProfileAdapter.mergeCiviFormProfile(Optional.empty(), profile, context);
+
+    // Verify.
+    assertThat(profileData).isNotNull();
+
+    // The email of the existing account is the pre-existing one, not a new profile
+    // one.
+    assertThat(profileData.getEmail()).isEqualTo(EMAIL);
+
+    Optional<Applicant> maybeApplicant = oidcProfileAdapter.getExistingApplicant(profile);
+    assertThat(maybeApplicant).isPresent();
+
+    ApplicantData applicantData = maybeApplicant.get().getApplicantData();
+
+    assertThat(applicantData.getApplicantName().orElse("<empty optional>"))
+        .isEqualTo("Fry, Philip");
+    Locale l = applicantData.preferredLocale();
+    assertThat(l).isEqualTo(Locale.FRENCH);
+
+    // Additional validations for enhanced logout behavior.
+    Account account = maybeApplicant.get().getAccount();
+    SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
+    assertThat(serializedIdTokens).isNotNull();
+    assertThat(serializedIdTokens.containsKey(SESSION_ID)).isTrue();
+  }
+
+  @Test
   public void mergeCiviFormProfile_skipped_forTrustedIntermediaries() {
     // Setup.
     AccountModel accountWithTiGroup = new AccountModel();
@@ -151,9 +215,12 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     CiviFormProfileData fakeProfileData = new CiviFormProfileData(123L);
     when(trustedIntermediary.getProfileData()).thenReturn(fakeProfileData);
 
+    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
+
     // Execute.
     CiviFormProfileData profileData =
-        oidcProfileAdapter.mergeCiviFormProfile(Optional.of(trustedIntermediary), profile);
+        oidcProfileAdapter.mergeCiviFormProfile(Optional.of(trustedIntermediary), profile, context);
 
     // Verify.
     // Profile data should still be present after the no-op merge.

--- a/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
+++ b/server/test/auth/oidc/CustomOidcLogoutRequestTest.java
@@ -18,7 +18,8 @@ public class CustomOidcLogoutRequestTest {
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
             /* clientId = */ Optional.empty(),
-            /* state= */ null);
+            /* state= */ null,
+            /* idTokenHint= */ null);
     assertThat(request.toURI().toString())
         .isEqualTo(
             "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F");
@@ -32,7 +33,8 @@ public class CustomOidcLogoutRequestTest {
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
             /* clientId = */ Optional.of("12345"),
-            /* state= */ null);
+            /* state= */ null,
+            /* idTokenHint= */ null);
     assertThat(request.toURI().toString())
         .isEqualTo(
             "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&client_id=12345");
@@ -46,7 +48,8 @@ public class CustomOidcLogoutRequestTest {
             "post_logout_redirect_uri",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
             /* clientId = */ Optional.empty(),
-            new State("stateValue"));
+            new State("stateValue"),
+            /* idTokenHint= */ null);
     assertThat(request.toURI().toString())
         .isEqualTo(
             "https://auth.com/logout?post_logout_redirect_uri=https%3A%2F%2Fciviform.com%2F&state=stateValue");
@@ -63,7 +66,8 @@ public class CustomOidcLogoutRequestTest {
             "",
             /* postLogoutRedirectURI= */ new URI("https://civiform.com/"),
             /* clientId = */ Optional.empty(),
-            /* state= */ null);
+            /* state= */ null,
+            /* idTokenHint= */ null);
     assertThat(request.toURI().toString()).isEqualTo("https://auth.com/logout#fragmentHere");
   }
 }

--- a/server/test/auth/oidc/IdTokensTest.java
+++ b/server/test/auth/oidc/IdTokensTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 public class IdTokensTest {
 
-  JWT getJwt(int expTimeInSeconds) {
+  JWT getJwtWithExpiration(int expTimeInSeconds) {
     JWTClaimsSet claims =
         new JWTClaimsSet.Builder()
             .expirationTime(Date.from(Instant.ofEpochSecond(expTimeInSeconds)))
@@ -31,14 +31,14 @@ public class IdTokensTest {
     IdTokens idTokens = new IdTokens(clock, serializedIdTokens);
 
     // We can use fake values for the tokens since these operations don't need to parse them.
-    idTokens.storeIdToken("s1", "token1");
-    idTokens.storeIdToken("s2", "token2");
-    assertThat(idTokens.getIdToken("s1")).hasValue("token1");
-    assertThat(idTokens.getIdToken("s2")).hasValue("token2");
+    idTokens.storeIdToken("session1", "token1");
+    idTokens.storeIdToken("session2", "token2");
+    assertThat(idTokens.getIdToken("session1")).hasValue("token1");
+    assertThat(idTokens.getIdToken("session2")).hasValue("token2");
 
-    idTokens.removeIdToken("s1");
-    assertThat(idTokens.getIdToken("s1")).isEmpty();
-    assertThat(idTokens.getIdToken("s2")).hasValue("token2");
+    idTokens.removeIdToken("session1");
+    assertThat(idTokens.getIdToken("session1")).isEmpty();
+    assertThat(idTokens.getIdToken("session2")).hasValue("token2");
   }
 
   @Test
@@ -47,19 +47,19 @@ public class IdTokensTest {
     SerializedIdTokens serializedIdTokens = new SerializedIdTokens(new HashMap<>());
     IdTokens idTokens = new IdTokens(clock, serializedIdTokens);
 
-    idTokens.storeIdToken("s1", getJwt(90).serialize());
-    idTokens.storeIdToken("s2", getJwt(99).serialize());
-    idTokens.storeIdToken("s3", getJwt(101).serialize());
+    idTokens.storeIdToken("session1", getJwtWithExpiration(90).serialize());
+    idTokens.storeIdToken("session2", getJwtWithExpiration(99).serialize());
+    idTokens.storeIdToken("session3", getJwtWithExpiration(101).serialize());
 
-    assertThat(idTokens.getIdToken("s1")).isNotEmpty();
-    assertThat(idTokens.getIdToken("s2")).isNotEmpty();
-    assertThat(idTokens.getIdToken("s3")).isNotEmpty();
+    assertThat(idTokens.getIdToken("session1")).isNotEmpty();
+    assertThat(idTokens.getIdToken("session2")).isNotEmpty();
+    assertThat(idTokens.getIdToken("session3")).isNotEmpty();
 
     idTokens.purgeExpiredIdTokens();
-    assertThat(idTokens.getIdToken("s1")).isEmpty();
-    assertThat(idTokens.getIdToken("s2")).isEmpty();
-    assertThat(idTokens.getIdToken("s3")).isNotEmpty();
-    assertThatCode(() -> JWTParser.parse(idTokens.getIdToken("s3").get()))
+    assertThat(idTokens.getIdToken("session1")).isEmpty();
+    assertThat(idTokens.getIdToken("session2")).isEmpty();
+    assertThat(idTokens.getIdToken("session3")).isNotEmpty();
+    assertThatCode(() -> JWTParser.parse(idTokens.getIdToken("session3").get()))
         .doesNotThrowAnyException();
   }
 }

--- a/server/test/auth/oidc/OidcClientProviderTest.java
+++ b/server/test/auth/oidc/OidcClientProviderTest.java
@@ -28,6 +28,7 @@ import support.CfTestHelpers;
 public class OidcClientProviderTest extends ResetPostgres {
   private OidcClientProvider oidcClientProvider;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountRepository;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
@@ -38,6 +39,7 @@ public class OidcClientProviderTest extends ResetPostgres {
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.of(
@@ -54,7 +56,10 @@ public class OidcClientProviderTest extends ResetPostgres {
     oidcClientProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test
@@ -111,7 +116,10 @@ public class OidcClientProviderTest extends ResetPostgres {
     OidcClientProvider oidcClientProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
 
     OidcClient client = oidcClientProvider.get();
 
@@ -182,6 +190,7 @@ public class OidcClientProviderTest extends ResetPostgres {
                       OidcClientProviderParams.create(
                           bad_secret_config,
                           profileFactory,
+                          idTokensFactory,
                           CfTestHelpers.userRepositoryProvider(accountRepository)));
               badOidcClientProvider.get();
             })

--- a/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -23,6 +24,7 @@ import support.CfTestHelpers;
 public class GenericOidcClientProviderTest extends ResetPostgres {
   private GenericOidcClientProvider genericOidcProvider;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountProvider;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
@@ -33,6 +35,7 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
   public void setup() {
     accountProvider = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -53,7 +56,10 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     genericOidcProvider =
         new GenericOidcClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountProvider)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountProvider)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -5,6 +5,7 @@ import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -41,6 +42,7 @@ public class Auth0ProviderTest extends ResetPostgres {
   public void setup() {
     AccountRepository accountRepository = instanceOf(AccountRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    IdTokensFactory idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -57,7 +59,10 @@ public class Auth0ProviderTest extends ResetPostgres {
     auth0Provider =
         new Auth0ClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test
@@ -72,7 +77,7 @@ public class Auth0ProviderTest extends ResetPostgres {
         auth0Provider
             .get()
             .getLogoutAction(
-                webContext, mockSessionStore, new CiviFormProfileData(), afterLogoutUri);
+                webContext, mockSessionStore, new CiviFormProfileData(1L), afterLogoutUri);
     assertThat(logoutAction).containsInstanceOf(FoundAction.class);
     var logoutUri = new URI(((FoundAction) logoutAction.get()).getLocation());
     assertThat(logoutUri)

--- a/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -25,6 +26,7 @@ import support.CfTestHelpers;
 public class GenericOidcClientProviderTest extends ResetPostgres {
   private GenericOidcClientProvider genericOidcProvider;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountRepository;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
@@ -35,6 +37,7 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -57,7 +60,10 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     genericOidcProvider =
         new GenericOidcClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -23,6 +24,7 @@ import support.CfTestHelpers;
 public class IdcsClientProviderTest extends ResetPostgres {
   private IdcsClientProvider idcsProvider;
   private ProfileFactory profileFactory;
+  private IdTokensFactory idTokensFactory;
   private static AccountRepository accountRepository;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
@@ -33,6 +35,7 @@ public class IdcsClientProviderTest extends ResetPostgres {
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.of(
@@ -49,7 +52,10 @@ public class IdcsClientProviderTest extends ResetPostgres {
     idcsProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
@@ -5,6 +5,7 @@ import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -44,6 +45,7 @@ public class LoginGovClientProviderTest extends ResetPostgres {
   public void setup() {
     AccountRepository accountRepository = instanceOf(AccountRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    IdTokensFactory idTokensFactory = instanceOf(IdTokensFactory.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -57,7 +59,10 @@ public class LoginGovClientProviderTest extends ResetPostgres {
     loginGovProvider =
         new LoginGovClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
+                config,
+                profileFactory,
+                idTokensFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test
@@ -118,7 +123,7 @@ public class LoginGovClientProviderTest extends ResetPostgres {
     String afterLogoutUri = "https://civiform.dev";
     var logoutAction =
         client.getLogoutAction(
-            webContext, mockSessionStore, new CiviFormProfileData(), afterLogoutUri);
+            webContext, mockSessionStore, new CiviFormProfileData(1L), afterLogoutUri);
     assertThat(logoutAction).containsInstanceOf(FoundAction.class);
     var logoutUri = new URI(((FoundAction) logoutAction.get()).getLocation());
     assertThat(logoutUri)

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -2,11 +2,15 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
 import models.AccountModel;
@@ -14,6 +18,7 @@ import models.Applicant;
 import models.LifecycleStage;
 import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.oidc.profile.OidcProfile;
 import services.CiviFormError;
 import services.Path;
 import services.program.ProgramDefinition;
@@ -251,6 +256,46 @@ public class AccountRepositoryTest extends ResetPostgres {
 
     assertThat(numberDeleted).isEqualTo(1);
     assertThat(remainingApplicants).hasSize(3);
+  }
+
+  @Test
+  public void updateSerializedIdTokens() {
+    AccountModel account = new AccountModel();
+    String fakeEmail = "fake email";
+    account.setEmailAddress(fakeEmail);
+    account.save();
+    long accountId = account.id;
+
+    // Create a JWT that just expired.
+    LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+    Instant timeInPast = now.minus(1, ChronoUnit.SECONDS).toInstant(ZoneOffset.UTC);
+    JWT expiredJwt = getJwtWithExpirationTime(timeInPast);
+    OidcProfile expiredOidcProfile = new OidcProfile();
+    expiredOidcProfile.setIdTokenString(expiredJwt.serialize());
+
+    repo.updateSerializedIdTokens(account, "sessionId1", expiredOidcProfile);
+
+    // Create a JWT that won't expire for an hour.
+    Instant timeInFuture = now.plus(1, ChronoUnit.HOURS).toInstant(ZoneOffset.UTC);
+    JWT validJwt = getJwtWithExpirationTime(timeInFuture);
+    OidcProfile validOidcProfile = new OidcProfile();
+    validOidcProfile.setIdTokenString(validJwt.serialize());
+
+    repo.updateSerializedIdTokens(account, "sessionId2", validOidcProfile);
+
+    Optional<AccountModel> retrievedAccount = repo.lookupAccount(accountId);
+    assertThat(retrievedAccount).isNotEmpty();
+    // Expired token
+    assertThat(retrievedAccount.get().getSerializedIdTokens().get("sessionId1")).isNull();
+    // Valid token
+    assertThat(retrievedAccount.get().getSerializedIdTokens().get("sessionId2"))
+        .isEqualTo(validJwt.serialize());
+  }
+
+  private JWT getJwtWithExpirationTime(Instant expirationTime) {
+    JWTClaimsSet claims =
+        new JWTClaimsSet.Builder().expirationTime(Date.from(expirationTime)).build();
+    return new PlainJWT(claims);
   }
 
   private Applicant saveApplicantWithDob(String name, String dob) {


### PR DESCRIPTION
### Description

Conditionally populate OIDC ID token in logout request.

This PR has two major parts:
1. Store ID token in db upon successful authentication
2. Retrieve ID token from db upon logout

The bulk of the logic for (1) is in `CiviformOidcProfileCreator.java`. For (2), the changes are concentrated in `CiviformOidcLogoutActionBuilder`. Most of the other files are touched because of changes to constructors to inject additional dependencies or changes in method signatures to propagate additional parameters.

Note that the feature flags must be accessed from the context of the `pac4j` callbacks in order to get the appropriate `Request` object.

## Release notes

This PR adds new handling of identity provider logout for OIDC. The new behavior is guarded by feature flags (`ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED` and `APPLICANT_OIDC_ENHANCED_LOGOUT_ENABLED`), which are `false` by default. These settings should not be enabled without testing in staging environments first.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Relates to #4359 
