### PR TITLE
Distinguish between admin and applicant profile creators

### DIFF
--- a/server/app/auth/IdentityProviderType.java
+++ b/server/app/auth/IdentityProviderType.java
@@ -1,0 +1,7 @@
+package auth;
+
+/** Enum that indicates the role of the identity provider. */
+public enum IdentityProviderType {
+  ADMIN_IDENTITY_PROVIDER,
+  APPLICANT_IDENTITY_PROVIDER;
+}

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -56,6 +56,9 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
   /** Create a totally new CiviForm profile informed by the provided OidcProfile. */
   public abstract CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile);
 
+  /** Returns true if the profile creator is for (global or program) admins. */
+  protected abstract boolean isAdminProfileCreator();
+
   protected final Optional<String> getEmail(OidcProfile oidcProfile) {
     final String emailAttributeName = emailAttributeName();
 

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -3,6 +3,7 @@ package auth.oidc;
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
 import auth.CiviFormProfileMerger;
+import auth.IdentityProviderType;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
 import auth.Role;
@@ -56,8 +57,8 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
   /** Create a totally new CiviForm profile informed by the provided OidcProfile. */
   public abstract CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile);
 
-  /** Returns true if the profile creator is for (global or program) admins. */
-  protected abstract boolean isAdminProfileCreator();
+  /** Returns the type of the identity provider used to create profiles. */
+  protected abstract IdentityProviderType identityProviderType();
 
   protected final Optional<String> getEmail(OidcProfile oidcProfile) {
     final String emailAttributeName = emailAttributeName();

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -69,4 +69,9 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
     }
     return profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin());
   }
+
+  @Override
+  protected boolean isAdminProfileCreator() {
+    return true;
+  }
 }

--- a/server/app/auth/oidc/admin/AdfsProfileCreator.java
+++ b/server/app/auth/oidc/admin/AdfsProfileCreator.java
@@ -1,6 +1,7 @@
 package auth.oidc.admin;
 
 import auth.CiviFormProfile;
+import auth.IdentityProviderType;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
 import auth.oidc.OidcClientProviderParams;
@@ -71,7 +72,7 @@ public class AdfsProfileCreator extends CiviformOidcProfileCreator {
   }
 
   @Override
-  protected boolean isAdminProfileCreator() {
-    return true;
+  protected IdentityProviderType identityProviderType() {
+    return IdentityProviderType.ADMIN_IDENTITY_PROVIDER;
   }
 }

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -77,4 +77,9 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
     }
     return profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin());
   }
+
+  @Override
+  protected boolean isAdminProfileCreator() {
+    return true;
+  }
 }

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -1,6 +1,7 @@
 package auth.oidc.admin;
 
 import auth.CiviFormProfile;
+import auth.IdentityProviderType;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
 import auth.oidc.OidcClientProviderParams;
@@ -79,7 +80,7 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
   }
 
   @Override
-  protected boolean isAdminProfileCreator() {
-    return true;
+  protected IdentityProviderType identityProviderType() {
+    return IdentityProviderType.ADMIN_IDENTITY_PROVIDER;
   }
 }

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -2,6 +2,7 @@ package auth.oidc.applicant;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
+import auth.IdentityProviderType;
 import auth.Role;
 import auth.oidc.CiviformOidcProfileCreator;
 import auth.oidc.OidcClientProviderParams;
@@ -120,7 +121,7 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
   }
 
   @Override
-  protected boolean isAdminProfileCreator() {
-    return false;
+  protected IdentityProviderType identityProviderType() {
+    return IdentityProviderType.APPLICANT_IDENTITY_PROVIDER;
   }
 }

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -118,4 +118,9 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
 
     return super.mergeCiviFormProfile(civiformProfile, oidcProfile);
   }
+
+  @Override
+  protected boolean isAdminProfileCreator() {
+    return false;
+  }
 }

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -75,4 +75,9 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
 
     assertThat(profileData.getRoles()).doesNotContain("ROLE_CIVIFORM_ADMIN");
   }
+
+  @Test
+  public void profileCreatorIsForAdmins() {
+    assertThat(genericOidcProfileCreator.isAdminProfileCreator()).isTrue();
+  }
 }

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -3,6 +3,7 @@ package auth.oidc.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.CiviFormProfileData;
+import auth.IdentityProviderType;
 import auth.ProfileFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
@@ -77,7 +78,8 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
   }
 
   @Test
-  public void profileCreatorIsForAdmins() {
-    assertThat(genericOidcProfileCreator.isAdminProfileCreator()).isTrue();
+  public void genericOidcProfileCreator_identityProviderTypeIsCorrect() {
+    assertThat(genericOidcProfileCreator.identityProviderType())
+        .isEqualTo(IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
   }
 }

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -3,6 +3,7 @@ package auth.oidc.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import auth.CiviFormProfileData;
+import auth.IdentityProviderType;
 import auth.ProfileFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.google.common.collect.ImmutableList;
@@ -80,7 +81,8 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
   }
 
   @Test
-  public void applicantProfileCreatorIsNotForAdmins() {
-    assertThat(oidcProfileAdapter.isAdminProfileCreator()).isFalse();
+  public void applicantProfileCreator_identityProviderTypeIsCorrect() {
+    assertThat(oidcProfileAdapter.identityProviderType())
+        .isEqualTo(IdentityProviderType.APPLICANT_IDENTITY_PROVIDER);
   }
 }

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -78,4 +78,9 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
     Locale l = applicantData.preferredLocale();
     assertThat(l).isEqualTo(Locale.ENGLISH);
   }
+
+  @Test
+  public void applicantProfileCreatorIsNotForAdmins() {
+    assertThat(oidcProfileAdapter.isAdminProfileCreator()).isFalse();
+  }
 }


### PR DESCRIPTION
### Description

Add a method that allows us to distinguish between admin and applicant profile creators.

Subsequent PRs will use this information during callback processing to check the appropriate feature flag for new logout processing.

I added test cases to existing test suites, but did not create any test suites just to test the new method.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Relates to #4359 