### PR TITLE
Create filter to store a session id.

### DIFF
--- a/server/app/auth/DefaultToGuestRedirector.java
+++ b/server/app/auth/DefaultToGuestRedirector.java
@@ -3,6 +3,7 @@ package auth;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static play.mvc.Results.redirect;
 
+import com.google.common.collect.ImmutableMap;
 import controllers.routes;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -17,11 +18,7 @@ public final class DefaultToGuestRedirector {
    * them, redirecting them to the original page afterward.
    */
   public static Result createGuestSessionAndRedirect(Http.Request request) {
-    System.out.println(
-        "XXX before creating guest session, the current session contains: "
-            + request.session().data());
     return redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url())
-        .addingToSession(request, REDIRECT_TO_SESSION_KEY, request.uri());
-    // .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
+        .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
   }
 }

--- a/server/app/auth/DefaultToGuestRedirector.java
+++ b/server/app/auth/DefaultToGuestRedirector.java
@@ -3,7 +3,6 @@ package auth;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static play.mvc.Results.redirect;
 
-import com.google.common.collect.ImmutableMap;
 import controllers.routes;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -18,9 +17,11 @@ public final class DefaultToGuestRedirector {
    * them, redirecting them to the original page afterward.
    */
   public static Result createGuestSessionAndRedirect(Http.Request request) {
-    System.out.println("XXX before creating guest session, the current session contains: " + request.session().data());
+    System.out.println(
+        "XXX before creating guest session, the current session contains: "
+            + request.session().data());
     return redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url())
         .addingToSession(request, REDIRECT_TO_SESSION_KEY, request.uri());
-        // .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
+    // .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
   }
 }

--- a/server/app/auth/DefaultToGuestRedirector.java
+++ b/server/app/auth/DefaultToGuestRedirector.java
@@ -18,7 +18,9 @@ public final class DefaultToGuestRedirector {
    * them, redirecting them to the original page afterward.
    */
   public static Result createGuestSessionAndRedirect(Http.Request request) {
+    System.out.println("XXX before creating guest session, the current session contains: " + request.session().data());
     return redirect(routes.CallbackController.callback(GuestClient.CLIENT_NAME).url())
-        .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
+        .addingToSession(request, REDIRECT_TO_SESSION_KEY, request.uri());
+        // .withSession(ImmutableMap.of(REDIRECT_TO_SESSION_KEY, request.uri()));
   }
 }

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -1,79 +1,40 @@
 package filters;
 
+import static play.mvc.Results.redirect;
+
 import akka.stream.Materializer;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-
-import akka.util.ByteString;
 import com.google.inject.Inject;
-import play.core.j.RequestImpl;
-import play.libs.streams.Accumulator;
-import play.mvc.EssentialAction;
-import play.mvc.EssentialFilter;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;
 
 /** Filter that stores a random session ID in the session, if not already present. */
-public final class SessionIdFilter extends EssentialFilter {
+public final class SessionIdFilter extends Filter {
   public static final String SESSION_ID = "sessionId";
 
-  private final Executor executor;
-
   @Inject
-  public SessionIdFilter(Executor executor) {
-    super();
-    this.executor = executor;
+  public SessionIdFilter(Materializer mat) {
+    super(mat);
   }
 
-//  @Override
-//  public CompletionStage<Result> apply(
-//      Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
-//      Http.RequestHeader requestHeader) {
-//    return nextFilter
-//        .apply(requestHeader)
-//        .thenApply(
-//            result -> {
-//              if (requestHeader.session().get(SESSION_ID).isEmpty()) {
-//                String sessionId = UUID.randomUUID().toString();
-//                System.out.println("XXX minted sessionId: " + sessionId);
-//                return result.withSession(requestHeader.session().adding(SESSION_ID, sessionId));
-//              } else {
-//                System.out.println("XXX found sessionId: " + requestHeader.session().get(SESSION_ID).get());
-//                return result;
-//              }
-//            });
-//  }
-
   @Override
-  public EssentialAction apply(EssentialAction next) {
-    return EssentialAction.of(
-      request -> {
-        Accumulator<ByteString, Result> accumulator = next.apply(request);
-        return accumulator.map(
-          result -> {
-            // XXX NPE below at startup using result.session()
-            // XXX request.session() is non-null but causes looping in browser test
-//            System.out.println("XXX request.session() = " + request.session());
-//            System.out.println("XXX result.session() = " + result.session());
-//            System.out.println("XXX request.session().get(SESSION_ID = " + request.session().get(SESSION_ID));
-            if (request.getCookie(SESSION_ID).isEmpty()) {
-              String sessionId = UUID.randomUUID().toString();
-              System.out.println("XXX minted sessionId: " + sessionId);
-              return result.withCookies(Http.Cookie.builder(SESSION_ID, sessionId).build());
-            } else {
-              System.out.println("XXX found sessionId: " + request.getCookie(SESSION_ID).get().value());
-              return result;
-            }
-          },
-          executor
-        );
-      }
-    );
+  public CompletionStage<Result> apply(
+      Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
+      Http.RequestHeader requestHeader) {
+    // If we don't have a session id, mint and store one.
+    //
+    // Since the Play session is immutable for a request, we must redirect in order to get Play to
+    // pick the new value. Since we are using redirects, we only apply one for a GET request.
+    if (requestHeader.session().get(SESSION_ID).isEmpty() && requestHeader.method().equals("GET")) {
+      String sessionId = UUID.randomUUID().toString();
+      return CompletableFuture.completedFuture(
+          redirect(requestHeader.uri())
+              .withSession(requestHeader.session().adding(SESSION_ID, sessionId)));
+    }
+    return nextFilter.apply(requestHeader);
   }
 }

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -17,7 +17,8 @@ import play.mvc.Result;
 public final class SessionIdFilter extends Filter {
   public static final String SESSION_ID = "sessionId";
 
-  public static final ImmutableSet<String> excludedPrefixes = ImmutableSet.of("/api/", "/dev/");
+  public static final ImmutableSet<String> excludedPrefixes =
+      ImmutableSet.of("/api/", "/dev/", "/favicon");
 
   @Inject
   public SessionIdFilter(Materializer mat) {

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -1,62 +1,81 @@
 package filters;
 
 import akka.stream.Materializer;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import akka.util.ByteString;
 import com.google.inject.Inject;
+import play.core.j.RequestImpl;
+import play.libs.streams.Accumulator;
+import play.mvc.EssentialAction;
+import play.mvc.EssentialFilter;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;
 
 /** Filter that stores a random session ID in the session, if not already present. */
-public final class SessionIdFilter extends Filter {
+public final class SessionIdFilter extends EssentialFilter {
   public static final String SESSION_ID = "sessionId";
 
-  @Inject
-  public SessionIdFilter(Materializer mat) {
-    super(mat);
-  }
+  private final Executor executor;
 
-  @Override
-  public CompletionStage<Result> apply(
-      Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
-      Http.RequestHeader requestHeader) {
-    return nextFilter
-        .apply(requestHeader)
-        .thenApply(
-            result -> {
-              if (requestHeader.session().get(SESSION_ID).isEmpty()) {
-                String sessionId = UUID.randomUUID().toString();
-                System.out.println("XXX minted sessionId: " + sessionId);
-                return result.withSession(requestHeader.session().adding(SESSION_ID, sessionId));
-              } else {
-                System.out.println("XXX found sessionId: " + requestHeader.session().get(SESSION_ID).get());
-                return result;
-              }
-            });
+  @Inject
+  public SessionIdFilter(Executor executor) {
+    super();
+    this.executor = executor;
   }
 
 //  @Override
-//  public EssentialAction apply(EssentialAction next) {
-//    return EssentialAction.of(
-//      request -> {
-//        Accumulator<ByteString, Result> accumulator = next.apply(request);
-//        return accumulator.map(
-//          result -> {
-//            if (request.session().get(SESSION_ID).isEmpty()) {
-//              String sessionId = UUID.randomUUID().toString();
-//              System.out.println("XXX minted sessionId: " + sessionId);
-//              return result.addingToSession(request, SESSION_ID, sessionId);
-//            } else {
-//              System.out.println("XXX found sessionId: " + request.session().get(SESSION_ID).get());
-//              return result;
-//            }
-//          },
-//          executor
-//        );
-//      }
-//    );
+//  public CompletionStage<Result> apply(
+//      Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
+//      Http.RequestHeader requestHeader) {
+//    return nextFilter
+//        .apply(requestHeader)
+//        .thenApply(
+//            result -> {
+//              if (requestHeader.session().get(SESSION_ID).isEmpty()) {
+//                String sessionId = UUID.randomUUID().toString();
+//                System.out.println("XXX minted sessionId: " + sessionId);
+//                return result.withSession(requestHeader.session().adding(SESSION_ID, sessionId));
+//              } else {
+//                System.out.println("XXX found sessionId: " + requestHeader.session().get(SESSION_ID).get());
+//                return result;
+//              }
+//            });
 //  }
+
+  @Override
+  public EssentialAction apply(EssentialAction next) {
+    return EssentialAction.of(
+      request -> {
+        Accumulator<ByteString, Result> accumulator = next.apply(request);
+        return accumulator.map(
+          result -> {
+            // XXX NPE below at startup using result.session()
+            // XXX request.session() is non-null but causes looping in browser test
+            System.out.println("XXX request.session() = " + request.session());
+            System.out.println("XXX result.session() = " + result.session());
+            System.out.println("XXX request.session().get(SESSION_ID = " + request.session().get(SESSION_ID));
+            if (request.session().get(SESSION_ID).isEmpty()) {
+              String sessionId = UUID.randomUUID().toString();
+              System.out.println("XXX minted sessionId: " + sessionId);
+              Map<String, String> newSessionData = new HashMap<>(request.session().data());
+              newSessionData.put(SESSION_ID, sessionId);
+              return result.withSession(new Http.Session(newSessionData));
+            } else {
+              System.out.println("XXX found sessionId: " + request.session().get(SESSION_ID).get());
+              return result;
+            }
+          },
+          executor
+        );
+      }
+    );
+  }
 }

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -59,17 +59,15 @@ public final class SessionIdFilter extends EssentialFilter {
           result -> {
             // XXX NPE below at startup using result.session()
             // XXX request.session() is non-null but causes looping in browser test
-            System.out.println("XXX request.session() = " + request.session());
-            System.out.println("XXX result.session() = " + result.session());
-            System.out.println("XXX request.session().get(SESSION_ID = " + request.session().get(SESSION_ID));
-            if (request.session().get(SESSION_ID).isEmpty()) {
+//            System.out.println("XXX request.session() = " + request.session());
+//            System.out.println("XXX result.session() = " + result.session());
+//            System.out.println("XXX request.session().get(SESSION_ID = " + request.session().get(SESSION_ID));
+            if (request.getCookie(SESSION_ID).isEmpty()) {
               String sessionId = UUID.randomUUID().toString();
               System.out.println("XXX minted sessionId: " + sessionId);
-              Map<String, String> newSessionData = new HashMap<>(request.session().data());
-              newSessionData.put(SESSION_ID, sessionId);
-              return result.withSession(new Http.Session(newSessionData));
+              return result.withCookies(Http.Cookie.builder(SESSION_ID, sessionId).build());
             } else {
-              System.out.println("XXX found sessionId: " + request.session().get(SESSION_ID).get());
+              System.out.println("XXX found sessionId: " + request.getCookie(SESSION_ID).get().value());
               return result;
             }
           },

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -1,0 +1,41 @@
+package filters;
+
+import akka.stream.Materializer;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import javax.inject.Inject;
+import play.mvc.Filter;
+import play.mvc.Http;
+import play.mvc.Result;
+
+/** Filter that stores a random session ID in the session, if not already present. */
+public final class SessionIdFilter extends Filter {
+  public static final String SESSION_ID = "sessionId";
+
+  private Materializer mat;
+
+  @Inject
+  public SessionIdFilter(Materializer mat) {
+    super(mat);
+    this.mat = mat;
+  }
+
+  @Override
+  public CompletionStage<Result> apply(
+      Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
+      Http.RequestHeader requestHeader) {
+    return nextFilter
+        .apply(requestHeader)
+        .thenApplyAsync(
+            result -> {
+              if (requestHeader.session().get(SESSION_ID).isEmpty()) {
+                String sessionId = UUID.randomUUID().toString();
+                return result.withSession(requestHeader.session().adding(SESSION_ID, sessionId));
+              } else {
+                return result;
+              }
+            },
+            mat.executionContext());
+  }
+}

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -19,7 +19,7 @@ public final class SessionIdFilter extends Filter {
   public static final String SESSION_ID = "sessionId";
 
   private static final ImmutableSet<String> excludedPrefixes =
-      ImmutableSet.of("/api/", "/dev/", "/favicon");
+      ImmutableSet.of("/api/", "/assets/", "/dev/", "/favicon");
 
   private final SettingsManifest settingsManifest;
 

--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -5,6 +5,7 @@ import static play.mvc.Results.redirect;
 import akka.stream.Materializer;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -21,16 +22,16 @@ public final class SessionIdFilter extends Filter {
   private static final ImmutableSet<String> excludedPrefixes =
       ImmutableSet.of("/api/", "/assets/", "/dev/", "/favicon");
 
-  private final SettingsManifest settingsManifest;
+  private final Provider<SettingsManifest> settingsManifestProvider;
 
   @Inject
-  public SessionIdFilter(Materializer mat, SettingsManifest settingsManifest) {
+  public SessionIdFilter(Materializer mat, Provider<SettingsManifest> settingsManifestProvider) {
     super(mat);
-    this.settingsManifest = settingsManifest;
+    this.settingsManifestProvider = settingsManifestProvider;
   }
 
   private boolean shouldApplyThisFilter(Http.RequestHeader requestHeader) {
-    return settingsManifest.getEnhancedOidcLogoutEnabled(requestHeader)
+    return settingsManifestProvider.get().getEnhancedOidcLogoutEnabled()
         && excludedPrefixes.stream().noneMatch(prefix -> requestHeader.uri().startsWith(prefix))
         // Since we are using redirects, we only apply this filter for a GET request.
         && requestHeader.method().equals("GET")

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -340,6 +340,7 @@ play.filters {
   enabled += filters.DisableCachingFilter
   enabled += filters.HSTSFilter
   enabled += filters.RecordCookieSizeFilter
+  enabled += filters.SessionIdFilter
   enabled += filters.LoggingFilter
   enabled += filters.ValidAccountFilter
   enabled += play.filters.gzip.GzipFilter

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -340,12 +340,12 @@ play.filters {
   enabled += filters.DisableCachingFilter
   enabled += filters.HSTSFilter
   enabled += filters.RecordCookieSizeFilter
-  enabled += filters.SessionIdFilter
   enabled += filters.LoggingFilter
   enabled += filters.ValidAccountFilter
   enabled += play.filters.gzip.GzipFilter
   enabled += filters.UnsupportedBrowserFilter
   enabled += filters.SettingsFilter
+  enabled += filters.SessionIdFilter
 
   gzip {
     threshold = 1000        # don't compress very small responses

--- a/server/test/controllers/HomeControllerAuthenticatedTest.java
+++ b/server/test/controllers/HomeControllerAuthenticatedTest.java
@@ -3,7 +3,6 @@ package controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.fakeRequest;
-import static play.test.Helpers.route;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -18,8 +17,9 @@ import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.engine.DefaultSecurityLogic;
 import play.mvc.Http;
-import play.mvc.Result;
 import play.test.WithApplication;
+import support.CfTestHelpers;
+import support.CfTestHelpers.ResultWithFinalRequestUri;
 
 public class HomeControllerAuthenticatedTest extends WithApplication {
 
@@ -50,7 +50,8 @@ public class HomeControllerAuthenticatedTest extends WithApplication {
     Http.RequestBuilder request =
         fakeRequest(routes.HomeController.securePlayIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
-    Result result = route(app, request);
-    assertThat(result.status()).isEqualTo(HttpConstants.OK);
+    ResultWithFinalRequestUri resultWithFinalRequestUri =
+        CfTestHelpers.doRequestWithRedirects(app, request);
+    assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
   }
 }

--- a/server/test/controllers/HomeControllerAuthenticatedTest.java
+++ b/server/test/controllers/HomeControllerAuthenticatedTest.java
@@ -51,7 +51,7 @@ public class HomeControllerAuthenticatedTest extends WithApplication {
         fakeRequest(routes.HomeController.securePlayIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
-        CfTestHelpers.doRequestWithRedirects(app, request);
+        CfTestHelpers.doRequestWithInternalRedirects(app, request);
     assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
   }
 }

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -7,6 +7,7 @@ import static play.test.Helpers.fakeRequest;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import play.mvc.Http;
+import play.mvc.Result;
 import repository.ResetPostgres;
 import support.CfTestHelpers;
 import support.CfTestHelpers.ResultWithFinalRequestUri;
@@ -33,6 +34,8 @@ public class HomeControllerTest extends ResetPostgres {
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
         CfTestHelpers.doRequestWithRedirects(app, request);
-    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).contains("civiform.us/favicon");
+    Result result = resultWithFinalRequestUri.getResult();
+    assertThat(result.redirectLocation()).isNotEmpty();
+    assertThat(result.redirectLocation().get()).contains("civiform.us/favicon");
   }
 }

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -3,13 +3,13 @@ package controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.fakeRequest;
-import static play.test.Helpers.route;
 
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import play.mvc.Http;
-import play.mvc.Result;
 import repository.ResetPostgres;
+import support.CfTestHelpers;
+import support.CfTestHelpers.ResultWithFinalRequestUri;
 
 public class HomeControllerTest extends ResetPostgres {
 
@@ -18,10 +18,12 @@ public class HomeControllerTest extends ResetPostgres {
     Http.RequestBuilder request =
         fakeRequest(routes.HomeController.securePlayIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
-    Result result = route(app, request);
-    assertThat(result.status()).isNotEqualTo(HttpConstants.OK);
+    ResultWithFinalRequestUri resultWithFinalRequestUri =
+        CfTestHelpers.doRequestWithRedirects(app, request);
+    assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
 
-    assertThat(result.redirectLocation().get()).isEqualTo(routes.HomeController.index().url());
+    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).startsWith("/applicants/");
+    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).endsWith("/programs");
   }
 
   @Test
@@ -29,13 +31,8 @@ public class HomeControllerTest extends ResetPostgres {
     Http.RequestBuilder request =
         fakeRequest(routes.HomeController.favicon())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
-    Result result = route(app, request);
-    assertThat(result.status())
-        .as("Result status should 302 redirect")
-        .isEqualTo(HttpConstants.FOUND);
-    assertThat(result.redirectLocation().isPresent()).as("Should have redirect location").isTrue();
-    assertThat(result.redirectLocation().get())
-        .as("Should redirect to set favicon")
-        .contains("civiform.us");
+    ResultWithFinalRequestUri resultWithFinalRequestUri =
+        CfTestHelpers.doRequestWithRedirects(app, request);
+    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).contains("civiform.us/favicon");
   }
 }

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -20,7 +20,7 @@ public class HomeControllerTest extends ResetPostgres {
         fakeRequest(routes.HomeController.securePlayIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
-        CfTestHelpers.doRequestWithRedirects(app, request);
+        CfTestHelpers.doRequestWithInternalRedirects(app, request);
     assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
 
     assertThat(resultWithFinalRequestUri.getFinalRequestUri()).startsWith("/applicants/");
@@ -33,7 +33,7 @@ public class HomeControllerTest extends ResetPostgres {
         fakeRequest(routes.HomeController.favicon())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
-        CfTestHelpers.doRequestWithRedirects(app, request);
+        CfTestHelpers.doRequestWithInternalRedirects(app, request);
     Result result = resultWithFinalRequestUri.getResult();
     assertThat(result.redirectLocation()).isNotEmpty();
     assertThat(result.redirectLocation().get()).contains("civiform.us/favicon");

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -3,11 +3,8 @@ package filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.fakeRequest;
 
-import akka.stream.Materializer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -16,9 +13,7 @@ import play.test.WithApplication;
 public class SessionIdFilterTest extends WithApplication {
   @Test
   public void testSessionIdIsCreated() throws Exception {
-    // XXX Materializer mat = app.injector().instanceOf(Materializer.class);
-    Executor executor = app.injector().instanceOf(Executor.class);
-    SessionIdFilter filter = new SessionIdFilter(executor);
+    SessionIdFilter filter = new SessionIdFilter(mat);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -3,17 +3,45 @@ package filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.fakeRequest;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
+import services.settings.SettingDescription;
+import services.settings.SettingMode;
+import services.settings.SettingType;
+import services.settings.SettingsManifest;
+import services.settings.SettingsSection;
 
 public class SessionIdFilterTest extends WithApplication {
+
+  private SettingsManifest createSettingsManifest(boolean oidcLogoutEnabled) {
+    return new SettingsManifest(
+        ImmutableMap.of(
+            "section1",
+            SettingsSection.create(
+                "section1",
+                "description1",
+                ImmutableList.of(),
+                ImmutableList.of(
+                    SettingDescription.create(
+                        "ENHANCED_OIDC_LOGOUT_ENABLED",
+                        "Enhanced OIDC Logout logic enabled",
+                        false,
+                        SettingType.BOOLEAN,
+                        SettingMode.ADMIN_WRITEABLE)))),
+        ConfigFactory.parseMap(ImmutableMap.of("enhanced_oidc_logout_enabled", oidcLogoutEnabled)));
+  }
+
   @Test
-  public void testSessionIdIsCreatedForNonApiRoute() throws Exception {
-    SessionIdFilter filter = new SessionIdFilter(mat);
+  public void testSessionIdIsCreatedForNonExcludedRoute() throws Exception {
+    SettingsManifest settingsManifest = createSettingsManifest(true);
+    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();
@@ -31,11 +59,33 @@ public class SessionIdFilterTest extends WithApplication {
   }
 
   @Test
-  public void testSessionIdIsNotCreatedForApiRoute() throws Exception {
-    SessionIdFilter filter = new SessionIdFilter(mat);
+  public void testSessionIdIsNotCreatedForExcludedRoute() throws Exception {
+    SettingsManifest settingsManifest = createSettingsManifest(true);
+    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
 
     // The request is for an API route and has no session id.
     Http.RequestBuilder request = fakeRequest("GET", "/api/v1/admin");
+    assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
+
+    CompletionStage<Result> stage =
+        filter.apply(
+            header -> {
+              return CompletableFuture.completedFuture(play.mvc.Results.ok());
+            },
+            request.build());
+
+    Result result = stage.toCompletableFuture().get();
+    // The session has no session id. In fact, it has no session.
+    assertThat(result.session()).isNull();
+  }
+
+  @Test
+  public void testSessionIdIsNotCreatedWhenDisabled() throws Exception {
+    SettingsManifest settingsManifest = createSettingsManifest(false);
+    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
+
+    // The request has no session id.
+    Http.RequestBuilder request = fakeRequest();
     assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
 
     CompletionStage<Result> stage =

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -41,7 +41,7 @@ public class SessionIdFilterTest extends WithApplication {
   @Test
   public void testSessionIdIsCreatedForNonExcludedRoute() throws Exception {
     SettingsManifest settingsManifest = createSettingsManifest(true);
-    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
+    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();
@@ -61,7 +61,7 @@ public class SessionIdFilterTest extends WithApplication {
   @Test
   public void testSessionIdIsNotCreatedForExcludedRoute() throws Exception {
     SettingsManifest settingsManifest = createSettingsManifest(true);
-    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
+    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
 
     // The request is for an API route and has no session id.
     Http.RequestBuilder request = fakeRequest("GET", "/api/v1/admin");
@@ -82,7 +82,7 @@ public class SessionIdFilterTest extends WithApplication {
   @Test
   public void testSessionIdIsNotCreatedWhenDisabled() throws Exception {
     SettingsManifest settingsManifest = createSettingsManifest(false);
-    SessionIdFilter filter = new SessionIdFilter(mat, settingsManifest);
+    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -1,0 +1,34 @@
+package filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.test.Helpers.fakeRequest;
+
+import akka.stream.Materializer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.Test;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.test.WithApplication;
+
+public class SessionIdFilterTest extends WithApplication {
+  @Test
+  public void testSessionIdIsCreated() throws Exception {
+    Materializer mat = app.injector().instanceOf(Materializer.class);
+    SessionIdFilter filter = new SessionIdFilter(mat);
+
+    // The request has no session id.
+    Http.RequestBuilder request = fakeRequest();
+    assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
+
+    CompletionStage<Result> stage =
+        filter.apply(
+            header -> {
+              return CompletableFuture.completedFuture(play.mvc.Results.ok());
+            },
+            request.build());
+
+    Result result = stage.toCompletableFuture().get();
+    assertThat(result.session().get(SessionIdFilter.SESSION_ID)).isNotEmpty();
+  }
+}

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -6,6 +6,8 @@ import static play.test.Helpers.fakeRequest;
 import akka.stream.Materializer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -14,8 +16,9 @@ import play.test.WithApplication;
 public class SessionIdFilterTest extends WithApplication {
   @Test
   public void testSessionIdIsCreated() throws Exception {
-    Materializer mat = app.injector().instanceOf(Materializer.class);
-    SessionIdFilter filter = new SessionIdFilter(mat);
+    // XXX Materializer mat = app.injector().instanceOf(Materializer.class);
+    Executor executor = app.injector().instanceOf(Executor.class);
+    SessionIdFilter filter = new SessionIdFilter(executor);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -153,16 +153,16 @@ public class CfTestHelpers {
     return result.redirectLocation().isPresent() && result.redirectLocation().get().startsWith("/");
   }
 
-  // Makes a request and follows redirects, propagating session and cookies.
-  // Uses a maxRedirects of 10.
-  public static ResultWithFinalRequestUri doRequestWithRedirects(
+  // Makes a request and follows internal redirects, propagating session and cookies.
+  // Throws a runtime exception if maxRedirects (10) is exceeded.
+  public static ResultWithFinalRequestUri doRequestWithInternalRedirects(
       Application app, Http.RequestBuilder request) {
-    return doRequestWithRedirects(app, request, 10);
+    return doRequestWithInternalRedirects(app, request, 10);
   }
 
-  // Makes a request and follows redirects, propagating session and cookies.
+  // Makes a request and follows internal redirects, propagating session and cookies.
   // Throws a runtime exception if maxRedirects is exceeded.
-  public static ResultWithFinalRequestUri doRequestWithRedirects(
+  public static ResultWithFinalRequestUri doRequestWithInternalRedirects(
       Application app, Http.RequestBuilder request, int maxRedirects) {
     Result currentResult;
     String currentRequestUri = request.uri();

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -123,6 +123,7 @@ public class CfTestHelpers {
     return requestBuilder.attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settingsMap.build());
   }
 
+  /** Class to hold a Result as well as the final request URI after internal redirects. */
   public static class ResultWithFinalRequestUri {
     private Result result;
     private String finalRequestUri;


### PR DESCRIPTION
### Description

Add a filter that stores a session id in the browser session.

For OIDC logout, we want to store ID tokens in the database for an applicant. If they are logged in from more than one browser, then we need to index the ID tokens so that the proper one can be retrieved at logout time. We will use this new session key for the key.

**NOTE:** this code was previously under review as #5695 until the branch was deleted by gremlins.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Relates to #4359.
