### PR TITLE
Make the test_prod step output docker compose logs on failure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,11 +196,11 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
       - name: Build the stack
-        run: docker compose -f test-support/prod-simulator-compose.yml up -d > .dockerlogs 2>&1
+        run: docker compose -f test-support/prod-simulator-compose.yml up -d
       - name: Test
         # Confirm that we get a response on port 9000.
         run: while ! docker run --network host appropriate/curl -v -s --retry-max-time 180 --retry-connrefused http://localhost:8888/ ; do sleep 5; done
         timeout-minutes: 3
       - name: Print logs on failure
         if: failure()
-        run: cat .dockerlogs
+        run: docker compose logs


### PR DESCRIPTION
### Description

Previous attempt is only outputting info up to when the containers come up and the current step ends. Going to dump the docker compose logs on failure instead. This job is on it's own node so it should only have the prod test related stuff in the logs.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
