### PR TITLE
Use async version of cache API

### DIFF
--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -17,7 +17,7 @@ import models.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import play.cache.SyncCacheApi;
+import play.cache.AsyncCacheApi;
 import services.applicant.question.Scalar;
 import services.program.CantPublishProgramWithSharedQuestionsException;
 import services.program.EligibilityDefinition;
@@ -39,16 +39,16 @@ import support.ProgramBuilder;
 
 public class VersionRepositoryTest extends ResetPostgres {
   private VersionRepository versionRepository;
-  private SyncCacheApi questionsByVersionCache;
-  private SyncCacheApi programsByVersionCache;
+  private AsyncCacheApi questionsByVersionCache;
+  private AsyncCacheApi programsByVersionCache;
 
   private SettingsManifest mockSettingsManifest;
 
   @Before
   public void setupVersionRepository() {
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-    questionsByVersionCache = instanceOf(SyncCacheApi.class);
-    programsByVersionCache = instanceOf(SyncCacheApi.class);
+    questionsByVersionCache = instanceOf(AsyncCacheApi.class);
+    programsByVersionCache = instanceOf(AsyncCacheApi.class);
     versionRepository =
         new VersionRepository(
             instanceOf(ProgramRepository.class),
@@ -1004,7 +1004,8 @@ public class VersionRepositoryTest extends ResetPostgres {
     ImmutableList<Question> questionsForVersion =
         versionRepository.getQuestionsForVersion(version1);
 
-    assertThat(questionsByVersionCache.get(version1Key).get()).isEqualTo(questionsForVersion);
+    assertThat(questionsByVersionCache.sync().get(version1Key).get())
+        .isEqualTo(questionsForVersion);
   }
 
   @Test
@@ -1025,7 +1026,8 @@ public class VersionRepositoryTest extends ResetPostgres {
     ImmutableList<Question> questionsForVersion =
         versionRepository.getQuestionsForVersion(version1);
 
-    assertThat(questionsByVersionCache.get(version1Key).get()).isEqualTo(questionsForVersion);
+    assertThat(questionsByVersionCache.sync().get(version1Key).get())
+        .isEqualTo(questionsForVersion);
   }
 
   @Test
@@ -1039,11 +1041,11 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     String version1Key = String.valueOf(version1.id);
 
-    assertThat(questionsByVersionCache.get(version1Key).isPresent()).isFalse();
+    assertThat(questionsByVersionCache.sync().get(version1Key).isPresent()).isFalse();
 
     versionRepository.getQuestionsForVersion(version1);
 
-    assertThat(questionsByVersionCache.get(version1Key).isPresent()).isFalse();
+    assertThat(questionsByVersionCache.sync().get(version1Key).isPresent()).isFalse();
   }
 
   @Test
@@ -1065,7 +1067,7 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     ImmutableList<Program> programsForVersion = versionRepository.getProgramsForVersion(version1);
 
-    assertThat(programsByVersionCache.get(version1Key).get()).isEqualTo(programsForVersion);
+    assertThat(programsByVersionCache.sync().get(version1Key).get()).isEqualTo(programsForVersion);
   }
 
   @Test
@@ -1080,7 +1082,7 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     ImmutableList<Program> programsForVersion = versionRepository.getProgramsForVersion(version1);
 
-    assertThat(programsByVersionCache.get(version1Key).get()).isEqualTo(programsForVersion);
+    assertThat(programsByVersionCache.sync().get(version1Key).get()).isEqualTo(programsForVersion);
   }
 
   @Test
@@ -1092,10 +1094,10 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     String version1Key = String.valueOf(version1.id);
 
-    assertThat(programsByVersionCache.get(version1Key).isPresent()).isFalse();
+    assertThat(programsByVersionCache.sync().get(version1Key).isPresent()).isFalse();
 
     versionRepository.getProgramsForVersion(version1);
 
-    assertThat(programsByVersionCache.get(version1Key).isPresent()).isFalse();
+    assertThat(programsByVersionCache.sync().get(version1Key).isPresent()).isFalse();
   }
 }


### PR DESCRIPTION
### Description

Update from using SyncCacheApi to AsnycCacheApi. This is because we'd like to remove all cache data when the browser tests clear data and the SyncCacheApi doesn't let us do that. We can use sync() to use the AsyncCacheApi the same way in all other cases.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
