### PR TITLE
Refactor ApplicationEvent to ApplicationEventModel

### DIFF
--- a/server/app/models/ApplicationEventModel.java
+++ b/server/app/models/ApplicationEventModel.java
@@ -15,7 +15,7 @@ import services.application.ApplicationEventDetails;
 
 @Entity
 @Table(name = "application_events")
-public final class ApplicationEvent extends BaseModel {
+public final class ApplicationEventModel extends BaseModel {
 
   // The Application the event is on.
   @ManyToOne private ApplicationModel application;
@@ -37,7 +37,7 @@ public final class ApplicationEvent extends BaseModel {
    *
    * @param creator the Account that created the event.
    */
-  public ApplicationEvent(
+  public ApplicationEventModel(
       ApplicationModel application,
       Optional<AccountModel> creator,
       ApplicationEventDetails details) {
@@ -51,7 +51,7 @@ public final class ApplicationEvent extends BaseModel {
     return application;
   }
 
-  public ApplicationEvent setApplication(ApplicationModel application) {
+  public ApplicationEventModel setApplication(ApplicationModel application) {
     this.application = checkNotNull(application);
     return this;
   }
@@ -60,7 +60,7 @@ public final class ApplicationEvent extends BaseModel {
     return eventType;
   }
 
-  public ApplicationEvent setEventType(ApplicationEventDetails.Type eventType) {
+  public ApplicationEventModel setEventType(ApplicationEventDetails.Type eventType) {
     this.eventType = checkNotNull(eventType);
     return this;
   }
@@ -69,7 +69,7 @@ public final class ApplicationEvent extends BaseModel {
     return Optional.ofNullable(creator);
   }
 
-  public ApplicationEvent setCreator(AccountModel creator) {
+  public ApplicationEventModel setCreator(AccountModel creator) {
     this.creator = checkNotNull(creator);
     return this;
   }
@@ -78,7 +78,7 @@ public final class ApplicationEvent extends BaseModel {
     return details;
   }
 
-  public ApplicationEvent setDetails(ApplicationEventDetails details) {
+  public ApplicationEventModel setDetails(ApplicationEventDetails details) {
     this.details = checkNotNull(details);
     return this;
   }

--- a/server/app/models/ApplicationModel.java
+++ b/server/app/models/ApplicationModel.java
@@ -38,7 +38,7 @@ public class ApplicationModel extends BaseModel {
   // it and expect the number of results to be small.
   @OneToMany(mappedBy = "application")
   @OrderBy("createTime desc")
-  private List<ApplicationEvent> applicationEvents;
+  private List<ApplicationEventModel> applicationEvents;
 
   @Constraints.Required private LifecycleStage lifecycleStage;
 
@@ -115,7 +115,7 @@ public class ApplicationModel extends BaseModel {
     return this;
   }
 
-  public List<ApplicationEvent> getApplicationEvents() {
+  public List<ApplicationEventModel> getApplicationEvents() {
     return applicationEvents;
   }
 

--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -13,7 +13,7 @@ public final class Models {
           ApiKeyModel.class,
           ApplicantModel.class,
           ApplicationModel.class,
-          ApplicationEvent.class,
+          ApplicationEventModel.class,
           PersistedDurableJob.class,
           ProgramModel.class,
           Question.class,

--- a/server/app/repository/ApplicationEventRepository.java
+++ b/server/app/repository/ApplicationEventRepository.java
@@ -8,12 +8,12 @@ import io.ebean.DB;
 import io.ebean.Database;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 
 /**
- * ApplicationEventRepository performs operations on {@link ApplicationEvent} that often involve
- * other EBean models or asynchronous handling.
+ * ApplicationEventRepository performs operations on {@link ApplicationEventModel} that often
+ * involve other EBean models or asynchronous handling.
  */
 public final class ApplicationEventRepository {
   private static final QueryProfileLocationBuilder queryProfileLocationBuilder =
@@ -27,15 +27,15 @@ public final class ApplicationEventRepository {
     this.executionContext = checkNotNull(executionContext);
   }
 
-  /** Insert a new {@link ApplicationEvent} record synchronously. */
-  public ApplicationEvent insertSync(ApplicationEvent event) {
+  /** Insert a new {@link ApplicationEventModel} record synchronously. */
+  public ApplicationEventModel insertSync(ApplicationEventModel event) {
     database.insert(event);
     event.refresh();
     return event;
   }
 
-  /** Insert a new {@link ApplicationEvent} record asynchronously. */
-  public CompletionStage<ApplicationEvent> insertAsync(ApplicationEvent event) {
+  /** Insert a new {@link ApplicationEventModel} record asynchronously. */
+  public CompletionStage<ApplicationEventModel> insertAsync(ApplicationEventModel event) {
     return supplyAsync(
         () -> {
           database.insert(event);
@@ -46,18 +46,18 @@ public final class ApplicationEventRepository {
   }
 
   /**
-   * Returns all {@link ApplicationEvent} records for the {@link ApplicationModel} with id {@code
-   * applicationId} synchronously.
+   * Returns all {@link ApplicationEventModel} records for the {@link ApplicationModel} with id
+   * {@code applicationId} synchronously.
    */
-  public ImmutableList<ApplicationEvent> getEventsOrderByCreateTimeDesc(Long applicationId) {
+  public ImmutableList<ApplicationEventModel> getEventsOrderByCreateTimeDesc(Long applicationId) {
     return ImmutableList.copyOf(
         database
-            .find(ApplicationEvent.class)
+            .find(ApplicationEventModel.class)
             .where()
             .eq("application_id", applicationId)
             .orderBy()
             .desc("create_time")
-            .setLabel("ApplicationEvent.findSet")
+            .setLabel("ApplicationEventModel.findSet")
             .setProfileLocation(
                 queryProfileLocationBuilder.create("getEventsOrderByCreateTimeDesc"))
             .findList());

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.DisplayMode;
 import models.LifecycleStage;
@@ -424,7 +424,7 @@ public final class ApplicantService {
    * @param application the application on which to set the status
    * @param status the status to set the application to
    */
-  private CompletionStage<ApplicationEvent> setApplicationStatus(
+  private CompletionStage<ApplicationEventModel> setApplicationStatus(
       ApplicationModel application, StatusDefinitions.Status status) {
     // Set the status for the application automatically to the default status
     ApplicationEventDetails.StatusEvent statusEvent =
@@ -439,7 +439,7 @@ public final class ApplicantService {
             .build();
     // Because we are doing this automatically, set the Account to empty.
     return applicationEventRepository.insertAsync(
-        new ApplicationEvent(application, /* creator= */ Optional.empty(), details));
+        new ApplicationEventModel(application, /* creator= */ Optional.empty(), details));
   }
 
   @VisibleForTesting
@@ -467,7 +467,7 @@ public final class ApplicantService {
               Optional<StatusDefinitions.Status> maybeDefaultStatus =
                   applicationProgram.getDefaultStatus();
 
-              CompletableFuture<ApplicationEvent> updateStatusFuture =
+              CompletableFuture<ApplicationEventModel> updateStatusFuture =
                   maybeDefaultStatus
                       .map(
                           status -> setApplicationStatus(application, status).toCompletableFuture())

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 import java.util.Optional;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.ProgramModel;
 import play.i18n.Lang;
@@ -105,7 +105,8 @@ public final class ProgramAdminApplicationService {
             .setEventType(ApplicationEventDetails.Type.STATUS_CHANGE)
             .setStatusEvent(newStatusEvent)
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.of(admin), details);
+    ApplicationEventModel event =
+        new ApplicationEventModel(application, Optional.of(admin), details);
 
     // Send email if requested and present.
     if (sendEmail) {
@@ -207,7 +208,8 @@ public final class ProgramAdminApplicationService {
             .setEventType(ApplicationEventDetails.Type.NOTE_CHANGE)
             .setNoteEvent(note)
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.of(admin), details);
+    ApplicationEventModel event =
+        new ApplicationEventModel(application, Optional.of(admin), details);
     eventRepository.insertSync(event);
   }
 

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
 import models.ProgramModel;
@@ -424,7 +424,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.STATUS_CHANGE);
     assertThat(gotEvent.getDetails().statusEvent()).isPresent();
     assertThat(gotEvent.getDetails().statusEvent().get().statusText())
@@ -470,7 +470,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getDetails().statusEvent()).isPresent();
     assertThat(gotEvent.getDetails().statusEvent().get().emailSent()).isFalse();
   }
@@ -541,7 +541,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.NOTE_CHANGE);
     assertThat(gotEvent.getDetails().noteEvent()).isPresent();
     assertThat(gotEvent.getDetails().noteEvent().get().note()).isEqualTo(noteText);
@@ -571,7 +571,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getDetails().noteEvent()).isPresent();
     assertThat(gotEvent.getDetails().noteEvent().get().note()).isEqualTo(noteText);
   }

--- a/server/test/models/ApplicationEventModelTest.java
+++ b/server/test/models/ApplicationEventModelTest.java
@@ -10,7 +10,7 @@ import services.application.ApplicationEventDetails;
 import services.application.ApplicationEventDetails.NoteEvent;
 import services.application.ApplicationEventDetails.StatusEvent;
 
-public class ApplicationEventTest extends ResetPostgres {
+public class ApplicationEventModelTest extends ResetPostgres {
   @Test
   public void createNonStatusEventDoesNothing() {
     ProgramModel program = resourceCreator.insertActiveProgram("test program");
@@ -21,8 +21,8 @@ public class ApplicationEventTest extends ResetPostgres {
             resourceCreator.insertApplicantWithAccount(), program);
     assertThat(application.getLatestStatus()).isEmpty();
 
-    ApplicationEvent event =
-        new ApplicationEvent(
+    ApplicationEventModel event =
+        new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()
@@ -45,7 +45,7 @@ public class ApplicationEventTest extends ResetPostgres {
             resourceCreator.insertApplicantWithAccount(), program);
     assertThat(application.getLatestStatus()).isEmpty();
 
-    new ApplicationEvent(
+    new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()
@@ -59,7 +59,7 @@ public class ApplicationEventTest extends ResetPostgres {
     assertThat(application.getLatestStatus()).isEqualTo(Optional.of("approved"));
 
     // Create another event transitioning to empty and ensure that the result is empty.
-    new ApplicationEvent(
+    new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()
@@ -81,7 +81,7 @@ public class ApplicationEventTest extends ResetPostgres {
             resourceCreator.insertApplicantWithAccount(), program);
     assertThat(application.getLatestStatus()).isEmpty();
 
-    new ApplicationEvent(
+    new ApplicationEventModel(
             application,
             Optional.empty(),
             ApplicationEventDetails.builder()
@@ -105,8 +105,8 @@ public class ApplicationEventTest extends ResetPostgres {
             resourceCreator.insertApplicantWithAccount(), program);
     assertThat(application.getLatestStatus()).isEmpty();
 
-    ApplicationEvent firstEvent =
-        new ApplicationEvent(
+    ApplicationEventModel firstEvent =
+        new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()
@@ -123,8 +123,8 @@ public class ApplicationEventTest extends ResetPostgres {
     // update would have a distinct timestamp.
     TimeUnit.MILLISECONDS.sleep(5);
 
-    ApplicationEvent secondEvent =
-        new ApplicationEvent(
+    ApplicationEventModel secondEvent =
+        new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()

--- a/server/test/models/ApplicationModelTest.java
+++ b/server/test/models/ApplicationModelTest.java
@@ -36,8 +36,8 @@ public class ApplicationModelTest extends ResetPostgres {
             resourceCreator.insertApplicantWithAccount(), program);
     assertThat(application.getLatestStatus()).isEmpty();
 
-    ApplicationEvent event =
-        new ApplicationEvent(
+    ApplicationEventModel event =
+        new ApplicationEventModel(
             application,
             Optional.of(adminAccount),
             ApplicationEventDetails.builder()

--- a/server/test/repository/ApplicationEventRepositoryTest.java
+++ b/server/test/repository/ApplicationEventRepositoryTest.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 import java.util.Optional;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.ProgramModel;
 import org.junit.Before;
@@ -38,8 +38,9 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
             .setStatusEvent(
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.of(actor), details);
-    ApplicationEvent insertedEvent = repo.insertSync(event);
+    ApplicationEventModel event =
+        new ApplicationEventModel(application, Optional.of(actor), details);
+    ApplicationEventModel insertedEvent = repo.insertSync(event);
     // Generated values.
     assertThat(insertedEvent.id).isNotNull();
     assertThat(insertedEvent.getCreateTime()).isAfter(startInstant);
@@ -63,8 +64,8 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
             .setStatusEvent(
                 StatusEvent.builder().setStatusText("Status").setEmailSent(false).build())
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.empty(), details);
-    ApplicationEvent insertedEvent = repo.insertAsync(event).toCompletableFuture().join();
+    ApplicationEventModel event = new ApplicationEventModel(application, Optional.empty(), details);
+    ApplicationEventModel insertedEvent = repo.insertAsync(event).toCompletableFuture().join();
     // Generated values.
     assertThat(insertedEvent.id).isNotNull();
     assertThat(insertedEvent.getCreateTime()).isAfter(startInstant);
@@ -90,12 +91,14 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
 
-    ApplicationEvent event1 = new ApplicationEvent(application, Optional.of(actor), details);
-    ApplicationEvent insertedEvent1 = repo.insertSync(event1);
+    ApplicationEventModel event1 =
+        new ApplicationEventModel(application, Optional.of(actor), details);
+    ApplicationEventModel insertedEvent1 = repo.insertSync(event1);
 
-    ApplicationEvent event2 = new ApplicationEvent(application, Optional.of(actor), details);
+    ApplicationEventModel event2 =
+        new ApplicationEventModel(application, Optional.of(actor), details);
 
-    ApplicationEvent insertedEvent2 = repo.insertSync(event2);
+    ApplicationEventModel insertedEvent2 = repo.insertSync(event2);
 
     // Evaluate.
     assertThat(insertedEvent1.id).isNotEqualTo(insertedEvent2.id);
@@ -124,15 +127,17 @@ public class ApplicationEventRepositoryTest extends ResetPostgres {
             .setStatusEvent(
                 StatusEvent.builder().setStatusText("Status").setEmailSent(true).build())
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.of(actor), details);
+    ApplicationEventModel event =
+        new ApplicationEventModel(application, Optional.of(actor), details);
     repo.insertSync(event);
 
     // Execute
-    ImmutableList<ApplicationEvent> gotEvents = repo.getEventsOrderByCreateTimeDesc(application.id);
+    ImmutableList<ApplicationEventModel> gotEvents =
+        repo.getEventsOrderByCreateTimeDesc(application.id);
 
     // Verify
     assertThat(gotEvents).hasSize(1);
-    ApplicationEvent gotEvent = gotEvents.get(0);
+    ApplicationEventModel gotEvent = gotEvents.get(0);
     // Generated values.
     assertThat(gotEvent.id).isNotNull();
     assertThat(gotEvent.getCreateTime()).isAfter(startInstant);

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -17,7 +17,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.DisplayMode;
 import models.ProgramModel;
@@ -556,8 +556,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
               .setStatusEvent(
                   StatusEvent.builder().setStatusText(statusText).setEmailSent(true).build())
               .build();
-      ApplicationEvent event =
-          new ApplicationEvent(application, Optional.of(actorAccount), details);
+      ApplicationEventModel event =
+          new ApplicationEventModel(application, Optional.of(actorAccount), details);
       event.save();
 
       // When persisting models with @WhenModified fields, EBean

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.DisplayMode;
 import models.LifecycleStage;
@@ -947,7 +947,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     assertThat(application.getLatestStatus().get()).isEqualTo("Approved");
     assertThat(application.getApplicationEvents().size()).isEqualTo(1);
-    ApplicationEvent event = application.getApplicationEvents().get(0);
+    ApplicationEventModel event = application.getApplicationEvents().get(0);
     assertThat(event.getEventType().name()).isEqualTo("STATUS_CHANGE");
     assertThat(event.getDetails().statusEvent()).isNotEmpty();
     assertThat(event.getDetails().statusEvent().get().statusText()).isEqualTo("Approved");
@@ -2825,7 +2825,8 @@ public class ApplicantServiceTest extends ResetPostgres {
                     .setEmailSent(false)
                     .build())
             .build();
-    ApplicationEvent event = new ApplicationEvent(application, Optional.of(actorAccount), details);
+    ApplicationEventModel event =
+        new ApplicationEventModel(application, Optional.of(actorAccount), details);
     event.save();
     application.refresh();
   }

--- a/server/test/services/applications/ProgramAdminApplicationServiceTest.java
+++ b/server/test/services/applications/ProgramAdminApplicationServiceTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import junitparams.JUnitParamsRunner;
 import models.AccountModel;
 import models.ApplicantModel;
-import models.ApplicationEvent;
+import models.ApplicationEventModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
 import org.junit.Before;
@@ -222,7 +222,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
 
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.STATUS_CHANGE);
     assertThat(gotEvent.getDetails().statusEvent()).isPresent();
     assertThat(gotEvent.getDetails().statusEvent().get().statusText())
@@ -519,7 +519,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
 
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
-    ApplicationEvent gotEvent = application.getApplicationEvents().get(0);
+    ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
     assertThat(gotEvent.getEventType()).isEqualTo(ApplicationEventDetails.Type.STATUS_CHANGE);
     assertThat(gotEvent.getDetails().statusEvent()).isPresent();
     assertThat(gotEvent.getDetails().statusEvent().get().statusText()).isEqualTo(status);


### PR DESCRIPTION
### Description

Refactor the "ApplicationEvent" class to be "ApplicationEventModel", so it is clear when we may be accessing the database.

We'll do this to the other Models as well as a follow up.

Similar to https://github.com/civiform/civiform/pull/5960

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes
 
#5961
