### PR TITLE
Make the test_prod step output on failure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,8 +196,11 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
       - name: Build the stack
-        run: docker compose -f test-support/prod-simulator-compose.yml up -d
+        run: docker compose -f test-support/prod-simulator-compose.yml up -d > .dockerlogs 2> &1
       - name: Test
         # Confirm that we get a response on port 9000.
         run: while ! docker run --network host appropriate/curl -v -s --retry-max-time 180 --retry-connrefused http://localhost:8888/ ; do sleep 5; done
         timeout-minutes: 3
+      - name: Print logs on failure
+        if: failure()
+        run: cat .dockerlogs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,7 +196,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
       - name: Build the stack
-        run: docker compose -f test-support/prod-simulator-compose.yml up -d > .dockerlogs 2> &1
+        run: docker compose -f test-support/prod-simulator-compose.yml up -d > .dockerlogs 2>&1
       - name: Test
         # Confirm that we get a response on port 9000.
         run: while ! docker run --network host appropriate/curl -v -s --retry-max-time 180 --retry-connrefused http://localhost:8888/ ; do sleep 5; done


### PR DESCRIPTION
### Description

The output of the docker compose command used for the prod-simulator wasn't output the docker logs. I'm doing the same thing the [run-browser-test-env](https://github.com/civiform/civiform/blob/d269c7e1fdb45ebf060ffb4623a83a49e849080e/bin/run-browser-test-env#L150) script does here to redirect output to a file, then cat the file on error. This should give us more info when something fails.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
