### PR TITLE
Add program cache implementation behind flag

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions"]
 }
 
 ## Security rules for play-pac4j SecurityFilter

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -53,7 +53,6 @@ public class ProgramRepositoryTest extends ResetPostgres {
   private SyncCacheApi versionsByProgramCache;
   private SettingsManifest mockSettingsManifest;
 
-
   @Before
   public void setup() {
     versionRepo = instanceOf(VersionRepository.class);
@@ -61,12 +60,12 @@ public class ProgramRepositoryTest extends ResetPostgres {
     programCache = instanceOf(SyncCacheApi.class);
     versionsByProgramCache = instanceOf(SyncCacheApi.class);
     repo =
-      new ProgramRepository(
-        instanceOf(DatabaseExecutionContext.class),
-        Providers.of(versionRepo),
-        mockSettingsManifest,
-        programCache,
-        versionsByProgramCache);
+        new ProgramRepository(
+            instanceOf(DatabaseExecutionContext.class),
+            Providers.of(versionRepo),
+            mockSettingsManifest,
+            programCache,
+            versionsByProgramCache);
   }
 
   @Test

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.util.Providers;
 import io.ebean.DB;
 import io.ebean.DataIntegrityException;
 import java.time.Instant;
@@ -20,9 +21,12 @@ import models.Application;
 import models.ApplicationEvent;
 import models.DisplayMode;
 import models.Program;
+import models.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import play.cache.SyncCacheApi;
 import play.libs.F;
 import services.IdentifierBasedPaginationSpec;
 import services.LocalizedStrings;
@@ -36,6 +40,7 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramType;
 import services.program.StatusDefinitions;
 import services.question.QuestionAnswerer;
+import services.settings.SettingsManifest;
 import support.CfTestHelpers;
 import support.ProgramBuilder;
 
@@ -44,11 +49,24 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
   private ProgramRepository repo;
   private VersionRepository versionRepo;
+  private SyncCacheApi programCache;
+  private SyncCacheApi versionsByProgramCache;
+  private SettingsManifest mockSettingsManifest;
+
 
   @Before
   public void setup() {
-    repo = instanceOf(ProgramRepository.class);
     versionRepo = instanceOf(VersionRepository.class);
+    mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    programCache = instanceOf(SyncCacheApi.class);
+    versionsByProgramCache = instanceOf(SyncCacheApi.class);
+    repo =
+      new ProgramRepository(
+        instanceOf(DatabaseExecutionContext.class),
+        Providers.of(versionRepo),
+        mockSettingsManifest,
+        programCache,
+        versionsByProgramCache);
   }
 
   @Test
@@ -66,6 +84,21 @@ public class ProgramRepositoryTest extends ResetPostgres {
     Optional<Program> found = repo.lookupProgram(two.id).toCompletableFuture().join();
 
     assertThat(found).hasValue(two);
+  }
+
+  @Test
+  public void lookupProgram_usesCacheWhenEnabled() {
+    Mockito.when(mockSettingsManifest.getProgramCacheEnabled()).thenReturn(true);
+
+    resourceCreator.insertActiveProgram("one");
+    Program two = resourceCreator.insertActiveProgram("two");
+
+    assertThat(programCache.get(String.valueOf(two.id))).isEmpty();
+
+    Optional<Program> found = repo.lookupProgram(two.id).toCompletableFuture().join();
+
+    assertThat(found).hasValue(two);
+    assertThat(programCache.get(String.valueOf(two.id))).hasValue(found);
   }
 
   @Test
@@ -221,6 +254,25 @@ public class ProgramRepositoryTest extends ResetPostgres {
     ImmutableSet<String> result = repo.getAllProgramNames();
 
     assertThat(result).isEqualTo(ImmutableSet.of("old name", "new name"));
+  }
+
+  @Test
+  public void getVersionsForProgram() {
+    Program program = resourceCreator.insertActiveProgram("old name");
+
+    ImmutableList<Version> versions = repo.getVersionsForProgram(program);
+
+    assertThat(versions).hasSize(1);
+  }
+
+  @Test
+  public void getVersionsForProgram_usesCacheWhenEnabled() {
+    Mockito.when(mockSettingsManifest.getProgramCacheEnabled()).thenReturn(true);
+    Program program = resourceCreator.insertActiveProgram("old name");
+
+    ImmutableList<Version> versions = repo.getVersionsForProgram(program);
+
+    assertThat(versionsByProgramCache.get(String.valueOf(program.id)).get()).isEqualTo(versions);
   }
 
   @Test

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -41,6 +41,8 @@ public class VersionRepositoryTest extends ResetPostgres {
   private VersionRepository versionRepository;
   private SyncCacheApi questionsByVersionCache;
   private SyncCacheApi programsByVersionCache;
+  private SyncCacheApi programCache;
+  private SyncCacheApi versionsByProgramCache;
 
   private SettingsManifest mockSettingsManifest;
 
@@ -49,13 +51,17 @@ public class VersionRepositoryTest extends ResetPostgres {
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     questionsByVersionCache = instanceOf(SyncCacheApi.class);
     programsByVersionCache = instanceOf(SyncCacheApi.class);
+    programCache = instanceOf(SyncCacheApi.class);
+    versionsByProgramCache = instanceOf(SyncCacheApi.class);
     versionRepository =
         new VersionRepository(
             instanceOf(ProgramRepository.class),
             instanceOf(DatabaseExecutionContext.class),
             mockSettingsManifest,
             questionsByVersionCache,
-            programsByVersionCache);
+            programsByVersionCache,
+            programCache,
+            versionsByProgramCache);
   }
 
   @Test


### PR DESCRIPTION
### Description

This change adds caching for for data associated with programs, including versions and program data (gated behind a feature flag).

See [doc](https://docs.google.com/document/d/1COr52i3ouS-hGcVL4SqoDLYDdrCwir3rGKbkjE3Tfgw/edit) for more information.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)

### Issue(s) this completes

Fixes #5835
