### PR TITLE
Remove applicant id from URLs for index action

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -294,7 +294,7 @@ export const logout = async (page: Page, closeToast = true) => {
   // page with civiform js where we should waitForPageJsLoad. Because
   // the process goes through a sequence of redirects we need to wait
   // for the final destination URL (the programs index page), to make tests reliable.
-  await page.waitForURL('**/applicants/**')
+  await page.waitForURL('**/programs')
   await validateToastMessage(page, 'Your session has ended.')
   if (closeToast) await dismissToast(page)
 }
@@ -383,7 +383,7 @@ async function loginAsTestUserAwsStaging(
   await page.fill('input[name=username]', TEST_USER_LOGIN)
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await Promise.all([
-    page.waitForURL(isTi ? '**/admin/**' : '**/applicants/**', {
+    page.waitForURL(isTi ? '**/admin/**' : '/programs', {
       waitUntil: 'networkidle',
     }),
     // Auth0 has an additional hidden "Continue" button that does nothing for some reason
@@ -425,7 +425,7 @@ async function loginAsTestUserFakeOidc(
   // A screen is shown prompting the user to authorize a set of scopes.
   // This screen is skipped if the user has already logged in once.
   await Promise.all([
-    page.waitForURL(isTi ? '**/admin/**' : '**/applicants/**', {
+    page.waitForURL(isTi ? '**/admin/**' : /\/programs.*/, {
       waitUntil: 'networkidle',
     }),
     page.click('button:has-text("Continue")'),

--- a/server/app/auth/CiviFormProfileData.java
+++ b/server/app/auth/CiviFormProfileData.java
@@ -1,6 +1,5 @@
 package auth;
 
-import static auth.ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
@@ -84,17 +83,5 @@ public class CiviFormProfileData extends CommonProfile {
             },
             dbContext)
         .join();
-  }
-
-  /**
-   * Stores applicant id in user profile.
-   *
-   * <p>This allows us to know the applicant id instead of having to specify it in the URL path, or
-   * looking up the account each time and finding the corresponding applicant id.
-   */
-  public void populateApplicantId(AccountModel account) {
-    // Accounts correspond to a single applicant.
-    Long applicantId = account.ownedApplicantIds().stream().findAny().orElseThrow();
-    addAttribute(APPLICANT_ID_ATTRIBUTE_NAME, applicantId);
   }
 }

--- a/server/app/auth/CiviFormProfileData.java
+++ b/server/app/auth/CiviFormProfileData.java
@@ -1,5 +1,6 @@
 package auth;
 
+import static auth.ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
@@ -83,5 +84,17 @@ public class CiviFormProfileData extends CommonProfile {
             },
             dbContext)
         .join();
+  }
+
+  /**
+   * Stores applicant id in user profile.
+   *
+   * <p>This allows us to know the applicant id instead of having to specify it in the URL path, or
+   * looking up the account each time and finding the corresponding applicant id.
+   */
+  public void populateApplicantId(AccountModel account) {
+    // Accounts correspond to a single applicant.
+    Long applicantId = account.ownedApplicantIds().stream().findAny().orElseThrow();
+    addAttribute(APPLICANT_ID_ATTRIBUTE_NAME, applicantId);
   }
 }

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -1,5 +1,6 @@
 package auth;
 
+import auth.controllers.MissingOptionalException;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import javax.inject.Provider;
@@ -84,7 +85,12 @@ public final class CiviFormProfileMerger {
       // Ideally, the applicant id would already be populated in `guestProfile`. However, there
       // could be profiles in user sessions that were created before we started populating this
       // info.
-      guestProfile.orElseThrow().storeApplicantIdInProfile(applicantInDatabase.orElseThrow().id);
+      guestProfile
+          .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class))
+          .storeApplicantIdInProfile(
+              applicantInDatabase.orElseThrow(
+                      () -> new MissingOptionalException(ApplicantModel.class))
+                  .id);
     }
     return guestProfile;
   }

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -81,8 +81,20 @@ public final class CiviFormProfileMerger {
         // Merge the two applicants and prefer the newer one.
         guestProfile = Optional.of(mergeProfiles(applicantInDatabase.get(), guestProfile.get()));
       }
+      // Ideally, the applicant id would already be populated in `guestProfile`. However, there
+      // could be profiles in user sessions that were created before we started populating this
+      // info.
+      storeApplicantIdInProfile(guestProfile.orElseThrow(), applicantInDatabase.orElseThrow());
     }
     return guestProfile;
+  }
+
+  private void storeApplicantIdInProfile(CiviFormProfile profile, ApplicantModel applicant) {
+    if (!profile.getProfileData().containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
+      profile
+          .getProfileData()
+          .addAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, applicant.id);
+    }
   }
 
   private CiviFormProfile mergeProfiles(

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -84,17 +84,9 @@ public final class CiviFormProfileMerger {
       // Ideally, the applicant id would already be populated in `guestProfile`. However, there
       // could be profiles in user sessions that were created before we started populating this
       // info.
-      storeApplicantIdInProfile(guestProfile.orElseThrow(), applicantInDatabase.orElseThrow());
+      guestProfile.orElseThrow().storeApplicantIdInProfile(applicantInDatabase.orElseThrow().id);
     }
     return guestProfile;
-  }
-
-  private void storeApplicantIdInProfile(CiviFormProfile profile, ApplicantModel applicant) {
-    if (!profile.getProfileData().containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
-      profile
-          .getProfileData()
-          .addAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, applicant.id);
-    }
   }
 
   private CiviFormProfile mergeProfiles(

--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -52,14 +52,14 @@ public final class ProfileFactory {
   public CiviFormProfileData createNewApplicant() {
     CiviFormProfileData profileData = create(new Role[] {Role.ROLE_APPLICANT});
 
-    // Store the applicant id in the profile.
-    //
-    // The profile ID corresponds to the *account* id, but controllers need the applicant id. We
-    // store it in the profile for easy retrieval without a db lookup.
-    wrapProfileData(profileData)
-        .getAccount()
-        .thenAccept(account -> profileData.populateApplicantId(account))
-        .join();
+    if (settingsManifest.getNewApplicantUrlSchemaEnabled()) {
+      // Store the applicant id in the profile.
+      //
+      // The profile ID corresponds to the *account* id, but controllers need the applicant id. We
+      // store it in the profile for easy retrieval without a db lookup.
+      CiviFormProfile profile = wrapProfileData(profileData);
+      profile.getAccount().thenAccept(account -> profile.storeApplicantIdInProfile(account)).join();
+    }
 
     return profileData;
   }
@@ -121,7 +121,7 @@ public final class ProfileFactory {
   public CiviFormProfile wrap(ApplicantModel applicant) {
     CiviFormProfileData profileData = new CiviFormProfileData(applicant.getAccount().id);
     CiviFormProfile profile = wrapProfileData(profileData);
-    profile.getAccount().thenAccept(account -> profileData.populateApplicantId(account)).join();
+    profile.getAccount().thenAccept(account -> profile.storeApplicantIdInProfile(account)).join();
     return profile;
   }
 

--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -25,11 +25,12 @@ import services.settings.SettingsManifest;
 public final class ProfileFactory {
 
   public static final String FAKE_ADMIN_AUTHORITY_ID = "fake-admin";
+  public static final String APPLICANT_ID_ATTRIBUTE_NAME = "applicant_id";
   private final DatabaseExecutionContext dbContext;
   private final HttpExecutionContext httpContext;
   private final Provider<VersionRepository> versionRepositoryProvider;
   private final Provider<ApiKeyService> apiKeyService;
-  private final Provider<AccountRepository> userRepositoryProvider;
+  private final Provider<AccountRepository> accountRepositoryProvider;
   private final SettingsManifest settingsManifest;
 
   @Inject
@@ -38,18 +39,29 @@ public final class ProfileFactory {
       HttpExecutionContext httpContext,
       Provider<VersionRepository> versionRepositoryProvider,
       Provider<ApiKeyService> apiKeyService,
-      Provider<AccountRepository> userRepositoryProvider,
+      Provider<AccountRepository> accountRepositoryProvider,
       SettingsManifest settingsManifest) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
     this.versionRepositoryProvider = Preconditions.checkNotNull(versionRepositoryProvider);
     this.apiKeyService = Preconditions.checkNotNull(apiKeyService);
-    this.userRepositoryProvider = Preconditions.checkNotNull(userRepositoryProvider);
+    this.accountRepositoryProvider = Preconditions.checkNotNull(accountRepositoryProvider);
     this.settingsManifest = Preconditions.checkNotNull(settingsManifest);
   }
 
   public CiviFormProfileData createNewApplicant() {
-    return create(new Role[] {Role.ROLE_APPLICANT});
+    CiviFormProfileData profileData = create(new Role[] {Role.ROLE_APPLICANT});
+
+    // Store the applicant id in the profile.
+    //
+    // The profile ID corresponds to the *account* id, but controllers need the applicant id. We
+    // store it in the profile for easy retrieval without a db lookup.
+    wrapProfileData(profileData)
+        .getAccount()
+        .thenAccept(account -> profileData.populateApplicantId(account))
+        .join();
+
+    return profileData;
   }
 
   public CiviFormProfileData createNewAdmin() {
@@ -77,7 +89,8 @@ public final class ProfileFactory {
   }
 
   public CiviFormProfile wrapProfileData(CiviFormProfileData p) {
-    return new CiviFormProfile(dbContext, httpContext, p, settingsManifest);
+    return new CiviFormProfile(
+        dbContext, httpContext, p, settingsManifest, accountRepositoryProvider.get());
   }
 
   /**
@@ -106,7 +119,10 @@ public final class ProfileFactory {
   }
 
   public CiviFormProfile wrap(ApplicantModel applicant) {
-    return wrapProfileData(new CiviFormProfileData(applicant.getAccount().id));
+    CiviFormProfileData profileData = new CiviFormProfileData(applicant.getAccount().id);
+    CiviFormProfile profile = wrapProfileData(profileData);
+    profile.getAccount().thenAccept(account -> profileData.populateApplicantId(account)).join();
+    return profile;
   }
 
   public CiviFormProfileData createNewProgramAdmin() {
@@ -162,7 +178,7 @@ public final class ProfileFactory {
 
   /** This creates a trusted intermediary. */
   public CiviFormProfileData createFakeTrustedIntermediary() {
-    AccountRepository accountRepository = userRepositoryProvider.get();
+    AccountRepository accountRepository = accountRepositoryProvider.get();
     List<TrustedIntermediaryGroupModel> existingGroups =
         accountRepository.listTrustedIntermediaryGroups();
     TrustedIntermediaryGroupModel group;

--- a/server/app/auth/controllers/MissingOptionalException.java
+++ b/server/app/auth/controllers/MissingOptionalException.java
@@ -1,0 +1,8 @@
+package auth.controllers;
+
+/** Exception that represents a missing Optional value. */
+public final class MissingOptionalException extends RuntimeException {
+  public <T> MissingOptionalException(Class<T> clazz) {
+    super(String.format("Required %s is missing", clazz.getName()));
+  }
+}

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -2,9 +2,11 @@ package controllers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -73,7 +75,10 @@ public class CiviFormController extends Controller {
   /** Retrieves the applicant id from the user profile, if present. */
   protected Optional<Long> getApplicantId(Http.Request request) {
     CiviFormProfileData profileData =
-        profileUtils.currentUserProfile(request).orElseThrow().getProfileData();
+        profileUtils
+            .currentUserProfile(request)
+            .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class))
+            .getProfileData();
 
     if (profileData == null) {
       return Optional.empty();

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -2,8 +2,11 @@ package controllers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -65,5 +68,18 @@ public class CiviFormController extends Controller {
                 throw new SecurityException();
               }
             });
+  }
+
+  /** Retrieves the applicant id from the user profile, if present. */
+  protected Optional<Long> getApplicantId(Http.Request request) {
+    CiviFormProfileData profileData =
+        profileUtils.currentUserProfile(request).orElseThrow().getProfileData();
+
+    if (profileData == null) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(
+        profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class));
   }
 }

--- a/server/app/controllers/HomeController.java
+++ b/server/app/controllers/HomeController.java
@@ -7,6 +7,7 @@ import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
+import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -27,6 +28,7 @@ public class HomeController extends Controller {
   private final HttpExecutionContext httpExecutionContext;
   private final Optional<String> faviconURL;
   private final LanguageUtils languageUtils;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public HomeController(
@@ -34,12 +36,14 @@ public class HomeController extends Controller {
       ProfileUtils profileUtils,
       MessagesApi messagesApi,
       HttpExecutionContext httpExecutionContext,
-      LanguageUtils languageUtils) {
+      LanguageUtils languageUtils,
+      ApplicantRoutes applicantRoutes) {
     checkNotNull(configuration);
     this.profileUtils = checkNotNull(profileUtils);
     this.messagesApi = checkNotNull(messagesApi);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
     this.languageUtils = checkNotNull(languageUtils);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
     this.faviconURL =
         Optional.ofNullable(Strings.emptyToNull(configuration.getString("favicon_url")));
   }
@@ -79,9 +83,7 @@ public class HomeController extends Controller {
                 // If the applicant has not yet set their preferred language, redirect to
                 // the information controller to ask for preferred language.
                 if (data.hasPreferredLocale()) {
-                  return redirect(
-                          controllers.applicant.routes.ApplicantProgramsController.index(
-                              applicant.id))
+                  return redirect(applicantRoutes.index(profile, applicant.id))
                       .withLang(data.preferredLocale(), messagesApi);
                 } else {
                   return redirect(

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -3,6 +3,7 @@ package controllers.applicant;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import controllers.CiviFormController;
 import forms.ApplicantInformationForm;
@@ -39,6 +40,7 @@ public final class ApplicantInformationController extends CiviFormController {
   private final AccountRepository repository;
   private final FormFactory formFactory;
   private final ApplicantLayout layout;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ApplicantInformationController(
@@ -48,13 +50,15 @@ public final class ApplicantInformationController extends CiviFormController {
       FormFactory formFactory,
       ProfileUtils profileUtils,
       ApplicantLayout layout,
-      VersionRepository versionRepository) {
+      VersionRepository versionRepository,
+      ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
     this.httpExecutionContext = httpExecutionContext;
     this.messagesApi = messagesApi;
     this.repository = repository;
     this.formFactory = formFactory;
     this.layout = layout;
+    this.applicantRoutes = applicantRoutes;
   }
 
   /**
@@ -90,7 +94,8 @@ public final class ApplicantInformationController extends CiviFormController {
                             /* page= */ Optional.of(1))
                         .url();
               } else {
-                redirectLink = routes.ApplicantProgramsController.index(applicantId).url();
+                CiviFormProfile profile = profileUtils.currentUserProfile(request).orElseThrow();
+                redirectLink = applicantRoutes.index(profile, applicantId).url();
               }
 
               return redirect(redirectLink)
@@ -129,9 +134,10 @@ public final class ApplicantInformationController extends CiviFormController {
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
     String redirectLocation;
     Session session;
+    CiviFormProfile profile = profileUtils.currentUserProfile(request).orElseThrow();
 
     if (infoForm.getRedirectLink().isEmpty()) {
-      redirectLocation = routes.ApplicantProgramsController.index(applicantId).url();
+      redirectLocation = applicantRoutes.index(profile, applicantId).url();
       session = request.session();
     } else {
       redirectLocation = infoForm.getRedirectLink();

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -1,10 +1,12 @@
 package controllers.applicant;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import controllers.CiviFormController;
 import forms.ApplicantInformationForm;
 import java.util.Locale;
@@ -53,12 +55,12 @@ public final class ApplicantInformationController extends CiviFormController {
       VersionRepository versionRepository,
       ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
-    this.httpExecutionContext = httpExecutionContext;
-    this.messagesApi = messagesApi;
-    this.repository = repository;
-    this.formFactory = formFactory;
-    this.layout = layout;
-    this.applicantRoutes = applicantRoutes;
+    this.httpExecutionContext = checkNotNull(httpExecutionContext);
+    this.messagesApi = checkNotNull(messagesApi);
+    this.repository = checkNotNull(repository);
+    this.formFactory = checkNotNull(formFactory);
+    this.layout = checkNotNull(layout);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   /**
@@ -94,7 +96,10 @@ public final class ApplicantInformationController extends CiviFormController {
                             /* page= */ Optional.of(1))
                         .url();
               } else {
-                CiviFormProfile profile = profileUtils.currentUserProfile(request).orElseThrow();
+                CiviFormProfile profile =
+                    profileUtils
+                        .currentUserProfile(request)
+                        .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
                 redirectLink = applicantRoutes.index(profile, applicantId).url();
               }
 
@@ -134,7 +139,10 @@ public final class ApplicantInformationController extends CiviFormController {
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
     String redirectLocation;
     Session session;
-    CiviFormProfile profile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile profile =
+        profileUtils
+            .currentUserProfile(request)
+            .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
 
     if (infoForm.getRedirectLink().isEmpty()) {
       redirectLocation = applicantRoutes.index(profile, applicantId).url();

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -6,6 +6,7 @@ import static views.components.Modal.RepeatOpenBehavior.Group.PROGRAM_SLUG_LOGIN
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import java.util.Optional;
@@ -316,7 +317,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           roApplicantProgramService,
                           messagesApi.preferred(request),
                           applicantId,
-                          profileUtils.currentUserProfile(request).orElseThrow()));
+                          profileUtils
+                              .currentUserProfile(request)
+                              .orElseThrow(
+                                  () -> new MissingOptionalException(CiviFormProfile.class))));
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -59,6 +59,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   private final PreventDuplicateSubmissionView preventDuplicateSubmissionView;
   private final SettingsManifest settingsManifest;
   private final ProgramService programService;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ApplicantProgramReviewController(
@@ -71,7 +72,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
       ProfileUtils profileUtils,
       SettingsManifest settingsManifest,
       ProgramService programService,
-      VersionRepository versionRepository) {
+      VersionRepository versionRepository,
+      ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
     this.applicantService = checkNotNull(applicantService);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
@@ -81,6 +83,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
     this.preventDuplicateSubmissionView = checkNotNull(preventDuplicateSubmissionView);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.programService = checkNotNull(programService);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public CompletionStage<Result> review(Request request, long applicantId, long programId) {
@@ -258,7 +261,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                       applicantId,
                       programId,
                       applicationId,
-                      routes.ApplicantProgramsController.index(applicantId).url());
+                      applicantRoutes.index(submittingProfile, applicantId).url());
               return found(endOfProgramSubmission);
             },
             httpExecutionContext.current())
@@ -312,7 +315,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           request,
                           roApplicantProgramService,
                           messagesApi.preferred(request),
-                          applicantId));
+                          applicantId,
+                          profileUtils.currentUserProfile(request).orElseThrow()));
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -6,6 +6,7 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import controllers.CiviFormController;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -121,7 +122,8 @@ public final class ApplicantProgramsController extends CiviFormController {
       // gotten the URL from another source.
       return CompletableFuture.completedFuture(redirectToHome());
     }
-    return indexWithApplicantId(request, applicantId.orElseThrow());
+    return indexWithApplicantId(
+        request, applicantId.orElseThrow(() -> new MissingOptionalException(Long.class)));
   }
 
   @Secure

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -59,7 +59,7 @@ public final class ApplicantProgramsController extends CiviFormController {
   }
 
   @Secure
-  public CompletionStage<Result> index(Request request, long applicantId) {
+  public CompletionStage<Result> indexWithApplicantId(Request request, long applicantId) {
     Optional<CiviFormProfile> requesterProfile = profileUtils.currentUserProfile(request);
 
     // If the user doesn't have a profile, send them home.
@@ -102,6 +102,14 @@ public final class ApplicantProgramsController extends CiviFormController {
               }
               throw new RuntimeException(ex);
             });
+  }
+
+  @Secure
+  public CompletionStage<Result> index(Request request) {
+    // The route for this action should only be computed if the applicant ID is available in the
+    // session.
+    long applicantId = getApplicantId(request).orElseThrow();
+    return indexWithApplicantId(request, applicantId);
   }
 
   @Secure

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -1,15 +1,26 @@
 package controllers.applicant;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
+import com.google.inject.Inject;
 import io.prometheus.client.Counter;
 import play.api.mvc.Call;
+import services.settings.SettingsManifest;
 
 /**
  * Class that computes routes for applicant actions. The route for an applicant may be different
  * from that for a TI taking action on behalf of an applicant.
  */
 public final class ApplicantRoutes {
+  private final SettingsManifest settingsManifest;
+
+  @Inject
+  public ApplicantRoutes(SettingsManifest settingsManifest) {
+    this.settingsManifest = checkNotNull(settingsManifest);
+  }
+
   private static final Counter APPLICANT_ID_IN_PROFILE_COUNT =
       Counter.build()
           .name("applicant_id_in_profile")
@@ -17,11 +28,13 @@ public final class ApplicantRoutes {
           .labelNames("existence")
           .register();
 
-  // There are two cases where we want to use the URL that contains the applicant id:
+  // There are three cases where we want to use the URL that contains the applicant id:
+  // - The new schema is /not/ active yet.
   // - TIs performing actions on behalf of applicants.
-  // - The applicant has a profile that does not (yet) include the applicant id.
+  // - The applicant has a profile that does /not/ (yet) include the applicant id.
   //   This case will eventually go away once existing profiles have expired and been replaced.
   private boolean includeApplicantIdInRoute(CiviFormProfile profile) {
+    boolean newUrlSchemaEnabled = settingsManifest.getNewApplicantUrlSchemaEnabled();
     boolean isTi = profile.isTrustedIntermediary();
     boolean applicantIdInProfile =
         profile.getProfileData().containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
@@ -31,7 +44,7 @@ public final class ApplicantRoutes {
     String existence = applicantIdInProfile ? "present" : "absent";
     APPLICANT_ID_IN_PROFILE_COUNT.labels(existence).inc();
 
-    return isTi || !applicantIdInProfile;
+    return !newUrlSchemaEnabled || isTi || !applicantIdInProfile;
   }
 
   /**

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -1,0 +1,52 @@
+package controllers.applicant;
+
+import auth.CiviFormProfile;
+import auth.ProfileFactory;
+import io.prometheus.client.Counter;
+import play.api.mvc.Call;
+
+/**
+ * Class that computes routes for applicant actions. The route for an applicant may be different
+ * from that for a TI taking action on behalf of an applicant.
+ */
+public final class ApplicantRoutes {
+  private static final Counter APPLICANT_ID_IN_PROFILE_COUNT =
+      Counter.build()
+          .name("applicant_id_in_profile")
+          .help("Count of profiles that contain applicant id")
+          .labelNames("existence")
+          .register();
+
+  // There are two cases where we want to use the URL that contains the applicant id:
+  // - TIs performing actions on behalf of applicants.
+  // - The applicant has a profile that does not (yet) include the applicant id.
+  //   This case will eventually go away once existing profiles have expired and been replaced.
+  private boolean includeApplicantIdInRoute(CiviFormProfile profile) {
+    boolean isTi = profile.isTrustedIntermediary();
+    boolean applicantIdInProfile =
+        profile.getProfileData().containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+
+    // Count the occurrences so we know when it is safe to remove the special-case code for
+    // migration.
+    String existence = applicantIdInProfile ? "present" : "absent";
+    APPLICANT_ID_IN_PROFILE_COUNT.labels(existence).inc();
+
+    return isTi || !applicantIdInProfile;
+  }
+
+  /**
+   * Returns the route corresponding to the applicant index action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @return Route for the index action.
+   */
+  public Call index(CiviFormProfile profile, long applicantId) {
+    if (includeApplicantIdInRoute(profile)) {
+      return controllers.applicant.routes.ApplicantProgramsController.indexWithApplicantId(
+          applicantId);
+    } else {
+      return controllers.applicant.routes.ApplicantProgramsController.index();
+    }
+  }
+}

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -47,6 +47,7 @@ public final class UpsellController extends CiviFormController {
   private final MessagesApi messagesApi;
   private final PdfExporterService pdfExporterService;
   private final SettingsManifest settingsManifest;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public UpsellController(
@@ -60,7 +61,8 @@ public final class UpsellController extends CiviFormController {
       MessagesApi messagesApi,
       PdfExporterService pdfExporterService,
       SettingsManifest settingsManifest,
-      VersionRepository versionRepository) {
+      VersionRepository versionRepository,
+      ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
     this.httpContext = checkNotNull(httpContext);
     this.applicantService = checkNotNull(applicantService);
@@ -71,6 +73,7 @@ public final class UpsellController extends CiviFormController {
     this.messagesApi = checkNotNull(messagesApi);
     this.pdfExporterService = checkNotNull(pdfExporterService);
     this.settingsManifest = checkNotNull(settingsManifest);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   @Secure
@@ -142,15 +145,12 @@ public final class UpsellController extends CiviFormController {
                         applicantPersonalInfo.join(),
                         applicantId,
                         programId,
-                        profileUtils
-                            .currentUserProfile(request)
-                            .orElseThrow()
-                            .isTrustedIntermediary(),
+                        profile.orElseThrow(),
                         maybeEligiblePrograms.orElseGet(ImmutableList::of),
                         messagesApi.preferred(request),
-                        toastMessage));
+                        toastMessage,
+                        applicantRoutes));
               }
-
               return ok(
                   upsellView.render(
                       request,
@@ -161,9 +161,11 @@ public final class UpsellController extends CiviFormController {
                       roApplicantProgramService.join().getCustomConfirmationMessage(),
                       applicantPersonalInfo.join(),
                       applicantId,
+                      profile.orElseThrow(),
                       applicationId,
                       messagesApi.preferred(request),
-                      toastMessage));
+                      toastMessage,
+                      applicantRoutes));
             },
             httpContext.current())
         .exceptionally(

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import java.util.NoSuchElementException;
@@ -145,7 +146,8 @@ public final class UpsellController extends CiviFormController {
                         applicantPersonalInfo.join(),
                         applicantId,
                         programId,
-                        profile.orElseThrow(),
+                        profile.orElseThrow(
+                            () -> new MissingOptionalException(CiviFormProfile.class)),
                         maybeEligiblePrograms.orElseGet(ImmutableList::of),
                         messagesApi.preferred(request),
                         toastMessage,
@@ -161,7 +163,8 @@ public final class UpsellController extends CiviFormController {
                       roApplicantProgramService.join().getCustomConfirmationMessage(),
                       applicantPersonalInfo.join(),
                       applicantId,
-                      profile.orElseThrow(),
+                      profile.orElseThrow(
+                          () -> new MissingOptionalException(CiviFormProfile.class)),
                       applicationId,
                       messagesApi.preferred(request),
                       toastMessage,

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
@@ -12,8 +12,10 @@ import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.applicant.AuthenticateUpsellCreator.createNewAccountButton;
 
 import annotations.BindingAnnotations;
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import controllers.applicant.ApplicantRoutes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.SectionTag;
 import java.util.Optional;
@@ -57,17 +59,18 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
       ApplicantPersonalInfo personalInfo,
       Long applicantId,
       Long programId,
-      boolean isTrustedIntermediary,
+      CiviFormProfile profile,
       ImmutableList<ApplicantService.ApplicantProgramData> eligiblePrograms,
       Messages messages,
-      Optional<ToastMessage> bannerMessage) {
+      Optional<ToastMessage> bannerMessage,
+      ApplicantRoutes applicantRoutes) {
     boolean shouldUpsell = shouldUpsell(account);
 
     Modal loginPromptModal =
         createLoginPromptModal(
                 messages,
                 redirectTo,
-                /* description =*/ messages.at(MessageKey.GENERAL_LOGIN_MODAL_PROMPT.getKeyName()),
+                /* description= */ messages.at(MessageKey.GENERAL_LOGIN_MODAL_PROMPT.getKeyName()),
                 /* bypassMessage= */ MessageKey.BUTTON_CONTINUE_WITHOUT_AN_ACCOUNT)
             .build();
 
@@ -95,17 +98,20 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
           createApplyToProgramsButton(
               "apply-to-programs",
               messages.at(MessageKey.BUTTON_APPLY_TO_PROGRAMS.getKeyName()),
-              applicantId));
+              applicantId,
+              profile,
+              applicantRoutes));
     }
 
     String title =
-        isTrustedIntermediary
+        profile.isTrustedIntermediary()
             ? messages.at(MessageKey.TITLE_COMMON_INTAKE_CONFIRMATION_TI.getKeyName())
             : messages.at(MessageKey.TITLE_COMMON_INTAKE_CONFIRMATION.getKeyName());
     var content =
         createMainContent(
             title,
-            eligibleProgramsSection(request, eligiblePrograms, messages, isTrustedIntermediary)
+            eligibleProgramsSection(
+                    request, eligiblePrograms, messages, profile.isTrustedIntermediary())
                 .withClasses("mb-4"),
             shouldUpsell,
             messages,

--- a/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
@@ -8,8 +8,10 @@ import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.applicant.AuthenticateUpsellCreator.createNewAccountButton;
 
 import annotations.BindingAnnotations;
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
@@ -56,9 +58,11 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
       LocalizedStrings customConfirmationMessage,
       ApplicantPersonalInfo personalInfo,
       Long applicantId,
+      CiviFormProfile profile,
       Long applicationId,
       Messages messages,
-      Optional<ToastMessage> bannerMessage) {
+      Optional<ToastMessage> bannerMessage,
+      ApplicantRoutes applicantRoutes) {
     boolean shouldUpsell = shouldUpsell(account);
     String redirectUrl = routes.UpsellController.download(applicationId, applicantId).url();
     Modal loginPromptModal =
@@ -92,7 +96,9 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
                 createApplyToProgramsButton(
                     "another-program",
                     messages.at(MessageKey.LINK_APPLY_TO_ANOTHER_PROGRAM.getKeyName()),
-                    applicantId));
+                    applicantId,
+                    profile,
+                    applicantRoutes));
 
     String title = messages.at(MessageKey.TITLE_APPLICATION_CONFIRMATION.getKeyName());
     var content =
@@ -106,8 +112,8 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
                     .with(
                         TextFormatter.formatText(
                             customConfirmationMessage.getOrDefault(locale),
-                            /*preserveEmptyLines= */ true,
-                            /*addRequiredIndicator= */ false))
+                            /* preserveEmptyLines= */ true,
+                            /* addRequiredIndicator= */ false))
                     .withClasses("mb-4")),
             shouldUpsell,
             messages,

--- a/server/app/views/applicant/ApplicantUpsellView.java
+++ b/server/app/views/applicant/ApplicantUpsellView.java
@@ -5,8 +5,10 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.section;
 
+import auth.CiviFormProfile;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import controllers.applicant.ApplicantRoutes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -28,11 +30,12 @@ import views.style.StyleUtils;
 public abstract class ApplicantUpsellView extends BaseHtmlView {
 
   protected static ButtonTag createApplyToProgramsButton(
-      String buttonId, String buttonText, Long applicantId) {
-    return redirectButton(
-            buttonId,
-            buttonText,
-            controllers.applicant.routes.ApplicantProgramsController.index(applicantId).url())
+      String buttonId,
+      String buttonText,
+      Long applicantId,
+      CiviFormProfile profile,
+      ApplicantRoutes applicantRoutes) {
+    return redirectButton(buttonId, buttonText, applicantRoutes.index(profile, applicantId).url())
         .withClasses(ButtonStyles.SOLID_BLUE);
   }
 

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -9,6 +9,7 @@ import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.ul;
 
 import auth.CiviFormProfile;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
@@ -36,10 +37,12 @@ import views.style.StyleUtils;
 public final class IneligibleBlockView extends ApplicationBaseView {
 
   private final ApplicantLayout layout;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
-  IneligibleBlockView(ApplicantLayout layout) {
+  IneligibleBlockView(ApplicantLayout layout, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public Content render(
@@ -100,7 +103,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
                     .with(div().withClasses("flex-grow"))
                     .with(
                         new LinkElement()
-                            .setHref(routes.ApplicantProgramsController.index(applicantId).url())
+                            .setHref(applicantRoutes.index(submittingProfile, applicantId).url())
                             .setText(
                                 messages.at(MessageKey.LINK_APPLY_TO_ANOTHER_PROGRAM.getKeyName()))
                             .asButton()

--- a/server/app/views/applicant/PreventDuplicateSubmissionView.java
+++ b/server/app/views/applicant/PreventDuplicateSubmissionView.java
@@ -6,6 +6,8 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.p;
 
+import auth.CiviFormProfile;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
@@ -30,17 +32,20 @@ import views.style.StyleUtils;
 public final class PreventDuplicateSubmissionView extends ApplicationBaseView {
 
   private final ApplicantLayout layout;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
-  PreventDuplicateSubmissionView(ApplicantLayout layout) {
+  PreventDuplicateSubmissionView(ApplicantLayout layout, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public Content render(
       Request request,
       ReadOnlyApplicantProgramService roApplicantProgramService,
       Messages messages,
-      long applicantId) {
+      long applicantId,
+      CiviFormProfile profile) {
 
     DivTag content =
         div()
@@ -66,7 +71,7 @@ public final class PreventDuplicateSubmissionView extends ApplicationBaseView {
                         redirectButton(
                                 "exit-application-button",
                                 messages.at(MessageKey.BUTTON_EXIT_APPLICATION.getKeyName()),
-                                routes.ApplicantProgramsController.index(applicantId).url())
+                                applicantRoutes.index(profile, applicantId).url())
                             .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)));
 
     String title = "No changes to save";

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -306,7 +306,7 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
                 .setId(String.format("act-as-%d-button", newestApplicant.get().id))
                 .setText("Applicant Dashboard ➔")
                 .setHref(
-                    controllers.applicant.routes.ApplicantProgramsController.index(
+                    controllers.applicant.routes.ApplicantProgramsController.indexWithApplicantId(
                             newestApplicant.get().id)
                         .url())
                 .asAnchorText())

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -147,8 +147,16 @@ GET     /assets/*file               controllers.Assets.versioned(file)
 GET     /applicants/:applicantId/edit                                       controllers.applicant.ApplicantInformationController.setLangFromBrowser(request: Request, applicantId: Long)
 POST    /applicants/:applicantId                                            controllers.applicant.ApplicantInformationController.setLangFromSwitcher(request: Request, applicantId: Long)
 
-# Program methods for applicants
-GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.index(request: Request, applicantId: Long)
+# Program methods for applicants (new)
+GET     /programs                   controllers.applicant.ApplicantProgramsController.index(request: Request)
+
+# Program methods for TI actions on behalf of applicants.
+#
+# Also: Program methods for applicants (legacy). Maintained for now
+# because some applicants will have profiles in the sessions that
+# do not yet contain the applicant id, so we maintain these routes
+# during migration.
+GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.indexWithApplicantId(request: Request, applicantId: Long)
 GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.view(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.edit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.review(request: Request, applicantId: Long, programId: Long)

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -5,15 +5,23 @@ import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.ResetPostgres;
+import services.settings.SettingsManifest;
 import support.CfTestHelpers;
 import support.CfTestHelpers.ResultWithFinalRequestUri;
 
 public class HomeControllerTest extends ResetPostgres {
+  private SettingsManifest settingsManifest;
+
+  @Before
+  public void setup() {
+    settingsManifest = instanceOf(SettingsManifest.class);
+  }
 
   @Test
   public void testUnauthenticatedSecurePage() {
@@ -24,7 +32,11 @@ public class HomeControllerTest extends ResetPostgres {
         CfTestHelpers.doRequestWithInternalRedirects(app, request);
 
     assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
-    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).isEqualTo("/programs");
+    if (settingsManifest.getNewApplicantUrlSchemaEnabled()) {
+      assertThat(resultWithFinalRequestUri.getFinalRequestUri()).isEqualTo("/programs");
+    } else {
+      assertThat(resultWithFinalRequestUri.getFinalRequestUri()).endsWith("/programs");
+    }
   }
 
   @Test

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -22,10 +22,9 @@ public class HomeControllerTest extends ResetPostgres {
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
         CfTestHelpers.doRequestWithInternalRedirects(app, request);
-    assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
 
-    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).startsWith("/applicants/");
-    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).endsWith("/programs");
+    assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
+    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).isEqualTo("/programs");
   }
 
   @Test

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -45,6 +45,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
 
@@ -55,8 +56,9 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             instanceOf(MessagesApi.class),
             instanceOf(HttpExecutionContext.class),
             languageUtils,
-            new ApplicantRoutes());
+            new ApplicantRoutes(mockSettingsManifest));
     Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
-    assertThat(result.redirectLocation()).hasValue("/programs");
+    assertThat(result.redirectLocation()).isNotEmpty();
+    assertThat(result.redirectLocation().orElseThrow()).endsWith("/programs");
   }
 }

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import static play.test.Helpers.fakeRequest;
 
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import controllers.applicant.ApplicantRoutes;
@@ -59,6 +60,8 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             new ApplicantRoutes(mockSettingsManifest));
     Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
     assertThat(result.redirectLocation()).isNotEmpty();
-    assertThat(result.redirectLocation().orElseThrow()).endsWith("/programs");
+    assertThat(
+            result.redirectLocation().orElseThrow(() -> new MissingOptionalException(String.class)))
+        .endsWith("/programs");
   }
 }

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -7,6 +7,7 @@ import static play.test.Helpers.fakeRequest;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
+import controllers.applicant.ApplicantRoutes;
 import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
 
   @Test
   public void testLanguageSelectorNotShownOneLanguage() {
-    ApplicantModel applicant = createApplicantWithMockedProfile();
+    createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
@@ -53,10 +54,9 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             instanceOf(ProfileUtils.class),
             instanceOf(MessagesApi.class),
             instanceOf(HttpExecutionContext.class),
-            languageUtils);
+            languageUtils,
+            new ApplicantRoutes());
     Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
-    assertThat(result.redirectLocation())
-        .contains(
-            controllers.applicant.routes.ApplicantProgramsController.index(applicant.id).url());
+    assertThat(result.redirectLocation()).hasValue("/programs");
   }
 }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -40,6 +40,7 @@ import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.test.Helpers;
+import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
 import repository.VersionRepository;
@@ -584,7 +585,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             instanceOf(HttpExecutionContext.class),
             instanceOf(CiviFormProfileData.class),
             instanceOf(SettingsManifest.class),
-            adminAccount);
+            adminAccount,
+            instanceOf(AccountRepository.class));
     ProfileUtils profileUtilsNoOpTester =
         new ProfileUtilsNoOpTester(
             instanceOf(SessionStore.class), instanceOf(ProfileFactory.class), profileTester);
@@ -632,8 +634,9 @@ public class AdminApplicationControllerTest extends ResetPostgres {
           HttpExecutionContext httpContext,
           CiviFormProfileData profileData,
           SettingsManifest settingsManifest,
-          Optional<AccountModel> adminAccount) {
-        super(dbContext, httpContext, profileData, settingsManifest);
+          Optional<AccountModel> adminAccount,
+          AccountRepository accountRepository) {
+        super(dbContext, httpContext, profileData, settingsManifest, accountRepository);
         this.adminAccount = adminAccount;
       }
 

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -159,12 +159,12 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void index_withProgram_includesApplyButtonWithRedirect() {
+  public void indexWithApplicantId_withProgram_includesApplyButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    // The applicant id is not required since the applicant profile contains the id.
-    Result result = controller.index(request).toCompletableFuture().join();
+    Result result =
+        controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -159,19 +159,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void indexWithApplicantId_withProgram_includesApplyButtonWithRedirect() {
-    ProgramModel program = resourceCreator().insertActiveProgram("program");
-
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    Result result =
-        controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
-
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result))
-        .contains(routes.ApplicantProgramsController.view(currentApplicant.id, program.id).url());
-  }
-
-  @Test
   public void indexWithApplicantId_withCommonIntakeform_includesStartHereButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveCommonIntakeForm("benefits");
 

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -1,0 +1,101 @@
+package controllers.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import auth.CiviFormProfile;
+import auth.CiviFormProfileData;
+import auth.ProfileFactory;
+import auth.Role;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import repository.ResetPostgres;
+
+public class ApplicantRoutesTest extends ResetPostgres {
+
+  private ProfileFactory profileFactory;
+  private static long applicantId = 123L;
+  private static long applicantAccountId = 456L;
+  private static long tiAccountId = 789L;
+
+  // Class to hold counter values.
+  static class Counts {
+    double present = 0;
+    double absent = 0;
+  }
+
+  private Counts getApplicantIdInProfileCounts() {
+    Counts counts = new Counts();
+    CollectorRegistry registry = CollectorRegistry.defaultRegistry;
+    for (MetricFamilySamples mfs : Collections.list(registry.metricFamilySamples())) {
+      if (mfs.name.equals("applicant_id_in_profile")) {
+        for (MetricFamilySamples.Sample sample : mfs.samples) {
+          if (sample.labelValues.contains("present")) {
+            counts.present = sample.value;
+          } else if (sample.labelValues.contains("absent")) {
+            counts.absent = sample.value;
+          }
+        }
+      }
+    }
+    return counts;
+  }
+
+  @Before
+  public void setup() {
+    profileFactory = instanceOf(ProfileFactory.class);
+  }
+
+  @Test
+  public void testIndexRouteForApplicantWithIdInProfile() {
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    assertThat(new ApplicantRoutes().index(applicantProfile, applicantId).url())
+        .isEqualTo("/programs");
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testIndexRouteForApplicantWithoutIdInProfile() {
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
+    assertThat(new ApplicantRoutes().index(applicantProfile, applicantId).url())
+        .isEqualTo(expectedIndexUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testIndexRouteForTrustedIntermediary() {
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
+    assertThat(new ApplicantRoutes().index(tiProfile, applicantId).url())
+        .isEqualTo(expectedIndexUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+}


### PR DESCRIPTION
### Description

Currently, routes for applicant actions include the applicant id in the URL. We want to remove these for applicant actions to provide cleaner URLs for sharing and bookmarking. To accomplish this, we will store the applicant id in the user profile. A profile attribute is set in `ProfileFactory.createNewApplicant()` which will achieve the goal for every newly-created profile. If a user with an existing (legacy) profile authenticates successfully, then we also set the applicant id in the `CiviFormProfileMerger`.

This PR only affects the `ApplicantProgramsController.index()` action; subsequent PRs will address the other applicant actions.

This PR renames the existing `index()` method to `indexWithApplicantId()`. A new `index()` method extracts the applicant ID from the profile and then calls `indexWithApplicantId()`. The corresponding `routes` are configured appropriately.

Note that we want to retain the existing routes when _TIs_ are taking actions of an applicant's behalf.  Also, some applicants will have existing profiles that do not yet contain the applicant id, so we need to use the existing routes for them as well. Since routes for applicant actions are computed in a number of views as well as controllers (for redirects), the new `ApplicantRoutes` class will centralize the conditional logic for computing the appropriate route for a given situation. There are also some changes in plumbing to pass the user profile to views when this computation is required. Note that another reason to retain the existing routes, particularly for the home page, is that existing users may have the current URLs bookmarked.

In addition to the unit tests, this change was tested on a dev instance with an existing profile in the browser cookie. See instructions below.

### Release notes

Remove applicant ID from home page URL

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

- In a dev instance, check out `main`
- Navigate to `http://localhost:9000`
- This will redirect to the home page with the applicant ID in the URL. It will also create a user profile that does not include the applicant id
- Check out this branch
- Again, navigate to `http://localhost:9000`
- Again, this should redirect to the home page with the applicant ID in the URL
- Click "End session" in upper right. This will create a new user profile that _does_ include the applicant id
- Verify that the browser is now on `http://localhost:9000/programs` (no applicant id)

### Issue(s) this completes

Relates to #5905 