### PR TITLE
Adding some extra error trapping to aid in problem areas

### DIFF
--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -138,7 +138,7 @@ if (($? != 0)); then
   readonly FOUND_FILE="$(find "${ARTIFACT_FILE}" -type f -size -30720c)"
 
   if (($? != 0)); then
-    echo "The artifact file appears to not be set or another error cause 'find' to fail ${ARTIFACT_FILE}"
+    echo "The artifact file path appears to not be set or another error caused 'find' to fail ${ARTIFACT_FILE}"
     exit 1
   fi
 

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -3,8 +3,11 @@
 # DOC: Sync failed github action browser-test snapshots with local system.
 # DOC: With no arguments this defaults to the current active branch or
 # DOC: pass in the first argument to specify a branch name
-
 source bin/lib.sh
+
+# bin/lib.sh sets this to -e, but we want to trap errors to provided
+# users with better feedback
+set +e
 
 # Constants
 readonly CURL_ARGS=(-L
@@ -80,6 +83,7 @@ function verify_dependencies() {
     echo "You need a GitHub access token to download the archive."
     echo "Set 'GITHUB_TOKEN' environment variable with the value"
     echo "To create one go here: https://github.com/settings/tokens"
+    echo "You must have the actions scope to download artifacts."
     exit 1
   fi
 }
@@ -125,11 +129,39 @@ curl "${CURL_ARGS[@]}" "${ARTIFACT_DOWNLOAD_URL}" --output "${ARTIFACT_FILE}"
 # Unzip archive file
 unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
 
+# If there's an error unzipping the most common issue is permissions on the token
+# We'll attempt to print downloaded file as that often has the error message.
+if (($? != 0)); then
+  # This is looking to see if the zip file is 30k or smaller. This should be large enough
+  # for the error response, and also not spam the terminal if it somehow happens to be and
+  # large corrupt zip file.
+  readonly FOUND_FILE="$(find "${ARTIFACT_FILE}" -type f -size -30720c)"
+
+  if (($? != 0)); then
+    echo "The artifact file appears to not be set or another error cause 'find' to fail ${ARTIFACT_FILE}"
+    exit 1
+  fi
+
+  if [[ -z "${FOUND_FILE}" ]]; then
+    echo "Did not find a matching artifact file under 30k. Check this file manually ${ARTIFACT_FILE}"
+  fi
+  echo "Something is wrong with the artifact zip file."
+  echo "Here are the contents of the downloaded file."
+  echo
+  cat "${ARTIFACT_FILE}"
+  exit 1
+fi
+
 # Rename updated files removing the playwright "-received" suffix
 find "${SNAPSHOT_FOLDER}" \
   -type f \
   -name "*-received.png" \
   -exec bash -c 'mv "$0" "${0/-received.png/.png}"' {} \;
+
+if (($? != 0)); then
+  echo "Attempt to remove '-received' suffix from files failed."
+  exit 1
+fi
 
 # Display changes files
 git --no-pager diff --name-only "${SNAPSHOT_FOLDER}"

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -133,7 +133,7 @@ unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
 # We'll attempt to print downloaded file as that often has the error message.
 if (($? != 0)); then
   # This is looking to see if the zip file is 30k or smaller. This should be large enough
-  # for the error response, and also not spam the terminal if it somehow happens to be and
+  # for the error response, and also not spam the terminal if it somehow happens to be a
   # large corrupt zip file.
   readonly FOUND_FILE="$(find "${ARTIFACT_FILE}" -type f -size -30720c)"
 

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -5,7 +5,7 @@
 # DOC: pass in the first argument to specify a branch name
 source bin/lib.sh
 
-# bin/lib.sh sets this to -e, but we want to trap errors to provided
+# bin/lib.sh sets this to -e, but we want to trap errors to provide
 # users with better feedback
 set +e
 


### PR DESCRIPTION
### Description
- Provides info on what scope the GITHUB_TOKEN needs.
- Adds extra error handling to give more feed back on artifact download failures

