### PR TITLE
Only set submit time on previous applications that don't have it

### DIFF
--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -44,11 +44,6 @@ public class ApplicationRepositoryTest extends ResetPostgres {
 
   @Test
   public void submitApplication_updatesOtherApplicationVersions() {
-    Logger logger = (Logger) LoggerFactory.getLogger(ApplicationRepository.class);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-    listAppender.start();
-    logger.addAppender(listAppender);
-
     Applicant applicant = saveApplicant("Alice");
     Program program = createDraftProgram("Program");
 
@@ -78,15 +73,9 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     Application appTwoSubmitted =
         repo.getApplication(appTwoDraft.id).toCompletableFuture().join().get();
     assertThat(appTwoSubmitted.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
-
     assertThat(appTwoSubmitted.getApplicantData().getApplicantName().get()).isEqualTo("Alice");
-
-    ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
-    assertThat(logsList)
-        .anySatisfy(
-            event -> {
-              assertThat(event.getFormattedMessage()).matches(".*duplicate = true.*");
-            });
+    assertThat(repo.getApplication(appOne.id).toCompletableFuture().join().get().getSubmitTime())
+        .isEqualTo(initialSubmitTime);
   }
 
   @Test


### PR DESCRIPTION
In order to address https://github.com/civiform/civiform/issues/3227, we were iterating through all previous applications that were not marked OBSOLETE and setting the submit time. However, we had not obsoleted the previous, current ACTIVE application at this point, so the previous revision of the application would always get its submission time updated, causing problems with metrics. This changes the logic to only set the submit time on a currently ACTIVE application if it doesn't already have a time set.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

- Create a program
- Apply to that program as an applicant.  Note the submit_time for that application in the applications table in the database.
- Edit that application and resubmit
- Verify that submit_time on the previous application doesn't change

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/5779
