### PR TITLE
Always build prod with linux/amd64

### DIFF
--- a/bin/build-prod
+++ b/bin/build-prod
@@ -14,19 +14,6 @@ readonly LOCATION="."
 readonly DOCKERFILE="prod.Dockerfile"
 readonly HOST_CPU_ARCH="$(docker info --format='{{.Architecture}}')"
 
-if [[ "${HOST_CPU_ARCH}" != "x86_64" ]]; then
-  echo "----------------------------------------------------------------"
-  echo " WARNING"
-  echo "----------------------------------------------------------------"
-  echo " Detected ${HOST_CPU_ARCH} as host system cpu architecture."
-  echo " Currently only x86_64 is supported by our prod.Dockerfile."
-  echo ""
-  echo " For more info: https://github.com/civiform/civiform/issues/4785"
-  echo "----------------------------------------------------------------"
-  echo ""
-  exit 1
-fi
-
 echo "Building ${SNAPSHOT_TAG}..."
 
 BUILD_ARGS="-f ${DOCKERFILE}

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # For production images, use the adoptium.net official JRE & JDK docker images.
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11.0.20_8-jdk-alpine AS stage1
+FROM --platform=linux/amd64 eclipse-temurin:11.0.20_8-jdk-alpine AS stage1
 
 ENV SBT_VERSION "${SBT_VERSION:-1.8.2}"
 ENV INSTALL_DIR /usr/local
@@ -32,7 +32,7 @@ RUN cd "${PROJECT_LOC}" && \
 
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
-FROM eclipse-temurin:11.0.20_8-jre-alpine AS stage2
+FROM --platform=linux/amd64 eclipse-temurin:11.0.20_8-jre-alpine AS stage2
 COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.


### PR DESCRIPTION
As it turns out, we can build prod on M-series macs as long as we pass --platform=linux/amd64 in both stages. You can technically run it on macs too, though it won't run super well. It doesn't really work with the dev image, as compileIncremental gets all screwy trying to do its thing under emulation, so we should really only do this for prod images.