### PR TITLE
Collect metrics unconditionally

### DIFF
--- a/server/app/filters/RecordCookieSizeFilter.java
+++ b/server/app/filters/RecordCookieSizeFilter.java
@@ -1,14 +1,11 @@
 package filters;
 
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 import io.prometheus.client.Histogram;
 import play.mvc.EssentialAction;
 import play.mvc.EssentialFilter;
 import play.mvc.Http;
 import play.routing.HandlerDef;
 import play.routing.Router;
-import services.settings.SettingsManifest;
 
 /**
  * Filter that exports the size of the PLAY_SESSION cookie to prometheus, parameterized by
@@ -17,12 +14,6 @@ import services.settings.SettingsManifest;
 public final class RecordCookieSizeFilter extends EssentialFilter {
   public static int BUCKET_SIZE = 512;
   public static int NUM_BUCKETS = 10;
-  private final boolean metricsEnabled;
-
-  @Inject
-  public RecordCookieSizeFilter(Provider<SettingsManifest> settingsManifest) {
-    this.metricsEnabled = settingsManifest.get().getCiviformServerMetricsEnabled();
-  }
 
   private Histogram PLAY_SESSION_COOKIE_SIZE =
       Histogram.build()
@@ -34,13 +25,6 @@ public final class RecordCookieSizeFilter extends EssentialFilter {
 
   @Override
   public EssentialAction apply(EssentialAction next) {
-    if (!metricsEnabled) {
-      return EssentialAction.of(
-          requestHeader -> {
-            return next.apply(requestHeader);
-          });
-    }
-
     return EssentialAction.of(
         requestHeader -> {
           String controllerMethod = getControllerMethod(requestHeader);

--- a/server/app/services/cloud/aws/SimpleEmail.java
+++ b/server/app/services/cloud/aws/SimpleEmail.java
@@ -54,13 +54,11 @@ public final class SimpleEmail {
 
   private final String sender;
   private final Client client;
-  private final boolean metricsEnabled;
 
   @Inject
   public SimpleEmail(
       AwsRegion region, Config config, Environment environment, ApplicationLifecycle appLifecycle) {
     this.sender = checkNotNull(config).getString(AWS_SES_SENDER_CONF_PATH);
-    this.metricsEnabled = checkNotNull(config).getBoolean("civiform_server_metrics_enabled");
 
     if (environment.isDev()) {
       client = new LocalStackClient(region, config);
@@ -102,17 +100,13 @@ public final class SimpleEmail {
     } catch (SesException e) {
       logger.error(e.toString());
       e.printStackTrace();
-      if (metricsEnabled) {
-        EMAIL_FAIL_COUNT.inc();
-        EMAIL_SEND_COUNT.labels(String.valueOf(e.statusCode())).inc();
-      }
+      EMAIL_FAIL_COUNT.inc();
+      EMAIL_SEND_COUNT.labels(String.valueOf(e.statusCode())).inc();
     } finally {
-      if (metricsEnabled) {
-        // Increase the count of emails sent.
-        EMAIL_SEND_COUNT.labels(String.valueOf(HttpStatusCode.OK)).inc();
-        // Record the execution time of the email sending process.
-        timer.observeDuration();
-      }
+      // Increase the count of emails sent.
+      EMAIL_SEND_COUNT.labels(String.valueOf(HttpStatusCode.OK)).inc();
+      // Record the execution time of the email sending process.
+      timer.observeDuration();
     }
   }
 

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -55,7 +55,6 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
   @VisibleForTesting Optional<String> ESRI_FIND_ADDRESS_CANDIDATES_URL;
   private int ESRI_EXTERNAL_CALL_TRIES;
 
-  private final boolean metricsEnabled;
   private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
 
   @Inject
@@ -66,7 +65,6 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
       WSClient ws) {
     super(clock, esriServiceAreaValidationConfig, Optional.of(configuration));
     this.ws = checkNotNull(ws);
-    this.metricsEnabled = checkNotNull(configuration).getBoolean("civiform_server_metrics_enabled");
     this.ESRI_FIND_ADDRESS_CANDIDATES_URL =
         configuration.hasPath("esri_find_address_candidates_url")
             ? Optional.of(configuration.getString("esri_find_address_candidates_url"))
@@ -132,9 +130,7 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
     return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)
         .thenApply(
             res -> {
-              if (metricsEnabled) {
-                ESRI_REQUEST_C0UNT.labels(String.valueOf(res.getStatus())).inc();
-              }
+              ESRI_REQUEST_C0UNT.labels(String.valueOf(res.getStatus())).inc();
               // return empty if still failing after retries
               if (res.getStatus() != 200) {
                 return Optional.empty();


### PR DESCRIPTION
### Description

Do not guard collection of metrics with a server setting.

We have an existing server setting (`CIVIFORM_SERVER_METRICS_ENABLED`) which is used to enable a [controller action](https://github.com/civiform/civiform/blob/d501333d419bbfa177dfb716f461ca8f658e850d/server/app/controllers/monitoring/MetricsController.java#L61) that exposes metrics for scraping. Some existing code guards collection of metrics with this setting, which is unnecessary, as the cost is negligible and it introduces complexity.

Cleaning these occurrences up means that anyone looking for existing usages won't think they need to add the extra complexity.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary
