### PR TITLE
Update localstack to 2.3.2 with fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 
 services:
   localstack:
-    image: localstack/localstack:2.2.0
+    image: localstack/localstack:2.3.2
     profiles: ['aws', 'emulator']
     expose:
       - '4566'
@@ -16,7 +16,7 @@ services:
           # We use hosted-style for s3 bucket urls. Which matches production.
           # https://docs.localstack.cloud/user-guide/aws/s3/
           # So we need to add host mapping for test bucket civiform-local-s3
-          - civiform-local-s3.localhost.localstack.cloud
+          - civiform-local-s3.s3.localhost.localstack.cloud
           - localhost.localstack.cloud
 
   azurite:

--- a/localstack/localstack.Dockerfile
+++ b/localstack/localstack.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM localstack/localstack:2.2.0
+FROM localstack/localstack:2.3.2
 
 # Localstack tries to connect to the host specified
 # by success_redirect_url upon successful upload of


### PR DESCRIPTION
In localstack 2.3.x, the virtual hosted-style requests now require an 's3.' prefix to the endpoint. We're using the virtual hosted-style, rather than path-style, to try to more closely match what we're doing in production.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Create a program with a file upload question. Ensure that an applicant answering that question works correctly and doesn't give a 500 error from localstack.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5700
