### PR TITLE
Aligning local docker tag names

### DIFF
--- a/bin/build-mock-web-services
+++ b/bin/build-mock-web-services
@@ -41,4 +41,4 @@ if [[ "${PUSH_IMAGE}" ]]; then
   docker buildx build --push "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
 fi
 
-docker tag "${NAMESPACE}/${IMAGE}:latest" "${NAMESPACE}-${IMAGE}:latest"
+docker tag "${NAMESPACE}/${IMAGE}:latest" "civiform-${IMAGE}:latest"

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -26,20 +26,23 @@ function pull_all() {
   docker pull civiform/civiform-dev:latest
 
   # Explicitly pull dev dependencies. (in parallel)
-  docker pull docker.io/civiform/oidc-provider:latest &
+  docker pull civiform/oidc-provider:latest &
   docker pull mcr.microsoft.com/azure-storage/azurite &
   docker pull localstack/localstack &
 
-  docker pull docker.io/civiform/civiform-localstack:latest &
-  docker pull docker.io/civiform/formatter:latest &
-  docker pull docker.io/civiform/civiform-browser-test:latest &
-  docker pull docker.io/civiform/mock-web-services:latest &
+  docker pull civiform/civiform-localstack:latest &
+  docker pull civiform/formatter:latest &
+  docker pull civiform/civiform-browser-test:latest &
+  docker pull civiform/mock-web-services:latest &
 
   wait
 
   docker tag civiform/civiform-dev:latest civiform-dev
+  docker tag civiform/formatter:latest civiform-formatter
   docker tag civiform/civiform-localstack:latest civiform-localstack
-  docker tag docker.io/civiform/mock-web-services:latest civiform-mock-web-services
+  docker tag civiform/oidc-provider:latest civiform-oidc-provider
+  docker tag civiform/civiform-browser-test:latest civiform-browser-test
+  docker tag civiform/mock-web-services:latest civiform-mock-web-services
 }
 
 if [[ $# -eq 0 ]]; then
@@ -55,19 +58,19 @@ while [ "${1:-}" != "" ]; do
 
     "--dev")
       echo "Pull dev docker image"
-      docker pull docker.io/civiform/civiform-dev:latest
+      docker pull civiform/civiform-dev:latest
       docker tag civiform/civiform-dev:latest civiform-dev
-
       ;;
 
     "--formatter")
       echo "Pull formatter docker image"
-      docker pull docker.io/civiform/formatter:latest
+      docker pull civiform/formatter:latest
+      docker tag civiform/formatter:latest civiform-formatter
       ;;
 
     "--localstack")
       echo "Pull localstack docker image"
-      docker pull docker.io/civiform/civiform-localstack:latest
+      docker pull civiform/civiform-localstack:latest
       docker tag civiform/civiform-localstack:latest civiform-localstack
       ;;
 
@@ -78,18 +81,20 @@ while [ "${1:-}" != "" ]; do
 
     "--oidc-provider")
       echo "Pull oidc-provider docker image"
-      docker pull docker.io/civiform/oidc-provider:latest
+      docker pull civiform/oidc-provider:latest
+      docker tag civiform/oidc-provider:latest civiform-oidc-provider
       ;;
 
     "--browser-tests")
       echo "Pull browser-tests docker image"
-      docker pull docker.io/civiform/civiform-browser-test:latest
+      docker pull civiform/civiform-browser-test:latest
+      docker tag civiform/civiform-browser-test:latest civiform-browser-test
       ;;
 
     "--mock-web-services")
       echo "Pull mock-web-services docker image"
-      docker pull docker.io/civiform/mock-web-services:latest
-      docker tag docker.io/civiform/mock-web-services:latest civiform-mock-web-services
+      docker pull civiform/mock-web-services:latest
+      docker tag civiform/mock-web-services:latest civiform-mock-web-services
       ;;
 
     *)

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -17,6 +17,6 @@ docker run --rm -it \
   -e TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
   --network "${DOCKER_NETWORK_NAME}" \
   --init \
-  civiform/civiform-browser-test:latest \
+  civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \
   "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   # container name in their /etc/hosts file for the web brower to load the auth url.
   # EG: 127.0.0.1 dev-oidc
   dev-oidc:
-    image: civiform/oidc-provider
+    image: civiform-oidc-provider
     restart: always
     expose:
       - 3390
@@ -45,7 +45,7 @@ services:
       - OIDC_PORT=3390
 
   mock-web-services:
-    image: civiform/mock-web-services
+    image: civiform-mock-web-services
 
   db:
     image: postgres:12.14


### PR DESCRIPTION
### Description

I found some discrepancies in how some scripts are referencing our Docker images. Based on what I've seen the original intent was to have things reference images by the local tag name.

The various `bin/build-*` scripts all add a local tag to the images they build. Example: `civiform/formatter` is locally tagged as `civiform-formatter`. The `bin/pull-image` script however was not consistent in applying the same tags.

Additionally, the `docker-compose.yml` file was referencing two images with the the remote/published name, and not the local tag like it does everything else. This was the source of a problem I noticed a while ago where I'd build the mock web services and it wasn't always using the expected image.

I also removed the `docker.io` registry from `bin/pull-image` as it's already Docker's default and wasn't used consistently.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

