### PR TITLE
Put program header button rendering all in one place.

### DIFF
--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -21,7 +21,6 @@ import services.question.types.QuestionDefinition;
 import views.BaseHtmlView;
 import views.ViewUtils;
 import views.ViewUtils.ProgramDisplayType;
-import views.components.ButtonStyles;
 import views.components.Icons;
 import views.components.TextFormatter;
 import views.style.StyleUtils;

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -5,11 +5,15 @@ import static j2html.TagCreator.li;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 import static j2html.TagCreator.ul;
+import static views.style.AdminStyles.HEADER_BUTTON_STYLES;
 
 import com.google.common.collect.ImmutableList;
+import controllers.admin.routes;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.UlTag;
+import java.util.List;
+import play.mvc.Http;
 import services.program.ProgramDefinition;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
@@ -24,8 +28,35 @@ import views.style.StyleUtils;
 
 abstract class ProgramBaseView extends BaseHtmlView {
 
-  /** Renders a div with internal/admin program information. */
-  protected final DivTag renderProgramInfo(ProgramDefinition programDefinition) {
+  /** Represents different buttons that can be displayed in the program information header. */
+  public enum ProgramHeaderButton {
+    /**
+     * Redirects program to an editable view. Should be used only if the program is currently read
+     * only.
+     */
+    EDIT_PROGRAM,
+    /** Redirects to the program details editing page. */
+    EDIT_PROGRAM_DETAILS,
+    /** Redirects to previewing this program as an applicant. */
+    PREVIEW_AS_APPLICANT,
+  }
+
+  /**
+   * Renders a header div with internal/admin program information.
+   *
+   * @param headerButtons the main action buttons to be displayed in the header
+   * @throws IllegalArgumentException if {@code headerButtons} contains both {@link
+   *     ProgramHeaderButton#EDIT_PROGRAM} and {@link ProgramHeaderButton#EDIT_PROGRAM_DETAILS}.
+   */
+  protected final DivTag renderProgramInfoHeader(
+      ProgramDefinition programDefinition,
+      List<ProgramHeaderButton> headerButtons,
+      Http.Request request) {
+    if (headerButtons.contains(ProgramHeaderButton.EDIT_PROGRAM)
+        && headerButtons.contains(ProgramHeaderButton.EDIT_PROGRAM_DETAILS)) {
+      throw new IllegalArgumentException(
+          "At most one of [EDIT_PROGRAM, EDIT_PROGRAM_DETAILS] should be included");
+    }
     DivTag title =
         div(programDefinition.localizedName().getDefault())
             .withId("program-title")
@@ -43,8 +74,20 @@ abstract class ProgramBaseView extends BaseHtmlView {
             .withClasses("text-sm")
             .with(span("Admin note: ").withClasses("font-semibold"))
             .with(span(programDefinition.adminDescription()));
+    DivTag headerButtonsDiv =
+        div()
+            .withClasses("flex")
+            .with(
+                headerButtons.stream()
+                    .map(
+                        headerButton ->
+                            renderHeaderButton(headerButton, programDefinition, request)));
     return div(
-            ViewUtils.makeLifecycleBadge(getProgramDisplayStatus()), title, description, adminNote)
+            ViewUtils.makeLifecycleBadge(getProgramDisplayStatus()),
+            title,
+            description,
+            adminNote,
+            headerButtonsDiv)
         .withClasses("bg-gray-100", "text-gray-800", "shadow-md", "p-8", "pt-4", "-mx-2");
   }
 
@@ -102,19 +145,31 @@ abstract class ProgramBaseView extends BaseHtmlView {
     return container.with(conditionList);
   }
 
-  /**
-   * Returns a standardized Edit Button that can be added to the program info. A typical use case
-   * would be for a subclass to:
-   *
-   * <ul>
-   *   <li>create a button with this method
-   *   <li>add subclass specific navigation behaviour to the button
-   *   <li>add the button to the program info after creating it with renderProductInfo()
-   * </ul>
-   */
-  protected ButtonTag getStandardizedEditButton(String buttonText) {
+  private ButtonTag renderHeaderButton(
+      ProgramHeaderButton headerButton, ProgramDefinition programDefinition, Http.Request request) {
+    switch (headerButton) {
+      case EDIT_PROGRAM:
+        ButtonTag editButton = getStandardizedEditButton("Edit program");
+        String editLink =
+            routes.AdminProgramController.newVersionFrom(programDefinition.id()).url();
+        return toLinkButtonForPost(editButton, editLink, request);
+      case EDIT_PROGRAM_DETAILS:
+        return asRedirectElement(
+            getStandardizedEditButton("Edit program details"),
+            routes.AdminProgramController.edit(programDefinition.id()).url());
+      case PREVIEW_AS_APPLICANT:
+        return asRedirectElement(
+            ViewUtils.makeSvgTextButton("Preview as applicant", Icons.VIEW)
+                .withClasses(HEADER_BUTTON_STYLES),
+            routes.AdminProgramPreviewController.preview(programDefinition.id()).url());
+      default:
+        throw new IllegalStateException("All header buttons handled");
+    }
+  }
+
+  private ButtonTag getStandardizedEditButton(String buttonText) {
     return ViewUtils.makeSvgTextButton(buttonText, Icons.EDIT)
-        .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5")
+        .withClasses(HEADER_BUTTON_STYLES)
         .withId("header_edit_button");
   }
 

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -156,6 +156,13 @@ public final class ProgramBlocksView extends ProgramBaseView {
         programDefinition.getNonRepeatedBlockDefinitions().stream()
             .anyMatch(BlockDefinition::hasNullQuestion);
 
+    ImmutableList<ProgramHeaderButton> headerButtons =
+        viewAllowsEditingProgram()
+            ? ImmutableList.of(
+                ProgramHeaderButton.EDIT_PROGRAM_DETAILS, ProgramHeaderButton.PREVIEW_AS_APPLICANT)
+            : ImmutableList.of(
+                ProgramHeaderButton.EDIT_PROGRAM, ProgramHeaderButton.PREVIEW_AS_APPLICANT);
+
     HtmlBundle htmlBundle =
         layout
             .getBundle(request)
@@ -169,12 +176,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                         "px-2",
                         StyleUtils.responsive2XLarge("px-16"))
                     .with(
-                        renderProgramInfo(programDefinition)
-                            .with(
-                                div()
-                                    .withClasses("flex")
-                                    .with(renderEditButton(request, programDefinition))
-                                    .with(renderPreviewButton(programDefinition)))
+                        renderProgramInfoHeader(programDefinition, headerButtons, request)
                             .with(
                                 iff(
                                     malformedQuestionDefinition,
@@ -1214,30 +1216,6 @@ public final class ProgramBlocksView extends ProgramBaseView {
   /** Returns if this view is editable or not. A view is editable only if it represents a draft. */
   private boolean viewAllowsEditingProgram() {
     return programDisplayType.equals(DRAFT);
-  }
-
-  /**
-   * Creates the Edit button shown at the top of the page. For a read only view it redirects to an
-   * editable view.
-   */
-  private ButtonTag renderEditButton(Request request, ProgramDefinition programDefinition) {
-    if (viewAllowsEditingProgram()) {
-      ButtonTag editButton = getStandardizedEditButton("Edit program details");
-      String editLink = routes.AdminProgramController.edit(programDefinition.id()).url();
-      return asRedirectElement(editButton, editLink);
-    } else {
-      ButtonTag editButton = getStandardizedEditButton("Edit program");
-      String editLink = routes.AdminProgramController.newVersionFrom(programDefinition.id()).url();
-      return toLinkButtonForPost(editButton, editLink, request);
-    }
-  }
-
-  private ButtonTag renderPreviewButton(ProgramDefinition programDefinition) {
-    return asRedirectElement(
-        ViewUtils.makeSvgTextButton("Preview as applicant", Icons.VIEW)
-            .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5", "mx-2"),
-        controllers.admin.routes.AdminProgramPreviewController.preview(programDefinition.id())
-            .url());
   }
 
   /** Indicates if this view is showing a draft or published program. */

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.admin.routes;
 import j2html.tags.specialized.ATag;
-import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.LabelTag;
@@ -241,8 +240,10 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
             .getBundle(request)
             .setTitle(String.format("Configure %s predicate", typeDisplayName))
             .addMainContent(
-                renderProgramInfo(programDefinition)
-                    .with(renderEditProgramDetailsButton(programDefinition)),
+                renderProgramInfoHeader(
+                    programDefinition,
+                    ImmutableList.of(ProgramHeaderButton.EDIT_PROGRAM_DETAILS),
+                    request),
                 content);
     return layout.renderCentered(htmlBundle);
   }
@@ -846,12 +847,6 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
         .splitToStream(value.substring(1, value.length() - 1))
         // Join to CSV
         .collect(Collectors.joining(","));
-  }
-
-  private ButtonTag renderEditProgramDetailsButton(ProgramDefinition programDefinition) {
-    ButtonTag editButton = getStandardizedEditButton("Edit program details");
-    String editLink = routes.AdminProgramController.edit(programDefinition.id()).url();
-    return asRedirectElement(editButton, editLink);
   }
 
   @Override

--- a/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
@@ -14,7 +14,6 @@ import static views.ViewUtils.ProgramDisplayType.DRAFT;
 
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
-import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.InputTag;
@@ -243,8 +242,10 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
             .getBundle(request)
             .setTitle(title)
             .addMainContent(
-                renderProgramInfo(programDefinition)
-                    .with(renderEditProgramDetailsButton(programDefinition)),
+                renderProgramInfoHeader(
+                    programDefinition,
+                    ImmutableList.of(ProgramHeaderButton.EDIT_PROGRAM_DETAILS),
+                    request),
                 content);
 
     Http.Flash flash = request.flash();
@@ -285,12 +286,6 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
                     div(questionHelpText).withClasses("mt-1", "text-sm"),
                     div(String.format("Admin ID: %s", questionDefinition.getName()))
                         .withClasses("mt-1", "text-sm")));
-  }
-
-  private ButtonTag renderEditProgramDetailsButton(ProgramDefinition programDefinition) {
-    ButtonTag editButton = getStandardizedEditButton("Edit program details");
-    String editLink = routes.AdminProgramController.edit(programDefinition.id()).url();
-    return asRedirectElement(editButton, editLink);
   }
 
   @Override

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -1,5 +1,7 @@
 package views.style;
 
+import views.components.ButtonStyles;
+
 /** Styles for admin pages. */
 public final class AdminStyles {
 
@@ -66,4 +68,7 @@ public final class AdminStyles {
   public static final String MAIN =
       StyleUtils.joinStyles(
           "bg-white", "border", "border-gray-200", "mt-12", "shadow-lg", "w-screen");
+
+  public static final String HEADER_BUTTON_STYLES =
+    StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5", "mr-2");
 }

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -70,5 +70,5 @@ public final class AdminStyles {
           "bg-white", "border", "border-gray-200", "mt-12", "shadow-lg", "w-screen");
 
   public static final String HEADER_BUTTON_STYLES =
-    StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5", "mr-2");
+      StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5", "mr-2");
 }


### PR DESCRIPTION
### Description

Updates `ProgramBaseView` to do all the header button rendering. Specific admin program views now just pass the buttons that they want to the render method.

For #5676 we're going to add a third "Edit program image" button, and this refactor helps add that button more easily.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible) -- **Existing browser tests should cover**
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

As an admin:
1) View a program that doesn't have a draft -> verify button says "Edit program" not "Edit program details". Verify clicking on "Edit program" reloads the page to then show the program as editable.
2) View a draft program -> verify "Edit program details" and "Preview as applicant" buttons appear.
2) Add or edit a visibility condition -> verify "Edit program details" button appears.
3) Add or edit an eligibility condition -> verify "Edit program details" button appears.

### Issue(s) this completes
Pre-refactor for #5676 

