### PR TITLE
Add short sha to images built for testing

### DIFF
--- a/bin/build-and-push-image-for-testing
+++ b/bin/build-and-push-image-for-testing
@@ -26,7 +26,8 @@ docker::do_dockerhub_login
 
 echo "Building ${IMAGE_TAG}..."
 
-readonly IMAGE_TAG="DEV-${DEV_BRANCH_NAME/\//-}"
+readonly SHORT_SHA="$(git rev-parse --short HEAD)"
+readonly IMAGE_TAG="DEV-${SHORT_SHA}-${DEV_BRANCH_NAME/\//-}"
 readonly GIT_SHA="$(git rev-parse HEAD)"
 export DOCKER_BUILDKIT=1
 


### PR DESCRIPTION
The deployment system needs to be able to resolve a specific commit from an image tag in order to generate configuration during the deployment. Adding the short SHA to images built for testing allows this to happen.

See https://github.com/civiform/cloud-deploy-infra/pull/269