### PR TITLE
Make "Choose File" button keyboard accessible.

### DIFF
--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -73,6 +73,7 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
             label()
                 .withFor(fileInputId)
                 .withText(messages.at(MessageKey.BUTTON_CHOOSE_FILE.getKeyName()))
+                .attr("role", "button")
                 .attr("tabindex", 0)
                 .withClasses(ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "mt-2", "cursor-pointer"));
   }

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -2,6 +2,7 @@ package views.questiontypes;
 
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.label;
+import static j2html.TagCreator.span;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -70,15 +71,15 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
             fileUploadViewStrategy.signedFileUploadFields(
                 params, fileUploadQuestion, fileInputId, ariaDescribedByIds, hasErrors))
         .with(
-            div()
-                .attr("role", "button")
-                .attr("tabindex", 0)
-                .withClasses("inline-block", "mt-2")
+            label()
+                .withFor(fileInputId)
                 .with(
-                    label()
-                        .withFor(fileInputId)
+                    span()
+                        .attr("role", "button")
+                        .attr("tabindex", 0)
                         .withText(messages.at(MessageKey.BUTTON_CHOOSE_FILE.getKeyName()))
-                        .withClasses(ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "cursor-pointer")));
+                        .withClasses(
+                            ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "mt-2", "cursor-pointer")));
   }
 
   @Override

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -70,12 +70,15 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
             fileUploadViewStrategy.signedFileUploadFields(
                 params, fileUploadQuestion, fileInputId, ariaDescribedByIds, hasErrors))
         .with(
-            label()
-                .withFor(fileInputId)
-                .withText(messages.at(MessageKey.BUTTON_CHOOSE_FILE.getKeyName()))
+            div()
                 .attr("role", "button")
                 .attr("tabindex", 0)
-                .withClasses(ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "mt-2", "cursor-pointer"));
+                .withClasses("inline-block", "mt-2")
+                .with(
+                    label()
+                        .withFor(fileInputId)
+                        .withText(messages.at(MessageKey.BUTTON_CHOOSE_FILE.getKeyName()))
+                        .withClasses(ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "cursor-pointer")));
   }
 
   @Override

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -73,6 +73,7 @@ public class FileUploadQuestionRenderer extends ApplicantSingleQuestionRenderer 
             label()
                 .withFor(fileInputId)
                 .withText(messages.at(MessageKey.BUTTON_CHOOSE_FILE.getKeyName()))
+                .attr("tabindex", 0)
                 .withClasses(ButtonStyles.OUTLINED_TRANSPARENT, "w-44", "mt-2", "cursor-pointer"));
   }
 


### PR DESCRIPTION
### Description

Make "Choose File" button keyboard accessible.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method -- **Looks like test already exists in browser-test/src/file.test.ts**
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

As an applicant, open a file upload question and verify keyboard tabbing includes the "Choose file" button.

### Issue(s) this completes

Fixes #5523 
