### PR TITLE
Enable program cache in browser tests

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -36,6 +36,8 @@ public class DevDatabaseSeedController extends Controller {
   private final SettingsManifest settingsManifest;
   private final AsyncCacheApi questionsByVersionCache;
   private final AsyncCacheApi programsByVersionCache;
+  private final AsyncCacheApi programCache;
+  private final AsyncCacheApi versionsByProgramCache;
 
   @Inject
   public DevDatabaseSeedController(
@@ -47,7 +49,9 @@ public class DevDatabaseSeedController extends Controller {
       DeploymentType deploymentType,
       SettingsManifest settingsManifest,
       @NamedCache("version-questions") AsyncCacheApi questionsByVersionCache,
-      @NamedCache("version-programs") AsyncCacheApi programsByVersionCache) {
+      @NamedCache("version-programs") AsyncCacheApi programsByVersionCache,
+      @NamedCache("program") AsyncCacheApi programCache,
+      @NamedCache("program-versions") AsyncCacheApi versionsByProgramCache) {
     this.devDatabaseSeedTask = checkNotNull(devDatabaseSeedTask);
     this.view = checkNotNull(view);
     this.database = DB.getDefault();
@@ -58,6 +62,8 @@ public class DevDatabaseSeedController extends Controller {
     this.settingsManifest = checkNotNull(settingsManifest);
     this.questionsByVersionCache = checkNotNull(questionsByVersionCache);
     this.programsByVersionCache = checkNotNull(programsByVersionCache);
+    this.programCache = checkNotNull(programCache);
+    this.versionsByProgramCache = checkNotNull(versionsByProgramCache);
   }
 
   /**
@@ -117,6 +123,8 @@ public class DevDatabaseSeedController extends Controller {
   private void clearCache() {
     programsByVersionCache.removeAll().toCompletableFuture().join();
     questionsByVersionCache.removeAll().toCompletableFuture().join();
+    programCache.removeAll().toCompletableFuture().join();
+    versionsByProgramCache.removeAll().toCompletableFuture().join();
   }
 
   // Create a date question definition with the given name and questionText. We currently create

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -96,8 +96,7 @@ public final class ProgramRepository {
   }
 
   public ImmutableList<Version> getVersionsForProgram(Program program) {
-    if (settingsManifest.getProgramCacheEnabled()
-        && !versionRepository.get().getDraftVersion().isPresent()) {
+    if (settingsManifest.getProgramCacheEnabled()) {
       return versionsByProgramCache.getOrElseUpdate(
           String.valueOf(program.id), () -> program.getVersions());
     }

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -70,6 +70,7 @@ public final class ProgramRepository {
   }
 
   public CompletionStage<Optional<Program>> lookupProgram(long id) {
+    // Use the cache if it is enabled and there isn't a draft version in progress.
     if (settingsManifest.getProgramCacheEnabled()
         && !versionRepository.get().getDraftVersion().isPresent()) {
       return supplyAsync(

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -145,7 +145,7 @@ public final class VersionRepository {
           .forEach(
               program -> {
                 draft.addProgram(program);
-                removeCacheForProgram(String.valueOf(program.id));
+                removeCacheForProgram(program.id);
               });
 
       // Associate any active questions that aren't present in the draft with the draft.
@@ -178,7 +178,7 @@ public final class VersionRepository {
               programToDelete -> {
                 draft.removeTombstoneForProgram(programToDelete);
                 draft.removeProgram(programToDelete);
-                removeCacheForProgram(String.valueOf(programToDelete.id));
+                removeCacheForProgram(programToDelete.id);
               });
 
       // Move forward the ACTIVE version.
@@ -259,7 +259,7 @@ public final class VersionRepository {
               program -> {
                 newDraft.addProgram(program);
                 existingDraft.removeProgram(program);
-                removeCacheForProgram(String.valueOf(program.id));
+                removeCacheForProgram(program.id);
               });
       getQuestionsForVersion(existingDraft).stream()
           .filter(
@@ -281,7 +281,7 @@ public final class VersionRepository {
           .forEach(
               program -> {
                 existingDraft.addProgram(program);
-                removeCacheForProgram(String.valueOf(program.id));
+                removeCacheForProgram(program.id);
               });
       getQuestionsForVersion(active).stream()
           .filter(
@@ -515,6 +515,10 @@ public final class VersionRepository {
       versionsByProgramCache.remove(programKey);
       programCache.remove(programKey);
     }
+  }
+
+  private void removeCacheForProgram(Long programId) {
+    removeCacheForProgram(String.valueOf(programId));
   }
 
   /**

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -181,6 +181,10 @@ public final class VersionRepository {
               programToDelete -> {
                 draft.removeTombstoneForProgram(programToDelete);
                 draft.removeProgram(programToDelete);
+                if (settingsManifest.getProgramCacheEnabled()) {
+                  versionsByProgramCache.remove(String.valueOf(programToDelete.id));
+                  programCache.remove(String.valueOf(programToDelete.id));
+                }
               });
 
       // Move forward the ACTIVE version.
@@ -261,6 +265,10 @@ public final class VersionRepository {
               program -> {
                 newDraft.addProgram(program);
                 existingDraft.removeProgram(program);
+                if (settingsManifest.getProgramCacheEnabled()) {
+                  versionsByProgramCache.remove(String.valueOf(program.id));
+                  programCache.remove(String.valueOf(program.id));
+                }
               });
       getQuestionsForVersion(existingDraft).stream()
           .filter(
@@ -279,7 +287,14 @@ public final class VersionRepository {
               activeProgram ->
                   !programToPublishAdminName.equals(
                       activeProgram.getProgramDefinition().adminName()))
-          .forEach(existingDraft::addProgram);
+          .forEach(
+              program -> {
+                existingDraft.addProgram(program);
+                if (settingsManifest.getProgramCacheEnabled()) {
+                  versionsByProgramCache.remove(String.valueOf(program.id));
+                  programCache.remove(String.valueOf(program.id));
+                }
+              });
       getQuestionsForVersion(active).stream()
           .filter(
               activeQuestion ->

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -145,10 +145,7 @@ public final class VersionRepository {
           .forEach(
               program -> {
                 draft.addProgram(program);
-                if (settingsManifest.getProgramCacheEnabled()) {
-                  versionsByProgramCache.remove(String.valueOf(program.id));
-                  programCache.remove(String.valueOf(program.id));
-                }
+                removeCacheForProgram(String.valueOf(program.id));
               });
 
       // Associate any active questions that aren't present in the draft with the draft.
@@ -181,10 +178,7 @@ public final class VersionRepository {
               programToDelete -> {
                 draft.removeTombstoneForProgram(programToDelete);
                 draft.removeProgram(programToDelete);
-                if (settingsManifest.getProgramCacheEnabled()) {
-                  versionsByProgramCache.remove(String.valueOf(programToDelete.id));
-                  programCache.remove(String.valueOf(programToDelete.id));
-                }
+                removeCacheForProgram(String.valueOf(programToDelete.id));
               });
 
       // Move forward the ACTIVE version.
@@ -265,10 +259,7 @@ public final class VersionRepository {
               program -> {
                 newDraft.addProgram(program);
                 existingDraft.removeProgram(program);
-                if (settingsManifest.getProgramCacheEnabled()) {
-                  versionsByProgramCache.remove(String.valueOf(program.id));
-                  programCache.remove(String.valueOf(program.id));
-                }
+                removeCacheForProgram(String.valueOf(program.id));
               });
       getQuestionsForVersion(existingDraft).stream()
           .filter(
@@ -290,10 +281,7 @@ public final class VersionRepository {
           .forEach(
               program -> {
                 existingDraft.addProgram(program);
-                if (settingsManifest.getProgramCacheEnabled()) {
-                  versionsByProgramCache.remove(String.valueOf(program.id));
-                  programCache.remove(String.valueOf(program.id));
-                }
+                removeCacheForProgram(String.valueOf(program.id));
               });
       getQuestionsForVersion(active).stream()
           .filter(
@@ -519,6 +507,13 @@ public final class VersionRepository {
     if (settingsManifest.getVersionCacheEnabled()) {
       questionsByVersionCache.remove(versionKey);
       programsByVersionCache.remove(versionKey);
+    }
+  }
+
+  private void removeCacheForProgram(String programKey) {
+    if (settingsManifest.getProgramCacheEnabled()) {
+      versionsByProgramCache.remove(programKey);
+      programCache.remove(programKey);
     }
   }
 

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -25,3 +25,4 @@ reporting_use_deterministic_stats = true
 api_generated_docs_enabled = true
 
 version_cache_enabled=true
+program_cache_enabled=true


### PR DESCRIPTION
### Description

Enable program cache in browser tests. When looking up the program, we check if there is a draft version and in that case we don't use the cache, so an incorrect version doesn't get loaded. In the future, we can further optimize this by either: 

1. Only looking up data from the cache if we're in the applicant flow and calling a separate function from the admin flow that doesn't use the cache if there is a draft version
2. Checking if the user is an admin when attempting to lookup a program and if so then check if there is a draft version and only use the cache if so, and if not always using the cache


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Related to #5845
