### PR TITLE
Refactor program.getVersions to be called from programRepository

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -73,6 +73,10 @@ public final class ProgramRepository {
     return program;
   }
 
+  public ImmutableList<Version> getVersionsForProgram(Program program) {
+    return program.getVersions();
+  }
+
   public ImmutableSet<String> getAllProgramNames() {
     ImmutableSet.Builder<String> names = ImmutableSet.builder();
     List<SqlRow> rows = database.sqlQuery("SELECT DISTINCT name FROM programs").findList();

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -226,7 +226,7 @@ public final class ProgramService {
     }
 
     // Any version that the program is in has all the questions the program has.
-    Version version = program.getVersions().stream().findAny().get();
+    Version version = programRepository.getVersionsForProgram(program).stream().findAny().get();
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(program.getProgramDefinition(), version);
 
@@ -1312,7 +1312,7 @@ public final class ProgramService {
       p.refresh();
       // We only need to get the question data if the program has eligibility conditions.
       if (programDef.hasEligibilityEnabled()) {
-        Version v = p.getVersions().stream().findAny().orElseThrow();
+        Version v = programRepository.getVersionsForProgram(p).stream().findAny().orElseThrow();
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
         if (questionServiceForVersion == null) {
           questionServiceForVersion =


### PR DESCRIPTION
### Description

Refactors places that call `program.getVersions()` to use a new function `getVersionsForProgram()`. The new function calls `program.getVersions()` for now, but in the future we'll set up caching within that function. For now, no functionality is updated with this change. 

See more information in [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

Fixes #5833
