### PR TITLE
Add version cache implementation gated behind feature flag

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -62,8 +62,8 @@ public final class VersionRepository {
   private final DatabaseExecutionContext databaseExecutionContext;
 
   private final SettingsManifest settingsManifest;
-  private SyncCacheApi questionsByVersionCache;
-  private SyncCacheApi programsByVersionCache;
+  private final SyncCacheApi questionsByVersionCache;
+  private final SyncCacheApi programsByVersionCache;
 
   @Inject
   public VersionRepository(

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -35,6 +35,8 @@ import models.Question;
 import models.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.cache.NamedCache;
+import play.cache.SyncCacheApi;
 import services.program.BlockDefinition;
 import services.program.CantPublishProgramWithSharedQuestionsException;
 import services.program.EligibilityDefinition;
@@ -49,6 +51,7 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
+import services.settings.SettingsManifest;
 
 /** A repository object for dealing with versioning of questions and programs. */
 public final class VersionRepository {
@@ -58,12 +61,23 @@ public final class VersionRepository {
   private final ProgramRepository programRepository;
   private final DatabaseExecutionContext databaseExecutionContext;
 
+  private final SettingsManifest settingsManifest;
+  private SyncCacheApi questionsByVersionCache;
+  private SyncCacheApi programsByVersionCache;
+
   @Inject
   public VersionRepository(
-      ProgramRepository programRepository, DatabaseExecutionContext databaseExecutionContext) {
+      ProgramRepository programRepository,
+      DatabaseExecutionContext databaseExecutionContext,
+      SettingsManifest settingsManifest,
+      @NamedCache("version-questions") SyncCacheApi questionsByVersionCache,
+      @NamedCache("version-programs") SyncCacheApi programsByVersionCache) {
     this.database = DB.getDefault();
     this.programRepository = checkNotNull(programRepository);
     this.databaseExecutionContext = checkNotNull(databaseExecutionContext);
+    this.settingsManifest = checkNotNull(settingsManifest);
+    this.questionsByVersionCache = checkNotNull(questionsByVersionCache);
+    this.programsByVersionCache = checkNotNull(programsByVersionCache);
   }
 
   /**
@@ -410,10 +424,15 @@ public final class VersionRepository {
   /**
    * Returns the questions for a version.
    *
-   * <p>This replaces all calls for version.getQuestions() and will eventually be where
-   * version-questions caching is implemented.
+   * <p>If the cache is enabled, we will get the data from the cache and set it if it is not
+   * present.
    */
   public ImmutableList<Question> getQuestionsForVersion(Version version) {
+    // Only set the version cache for active and obsolete versions
+    if (settingsManifest.getVersionCacheEnabled() && version.id <= getActiveVersion().id) {
+      return questionsByVersionCache.getOrElseUpdate(
+          String.valueOf(version.id), () -> version.getQuestions());
+    }
     return version.getQuestions();
   }
 
@@ -438,10 +457,15 @@ public final class VersionRepository {
   /**
    * Returns the programs for a version.
    *
-   * <p>This replaces all calls for version.getPrograms() and will eventually be where
-   * version-programs caching is implemented.
+   * <p>If the cache is enabled, we will get the data from the cache and set it if it is not
+   * present.
    */
   public ImmutableList<Program> getProgramsForVersion(Version version) {
+    // Only set the version cache for active and obsolete versions
+    if (settingsManifest.getVersionCacheEnabled() && version.id <= getActiveVersion().id) {
+      return programsByVersionCache.getOrElseUpdate(
+          String.valueOf(version.id), () -> version.getPrograms());
+    }
     return version.getPrograms();
   }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions"]
 }
 
 ## Security rules for play-pac4j SecurityFilter


### PR DESCRIPTION
### Description

This change adds caching for for data associated with versions, including questions and programs (gated behind a feature flag). We aren't caching versions themselves, since we don't seem to be requesting any version data except previous version data (from admin flow) and active data. The questionList and programList calls are the most expensive, so going to begin by caching those.

See [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit) for more information.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
