### PR TITLE
Run Presubmits on all PRs

### DIFF
--- a/.github/workflows/pr_server.yaml
+++ b/.github/workflows/pr_server.yaml
@@ -8,8 +8,8 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - 'main'
+    branches-ignore:
+      - 'spike/**'
     paths:
       - 'server/**'
       - 'bin/**'


### PR DESCRIPTION
Runs presubmits on all PRs, unless the branch starts with `spike/`
