### PR TITLE
Create class to hold parameters for OidcClientProvider and related classes

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -40,13 +40,10 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
   protected final CiviFormProfileMerger civiFormProfileMerger;
 
   public CiviformOidcProfileCreator(
-      OidcConfiguration configuration,
-      OidcClient client,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
+      OidcConfiguration configuration, OidcClient client, OidcClientProviderParams params) {
     super(Preconditions.checkNotNull(configuration), Preconditions.checkNotNull(client));
-    this.profileFactory = Preconditions.checkNotNull(profileFactory);
-    this.accountRepositoryProvider = Preconditions.checkNotNull(accountRepositoryProvider);
+    this.profileFactory = Preconditions.checkNotNull(params.profileFactory());
+    this.accountRepositoryProvider = Preconditions.checkNotNull(params.accountRepositoryProvider());
     this.civiFormProfileMerger =
         new CiviFormProfileMerger(profileFactory, accountRepositoryProvider);
   }

--- a/server/app/auth/oidc/OidcClientProvider.java
+++ b/server/app/auth/oidc/OidcClientProvider.java
@@ -29,18 +29,17 @@ import repository.AccountRepository;
 public abstract class OidcClientProvider implements Provider<OidcClient> {
 
   private static final Logger logger = LoggerFactory.getLogger(OidcClientProvider.class);
+  protected final OidcClientProviderParams params;
   protected final Config civiformConfig;
   protected final ProfileFactory profileFactory;
   protected final Provider<AccountRepository> accountRepositoryProvider;
   protected final String baseUrl;
 
-  public OidcClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    this.civiformConfig = checkNotNull(configuration);
-    this.profileFactory = checkNotNull(profileFactory);
-    this.accountRepositoryProvider = checkNotNull(accountRepositoryProvider);
+  public OidcClientProvider(OidcClientProviderParams params) {
+    this.params = params;
+    this.civiformConfig = checkNotNull(params.configuration());
+    this.profileFactory = checkNotNull(params.profileFactory());
+    this.accountRepositoryProvider = checkNotNull(params.accountRepositoryProvider());
 
     this.baseUrl =
         getBaseConfigurationValue("base_url")

--- a/server/app/auth/oidc/OidcClientProviderParams.java
+++ b/server/app/auth/oidc/OidcClientProviderParams.java
@@ -1,0 +1,35 @@
+package auth.oidc;
+
+import auth.ProfileFactory;
+import com.google.auto.value.AutoValue;
+import com.google.errorprone.annotations.RestrictedApi;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import javax.inject.Provider;
+import repository.AccountRepository;
+
+/** Class that holds parameters required by OidcClientProvider and its subclasses. */
+@AutoValue
+public abstract class OidcClientProviderParams {
+  public static OidcClientProviderParams create(
+      Config configuration,
+      ProfileFactory profileFactory,
+      Provider<AccountRepository> accountRepositoryProvider) {
+    return new AutoValue_OidcClientProviderParams(
+        configuration, profileFactory, accountRepositoryProvider);
+  }
+
+  // Our tests have paths like:
+  //   /usr/src/server/test/auth/ProfileMergeTest.java
+  @RestrictedApi(explanation = "Only allow for tests", allowedOnPath = ".*/test/.*")
+  public static OidcClientProviderParams create(
+      ProfileFactory profileFactory, Provider<AccountRepository> accountRepositoryProvider) {
+    return create(ConfigFactory.empty(), profileFactory, accountRepositoryProvider);
+  }
+
+  public abstract Config configuration();
+
+  abstract ProfileFactory profileFactory();
+
+  abstract Provider<AccountRepository> accountRepositoryProvider();
+}

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -3,6 +3,7 @@ package auth.oidc.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.typesafe.config.Config;
@@ -83,7 +84,10 @@ public class AdfsClientProvider implements Provider<OidcClient> {
     // This is what links the user to the stuff they have access to.
     client.setProfileCreator(
         new AdfsProfileCreator(
-            config, client, profileFactory, configuration, userRepositoryProvider));
+            config,
+            client,
+            OidcClientProviderParams.create(
+                configuration, profileFactory, userRepositoryProvider)));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.init();
     return client;

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -1,17 +1,14 @@
 package auth.oidc.admin;
 
 import auth.CiviFormProfile;
-import auth.ProfileFactory;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableSet;
-import com.typesafe.config.Config;
 import java.util.List;
-import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
-import repository.AccountRepository;
 
 /**
  * This class takes an existing CiviForm profile and augments it with the information from an AD
@@ -20,17 +17,13 @@ import repository.AccountRepository;
  */
 public class AdfsProfileCreator extends CiviformOidcProfileCreator {
   private final String adminGroupName;
-  private final String ad_groups_attribute_name;
+  private final String adGroupsAttributeName;
 
   public AdfsProfileCreator(
-      OidcConfiguration configuration,
-      OidcClient client,
-      ProfileFactory profileFactory,
-      Config appConfig,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    super(configuration, client, profileFactory, accountRepositoryProvider);
-    this.adminGroupName = appConfig.getString("adfs.admin_group");
-    this.ad_groups_attribute_name = appConfig.getString("adfs.ad_groups_attribute_name");
+      OidcConfiguration oidcConfiguration, OidcClient client, OidcClientProviderParams params) {
+    super(oidcConfiguration, client, params);
+    this.adminGroupName = params.configuration().getString("adfs.admin_group");
+    this.adGroupsAttributeName = params.configuration().getString("adfs.ad_groups_attribute_name");
   }
 
   @Override
@@ -65,7 +58,7 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
   }
 
   private boolean isGlobalAdmin(OidcProfile profile) {
-    List<String> groups = AdfsGroupAccessor.getGroups(profile, this.ad_groups_attribute_name);
+    List<String> groups = AdfsGroupAccessor.getGroups(profile, this.adGroupsAttributeName);
     return groups.contains(this.adminGroupName);
   }
 

--- a/server/app/auth/oidc/admin/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/admin/GenericOidcClientProvider.java
@@ -1,17 +1,14 @@
 package auth.oidc.admin;
 
-import auth.ProfileFactory;
 import auth.oidc.OidcClientProvider;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.typesafe.config.Config;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import repository.AccountRepository;
 
 /**
  * This class implements a `Provider` of a generic `OidcClient` for use in authenticating and
@@ -33,11 +30,8 @@ public class GenericOidcClientProvider extends OidcClientProvider {
   private static final String USE_CSRF = "use_csrf";
 
   @Inject
-  GenericOidcClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    super(configuration, profileFactory, accountRepositoryProvider);
+  GenericOidcClientProvider(OidcClientProviderParams params) {
+    super(params);
   }
 
   @Override
@@ -53,8 +47,7 @@ public class GenericOidcClientProvider extends OidcClientProvider {
 
   @Override
   public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
-    return new GenericOidcProfileCreator(
-        config, client, profileFactory, civiformConfig, this.accountRepositoryProvider);
+    return new GenericOidcProfileCreator(config, client, params);
   }
 
   @Override

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -1,17 +1,14 @@
 package auth.oidc.admin;
 
 import auth.CiviFormProfile;
-import auth.ProfileFactory;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableSet;
-import com.typesafe.config.Config;
 import java.util.List;
-import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
-import repository.AccountRepository;
 
 /**
  * This class creates a pac4j `UserProfile` for admins when the identity provider is a generic OIDC
@@ -29,14 +26,10 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
   private static String ADMIN_GROUP_CONFIG_NAME = "admin_generic_oidc_admin_group_name";
 
   public GenericOidcProfileCreator(
-      OidcConfiguration configuration,
-      OidcClient client,
-      ProfileFactory profileFactory,
-      Config appConfig,
-      Provider<AccountRepository> userRepositoryProvider) {
-    super(configuration, client, profileFactory, userRepositoryProvider);
-    this.groupsAttributeName = appConfig.getString(ID_GROUPS_ATTRIBUTE_NAME);
-    this.adminGroupName = appConfig.getString(ADMIN_GROUP_CONFIG_NAME);
+      OidcConfiguration oidcConfiguration, OidcClient client, OidcClientProviderParams params) {
+    super(oidcConfiguration, client, params);
+    this.groupsAttributeName = params.configuration().getString(ID_GROUPS_ATTRIBUTE_NAME);
+    this.adminGroupName = params.configuration().getString(ADMIN_GROUP_CONFIG_NAME);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -2,9 +2,9 @@ package auth.oidc.applicant;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
-import auth.ProfileFactory;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
+import auth.oidc.OidcClientProviderParams;
 import com.beust.jcommander.internal.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -14,11 +14,9 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
-import repository.AccountRepository;
 
 /**
  * This class ensures that the OidcProfileCreator that both the AD and IDCS clients use will
@@ -38,12 +36,11 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
   public ApplicantProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider,
+      OidcClientProviderParams params,
       String emailAttributeName,
       @Nullable String localeAttributeName,
       ImmutableList<String> nameAttributeNames) {
-    super(configuration, client, profileFactory, accountRepositoryProvider);
+    super(configuration, client, params);
     this.emailAttributeName = Preconditions.checkNotNull(emailAttributeName);
     this.localeAttributeName = Optional.ofNullable(localeAttributeName);
     this.nameAttributeNames = Preconditions.checkNotNull(nameAttributeNames);

--- a/server/app/auth/oidc/applicant/Auth0ClientProvider.java
+++ b/server/app/auth/oidc/applicant/Auth0ClientProvider.java
@@ -1,15 +1,12 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
 import auth.oidc.CiviformOidcLogoutActionBuilder;
+import auth.oidc.OidcClientProviderParams;
 import com.google.inject.Inject;
-import com.typesafe.config.Config;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
-import repository.AccountRepository;
 
 /**
  * Provider for auth0.com. Auth0 mostly implements OIDC protocol so it relies on base implementation
@@ -21,11 +18,8 @@ import repository.AccountRepository;
 public class Auth0ClientProvider extends GenericOidcClientProvider {
 
   @Inject
-  public Auth0ClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    super(configuration, profileFactory, accountRepositoryProvider);
+  public Auth0ClientProvider(OidcClientProviderParams params) {
+    super(params);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/GenericApplicantProfileCreator.java
@@ -1,11 +1,9 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
-import javax.inject.Provider;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import repository.AccountRepository;
 
 /**
  * This class takes an existing CiviForm profile and augments it with the information from an AD
@@ -16,18 +14,11 @@ public class GenericApplicantProfileCreator extends ApplicantProfileCreator {
   public GenericApplicantProfileCreator(
       OidcConfiguration configuration,
       OidcClient client,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider,
+      OidcClientProviderParams params,
       String emailAttributeName,
       String localeAttributeName,
       ImmutableList<String> nameAttributeNames) {
     super(
-        configuration,
-        client,
-        profileFactory,
-        accountRepositoryProvider,
-        emailAttributeName,
-        localeAttributeName,
-        nameAttributeNames);
+        configuration, client, params, emailAttributeName, localeAttributeName, nameAttributeNames);
   }
 }

--- a/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
+++ b/server/app/auth/oidc/applicant/GenericOidcClientProvider.java
@@ -1,17 +1,14 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
 import auth.oidc.OidcClientProvider;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.typesafe.config.Config;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import repository.AccountRepository;
 
 public class GenericOidcClientProvider extends OidcClientProvider {
 
@@ -34,11 +31,8 @@ public class GenericOidcClientProvider extends OidcClientProvider {
   private static final String LOCALE_ATTRIBUTE_CONFIG_NAME = "locale_attribute";
 
   @Inject
-  public GenericOidcClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> applicantRepositoryProvider) {
-    super(configuration, profileFactory, applicantRepositoryProvider);
+  public GenericOidcClientProvider(OidcClientProviderParams params) {
+    super(params);
   }
 
   @Override
@@ -62,13 +56,7 @@ public class GenericOidcClientProvider extends OidcClientProvider {
     getConfigurationValue(MIDDLE_NAME_ATTRIBUTE_CONFIG_NAME).ifPresent(nameAttrsBuilder::add);
     getConfigurationValue(LAST_NAME_ATTRIBUTE_CONFIG_NAME).ifPresent(nameAttrsBuilder::add);
     return new GenericApplicantProfileCreator(
-        config,
-        client,
-        profileFactory,
-        accountRepositoryProvider,
-        emailAttr,
-        localeAttr.orElse(null),
-        nameAttrsBuilder.build());
+        config, client, params, emailAttr, localeAttr.orElse(null), nameAttrsBuilder.build());
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/IdcsApplicantProfileCreator.java
@@ -1,6 +1,6 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.nimbusds.jose.util.DefaultResourceRetriever;
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.Credentials;
@@ -23,7 +22,6 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import repository.AccountRepository;
 
 /**
  * This class takes an existing CiviForm profile and augments it with the information from an IDCS
@@ -37,15 +35,11 @@ public final class IdcsApplicantProfileCreator extends ApplicantProfileCreator {
   private static final String NAME_ATTRIBUTE_NAME = "user_displayname";
 
   public IdcsApplicantProfileCreator(
-      OidcConfiguration configuration,
-      OidcClient client,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> userRepositoryProvider) {
+      OidcConfiguration oidcConfiguration, OidcClient client, OidcClientProviderParams params) {
     super(
-        configuration,
+        oidcConfiguration,
         client,
-        profileFactory,
-        userRepositoryProvider,
+        params,
         EMAIL_ATTRIBUTE_NAME,
         LOCALE_ATTRIBUTE_NAME,
         ImmutableList.of(NAME_ATTRIBUTE_NAME));

--- a/server/app/auth/oidc/applicant/IdcsClientProvider.java
+++ b/server/app/auth/oidc/applicant/IdcsClientProvider.java
@@ -1,16 +1,13 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
 import auth.oidc.OidcClientProvider;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.typesafe.config.Config;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import repository.AccountRepository;
 
 /** This class customized the OIDC provider to a specific provider, allowing overrides to be set. */
 public final class IdcsClientProvider extends OidcClientProvider {
@@ -24,11 +21,8 @@ public final class IdcsClientProvider extends OidcClientProvider {
       ImmutableList.of("openid", "profile", "email");
 
   @Inject
-  public IdcsClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    super(configuration, profileFactory, accountRepositoryProvider);
+  public IdcsClientProvider(OidcClientProviderParams params) {
+    super(params);
   }
 
   @Override
@@ -43,8 +37,7 @@ public final class IdcsClientProvider extends OidcClientProvider {
 
   @Override
   public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
-    return new IdcsApplicantProfileCreator(
-        config, client, profileFactory, accountRepositoryProvider);
+    return new IdcsApplicantProfileCreator(config, client, params);
   }
 
   @Override

--- a/server/app/auth/oidc/applicant/LoginGovClientProvider.java
+++ b/server/app/auth/oidc/applicant/LoginGovClientProvider.java
@@ -1,19 +1,16 @@
 package auth.oidc.applicant;
 
-import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
-import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Optional;
-import javax.inject.Provider;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.core.util.generator.RandomValueGenerator;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import repository.AccountRepository;
 
 /*
  * Login.gov (https://developers.login.gov/oidc/) OIDC provider using the PKCE method.
@@ -23,11 +20,8 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
   static final RandomValueGenerator stateGenerator = new RandomValueGenerator(30);
 
   @Inject
-  public LoginGovClientProvider(
-      Config configuration,
-      ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    super(configuration, profileFactory, accountRepositoryProvider);
+  public LoginGovClientProvider(OidcClientProviderParams params) {
+    super(params);
   }
 
   @Override
@@ -41,13 +35,7 @@ public final class LoginGovClientProvider extends GenericOidcClientProvider {
 
     var nameAttrs = ImmutableList.of("given_name", "family_name");
     return new GenericApplicantProfileCreator(
-        config,
-        client,
-        profileFactory,
-        accountRepositoryProvider,
-        "email",
-        /*localeAttributeName*/ null,
-        nameAttrs);
+        config, client, params, "email", /*localeAttributeName*/ null, nameAttrs);
   }
 
   @Override

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import annotations.BindingAnnotations.ApplicantAuthProviderName;
 import annotations.BindingAnnotations.EnUsLang;
 import annotations.BindingAnnotations.Now;
+import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.github.slugify.Slugify;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
@@ -13,9 +15,11 @@ import com.typesafe.config.Config;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import javax.inject.Provider;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
+import repository.AccountRepository;
 
 /**
  * This class is a Guice module that tells Guice how to bind several different types. This Guice
@@ -63,5 +67,13 @@ public class MainModule extends AbstractModule {
     }
 
     return config.getString("whitelabel_civic_entity_full_name");
+  }
+
+  @Provides
+  public OidcClientProviderParams provideOidcClientProviderParams(
+      Config config,
+      ProfileFactory profileFactory,
+      Provider<AccountRepository> accountRepositoryProvider) {
+    return OidcClientProviderParams.create(config, profileFactory, accountRepositoryProvider);
   }
 }

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import auth.oidc.InvalidOidcProfileException;
+import auth.oidc.OidcClientProviderParams;
 import auth.oidc.applicant.IdcsApplicantProfileCreator;
 import auth.saml.InvalidSamlProfileException;
 import auth.saml.SamlProfileCreator;
@@ -48,8 +49,8 @@ public class ProfileMergeTest extends ResetPostgres {
         new IdcsApplicantProfileCreator(
             client_config,
             client,
-            profileFactory,
-            CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
     samlProfileCreator =
         new SamlProfileCreator(
             /* configuration = */ null,

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -49,8 +49,8 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
         new IdcsApplicantProfileCreator(
             client_config,
             client,
-            profileFactory,
-            CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
 
     profile = new OidcProfile();
     profile.addAttribute("user_emailid", EMAIL);

--- a/server/test/auth/oidc/OidcClientProviderTest.java
+++ b/server/test/auth/oidc/OidcClientProviderTest.java
@@ -53,7 +53,8 @@ public class OidcClientProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     oidcClientProvider =
         new IdcsClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test
@@ -109,7 +110,8 @@ public class OidcClientProviderTest extends ResetPostgres {
 
     OidcClientProvider oidcClientProvider =
         new IdcsClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
 
     OidcClient client = oidcClientProvider.get();
 
@@ -177,9 +179,10 @@ public class OidcClientProviderTest extends ResetPostgres {
             () -> {
               OidcClientProvider badOidcClientProvider =
                   new IdcsClientProvider(
-                      bad_secret_config,
-                      profileFactory,
-                      CfTestHelpers.userRepositoryProvider(accountRepository));
+                      OidcClientProviderParams.create(
+                          bad_secret_config,
+                          profileFactory,
+                          CfTestHelpers.userRepositoryProvider(accountRepository)));
               badOidcClientProvider.get();
             })
         .isInstanceOf(RuntimeException.class);

--- a/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -51,7 +52,8 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     genericOidcProvider =
         new GenericOidcClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountProvider));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountProvider)));
   }
 
   @Test

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -39,9 +40,10 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
         new GenericOidcProfileCreator(
             client_config,
             client,
-            profileFactory,
-            serverConfig,
-            CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                serverConfig,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -5,6 +5,7 @@ import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -55,7 +56,8 @@ public class Auth0ProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     auth0Provider =
         new Auth0ClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
@@ -43,8 +44,8 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
         new GenericApplicantProfileCreator(
             client_config,
             client,
-            profileFactory,
-            CfTestHelpers.userRepositoryProvider(accountRepository),
+            OidcClientProviderParams.create(
+                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
             EMAIL_ATTRIBUTE_NAME,
             LOCALE_ATTRIBUTE_NAME,
             ImmutableList.of(

--- a/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -55,7 +56,8 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     genericOidcProvider =
         new GenericOidcClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
@@ -3,6 +3,7 @@ package auth.oidc.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -47,7 +48,8 @@ public class IdcsClientProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     idcsProvider =
         new IdcsClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test

--- a/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
@@ -5,6 +5,7 @@ import static play.test.Helpers.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
+import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -55,7 +56,8 @@ public class LoginGovClientProviderTest extends ResetPostgres {
     // Just need some complete adaptor to access methods.
     loginGovProvider =
         new LoginGovClientProvider(
-            config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository));
+            OidcClientProviderParams.create(
+                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)));
   }
 
   @Test


### PR DESCRIPTION
### Description

Create `OidcClientProviderParams` class to hold parameters for OidcClientProvider and related classes.

This pure refactoring will simplify upcoming PRs that require additional parameters to support enhanced OIDC logout.

### Issue(s) this completes

Relates to #4359 