### PR TITLE
Admin can use more than 4 questions in a predicate

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -471,18 +471,6 @@ describe('create and edit predicates', () => {
         'Screen 1',
       )
 
-      // Select all questions
-      for (const question of questions) {
-        await adminPredicates.selectQuestionForPredicate(question)
-      }
-      await adminPredicates.clickAddConditionButton()
-      await validateToastMessage(page, 'select fewer than 5 questions')
-
-      // Unselect all questions
-      for (const question of questions) {
-        await adminPredicates.selectQuestionForPredicate(question)
-      }
-
       await adminPredicates.addPredicates([
         {
           questionName: 'predicate-date-is-earlier-than',

--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -166,13 +166,10 @@ class AdminPredicateConfiguration {
         '.cf-predicate-question-options',
       ),
     ).filter((el) => el.checked).length
+
     if (numChecked == 0) {
       event.preventDefault()
       this.showErrorMessage('Please select a question.')
-    }
-    if (numChecked > 4) {
-      event.preventDefault()
-      this.showErrorMessage('Please select fewer than 5 questions.')
     }
   }
 

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -273,7 +273,11 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
             .withAction(formAction)
             .withMethod(POST)
             .withClasses(
-                "p-8", "bg-gray-100", "predicate-config-form", ReferenceClasses.PREDICATE_OPTIONS);
+                "overflow-x-scroll",
+                "p-8",
+                "bg-gray-100",
+                "predicate-config-form",
+                ReferenceClasses.PREDICATE_OPTIONS);
 
     DivTag valueRowContainer = div().withId("predicate-config-value-row-container");
 
@@ -432,7 +436,8 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
       ImmutableList<QuestionDefinition> questionDefinitions,
       int groupId,
       Optional<AndNode> maybeAndNode) {
-    DivTag row = div().withClasses("flex", "mb-6", "predicate-config-value-row");
+    DivTag innerRow = div().withClasses("flex");
+    DivTag row = div(innerRow).withClasses("flex", "mb-6", "predicate-config-value-row");
     DivTag andText = div("and").withClasses("object-center", "w-16", "p-4", "leading-10");
 
     if (maybeAndNode.isPresent()) {
@@ -447,14 +452,16 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
       for (var qd : questionDefinitions) {
         var leafNode = questionIdLeafNodeMap.get(qd.getId());
 
-        row.condWith(columnNumber++ != 1, andText)
+        innerRow
+            .condWith(columnNumber++ != 1, andText)
             .with(createValueField(qd, groupId, Optional.of(leafNode)));
       }
     } else {
       int columnNumber = 1;
 
       for (var questionDefinition : questionDefinitions) {
-        row.condWith(columnNumber++ != 1, andText)
+        innerRow
+            .condWith(columnNumber++ != 1, andText)
             .with(
                 createValueField(
                     questionDefinition, groupId, /* maybeLeafNode= */ Optional.empty()));


### PR DESCRIPTION
### Description

Enables x-axis scrolling in predicate configurator to allow more than four questions to be used in a single predicate. The UX here is not ideal, but this change makes the feature more capable for the time being. We anticipate a holistic redesign of the predicate configuration UX to be prioritized within the next quarter or two.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5758