### PR TITLE
Make unit test pass under sbt-test

### DIFF
--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -107,6 +107,8 @@ public final class MetricsController extends CiviFormController {
 
   @VisibleForTesting
   static void initializeCounters() {
+    CollectorRegistry.defaultRegistry.clear();
+
     QUERY_METRIC_COUNT =
         Counter.build()
             .name("ebean_queries_total")

--- a/server/test/controllers/monitoring/MetricsControllerTest.java
+++ b/server/test/controllers/monitoring/MetricsControllerTest.java
@@ -24,8 +24,6 @@ public class MetricsControllerTest extends WithMockedProfiles {
   @Before
   public void setUp() {
     resetDatabase();
-    CollectorRegistry.defaultRegistry.clear();
-    // TODO(#5933) initializing counters causes the test to fail in bin/sbt-test
     MetricsController.initializeCounters();
   }
 

--- a/server/test/controllers/monitoring/MetricsControllerTest.java
+++ b/server/test/controllers/monitoring/MetricsControllerTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import controllers.WithMockedProfiles;
-import io.prometheus.client.CollectorRegistry;
 import java.util.Locale;
 import models.ApplicantModel;
 import models.ApplicationModel;


### PR DESCRIPTION
### Description

Make unit test pass under sbt-test.

Before this fix, the default `CollectorRegistry` was cleared between test cases, but only initialized statically in the controller. By moving the clear step to the static method in the controller, the counters are always re-initialized after the registry is cleared.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

Fixes #5933 
