### PR TITLE
Set default localized status text in seeding task

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -218,7 +218,7 @@ public final class DevDatabaseSeedTask {
               StatusDefinitions.Status.builder()
                   .setStatusText("Pending Review")
                   .setDefaultStatus(Optional.of(true))
-                  .setLocalizedStatusText(LocalizedStrings.empty())
+                  .setLocalizedStatusText(LocalizedStrings.withDefaultValue("Pending Review"))
                   .setLocalizedEmailBodyText(Optional.empty())
                   .build());
       if (appendStatusResult.isError()) {


### PR DESCRIPTION
By setting the localized status text to empty when we create the Pending Review status, we end up with an unhandled exception when trying to edit statuses on this program, and the program index page shows "Status: " because there is no localized text.  

When an admin adds a status, we always set the default localized value. So we'll do it here too. https://github.com/civiform/civiform/blob/a9a279fc5bd21c2927fb446c78498c7424ce6e29/server/app/controllers/admin/AdminProgramStatusesController.java#L153
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

- Start fresh with an empty database
- From the dev seeding screen, populate questions and programs
- Apply as either a guest or regular applicant to the Comprehensive Sample Program
- Ensure status on the program index page shows the correct status text
- Ensure you can edit statuses for Comprehensive Sample Program

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5681
