### PR TITLE
Populate session id unconditionally

### DIFF
--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -3,46 +3,18 @@ package filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.fakeRequest;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.typesafe.config.ConfigFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
-import services.settings.SettingDescription;
-import services.settings.SettingMode;
-import services.settings.SettingType;
-import services.settings.SettingsManifest;
-import services.settings.SettingsSection;
 
 public class SessionIdFilterTest extends WithApplication {
 
-  private SettingsManifest createSettingsManifest(boolean adminOidcEnhancedLogoutEnabled) {
-    return new SettingsManifest(
-        ImmutableMap.of(
-            "section1",
-            SettingsSection.create(
-                "section1",
-                "description1",
-                ImmutableList.of(),
-                ImmutableList.of(
-                    SettingDescription.create(
-                        "ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED",
-                        "Enhanced OIDC Logout logic enabled for admin identity provider",
-                        false,
-                        SettingType.BOOLEAN,
-                        SettingMode.ADMIN_WRITEABLE)))),
-        ConfigFactory.parseMap(
-            ImmutableMap.of("admin_oidc_enhanced_logout_enabled", adminOidcEnhancedLogoutEnabled)));
-  }
-
   @Test
   public void testSessionIdIsCreatedForNonExcludedRoute() throws Exception {
-    SettingsManifest settingsManifest = createSettingsManifest(true);
-    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
+    SessionIdFilter filter = new SessionIdFilter(mat);
 
     // The request has no session id.
     Http.RequestBuilder request = fakeRequest();
@@ -61,32 +33,10 @@ public class SessionIdFilterTest extends WithApplication {
 
   @Test
   public void testSessionIdIsNotCreatedForExcludedRoute() throws Exception {
-    SettingsManifest settingsManifest = createSettingsManifest(true);
-    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
+    SessionIdFilter filter = new SessionIdFilter(mat);
 
     // The request is for an API route and has no session id.
     Http.RequestBuilder request = fakeRequest("GET", "/api/v1/admin");
-    assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
-
-    CompletionStage<Result> stage =
-        filter.apply(
-            header -> {
-              return CompletableFuture.completedFuture(play.mvc.Results.ok());
-            },
-            request.build());
-
-    Result result = stage.toCompletableFuture().get();
-    // The session has no session id. In fact, it has no session.
-    assertThat(result.session()).isNull();
-  }
-
-  @Test
-  public void testSessionIdIsNotCreatedWhenDisabled() throws Exception {
-    SettingsManifest settingsManifest = createSettingsManifest(false);
-    SessionIdFilter filter = new SessionIdFilter(mat, () -> settingsManifest);
-
-    // The request has no session id.
-    Http.RequestBuilder request = fakeRequest();
     assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
 
     CompletionStage<Result> stage =


### PR DESCRIPTION
### Description

Populate session id unconditionally, rather than only when certain feature flags are enabled.

This prevents error messages due to a startup race condition like:

`[warn] SettingsManifest - Settings not found on request when looking up value for ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED`

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Relates to #4359 
