### PR TITLE
A11y: add the word "error" to validation messages

### DIFF
--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -18,8 +18,8 @@ header.endSession=End session
 toast.sessionEnded=Your session has ended.
 header.guestIndicator=You''re a guest user.
 header.userName=Logged in as {0}
-validation.isRequired=This question is required.
-validation.invalidInput=Please enter valid input.
+validation.isRequired=Error: this question is required.
+validation.invalidInput=Error: please enter valid input.
 validation.errorAnnouncementSr=There are errors in the form. Please fix before continuing.
 content.requiredFieldsAnnotation=Note: Fields marked with a * are required.
 content.requiredFieldsNote=Note: Fields marked with a {0} are required.
@@ -225,8 +225,8 @@ validation.dateMisformatted=Please enter a date in the format YYYY/MM/DD.
 button.addEntity=Add {0}
 button.removeEntity=Remove {0}
 dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
-validation.entityNameRequired=Please enter a value for each line.
-validation.duplicateEntityName=Please enter a unique value for each line.
+validation.entityNameRequired=Error: please enter a value for each line.
+validation.duplicateEntityName=Error: please enter a unique value for each line.
 placeholder.entityName={0} name
 
 #---------------------------------------------------------------------------------#
@@ -263,8 +263,8 @@ placeholder.firstName=First name
 placeholder.lastName=Last name
 placeholder.middleName=Middle name
 
-validation.firstNameRequired=Please enter your first name.
-validation.lastNameRequired=Please enter your last name.
+validation.firstNameRequired=Error: please enter your first name.
+validation.lastNameRequired=Error: please enter your last name.
 
 #------------------------------------------------------------------------#
 # NUMBER QUESTION - text specific to answering a question with a number. #


### PR DESCRIPTION
### Description

This PR adds the word "error" before form validation messages for applicants.

See associated issue: https://github.com/civiform/civiform/issues/5533

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method

### Issue(s) this completes

Fixes [5484](https://github.com/civiform/civiform/issues/5484)