### PR TITLE
Add additional data to database query metrics for prometheus 

### DIFF
--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -76,7 +76,8 @@ public final class MetricsController extends CiviFormController {
                 String className = metric.getType().toString().substring(CLASS_SUBSTRING_INDEX);
                 String location = metric.getLocation() != null ? metric.getLocation() : "";
                 // When we use JPA in the model to get the data, we often see incorrect information
-                // after the underscore. In these cases, we set the model class for the name and location.
+                // after the underscore. In these cases, we set the model class for the name and
+                // location.
                 // TODO(#5934) remove reliance on JPA for database queries
                 if (name.contains("_")) {
                   name = className;

--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -41,6 +41,10 @@ public final class MetricsController extends CiviFormController {
   // "orm.", which is why we use 4 as the start index.
   private static final int SUBSTRING_INDEX = 4;
 
+  // The start index we use for the metric substring. By default, the metric names start with
+  // "class ", which is why we use 6 as the start index.
+  private static final int CLASS_SUBSTRING_INDEX = 6;
+
   @Inject
   public MetricsController(
       Config config, ProfileUtils profileUtils, VersionRepository versionRepository) {
@@ -69,11 +73,29 @@ public final class MetricsController extends CiviFormController {
           .forEach(
               metric -> {
                 String name = metric.getName().substring(SUBSTRING_INDEX);
-                QUERY_METRIC_COUNT.labels(name).inc((double) metric.getCount());
-                QUERY_METRIC_MEAN_LATENCY.labels(name).inc((double) metric.getMean());
-                QUERY_METRIC_MAX_LATENCY.labels(name).inc((double) metric.getMax());
-                QUERY_METRIC_TOTAL_LATENCY.labels(name).inc((double) metric.getTotal());
+                String className = metric.getType().toString().substring(CLASS_SUBSTRING_INDEX);
+                String location = metric.getLocation() != null ? metric.getLocation() : "";
+                // When we use JPA in the model to get the data, we often see incorrect information
+                // after the underscore. In these cases, we set the model class for the name and location.
+                // TODO(#5934) remove reliance on JPA for database queries
+                if (name.contains("_")) {
+                  name = className;
+                  location = className;
+                }
+                QUERY_METRIC_COUNT
+                    .labels(name, location, className)
+                    .inc((double) metric.getCount());
+                QUERY_METRIC_MEAN_LATENCY
+                    .labels(name, location, className)
+                    .inc((double) metric.getMean());
+                QUERY_METRIC_MAX_LATENCY
+                    .labels(name, location, className)
+                    .inc((double) metric.getMax());
+                QUERY_METRIC_TOTAL_LATENCY
+                    .labels(name, location, className)
+                    .inc((double) metric.getTotal());
               });
+
       TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -88,28 +110,28 @@ public final class MetricsController extends CiviFormController {
         Counter.build()
             .name("ebean_queries_total")
             .help("Count of database queries")
-            .labelNames("name")
+            .labelNames("name", "location", "className")
             .register();
 
     QUERY_METRIC_MEAN_LATENCY =
         Counter.build()
             .name("ebean_queries_mean_latency_micros")
             .help("Mean latency of database queries in micros")
-            .labelNames("name")
+            .labelNames("name", "location", "className")
             .register();
 
     QUERY_METRIC_MAX_LATENCY =
         Counter.build()
             .name("ebean_queries_max_latency_micros")
             .help("Max latency of database queries in micros")
-            .labelNames("name")
+            .labelNames("name", "location", "className")
             .register();
 
     QUERY_METRIC_TOTAL_LATENCY =
         Counter.build()
             .name("ebean_queries_total_latency_micros")
             .help("Total latency of database queries in micros")
-            .labelNames("name")
+            .labelNames("name", "location", "className")
             .register();
   }
 }

--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -39,7 +39,7 @@ public final class MetricsController extends CiviFormController {
 
   // The start index we use for the metric substring. By default, the metric names start with
   // "orm.", which is why we use 4 as the start index.
-  private static final int SUBSTRING_INDEX = 4;
+  private static final int NAME_SUBSTRING_INDEX = 4;
 
   // The start index we use for the metric substring. By default, the metric names start with
   // "class ", which is why we use 6 as the start index.
@@ -72,7 +72,7 @@ public final class MetricsController extends CiviFormController {
           .getQueryMetrics()
           .forEach(
               metric -> {
-                String name = metric.getName().substring(SUBSTRING_INDEX);
+                String name = metric.getName().substring(NAME_SUBSTRING_INDEX);
                 String className = metric.getType().toString().substring(CLASS_SUBSTRING_INDEX);
                 String location = metric.getLocation() != null ? metric.getLocation() : "";
                 // When we use JPA in the model to get the data, we often see incorrect information

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -46,7 +46,8 @@ import services.settings.SettingsManifest;
  */
 public final class ProgramRepository {
   private static final Logger logger = LoggerFactory.getLogger(ProgramRepository.class);
-  private final QueryUtils queryUtils = new QueryUtils("ProgramRepository");
+  private static final QueryProfileLocationBuilder queryProfileLocationBuilder =
+      new QueryProfileLocationBuilder("ProgramRepository");
 
   private final Database database;
   private final DatabaseExecutionContext executionContext;
@@ -85,7 +86,7 @@ public final class ProgramRepository {
     return database
         .find(Program.class)
         .setLabel("Program.findById")
-        .setProfileLocation(queryUtils.createProfileLocation("lookupProgramSync"))
+        .setProfileLocation(queryProfileLocationBuilder.create("lookupProgramSync"))
         .where()
         .eq("id", id)
         .findOneOrEmpty();
@@ -234,7 +235,7 @@ public final class ProgramRepository {
         database
             .find(Account.class)
             .setLabel("Account.findList")
-            .setProfileLocation(queryUtils.createProfileLocation("getProgramAdministrators"))
+            .setProfileLocation(queryProfileLocationBuilder.create("getProgramAdministrators"))
             .where()
             .arrayContains("admin_of", programName)
             .findList());
@@ -246,7 +247,7 @@ public final class ProgramRepository {
         database
             .find(Program.class)
             .setLabel("Program.findById")
-            .setProfileLocation(queryUtils.createProfileLocation("getProgramAdministrators"))
+            .setProfileLocation(queryProfileLocationBuilder.create("getProgramAdministrators"))
             .setId(programId)
             .findOneOrEmpty();
     if (program.isEmpty()) {
@@ -260,7 +261,7 @@ public final class ProgramRepository {
         database
             .find(Program.class)
             .setLabel("Program.findById")
-            .setProfileLocation(queryUtils.createProfileLocation("getAllProgramVersions"))
+            .setProfileLocation(queryProfileLocationBuilder.create("getAllProgramVersions"))
             .select("name")
             .where()
             .eq("id", programId)
@@ -270,7 +271,7 @@ public final class ProgramRepository {
     return database
         .find(Program.class)
         .setLabel("Program.findList")
-        .setProfileLocation(queryUtils.createProfileLocation("getAllProgramVersions"))
+        .setProfileLocation(queryProfileLocationBuilder.create("getAllProgramVersions"))
         .where()
         .in("name", programNameQuery)
         .query()
@@ -298,7 +299,7 @@ public final class ProgramRepository {
             .find(Application.class)
             .setLabel("Application.findList")
             .setProfileLocation(
-                queryUtils.createProfileLocation("getApplicationsForAllProgramVersions"))
+                queryProfileLocationBuilder.create("getApplicationsForAllProgramVersions"))
             .fetch("program")
             .fetch("applicant")
             .orderBy("id desc")
@@ -378,7 +379,7 @@ public final class ProgramRepository {
             .find(Program.class)
             .select("name")
             .setLabel("Program.findByName")
-            .setProfileLocation(queryUtils.createProfileLocation("allProgramVersionsQuery"))
+            .setProfileLocation(queryProfileLocationBuilder.create("allProgramVersionsQuery"))
             .where()
             .eq("id", programId)
             .query();
@@ -387,7 +388,7 @@ public final class ProgramRepository {
         .find(Program.class)
         .select("id")
         .setLabel("Program.findById")
-        .setProfileLocation(queryUtils.createProfileLocation("allProgramVersionsQuery"))
+        .setProfileLocation(queryProfileLocationBuilder.create("allProgramVersionsQuery"))
         .where()
         .in("name", programNameQuery)
         .query();

--- a/server/app/repository/QueryProfileLocationBuilder.java
+++ b/server/app/repository/QueryProfileLocationBuilder.java
@@ -3,7 +3,7 @@ package repository;
 import io.ebean.ProfileLocation;
 
 /** Utility class for creating ProfileLocation objects. */
-public final class QueryUtils {
+public final class QueryProfileLocationBuilder {
   private final String fileName;
 
   /**
@@ -11,7 +11,7 @@ public final class QueryUtils {
    *
    * @param fileName The file name to be used in ProfileLocation.
    */
-  public QueryUtils(String fileName) {
+  public QueryProfileLocationBuilder(String fileName) {
     this.fileName = fileName;
   }
 
@@ -21,7 +21,7 @@ public final class QueryUtils {
    * @param functionName The name of the function.
    * @return ProfileLocation created using the provided file name and function name.
    */
-  ProfileLocation createProfileLocation(String functionName) {
+  ProfileLocation create(String functionName) {
     return ProfileLocation.createAt(fileName + "." + functionName);
   }
 }

--- a/server/app/repository/QueryUtils.java
+++ b/server/app/repository/QueryUtils.java
@@ -3,7 +3,7 @@ package repository;
 import io.ebean.ProfileLocation;
 
 /** Utility class for creating ProfileLocation objects. */
-public class QueryUtils {
+public final class QueryUtils {
   private final String fileName;
 
   /**

--- a/server/app/repository/QueryUtils.java
+++ b/server/app/repository/QueryUtils.java
@@ -1,0 +1,27 @@
+package repository;
+
+import io.ebean.ProfileLocation;
+
+/** Utility class for creating ProfileLocation objects. */
+public class QueryUtils {
+  private final String fileName;
+
+  /**
+   * Initializes the QueryUtils with a file name.
+   *
+   * @param fileName The file name to be used in ProfileLocation.
+   */
+  public QueryUtils(String fileName) {
+    this.fileName = fileName;
+  }
+
+  /**
+   * Create a ProfileLocation based on the provided function name.
+   *
+   * @param functionName The name of the function.
+   * @return ProfileLocation created using the provided file name and function name.
+   */
+  ProfileLocation createProfileLocation(String functionName) {
+    return ProfileLocation.createAt(fileName + "." + functionName);
+  }
+}

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -57,6 +57,7 @@ import services.settings.SettingsManifest;
 public final class VersionRepository {
 
   private static final Logger logger = LoggerFactory.getLogger(VersionRepository.class);
+  private final QueryUtils queryUtils = new QueryUtils("VersionRepository");
   private final Database database;
   private final ProgramRepository programRepository;
   private final DatabaseExecutionContext databaseExecutionContext;
@@ -332,6 +333,8 @@ public final class VersionRepository {
         .find(Version.class)
         .where()
         .eq("lifecycle_stage", LifecycleStage.DRAFT)
+        .setLabel("Version.findDraft")
+        .setProfileLocation(queryUtils.createProfileLocation("getDraftVersion"))
         .findOneOrEmpty();
   }
 
@@ -362,6 +365,8 @@ public final class VersionRepository {
           .forUpdate()
           .where()
           .eq("lifecycle_stage", LifecycleStage.DRAFT)
+          .setLabel("Version.findDraft")
+          .setProfileLocation(queryUtils.createProfileLocation("getDraftVersionOrCreate"))
           .findOne();
       transaction.commit();
       return newDraftVersion;
@@ -386,6 +391,8 @@ public final class VersionRepository {
         .find(Version.class)
         .where()
         .eq("lifecycle_stage", LifecycleStage.ACTIVE)
+        .setLabel("Version.findActive")
+        .setProfileLocation(queryUtils.createProfileLocation("getActiveVersion"))
         .findOne();
   }
 
@@ -406,6 +413,8 @@ public final class VersionRepository {
             .orderBy()
             .desc("id")
             .setMaxRows(1)
+            .setLabel("Version.findPrevious")
+            .setProfileLocation(queryUtils.createProfileLocation("getPreviousVersion"))
             .findOne();
 
     return Optional.ofNullable(previousVersion);
@@ -527,7 +536,13 @@ public final class VersionRepository {
    */
   public Optional<Question> getLatestVersionOfQuestion(long questionId) {
     String questionName =
-        database.find(Question.class).setId(questionId).select("name").findSingleAttribute();
+        database
+            .find(Question.class)
+            .setId(questionId)
+            .select("name")
+            .setLabel("Question.findLatest")
+            .setProfileLocation(queryUtils.createProfileLocation("getLatestVersionOfQuestion"))
+            .findSingleAttribute();
     Optional<Question> draftQuestion =
         getQuestionsForVersion(getDraftVersionOrCreate()).stream()
             .filter(question -> question.getQuestionDefinition().getName().equals(questionName))

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -57,7 +57,8 @@ import services.settings.SettingsManifest;
 public final class VersionRepository {
 
   private static final Logger logger = LoggerFactory.getLogger(VersionRepository.class);
-  private final QueryUtils queryUtils = new QueryUtils("VersionRepository");
+  private static final QueryProfileLocationBuilder profileLocationBuilder =
+      new QueryProfileLocationBuilder("VersionRepository");
   private final Database database;
   private final ProgramRepository programRepository;
   private final DatabaseExecutionContext databaseExecutionContext;
@@ -334,7 +335,7 @@ public final class VersionRepository {
         .where()
         .eq("lifecycle_stage", LifecycleStage.DRAFT)
         .setLabel("Version.findDraft")
-        .setProfileLocation(queryUtils.createProfileLocation("getDraftVersion"))
+        .setProfileLocation(profileLocationBuilder.create("getDraftVersion"))
         .findOneOrEmpty();
   }
 
@@ -366,7 +367,7 @@ public final class VersionRepository {
           .where()
           .eq("lifecycle_stage", LifecycleStage.DRAFT)
           .setLabel("Version.findDraft")
-          .setProfileLocation(queryUtils.createProfileLocation("getDraftVersionOrCreate"))
+          .setProfileLocation(profileLocationBuilder.create("getDraftVersionOrCreate"))
           .findOne();
       transaction.commit();
       return newDraftVersion;
@@ -392,7 +393,7 @@ public final class VersionRepository {
         .where()
         .eq("lifecycle_stage", LifecycleStage.ACTIVE)
         .setLabel("Version.findActive")
-        .setProfileLocation(queryUtils.createProfileLocation("getActiveVersion"))
+        .setProfileLocation(profileLocationBuilder.create("getActiveVersion"))
         .findOne();
   }
 
@@ -414,7 +415,7 @@ public final class VersionRepository {
             .desc("id")
             .setMaxRows(1)
             .setLabel("Version.findPrevious")
-            .setProfileLocation(queryUtils.createProfileLocation("getPreviousVersion"))
+            .setProfileLocation(profileLocationBuilder.create("getPreviousVersion"))
             .findOne();
 
     return Optional.ofNullable(previousVersion);
@@ -541,7 +542,7 @@ public final class VersionRepository {
             .setId(questionId)
             .select("name")
             .setLabel("Question.findLatest")
-            .setProfileLocation(queryUtils.createProfileLocation("getLatestVersionOfQuestion"))
+            .setProfileLocation(profileLocationBuilder.create("getLatestVersionOfQuestion"))
             .findSingleAttribute();
     Optional<Question> draftQuestion =
         getQuestionsForVersion(getDraftVersionOrCreate()).stream()

--- a/server/test/controllers/monitoring/MetricsControllerTest.java
+++ b/server/test/controllers/monitoring/MetricsControllerTest.java
@@ -25,6 +25,7 @@ public class MetricsControllerTest extends WithMockedProfiles {
   public void setUp() {
     resetDatabase();
     CollectorRegistry.defaultRegistry.clear();
+    // TODO(#5933) initializing counters causes the test to fail in bin/sbt-test
     MetricsController.initializeCounters();
   }
 
@@ -59,9 +60,11 @@ public class MetricsControllerTest extends WithMockedProfiles {
     assertThat(metricsContent).contains("ebean_queries_mean_latency_micros");
     assertThat(metricsContent).contains("ebean_queries_max_latency_micros");
     assertThat(metricsContent).contains("ebean_queries_total_latency_micros");
-    assertThat(metricsContent).contains(getEbeanCountName("Program.findList"));
-    assertThat(metricsContent).contains(getEbeanCountName("Question.findList"));
+    assertThat(metricsContent).contains(getEbeanCountName("models.Program"));
+    assertThat(metricsContent).contains(getEbeanCountName("models.Question"));
     assertThat(metricsContent).contains(getEbeanCountName("Version.byId"));
+    assertThat(metricsContent).contains("location=\"VersionRepository.getActiveVersion");
+    assertThat(metricsContent).contains("className=\"models.Version");
   }
 
   @Test
@@ -78,6 +81,6 @@ public class MetricsControllerTest extends WithMockedProfiles {
   }
 
   private String getEbeanCountName(String queryName) {
-    return String.format("ebean_queries_total{name=\"%s\",}", queryName);
+    return String.format("ebean_queries_total{name=\"%s", queryName);
   }
 }


### PR DESCRIPTION
### Description

Add a profile location and class name to our database query metrics, so we can better see which queries are still being executed to analyze the benefit of the cache and how we can further optimize it.

This adds this data specifically to the VersionRepository and ProgramRepository class, but we will extend this to other repository files in the future. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary (will do as a follow up once this is in production)

### Issue(s) this completes

Fixes #5958
