### PR TITLE
Add snapshot sync script

### DIFF
--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -1,7 +1,23 @@
 #! /usr/bin/env bash
 
 # DOC: Sync failed github action browser-test snapshots with local system.
+#      With no arguments this defaults to the current active branch or
+#      pass in the first argument to specify a branch name
 
+# Constants
+readonly CURL_ARGS=(-L
+  --silent
+  -H "Accept: application/vnd.github+json"
+  -H "Authorization: Bearer ${GITHUB_TOKEN}"
+  -H "X-GitHub-Api-Version: 2022-11-28")
+
+#######################################
+# Exit if jq query fails or is null
+# Arguments:
+#   last_exit_code - preseverd exit code of jq query
+#   value - value returned from jq query
+#   message - message to print on failure
+#######################################
 function exit_on_jq_failure() {
   local last_exit_code="${1}"
   local value="${2}"
@@ -18,16 +34,39 @@ function exit_on_jq_failure() {
   fi
 }
 
-function exit_on_curl_failure() {
-  local last_exit_code="${1}"
-  local url="${2}"
+#######################################
+# Calls curl to get json response or exits the application
+# Globals:
+#   CURL_ARGS - constant variable of shared curl arguments
+# Arguments:
+#   url - full url for curl to call
+#######################################
+function get_json_or_exit_on_failure() {
+  local url="${1}"
 
-  if [[ "${last_exit_code}" != "0" ]]; then
+  ## Setup common curl arguments
+  #local curl_args=(-L
+  #  --silent
+  #  -H "Accept: application/vnd.github+json"
+  #  -H "Authorization: Bearer ${GITHUB_TOKEN}"
+  #  -H "X-GitHub-Api-Version: 2022-11-28")
+
+  local json
+  json="$(curl "${CURL_ARGS[@]}" "${url}")"
+
+  if (($? != 0)); then
     echo "Curl failed trying to call ${url}"
     exit 1
   fi
+
+  echo "${json}"
 }
 
+#######################################
+# Print helpful info in external requirements are not fulfilled
+# Globals:
+#   GITHUB_TOKEN - environemnt variable of a valid GitHub Personal access token
+#######################################
 function verify_dependencies() {
   if ! command -v jq &>/dev/null; then
     echo "Missing jq command"
@@ -46,22 +85,15 @@ function verify_dependencies() {
 verify_dependencies
 
 # Set path to root of repo
-pushd "$(git rev-parse --show-toplevel)" >/dev/null || exit
-
-# Setup common curl arguments
-CURL_ARGS=(-L
-  --silent
-  -H "Accept: application/vnd.github+json"
-  -H "Authorization: Bearer ${GITHUB_TOKEN}"
-  -H "X-GitHub-Api-Version: 2022-11-28")
+pushd "$(git rev-parse --show-toplevel)" >/dev/null || exit 1
 
 # Set branch name to user provided value or default to the current active branch
 readonly BRANCH_NAME="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+echo "Checking for failed browser tests snapshots for branch: ${BRANCH_NAME}"
 
 # Get details on the failed run for the active branch
 readonly JOB_RUN_LIST_URL="https://api.github.com/repos/civiform/civiform/actions/runs?per_page=20&status=failure&branch=${BRANCH_NAME}"
-readonly JOB_RUN_LIST_JSON=$(curl "${CURL_ARGS[@]}" "${JOB_RUN_LIST_URL}")
-exit_on_curl_failure "$?" "${JOB_RUN_LIST_URL}"
+readonly JOB_RUN_LIST_JSON="$(get_json_or_exit_on_failure "${JOB_RUN_LIST_URL}")"
 
 # Determine the url for the artifacts endpoint
 readonly ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
@@ -74,8 +106,7 @@ readonly ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
 exit_on_jq_failure "$?" "${ARTIFACT_LIST_URL}" "Branch '${BRANCH_NAME}' doesn't appear to have any snapshots to download"
 
 # Determine the url for the artifact we want to download
-readonly ARTIFACT_LIST_JSON=$(curl "${CURL_ARGS[@]}" "${ARTIFACT_LIST_URL}")
-exit_on_curl_failure "$?" "${ARTIFACT_LIST_URL}"
+readonly ARTIFACT_LIST_JSON="$(get_json_or_exit_on_failure "${ARTIFACT_LIST_URL}")"
 
 readonly ARTIFACT_DOWNLOAD_URL="$(echo "${ARTIFACT_LIST_JSON}" | jq -r -c '
 .artifacts 
@@ -87,20 +118,22 @@ readonly ARTIFACT_DOWNLOAD_URL="$(echo "${ARTIFACT_LIST_JSON}" | jq -r -c '
 exit_on_jq_failure "$?" "${ARTIFACT_DOWNLOAD_URL}" "Unable to find artifact url"
 
 # Download the archive
-readonly ARTIFACT_FILE="snapshots.zip"
+readonly ARTIFACT_FILE="$(mktemp)"
 readonly SNAPSHOT_FOLDER="./browser-test/image_snapshots"
 
 curl "${CURL_ARGS[@]}" "${ARTIFACT_DOWNLOAD_URL}" --output "${ARTIFACT_FILE}"
 
-# Unzip and remove archive file
+# Unzip archive file
 unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
-rm "${ARTIFACT_FILE}"
 
 # Rename updated files removing the playwright "-received" suffix
-find "${SNAPSHOT_FOLDER}" -type f -name "*-received.png" -exec bash -c 'mv "$0" "${0/-received.png/.png}"' {} \;
+find "${SNAPSHOT_FOLDER}" \
+  -type f \
+  -name "*-received.png" \
+  -exec bash -c 'mv "$0" "${0/-received.png/.png}"' {} \;
 
 # Display changes files
-git diff --name-only "${SNAPSHOT_FOLDER}"
+git --no-pager diff --name-only "${SNAPSHOT_FOLDER}"
 
 #########
 echo

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -1,0 +1,108 @@
+#! /usr/bin/env bash
+
+# DOC: Sync failed github action browser-test snapshots with local system.
+
+function exit_on_jq_failure() {
+  local last_exit_code="${1}"
+  local value="${2}"
+  local message="${3}"
+
+  if [[ "${last_exit_code}" != "0" ]]; then
+    echo "jq command failed. ${message}"
+    exit 1
+  fi
+
+  if [[ "${value}" == "null" ]]; then
+    echo "${message}"
+    exit 1
+  fi
+}
+
+function exit_on_curl_failure() {
+  local last_exit_code="${1}"
+  local url="${2}"
+
+  if [[ "${last_exit_code}" != "0" ]]; then
+    echo "Curl failed trying to call ${url}"
+    exit 1
+  fi
+}
+
+function verify_dependencies() {
+  if ! command -v jq &>/dev/null; then
+    echo "Missing jq command"
+    echo "https://jqlang.github.io/jq"
+    exit 1
+  fi
+
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "You need a GitHub access token to download the archive."
+    echo "Set 'GITHUB_TOKEN' environment variable with the value"
+    echo "To create one go here: https://github.com/settings/tokens"
+    exit 1
+  fi
+}
+
+verify_dependencies
+
+# Set path to root of repo
+pushd "$(git rev-parse --show-toplevel)" >/dev/null || exit
+
+# Setup common curl arguments
+CURL_ARGS=(-L
+  --silent
+  -H "Accept: application/vnd.github+json"
+  -H "Authorization: Bearer ${GITHUB_TOKEN}"
+  -H "X-GitHub-Api-Version: 2022-11-28")
+
+# Set branch name to user provided value or default to the current active branch
+readonly BRANCH_NAME="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+
+# Get details on the failed run for the active branch
+readonly JOB_RUN_LIST_URL="https://api.github.com/repos/civiform/civiform/actions/runs?per_page=20&status=failure&branch=${BRANCH_NAME}"
+readonly JOB_RUN_LIST_JSON=$(curl "${CURL_ARGS[@]}" "${JOB_RUN_LIST_URL}")
+exit_on_curl_failure "$?" "${JOB_RUN_LIST_URL}"
+
+# Determine the url for the artifacts endpoint
+readonly ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
+.workflow_runs 
+| map(
+  select(.name == "Server - On PR to Main")
+  | .artifacts_url
+)[0]')"
+
+exit_on_jq_failure "$?" "${ARTIFACT_LIST_URL}" "Branch '${BRANCH_NAME}' doesn't appear to have any snapshots to download"
+
+# Determine the url for the artifact we want to download
+readonly ARTIFACT_LIST_JSON=$(curl "${CURL_ARGS[@]}" "${ARTIFACT_LIST_URL}")
+exit_on_curl_failure "$?" "${ARTIFACT_LIST_URL}"
+
+readonly ARTIFACT_DOWNLOAD_URL="$(echo "${ARTIFACT_LIST_JSON}" | jq -r -c '
+.artifacts 
+| map(
+  select(.name == "updated snapshots output directory" and .expired == false) 
+  | .archive_download_url
+)[0]')"
+
+exit_on_jq_failure "$?" "${ARTIFACT_DOWNLOAD_URL}" "Unable to find artifact url"
+
+# Download the archive
+readonly ARTIFACT_FILE="snapshots.zip"
+readonly SNAPSHOT_FOLDER="./browser-test/image_snapshots"
+
+curl "${CURL_ARGS[@]}" "${ARTIFACT_DOWNLOAD_URL}" --output "${ARTIFACT_FILE}"
+
+# Unzip and remove archive file
+unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
+rm "${ARTIFACT_FILE}"
+
+# Rename updated files removing the playwright "-received" suffix
+find "${SNAPSHOT_FOLDER}" -type f -name "*-received.png" -exec bash -c 'mv "$0" "${0/-received.png/.png}"' {} \;
+
+# Display changes files
+git diff --name-only "${SNAPSHOT_FOLDER}"
+
+#########
+echo
+echo "Done. Check if you need to commit new images"
+echo

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -1,8 +1,8 @@
 #! /usr/bin/env bash
 
 # DOC: Sync failed github action browser-test snapshots with local system.
-#      With no arguments this defaults to the current active branch or
-#      pass in the first argument to specify a branch name
+# DOC: With no arguments this defaults to the current active branch or
+# DOC: pass in the first argument to specify a branch name
 
 source bin/lib.sh
 

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -4,6 +4,8 @@
 #      With no arguments this defaults to the current active branch or
 #      pass in the first argument to specify a branch name
 
+source bin/lib.sh
+
 # Constants
 readonly CURL_ARGS=(-L
   --silent
@@ -83,9 +85,6 @@ function verify_dependencies() {
 }
 
 verify_dependencies
-
-# Set path to root of repo
-pushd "$(git rev-parse --show-toplevel)" >/dev/null || exit 1
 
 # Set branch name to user provided value or default to the current active branch
 readonly BRANCH_NAME="${1:-$(git rev-parse --abbrev-ref HEAD)}"


### PR DESCRIPTION
### Description

Script will determine your branch and attempt download an image snapshot artifact. If it finds the archive unzips, places the files where they should be, and removes the "-received" filename extension. From there it's up to the developer to decide to commit them or not.

#### Usage

Pull into the same branch **(preferred)**
```bash
git switch branch-name-that-failed
bin/sync-failed-browser-test-images
```

Pull into your current **active**. Good for testing another branch, but you have to do the work to get the images committed to the correct branch.
```bash
bin/sync-failed-browser-test-images branch-name-that-failed
```

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #4695
