### PR TITLE
Adding optional namespace to image build scripts

### DIFF
--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -1,18 +1,23 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new docker image for running the browser tests and optionally push to Docker Hub if PUSH_IMAGE is set to anything.
+# DOC: Build a new docker image for running the browser tests
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="civiform-browser-test"
-LOCATION="browser-test/"
-DOCKERFILE="browser-test/playwright.Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="civiform-browser-test"
+readonly LOCATION="browser-test/"
+readonly DOCKERFILE="browser-test/playwright.Dockerfile"
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}:latest
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
-  ${LOCATION}"
+  "${LOCATION}")
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,20 +26,17 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
   echo "push ${IMAGE} build"
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -1,18 +1,23 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new development docker image and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new development docker image
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="civiform-dev"
-LOCATION="."
-DOCKERFILE="Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="civiform-dev"
+readonly LOCATION="."
+readonly DOCKERFILE="Dockerfile"
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}:latest
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
-  ${LOCATION}"
+  "${LOCATION}")
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,20 +26,17 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -1,18 +1,23 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new fake oidc docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new fake oidc docker image
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="oidc-provider"
-LOCATION="test-support/"
-DOCKERFILE="test-support/oidc.Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="oidc-provider"
+readonly LOCATION="test-support/"
+readonly DOCKERFILE="test-support/oidc.Dockerfile"
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}:latest
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
-  ${LOCATION}"
+  "${LOCATION}")
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,20 +26,17 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-dev-oidc
+++ b/bin/build-dev-oidc
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-formatter
+++ b/bin/build-formatter
@@ -1,16 +1,21 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new formatter docker image, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new formatter docker image
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="formatter"
-LOCATION="."
-DOCKERFILE="formatter/formatter.Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="formatter"
+readonly LOCATION="."
+readonly DOCKERFILE="formatter/formatter.Dockerfile"
 
 BUILD_ARGS=(-f "${DOCKERFILE}"
-  -t "civiform/${IMAGE}:latest"
-  --cache-from "civiform/${IMAGE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   "${LOCATION}")
 
@@ -33,4 +38,5 @@ if [[ "${PUSH_IMAGE}" ]]; then
   echo "push ${IMAGE} build"
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
-docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"
+
+docker tag "${NAMESPACE}/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-localstack-env
+++ b/bin/build-localstack-env
@@ -1,18 +1,23 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new docker image for running the localstack container and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new docker image for running the localstack container
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="civiform-localstack"
-LOCATION="localstack/"
-DOCKERFILE="localstack/localstack.Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="civiform-localstack"
+readonly LOCATION="localstack/"
+readonly DOCKERFILE="localstack/localstack.Dockerfile"
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}:latest
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
-  ${LOCATION}"
+  "${LOCATION}")
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -21,20 +26,17 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "${IMAGE}:latest"

--- a/bin/build-mock-web-services
+++ b/bin/build-mock-web-services
@@ -5,6 +5,7 @@
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-mock-web-services
+++ b/bin/build-mock-web-services
@@ -1,19 +1,24 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new docker image for running the mock web services container and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new docker image for running the mock web services container
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
-IMAGE="mock-web-services"
-LOCATION="mock-web-services/"
-DOCKERFILE="mock-web-services/mock-web-services.Dockerfile"
+readonly NAMESPACE="${NAMESPACE:=civiform}"
+readonly IMAGE="mock-web-services"
+readonly LOCATION="mock-web-services/"
+readonly DOCKERFILE="mock-web-services/mock-web-services.Dockerfile"
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}:latest
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   --build-context server=server/
-  ${LOCATION}"
+  "${LOCATION}")
 
 PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
@@ -22,20 +27,17 @@ fi
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS[@]}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "civiform-${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "${NAMESPACE}-${IMAGE}:latest"

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp, 
+# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp,
 # DOC: Builds for "linux/amd64" unless PLATFORM is set
 # DOC: Optional environment variables:
 # DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value. Default: no value
 # DOC:   NAMESPACE  - Overrides the default docker namespace of civiform: Default: civiform
 # DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8). Default: linux/amd64
+# DOC: Does not support pushing to alternate registries
 
 source bin/lib.sh
 

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -1,10 +1,16 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp, and optionally push to Docker Hub if PUSH_IMAGE is set to anything. Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Build a new production docker image, tagged with short commit SHA and unix seconds timestamp, 
+# DOC: Builds for "linux/amd64" unless PLATFORM is set
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value. Default: no value
+# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform: Default: civiform
+# DOC:   PLATFORM   - Platform architechture to build (e.g. linux/amd64, arm64v8). Default: linux/amd64
 
 source bin/lib.sh
 
 export DOCKER_BUILDKIT=1
+readonly NAMESPACE="${NAMESPACE:=civiform}"
 readonly SHORT_SHA="$(git rev-parse --short HEAD)"
 readonly GIT_SHA="$(git rev-parse HEAD)"
 readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
@@ -16,35 +22,32 @@ readonly HOST_CPU_ARCH="$(docker info --format='{{.Architecture}}')"
 
 echo "Building ${SNAPSHOT_TAG}..."
 
-BUILD_ARGS="-f ${DOCKERFILE}
-  -t civiform/${IMAGE}
-  -t civiform/${IMAGE}:latest
-  -t civiform/${IMAGE}:${SNAPSHOT_TAG}
-  --cache-from civiform/${IMAGE}
+BUILD_ARGS=(-f "${DOCKERFILE}"
+  -t "${NAMESPACE}/${IMAGE}"
+  -t "${NAMESPACE}/${IMAGE}:latest"
+  -t "${NAMESPACE}/${IMAGE}:${SNAPSHOT_TAG}"
+  --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
-  --build-arg git_commit_sha=${GIT_SHA}
-  --build-arg image_tag=${SNAPSHOT_TAG}
-  ${LOCATION}"
+  --build-arg git_commit_sha="${GIT_SHA}"
+  --build-arg image_tag="${SNAPSHOT_TAG}"
+  "${LOCATION}")
 
 readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified
 readonly PLATFORM_ARG=(--platform "${PLATFORM}")
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"
-cmd="docker buildx build ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-$cmd
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 
 # Load the image from the cache
 echo "load ${IMAGE} build"
-cmd="docker buildx build --load ${BUILD_ARGS}"
-$cmd
+docker buildx build --load "${BUILD_ARGS[@]}"
 
 if [[ "${PUSH_IMAGE}" ]]; then
   docker::do_dockerhub_login
   # Push the image from the cache to dockerhub
   echo "push ${IMAGE} build"
-  cmd="docker buildx build --push ${PLATFORM_ARG[@]} ${BUILD_ARGS}"
-  $cmd
+  docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "civiform/${IMAGE}:latest" "${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "${IMAGE}:latest"


### PR DESCRIPTION
### Description

Adds an optional namespace override for the docker image build scripts. Also adds more details to the docs comment.

This will simplify the instructions listed in https://github.com/civiform/civiform/wiki/Deploy-System-Developer-Guide#building-your-docker-image-locally

Currently does not support pushing to alternate registries due to the `docker login` in `lib/docker.sh` logging into default registry (docker.io).

Since it defaults to the original value existing usage in GitHub actions do not need to be modified.

#### Examples

`bin/build-dev` defaults to current value of "civiform" and would be `civiform/civiform-dev:latest`
`NAMESPACE=alt-namespace bin/build-dev` will use "alt-namespace" and would be `alt_namespace/civiform-dev:latest`

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Performed manual testing