### PR TITLE
Fixing line2 bug

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -218,7 +218,7 @@ public abstract class EsriClient {
       JsonNode parentJsonNode, String keyName, Supplier<String> getDefaultValue) {
     JsonNode childJsonNode = parentJsonNode.get(keyName);
 
-    return (childJsonNode == null || childJsonNode.isNull())
+    return (childJsonNode == null || childJsonNode.isNull() || childJsonNode.asText().isEmpty())
         ? getDefaultValue.get()
         : childJsonNode.asText();
   }

--- a/server/test/resources/esri/findAddressCandidatesWithLine2.json
+++ b/server/test/resources/esri/findAddressCandidatesWithLine2.json
@@ -1,0 +1,23 @@
+{
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  },
+  "candidates": [
+    {
+      "address": "Apartment Address, Apt 123, Redlands, California, 92373",
+      "location": {
+        "x": -100,
+        "y": 100
+      },
+      "score": 100,
+      "attributes": {
+        "SubAddr": "Apt 123",
+        "Address": "Apartment Address",
+        "City": "Redlands",
+        "RegionAbbr": "CA",
+        "Postal": "92373"
+      }
+    }
+  ]
+}

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -21,6 +21,7 @@ import services.geo.AddressLocation;
 public class EsriTestHelper {
   public static enum TestType {
     STANDARD,
+    STANDARD_WITH_LINE_2,
     NO_CANDIDATES,
     ERROR,
     SERVICE_AREA_VALIDATION,
@@ -62,6 +63,17 @@ public class EsriTestHelper {
                     RoutingDsl.fromComponents(components)
                         .GET("/findAddressCandidates")
                         .routingTo(request -> ok().sendResource("esri/findAddressCandidates.json"))
+                        .build());
+        break;
+      case STANDARD_WITH_LINE_2:
+        server =
+            Server.forRouter(
+                (components) ->
+                    RoutingDsl.fromComponents(components)
+                        .GET("/findAddressCandidates")
+                        .routingTo(
+                            request ->
+                                ok().sendResource("esri/findAddressCandidatesWithLine2.json"))
                         .build());
         break;
       case NO_CANDIDATES:

--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -37,6 +37,21 @@ public class RealEsriClientTest {
   }
 
   @Test
+  public void fetchAddressSuggestionsHavingLine2Populated() throws Exception {
+    helper = new EsriTestHelper(TestType.STANDARD_WITH_LINE_2);
+    ObjectNode addressJson = Json.newObject();
+    addressJson.put("street", "380 New York St");
+    addressJson.put("line2", "Apt 123");
+    Optional<JsonNode> maybeResp =
+        helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
+    JsonNode resp = maybeResp.get();
+
+    JsonNode nodeWithLine2 = resp.get("candidates").get(0);
+    String actualLine2Value = nodeWithLine2.get("attributes").get("SubAddr").asText();
+    assertThat(actualLine2Value).isEqualTo("Apt 123");
+  }
+
+  @Test
   public void fetchAddressSuggestionsWithNoCandidates() throws Exception {
     helper = new EsriTestHelper(TestType.NO_CANDIDATES);
     ObjectNode addressJson = Json.newObject();


### PR DESCRIPTION
### Description

Correctly carry forward address line 2 if populated.

Address line 2 (often considered the apt # line) should be carried forward if there is a value set by the user and no value is returned from address correction. This is because some installs ignore the line for the purpose of finding the location. Other mapping tests check for this, but that appears was at too low a level. Jackson will potentially have internal double quotes on what is really an empty string until you call the `asText` method. This changes adds an addition check for empty string when determining if it should use the default (existing, use supplied value) or the one from the service.

## Release notes

Fixed bug where Address Line 2 does not always get used with address correction.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
