### PR TITLE
Update localstack service to have a link to the civiform service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     environment:
       - SERVICES=s3,ses
       - PROVIDER_OVERRIDE_S3=legacy
+    links:
+      # Once a file is uploaded to localstack, localstack redirects back to CiviForm.
+      # It does this by mapping any 'localhost' domain to the 'civiform' domain (see
+      # localstack/localstack.nginx.conf). So, we need the localstack service to be
+      # aware of the civiform service to do that redirect correctly.
+      - 'civiform:civiform-service'
     networks:
       default:
         aliases:

--- a/localstack/localstack.nginx.conf
+++ b/localstack/localstack.nginx.conf
@@ -3,6 +3,6 @@ server {
   server_name localhost;
 
   location / {
-    proxy_pass http://civiform:9000/;
+    proxy_pass http://civiform-service:9000/;
   }
 }


### PR DESCRIPTION
### Description

We have a file upload question which allows users to upload a file. For prod instances, these files get uploaded to a cloud service provider, which is AWS S3 for all current deployments. For local instances, those files instead get uploaded to localstack, which is a local service that mimics AWS S3.

Note that localstack is in a separate Docker container from the rest of civiform.

Currently, some devs get an error when uploading a file and then clicking "Save and Next":

```
<Error>
<Code>InternalError</Code>
<Message>exception while calling s3.PostObject: MyHTTPConnectionPool(host='localhost', port=9000): Max retries exceeded with url: /applicants/19/programs/1/blocks/1/updateFile/false?key=applicant-19%2Fprogram-1%2Fblock-1%2Fgemma-stpjHJGqZyw-unsplash.jpg&bucket=civiform-local-s3 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff801de550>: Failed to establish a new connection: [Errno 111] Connection refused'))</Message>
<RequestId>ca40a88a-d366-427d-9679-df5d63886e23</RequestId>
</Error>
```

Why this error happens: Once a file is uploaded to localstack, we want to redirect back to civiform so that we can save some file information to our database so we can fetch the file later ([link](https://github.com/civiform/civiform/blob/1cbc20e36fa62cf04619f8b84990d2994db9eeb4/server/app/views/FileUploadViewStrategy.java#L113-L120)). This redirect is failing.

A long time ago, this redirect was failing because it was trying to redirect to `localhost:9000`, and "localhost" in this context means the **localstack service's** localhost because localstack is in a separate container. https://github.com/civiform/civiform/pull/2659 fixed this by having localstack redirect to `civiform:9000` instead of `localhost:9000`.

Now, it seems that redirect is still failing because localstack doesn't know about the civiform host. This PR adds a link between localstack and civiform so the redirect succeeds. (I'm still not sure why the current implementation works for some devs but not others...)

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Run `bin/run-dev`.
2. As an applicant, answer a file upload question by uploading a file.
3. Click "Save and Next".
4. Verify the file is saved and the page re-loads saying the file has been uploaded.

### Issue(s) this completes

Fixes #2639
