### PR TITLE
Create feature flag to guard new OIDC logout logic

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -838,8 +838,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enables logic to populate more fields in OIDC logout requests. */
-  public boolean getEnhancedOidcLogoutEnabled(RequestHeader request) {
-    return getBool("ENHANCED_OIDC_LOGOUT_ENABLED", request);
+  public boolean getEnhancedOidcLogoutEnabled() {
+    return getBool("ENHANCED_OIDC_LOGOUT_ENABLED");
   }
 
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
@@ -1747,7 +1747,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "Enables logic to populate more fields in OIDC logout requests.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.ADMIN_WRITEABLE))),
+                      SettingMode.HIDDEN))),
           "Miscellaneous",
           SettingsSection.create(
               "Miscellaneous",

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -837,6 +837,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("QUESTION_CACHE_ENABLED");
   }
 
+  /** Enables logic to populate more fields in OIDC logout requests. */
+  public boolean getEnhancedOidcLogoutEnabled(RequestHeader request) {
+    return getBool("ENHANCED_OIDC_LOGOUT_ENABLED", request);
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.of(
           "Branding",
@@ -1736,7 +1741,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "Enables caching for questions and their associated data.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.HIDDEN))),
+                      SettingMode.HIDDEN),
+                  SettingDescription.create(
+                      "ENHANCED_OIDC_LOGOUT_ENABLED",
+                      "Enables logic to populate more fields in OIDC logout requests.",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.ADMIN_WRITEABLE))),
           "Miscellaneous",
           SettingsSection.create(
               "Miscellaneous",

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -709,7 +709,7 @@
         "type": "bool"
       },
       "ENHANCED_OIDC_LOGOUT_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "HIDDEN",
         "description": "Enables logic to populate more fields in OIDC logout requests.",
         "type": "bool"
       }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -707,6 +707,11 @@
         "mode": "HIDDEN",
         "description": "Enables caching for questions and their associated data.",
         "type": "bool"
+      },
+      "ENHANCED_OIDC_LOGOUT_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "Enables logic to populate more fields in OIDC logout requests.",
+        "type": "bool"
       }
     }
   }

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -38,3 +38,7 @@ program_cache_enabled = false
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}
 question_cache_enabled = false
 question_cache_enabled = ${?QUESTION_CACHE_ENABLED}
+
+# OIDC logout
+enhanced_oidc_logout_enabled = false
+enhanced_oidc_logout_enabled = ${?ENHANCED_OIDC_LOGOUT_ENABLED}


### PR DESCRIPTION
### Description

Add a feature flag to guard new logic required to support OIDC logout from certain identity providers.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [x] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Relates to #4359 
