### PR TITLE
Refactor Question to QuestionModel

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -9,7 +9,7 @@ import forms.ProgramQuestionDefinitionOptionalityForm;
 import java.util.Map.Entry;
 import java.util.Optional;
 import javax.inject.Inject;
-import models.Question;
+import models.QuestionModel;
 import org.pac4j.play.java.Secure;
 import play.data.DynamicForm;
 import play.data.FormFactory;
@@ -70,7 +70,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
     // The users' browser may be out of date. Find the last revision of each question.
     ImmutableList.Builder<Long> idBuilder = new ImmutableList.Builder<Long>();
     for (Long qId : questionIds) {
-      Optional<Question> latestQuestion = versionRepository.getLatestVersionOfQuestion(qId);
+      Optional<QuestionModel> latestQuestion = versionRepository.getLatestVersionOfQuestion(qId);
       if (latestQuestion.isEmpty()) {
         return notFound(String.format("Question ID %s not found", qId));
       }

--- a/server/app/forms/QuestionForm.java
+++ b/server/app/forms/QuestionForm.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import models.Question;
+import models.QuestionModel;
 import models.QuestionTag;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
@@ -177,7 +177,7 @@ public abstract class QuestionForm {
     }
 
     if (questionExportState.isEmpty()) {
-      Question q = new Question(this.qd);
+      QuestionModel q = new QuestionModel(this.qd);
       q.refresh();
       populateQuestionExportStateFromTags(q.getQuestionTags());
     }

--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -16,7 +16,7 @@ public final class Models {
           ApplicationEventModel.class,
           PersistedDurableJobModel.class,
           ProgramModel.class,
-          Question.class,
+          QuestionModel.class,
           StoredFile.class,
           TrustedIntermediaryGroup.class,
           VersionModel.class,

--- a/server/app/models/QuestionModel.java
+++ b/server/app/models/QuestionModel.java
@@ -53,7 +53,7 @@ import services.question.types.QuestionType;
  */
 @Entity
 @Table(name = "questions")
-public class Question extends BaseModel {
+public class QuestionModel extends BaseModel {
 
   private QuestionDefinition questionDefinition;
 
@@ -106,14 +106,14 @@ public class Question extends BaseModel {
   /** When the question was last modified. */
   @WhenModified private Instant lastModifiedTime;
 
-  @ManyToMany
+  @ManyToMany(mappedBy = "questions")
   @JoinTable(
       name = "versions_questions",
       joinColumns = @JoinColumn(name = "questions_id"),
       inverseJoinColumns = @JoinColumn(name = "versions_id"))
   private List<VersionModel> versions;
 
-  public Question(QuestionDefinition questionDefinition) {
+  public QuestionModel(QuestionDefinition questionDefinition) {
     this.questionDefinition = checkNotNull(questionDefinition);
     setFieldsFromQuestionDefinition(questionDefinition);
   }
@@ -122,7 +122,7 @@ public class Question extends BaseModel {
     return ImmutableList.copyOf(versions);
   }
 
-  public Question addVersion(VersionModel version) {
+  public QuestionModel addVersion(VersionModel version) {
     versions.add(version);
     return this;
   }
@@ -171,7 +171,7 @@ public class Question extends BaseModel {
    *
    * <p>The majority of questions should have `questionText` and not `legacyQuestionText`.
    */
-  private Question setQuestionText(QuestionDefinitionBuilder builder) {
+  private QuestionModel setQuestionText(QuestionDefinitionBuilder builder) {
     LocalizedStrings textToSet =
         Optional.ofNullable(questionText)
             .orElseGet(() -> LocalizedStrings.create(legacyQuestionText));
@@ -185,7 +185,7 @@ public class Question extends BaseModel {
    *
    * <p>The majority of questions should have `questionHelpText` and not `legacyQuestionHelpText`.
    */
-  private Question setQuestionHelpText(QuestionDefinitionBuilder builder) {
+  private QuestionModel setQuestionHelpText(QuestionDefinitionBuilder builder) {
     LocalizedStrings textToSet =
         Optional.ofNullable(questionHelpText)
             .orElseGet(
@@ -199,7 +199,7 @@ public class Question extends BaseModel {
    *
    * <p>The majority of questions should have a `questionOptions` and not `legacyQuestionOptions`.
    */
-  private Question setQuestionOptions(QuestionDefinitionBuilder builder)
+  private QuestionModel setQuestionOptions(QuestionDefinitionBuilder builder)
       throws InvalidQuestionTypeException {
     if (!QuestionType.of(questionType).isMultiOptionType()) {
       return this;
@@ -232,7 +232,7 @@ public class Question extends BaseModel {
     return this;
   }
 
-  private Question setEnumeratorEntityType(QuestionDefinitionBuilder builder)
+  private QuestionModel setEnumeratorEntityType(QuestionDefinitionBuilder builder)
       throws InvalidQuestionTypeException {
     if (QuestionType.of(questionType).equals(QuestionType.ENUMERATOR)) {
       builder.setEntityType(enumeratorEntityType);
@@ -244,7 +244,7 @@ public class Question extends BaseModel {
     return checkNotNull(questionDefinition);
   }
 
-  private Question setFieldsFromQuestionDefinition(QuestionDefinition questionDefinition) {
+  private QuestionModel setFieldsFromQuestionDefinition(QuestionDefinition questionDefinition) {
     if (questionDefinition.isPersisted()) {
       id = questionDefinition.getId();
     }

--- a/server/app/models/VersionModel.java
+++ b/server/app/models/VersionModel.java
@@ -36,7 +36,7 @@ public final class VersionModel extends BaseModel {
       name = "versions_questions",
       joinColumns = @JoinColumn(name = "versions_id"),
       inverseJoinColumns = @JoinColumn(name = "questions_id"))
-  private List<Question> questions;
+  private List<QuestionModel> questions;
 
   /**
    * A tombstoned question is a question that will not be copied to the next version published. It
@@ -89,12 +89,12 @@ public final class VersionModel extends BaseModel {
     return this.programs.remove(program);
   }
 
-  public VersionModel addQuestion(Question question) {
+  public VersionModel addQuestion(QuestionModel question) {
     this.questions.add(question);
     return this;
   }
 
-  public boolean removeQuestion(Question question) {
+  public boolean removeQuestion(QuestionModel question) {
     return this.questions.remove(question);
   }
 
@@ -110,7 +110,7 @@ public final class VersionModel extends BaseModel {
    * Returns all questions of a given version. Instead of calling this function directly,
    * getQuestionsForVersion should be called, since that will implement caching.
    */
-  public ImmutableList<Question> getQuestions() {
+  public ImmutableList<QuestionModel> getQuestions() {
     return ImmutableList.copyOf(questions);
   }
 
@@ -158,7 +158,7 @@ public final class VersionModel extends BaseModel {
    *
    * @return true if the question previously was tombstoned and false otherwise.
    */
-  public boolean removeTombstoneForQuestion(Question question) {
+  public boolean removeTombstoneForQuestion(QuestionModel question) {
     if (this.tombstonedQuestionNames == null) {
       this.tombstonedQuestionNames = new ArrayList<>();
     }

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import models.Question;
+import models.QuestionModel;
 import models.QuestionTag;
 import models.VersionModel;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -26,8 +26,8 @@ import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 
 /**
- * QuestionRepository performs complicated operations on {@link Question} that often involve other
- * EBean models or asynchronous handling.
+ * QuestionRepository performs complicated operations on {@link QuestionModel} that often involve
+ * other EBean models or asynchronous handling.
  */
 public final class QuestionRepository {
   private final QueryProfileLocationBuilder queryProfileLocationBuilder =
@@ -46,23 +46,23 @@ public final class QuestionRepository {
     this.versionRepositoryProvider = checkNotNull(versionRepositoryProvider);
   }
 
-  public CompletionStage<Set<Question>> listQuestions() {
+  public CompletionStage<Set<QuestionModel>> listQuestions() {
     return supplyAsync(
         () ->
             database
-                .find(Question.class)
-                .setLabel("Question.findSet")
+                .find(QuestionModel.class)
+                .setLabel("QuestionModel.findSet")
                 .setProfileLocation(queryProfileLocationBuilder.create("listQuestions"))
                 .findSet(),
         executionContext);
   }
 
-  public CompletionStage<Optional<Question>> lookupQuestion(long id) {
+  public CompletionStage<Optional<QuestionModel>> lookupQuestion(long id) {
     return supplyAsync(
         () ->
             database
-                .find(Question.class)
-                .setLabel("Question.findById")
+                .find(QuestionModel.class)
+                .setLabel("QuestionModel.findById")
                 .setProfileLocation(queryProfileLocationBuilder.create("lookupQuestion"))
                 .setId(id)
                 .findOneOrEmpty(),
@@ -73,28 +73,28 @@ public final class QuestionRepository {
    * Find and update the DRAFT of the question with this name, if one already exists. Create a new
    * DRAFT if there isn't one.
    */
-  public Question createOrUpdateDraft(QuestionDefinition definition) {
+  public QuestionModel createOrUpdateDraft(QuestionDefinition definition) {
     VersionModel draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try (Transaction transaction =
         database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
-      Optional<Question> existingDraft =
+      Optional<QuestionModel> existingDraft =
           versionRepositoryProvider
               .get()
               .getQuestionByNameForVersion(definition.getName(), draftVersion);
       try {
         if (existingDraft.isPresent()) {
-          Question updatedDraft =
-              new Question(
+          QuestionModel updatedDraft =
+              new QuestionModel(
                   new QuestionDefinitionBuilder(definition).setId(existingDraft.get().id).build());
           this.updateQuestionSync(updatedDraft);
           transaction.commit();
           return updatedDraft;
         }
-        Question newDraftQuestion =
-            new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
+        QuestionModel newDraftQuestion =
+            new QuestionModel(new QuestionDefinitionBuilder(definition).setId(null).build());
         insertQuestionSync(newDraftQuestion);
         // Fetch the tags off the old question.
-        Question oldQuestion = new Question(definition);
+        QuestionModel oldQuestion = new QuestionModel(definition);
         oldQuestion.refresh();
         oldQuestion.getQuestionTags().forEach(newDraftQuestion::addTag);
 
@@ -159,7 +159,7 @@ public final class QuestionRepository {
   }
 
   /**
-   * Maybe find a {@link Question} that conflicts with {@link QuestionDefinition}.
+   * Maybe find a {@link QuestionModel} that conflicts with {@link QuestionDefinition}.
    *
    * <p>This is intended to be used for new question definitions, since updates will collide with
    * themselves and previous versions, and new versions of an old question will conflict with the
@@ -168,15 +168,15 @@ public final class QuestionRepository {
    * <p>Questions collide if they share a {@link QuestionDefinition#getQuestionPathSegment()} and
    * {@link QuestionDefinition#getEnumeratorId()}.
    */
-  public Optional<Question> findConflictingQuestion(QuestionDefinition newQuestionDefinition) {
+  public Optional<QuestionModel> findConflictingQuestion(QuestionDefinition newQuestionDefinition) {
     ConflictDetector conflictDetector =
         new ConflictDetector(
             newQuestionDefinition.getEnumeratorId(),
             newQuestionDefinition.getQuestionPathSegment(),
             newQuestionDefinition.getName());
     database
-        .find(Question.class)
-        .setLabel("Question.findConflict")
+        .find(QuestionModel.class)
+        .setLabel("QuestionModel.findConflict")
         .setProfileLocation(queryProfileLocationBuilder.create("findConflictingQuestion"))
         .findEachWhile(question -> !conflictDetector.hasConflict(question));
     return conflictDetector.getConflictedQuestion();
@@ -190,8 +190,8 @@ public final class QuestionRepository {
             .map(q -> q.id)
             .collect(ImmutableSet.toImmutableSet());
     return database
-        .find(Question.class)
-        .setLabel("Question.findList")
+        .find(QuestionModel.class)
+        .setLabel("QuestionModel.findList")
         .setProfileLocation(queryProfileLocationBuilder.create("getAllQuestionsForTag"))
         .where()
         .arrayContains("question_tags", tag)
@@ -199,7 +199,7 @@ public final class QuestionRepository {
         .stream()
         .filter(question -> activeQuestionIds.contains(question.id))
         .sorted(Comparator.comparing(question -> question.getQuestionDefinition().getName()))
-        .map(Question::getQuestionDefinition)
+        .map(QuestionModel::getQuestionDefinition)
         .collect(ImmutableList.toImmutableList());
   }
 
@@ -209,8 +209,8 @@ public final class QuestionRepository {
     // with the same name can exist. We achieve this by a custom merge function that chooses the
     // value with the greater ID.
     return database
-        .find(Question.class)
-        .setLabel("Question.findList")
+        .find(QuestionModel.class)
+        .setLabel("QuestionModel.findList")
         .setProfileLocation(queryProfileLocationBuilder.create("getExistingQuestions"))
         .where()
         .in("name", questionNames)
@@ -218,7 +218,7 @@ public final class QuestionRepository {
         .asc("id")
         .findList()
         .stream()
-        .map(Question::getQuestionDefinition)
+        .map(QuestionModel::getQuestionDefinition)
         .collect(
             ImmutableMap.toImmutableMap(
                 QuestionDefinition::getName,
@@ -227,7 +227,7 @@ public final class QuestionRepository {
   }
 
   private static final class ConflictDetector {
-    private Optional<Question> conflictedQuestion = Optional.empty();
+    private Optional<QuestionModel> conflictedQuestion = Optional.empty();
     private final Optional<Long> enumeratorId;
     private final String questionPathSegment;
     private final String questionName;
@@ -239,11 +239,11 @@ public final class QuestionRepository {
       this.questionName = checkNotNull(questionName);
     }
 
-    private Optional<Question> getConflictedQuestion() {
+    private Optional<QuestionModel> getConflictedQuestion() {
       return conflictedQuestion;
     }
 
-    private boolean hasConflict(Question question) {
+    private boolean hasConflict(QuestionModel question) {
       QuestionDefinition definition = question.getQuestionDefinition();
       boolean isSameName = definition.getName().equals(questionName);
       boolean isSameEnumId = definition.getEnumeratorId().equals(enumeratorId);
@@ -256,7 +256,7 @@ public final class QuestionRepository {
     }
   }
 
-  public CompletionStage<Question> insertQuestion(Question question) {
+  public CompletionStage<QuestionModel> insertQuestion(QuestionModel question) {
     return supplyAsync(
         () -> {
           database.insert(question);
@@ -265,12 +265,12 @@ public final class QuestionRepository {
         executionContext);
   }
 
-  public Question insertQuestionSync(Question question) {
+  public QuestionModel insertQuestionSync(QuestionModel question) {
     database.insert(question);
     return question;
   }
 
-  public CompletionStage<Question> updateQuestion(Question question) {
+  public CompletionStage<QuestionModel> updateQuestion(QuestionModel question) {
     return supplyAsync(
         () -> {
           database.update(question);
@@ -279,7 +279,7 @@ public final class QuestionRepository {
         executionContext);
   }
 
-  public Question updateQuestionSync(Question question) {
+  public QuestionModel updateQuestionSync(QuestionModel question) {
     database.update(question);
     return question;
   }

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
 import models.ProgramModel;
+import models.QuestionModel;
 import services.Path;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Question;
@@ -40,7 +41,7 @@ public abstract class AnswerData {
   /** The repeated entity if this is an answer to a repeated question. Otherwise, empty. */
   public abstract Optional<RepeatedEntity> repeatedEntity();
 
-  /** The index of the {@link models.Question} this is an answer for in the block it appeared in. */
+  /** The index of the {@link QuestionModel} this is an answer for in the block it appeared in. */
   public abstract int questionIndex();
 
   /** The localized question text */

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Optional;
 import java.util.function.Function;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import repository.VersionRepository;
 import services.DeletionStatus;
@@ -49,13 +49,13 @@ public final class ActiveAndDraftQuestions {
     VersionModel withDraftEdits = repository.previewPublishNewSynchronizedVersion();
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
         repository.getQuestionsForVersion(active).stream()
-            .map(Question::getQuestionDefinition)
+            .map(QuestionModel::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.activeQuestions = activeNameToQuestion.values().asList();
 
     ImmutableMap<String, QuestionDefinition> draftNameToQuestion =
         repository.getQuestionsForVersion(draft).stream()
-            .map(Question::getQuestionDefinition)
+            .map(QuestionModel::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.draftQuestions = draftNameToQuestion.values().asList();
 

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
     Set<String> namesFoundInDraft = new HashSet<>();
     for (QuestionDefinition qd :
         repository.getQuestionsForVersion(draftVersion).stream()
-            .map(Question::getQuestionDefinition)
+            .map(QuestionModel::getQuestionDefinition)
             .collect(Collectors.toList())) {
       if (!draftVersion.getTombstonedQuestionNames().contains(qd.getName())) {
         // If the question is about to be deleted, it is not "up to date."
@@ -49,7 +49,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
     }
     for (QuestionDefinition qd :
         repository.getQuestionsForVersion(activeVersion).stream()
-            .map(Question::getQuestionDefinition)
+            .map(QuestionModel::getQuestionDefinition)
             .collect(Collectors.toList())) {
 
       questionIdMap.put(qd.getId(), qd);

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -2,7 +2,7 @@ package services.question;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +28,7 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
       VersionModel version, VersionRepository versionRepository) {
     questionsById =
         versionRepository.getQuestionsForVersion(version).stream()
-            .map(Question::getQuestionDefinition)
+            .map(QuestionModel::getQuestionDefinition)
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
   }
 

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -11,7 +11,7 @@ import static support.CfTestHelpers.requestBuilderWithSettings;
 
 import com.google.common.collect.ImmutableMap;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
@@ -147,7 +147,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .withName("Admin name")
             .withDescription("Admin description")
             .build();
-    Question applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result = controller.show(request, program.id, /*blockId =*/ 1L);
@@ -190,7 +190,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .withName("Admin name")
             .withDescription("Admin description")
             .build();
-    Question applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result = controller.edit(request, program.id, /*blockId =*/ 1L);

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -17,7 +17,7 @@ import forms.DropdownQuestionForm;
 import java.util.Locale;
 import java.util.Optional;
 import models.LifecycleStage;
-import models.Question;
+import models.QuestionModel;
 import models.QuestionTag;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,7 +73,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
     assertThat(questionIdsAfter.size()).isEqualTo(questionIdsBefore.size() + 1);
     Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
-    Question newQuestion =
+    QuestionModel newQuestion =
         questionRepo.lookupQuestion(newQuestionId).toCompletableFuture().join().get();
     assertThat(newQuestion.getQuestionDefinition().getName()).isEqualTo("name");
     assertThat(newQuestion.getQuestionDefinition().getDescription()).isEqualTo("desc");
@@ -104,7 +104,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
     assertThat(questionIdsAfter.size()).isEqualTo(questionIdsBefore.size() + 1);
     Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
-    Question newQuestion =
+    QuestionModel newQuestion =
         questionRepo.lookupQuestion(newQuestionId).toCompletableFuture().join().get();
     assertThat(newQuestion.getQuestionDefinition().getName()).isEqualTo("name");
     assertThat(newQuestion.getQuestionDefinition().getDescription()).isEqualTo("desc");
@@ -116,7 +116,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void create_repeatedQuestion_redirectsOnSuccess() {
-    Question enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "name")
@@ -136,7 +136,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
     assertThat(questionIdsAfter.size()).isEqualTo(questionIdsBefore.size() + 1);
     Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
-    Question newQuestion =
+    QuestionModel newQuestion =
         questionRepo.lookupQuestion(newQuestionId).toCompletableFuture().join().get();
     assertThat(newQuestion.getQuestionDefinition().getName()).isEqualTo("name");
     assertThat(newQuestion.getQuestionDefinition().getDescription()).isEqualTo("desc");
@@ -186,8 +186,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsRedirectWhenEditingQuestionWithExistingDraft() {
-    Question publishedQuestion = testQuestionBank.applicantName();
-    Question draftQuestion =
+    QuestionModel publishedQuestion = testQuestionBank.applicantName();
+    QuestionModel draftQuestion =
         testQuestionBank.maybeSave(
             this.createNameQuestionDuplicate(publishedQuestion), LifecycleStage.DRAFT);
 
@@ -204,7 +204,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsPopulatedForm() {
-    Question question = testQuestionBank.applicantName();
+    QuestionModel question = testQuestionBank.applicantName();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result = controller.edit(request, question.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
@@ -215,7 +215,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_repeatedQuestion_hasEnumeratorName() {
-    Question repeatedQuestion = testQuestionBank.applicantHouseholdMemberName();
+    QuestionModel repeatedQuestion = testQuestionBank.applicantHouseholdMemberName();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result = controller.edit(request, repeatedQuestion.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
@@ -314,7 +314,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   @Test
   public void update_redirectsOnSuccessAndUpdatesQuestion() {
     // We can only update draft questions, so save this in the DRAFT version.
-    Question originalNameQuestion =
+    QuestionModel originalNameQuestion =
         testQuestionBank.maybeSave(
             this.createNameQuestionDuplicate(testQuestionBank.applicantName()),
             LifecycleStage.DRAFT);
@@ -341,7 +341,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation()).hasValue(routes.AdminQuestionController.index().url());
     assertThat(result.flash().get("success").get()).contains("updated");
 
-    Question updatedNameQuestion =
+    QuestionModel updatedNameQuestion =
         questionRepo
             .lookupQuestion(originalNameQuestion.getQuestionDefinition().getId())
             .toCompletableFuture()
@@ -439,7 +439,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
 
     // We can only update draft questions, so save this in the DRAFT version.
-    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
     ImmutableMap<String, String> formData =
         ImmutableMap.<String, String>builder()
@@ -467,7 +467,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             requestBuilder.build(), question.id, definition.getQuestionType().toString());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found =
+        questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getQuestionText().translations())
         .containsExactlyInAnyOrderEntriesOf(
@@ -531,7 +532,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
 
     // We can only update draft questions, so save this in the DRAFT version.
-    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
     ImmutableMap<String, String> formData =
         ImmutableMap.<String, String>builder()
@@ -552,7 +553,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     RequestBuilder requestBuilder = addCSRFToken(requestBuilderWithSettings().bodyForm(formData));
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
-    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found =
+        questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     ImmutableList<QuestionOption> expectedOptions =
         ImmutableList.of(
@@ -597,7 +599,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
 
     // We can only update draft questions, so save this in the DRAFT version.
-    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
     ImmutableMap<String, String> formData =
         ImmutableMap.<String, String>builder()
@@ -618,7 +620,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     RequestBuilder requestBuilder = addCSRFToken(requestBuilderWithSettings().bodyForm(formData));
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
-    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found =
+        questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     ImmutableList<QuestionOption> expectedOptions =
         ImmutableList.of(
@@ -663,7 +666,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             config, questionOptions, MultiOptionQuestionType.DROPDOWN);
 
     // We can only update draft questions, so save this in the DRAFT version.
-    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
     ImmutableMap<String, String> formData =
         ImmutableMap.<String, String>builder()
@@ -685,7 +688,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     RequestBuilder requestBuilder = addCSRFToken(requestBuilderWithSettings().bodyForm(formData));
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
-    Question found = questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found =
+        questionRepo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     ImmutableList<QuestionOption> expectedOptions =
         ImmutableList.of(
@@ -705,7 +709,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
-    Question question = testQuestionBank.applicantFavoriteColor();
+    QuestionModel question = testQuestionBank.applicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "favorite_color")
@@ -723,7 +727,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void update_failsWithInvalidQuestionType() {
-    Question question = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel question = testQuestionBank.applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionType", "INVALID_TYPE").put("questionText", "question text updated!");
     RequestBuilder requestBuilder = requestBuilderWithSettings().bodyForm(formData.build());
@@ -733,7 +737,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
-  private NameQuestionDefinition createNameQuestionDuplicate(Question question) {
+  private NameQuestionDefinition createNameQuestionDuplicate(QuestionModel question) {
     QuestionDefinition def = question.getQuestionDefinition();
     return new NameQuestionDefinition(
         QuestionDefinitionConfig.builder()

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -11,7 +11,7 @@ import static play.test.Helpers.fakeRequest;
 import com.google.common.collect.ImmutableMap;
 import controllers.BadRequestException;
 import java.util.Locale;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_defaultLocaleRedirectsWithError() {
-    Question question = createDraftQuestionEnglishAndSpanish();
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
         controller.edit(
@@ -67,7 +67,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_rendersForm_otherLocale() throws UnsupportedQuestionTypeException {
-    Question question = createDraftQuestionEnglishAndSpanish();
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
         controller.edit(
@@ -99,7 +99,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void update_addsNewLocalesAndRedirects() throws TranslationNotFoundException {
-    Question question = createDraftQuestionEnglishOnly();
+    QuestionModel question = createDraftQuestionEnglishOnly();
     Http.RequestBuilder requestBuilder =
         fakeRequest()
             .bodyForm(
@@ -133,7 +133,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   @Test
   public void update_updatesExistingLocalesAndRedirects()
       throws TranslationNotFoundException, UnsupportedQuestionTypeException {
-    Question question = createDraftQuestionEnglishAndSpanish();
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
     Http.RequestBuilder requestBuilder =
         fakeRequest()
             .bodyForm(
@@ -177,7 +177,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   @Test
   public void update_validationErrors_rendersEditFormWithMessage()
       throws UnsupportedQuestionTypeException {
-    Question question = createDraftQuestionEnglishAndSpanish();
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
     Http.RequestBuilder requestBuilder =
         fakeRequest().bodyForm(ImmutableMap.of("questionText", "", "questionHelpText", ""));
 
@@ -195,7 +195,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
             "Question text cannot be blank");
   }
 
-  private Question createDraftQuestionEnglishOnly() {
+  private QuestionModel createDraftQuestionEnglishOnly() {
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -204,14 +204,14 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_TEXT))
                 .setQuestionHelpText(LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT))
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
     // Only draft questions are editable.
     question.addVersion(draftVersion);
     question.save();
     return question;
   }
 
-  private Question createDraftQuestionEnglishAndSpanish() {
+  private QuestionModel createDraftQuestionEnglishAndSpanish() {
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -224,7 +224,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     LocalizedStrings.withDefaultValue(ENGLISH_QUESTION_HELP_TEXT)
                         .updateTranslation(ES_LOCALE, SPANISH_QUESTION_HELP_TEXT))
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
     // Only draft questions are editable.
     question.addVersion(draftVersion);
     question.save();

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -12,7 +12,7 @@ import auth.ProfileFactory;
 import controllers.WithMockedProfiles;
 import models.ApplicantModel;
 import models.ApplicationModel;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Result;
@@ -65,7 +65,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
   @Test
   public void
       considerRegister_redirectsToUpsellViewForCommonIntakeWithNoRecommendedProgramsFound() {
-    Question predicateQuestion = testQuestionBank().applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank().applicantFavoriteColor();
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -123,7 +123,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
 
   @Test
   public void considerRegister_redirectsToUpsellViewForCommonIntakeWithRecommendedPrograms() {
-    Question predicateQuestion = testQuestionBank().applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank().applicantFavoriteColor();
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
             .setPredicate(

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Set;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ProgramRepository;
@@ -61,7 +61,7 @@ public class DevDatabaseSeedTaskTest extends ResetPostgres {
         .containsExactlyInAnyOrder("comprehensive-sample-program", "minimal-sample-program");
   }
 
-  private Set<Question> getAllQuestions() {
+  private Set<QuestionModel> getAllQuestions() {
     return questionRepository.listQuestions().toCompletableFuture().join();
   }
 }

--- a/server/test/models/QuestionModelTest.java
+++ b/server/test/models/QuestionModelTest.java
@@ -23,7 +23,7 @@ import services.question.types.QuestionType;
 import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
-public class QuestionTest extends ResetPostgres {
+public class QuestionModelTest extends ResetPostgres {
 
   private QuestionRepository repo;
 
@@ -42,11 +42,11 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     QuestionDefinition expected =
         new QuestionDefinitionBuilder(definition).setId(question.id).build();
@@ -63,10 +63,10 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(questionDefinition);
+    QuestionModel question = new QuestionModel(questionDefinition);
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getEnumeratorId()).isEmpty();
   }
@@ -82,10 +82,10 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setEnumeratorId(Optional.of(10L))
                 .build());
-    Question question = new Question(questionDefinition);
+    QuestionModel question = new QuestionModel(questionDefinition);
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getEnumeratorId()).hasValue(10L);
   }
@@ -100,11 +100,11 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "hello"))
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getQuestionText())
         .isEqualTo(LocalizedStrings.of(Locale.US, "hello"));
@@ -122,11 +122,11 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(address);
+    QuestionModel question = new QuestionModel(address);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition()).isInstanceOf(AddressQuestionDefinition.class);
   }
@@ -142,11 +142,11 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(TextValidationPredicates.create(0, 128))
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getValidationPredicates())
         .isEqualTo(TextValidationPredicates.create(0, 128));
@@ -167,11 +167,11 @@ public class QuestionTest extends ResetPostgres {
                 ImmutableList.of(
                     QuestionOption.create(1L, "opt1", LocalizedStrings.of(Locale.US, "option"))))
             .build();
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getQuestionType().isMultiOptionType()).isTrue();
     MultiOptionQuestionDefinition multiOption =
@@ -199,11 +199,11 @@ public class QuestionTest extends ResetPostgres {
             .setQuestionHelpText(LocalizedStrings.empty())
             .setEntityType(entityType)
             .build();
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
 
     question.save();
 
-    Question found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel found = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
 
     assertThat(found.getQuestionDefinition().getQuestionType()).isEqualTo(QuestionType.ENUMERATOR);
     EnumeratorQuestionDefinition enumerator =
@@ -223,14 +223,14 @@ public class QuestionTest extends ResetPostgres {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setEnumeratorId(Optional.of(10L))
                 .build());
-    Question initialQuestion = new Question(questionDefinition);
+    QuestionModel initialQuestion = new QuestionModel(questionDefinition);
     initialQuestion.save();
 
     assertThat(initialQuestion.getCreateTime()).isNotEmpty();
     assertThat(initialQuestion.getQuestionDefinition().getLastModifiedTime()).isNotEmpty();
 
     // Ensure a freshly loaded copy has the same timestamps.
-    Question freshlyLoaded =
+    QuestionModel freshlyLoaded =
         repo.lookupQuestion(initialQuestion.id).toCompletableFuture().join().get();
     assertThat(freshlyLoaded.getCreateTime()).isEqualTo(initialQuestion.getCreateTime());
     assertThat(freshlyLoaded.getQuestionDefinition().getLastModifiedTime())
@@ -246,7 +246,7 @@ public class QuestionTest extends ResetPostgres {
     freshlyLoaded.markAsDirty();
     freshlyLoaded.save();
 
-    Question afterUpdate =
+    QuestionModel afterUpdate =
         repo.lookupQuestion(initialQuestion.id).toCompletableFuture().join().get();
     assertThat(afterUpdate.getCreateTime()).isEqualTo(initialQuestion.getCreateTime());
     assertThat(afterUpdate.getQuestionDefinition().getLastModifiedTime()).isPresent();
@@ -267,17 +267,17 @@ public class QuestionTest extends ResetPostgres {
     QuestionDefinition nonUniversalQuestionDefinition =
         new TextQuestionDefinition(builder.setUniversal(false).build());
 
-    Question universalQuestion = new Question(universalQuestionDefinition);
+    QuestionModel universalQuestion = new QuestionModel(universalQuestionDefinition);
     universalQuestion.save();
-    Question nonUniversalQuestion = new Question(nonUniversalQuestionDefinition);
+    QuestionModel nonUniversalQuestion = new QuestionModel(nonUniversalQuestionDefinition);
     nonUniversalQuestion.save();
 
-    Question universalFound =
+    QuestionModel universalFound =
         repo.lookupQuestion(universalQuestion.id).toCompletableFuture().join().get();
     assertThat(universalFound.getQuestionDefinition().isUniversal()).isTrue();
     assertThat(universalFound.containsTag(QuestionTag.UNIVERSAL)).isTrue();
 
-    Question nonUniversalFound =
+    QuestionModel nonUniversalFound =
         repo.lookupQuestion(nonUniversalQuestion.id).toCompletableFuture().join().get();
     assertThat(nonUniversalFound.getQuestionDefinition().isUniversal()).isFalse();
     assertThat(nonUniversalFound.containsTag(QuestionTag.UNIVERSAL)).isFalse();

--- a/server/test/models/VersionModelTest.java
+++ b/server/test/models/VersionModelTest.java
@@ -51,7 +51,7 @@ public class VersionModelTest extends ResetPostgres {
   @Test
   public void addAndRemoveQuestion() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
-    Question question = resourceCreator.insertQuestion("name");
+    QuestionModel question = resourceCreator.insertQuestion("name");
 
     version.addQuestion(question);
     assertThat(version.getQuestions()).hasSize(1);
@@ -109,11 +109,11 @@ public class VersionModelTest extends ResetPostgres {
   public void getQuestionNames() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     String questionTwoName = "two";
-    Question questionTwo = resourceCreator.insertQuestion(questionTwoName);
+    QuestionModel questionTwo = resourceCreator.insertQuestion(questionTwoName);
     String tombstonedQuestionOneName = "tombstoneOne";
-    Question tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
+    QuestionModel tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
 
     version.addQuestion(questionOne);
     version.addQuestion(questionTwo);
@@ -153,11 +153,11 @@ public class VersionModelTest extends ResetPostgres {
   public void getTombstonedQuestionNames() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     String tombstonedQuestionOneName = "tombstoneOne";
-    Question tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
+    QuestionModel tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
     String tombstonedQuestionTwoName = "tombstoneTwo";
-    Question tombstonedQuestionTwo = resourceCreator.insertQuestion(tombstonedQuestionTwoName);
+    QuestionModel tombstonedQuestionTwo = resourceCreator.insertQuestion(tombstonedQuestionTwoName);
 
     version.addQuestion(questionOne);
     version.addQuestion(tombstonedQuestionOne);
@@ -175,9 +175,9 @@ public class VersionModelTest extends ResetPostgres {
   public void questionIsTombstoned() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     String tombstonedQuestionOneName = "tombstoneOne";
-    Question tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
+    QuestionModel tombstonedQuestionOne = resourceCreator.insertQuestion(tombstonedQuestionOneName);
 
     version.addQuestion(questionOne);
     version.addQuestion(tombstonedQuestionOne);
@@ -216,7 +216,7 @@ public class VersionModelTest extends ResetPostgres {
   public void addTombstoneForQuestion() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     boolean succeeded = versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
@@ -231,7 +231,7 @@ public class VersionModelTest extends ResetPostgres {
   public void addTombstoneForQuestion_alreadyTombstoned() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     boolean succeeded = versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
@@ -249,7 +249,7 @@ public class VersionModelTest extends ResetPostgres {
     VersionModel activeVersion = versionRepository.getActiveVersion();
     VersionModel draftVersion = versionRepository.getDraftVersionOrCreate();
 
-    Question question = resourceCreator.insertQuestion("question");
+    QuestionModel question = resourceCreator.insertQuestion("question");
     question.addVersion(activeVersion).save();
     activeVersion.refresh();
 
@@ -262,7 +262,7 @@ public class VersionModelTest extends ResetPostgres {
   public void removeTombstoneForQuestion() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
@@ -279,7 +279,7 @@ public class VersionModelTest extends ResetPostgres {
   public void removeTombstoneForQuestion_forNonTombstonedQuestion() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     boolean succeeded = version.removeTombstoneForQuestion(questionOne);
@@ -321,7 +321,7 @@ public class VersionModelTest extends ResetPostgres {
   public void hasAnyChanges_hasTombstonedQuestions() throws Exception {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
     versionRepository.addTombstoneForQuestionInVersion(questionOne, version);
 
@@ -342,7 +342,7 @@ public class VersionModelTest extends ResetPostgres {
   public void hasAnyChanges_hasQuestions() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     assertThat(version.hasAnyChanges()).isTrue();
@@ -362,7 +362,7 @@ public class VersionModelTest extends ResetPostgres {
   public void hasAnyChanges_noChanges() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionOneName = "one";
-    Question questionOne = resourceCreator.insertQuestion(questionOneName);
+    QuestionModel questionOne = resourceCreator.insertQuestion(questionOneName);
     version.addQuestion(questionOne);
 
     // Revert changes.

--- a/server/test/repository/ExportServiceRepositoryTest.java
+++ b/server/test/repository/ExportServiceRepositoryTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import models.LifecycleStage;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import services.LocalizedStrings;
@@ -42,7 +42,7 @@ public class ExportServiceRepositoryTest extends ResetPostgres {
   @Test
   public void getMultiSelectedHeaders_DraftVersionExcludedButPublishedVersionIncluded()
       throws Exception {
-    Question questionWeather =
+    QuestionModel questionWeather =
         createMultiSelectQuestion("weather", "fall", "spring", "summer", LifecycleStage.ACTIVE);
     MultiOptionQuestionDefinition multiOptionQuestionDefinition =
         (MultiOptionQuestionDefinition) questionWeather.getQuestionDefinition();
@@ -73,7 +73,7 @@ public class ExportServiceRepositoryTest extends ResetPostgres {
 
   @Test
   public void getMultiSelectedHeaders_DeletedOptionsIncluded() throws Exception {
-    Question questionWeather =
+    QuestionModel questionWeather =
         createMultiSelectQuestion("weather", "fall", "spring", "summer", LifecycleStage.ACTIVE);
     MultiOptionQuestionDefinition multiOptionQuestionDefinition =
         (MultiOptionQuestionDefinition) questionWeather.getQuestionDefinition();
@@ -147,7 +147,7 @@ public class ExportServiceRepositoryTest extends ResetPostgres {
 
   // TODO(#5957): Structuring this using the Builder pattern would make this easier to extend or
   // customize
-  private Question createMultiSelectQuestion(
+  private QuestionModel createMultiSelectQuestion(
       String name, String option1, String option2, String option3, LifecycleStage stage) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import services.LocalizedStrings;
@@ -36,17 +36,17 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void listQuestions() {
-    Question one = resourceCreator.insertQuestion();
-    Question two = resourceCreator.insertQuestion();
+    QuestionModel one = resourceCreator.insertQuestion();
+    QuestionModel two = resourceCreator.insertQuestion();
 
-    Set<Question> list = repo.listQuestions().toCompletableFuture().join();
+    Set<QuestionModel> list = repo.listQuestions().toCompletableFuture().join();
 
     assertThat(list).containsExactly(one, two);
   }
 
   @Test
   public void lookupQuestion_returnsEmptyOptionalWhenQuestionNotFound() {
-    Optional<Question> found = repo.lookupQuestion(1L).toCompletableFuture().join();
+    Optional<QuestionModel> found = repo.lookupQuestion(1L).toCompletableFuture().join();
 
     assertThat(found).isEmpty();
   }
@@ -54,9 +54,9 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void lookupQuestion_findsCorrectQuestion() {
     resourceCreator.insertQuestion();
-    Question existing = resourceCreator.insertQuestion();
+    QuestionModel existing = resourceCreator.insertQuestion();
 
-    Optional<Question> found = repo.lookupQuestion(existing.id).toCompletableFuture().join();
+    Optional<QuestionModel> found = repo.lookupQuestion(existing.id).toCompletableFuture().join();
 
     assertThat(found).hasValue(existing);
   }
@@ -71,35 +71,35 @@ public class QuestionRepositoryTest extends ResetPostgres {
             .setName("a brand new question")
             .build();
 
-    Optional<Question> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
 
     assertThat(maybeConflict).isEmpty();
   }
 
   @Test
   public void findConflictingQuestion_sameName_hasConflict() throws Exception {
-    Question applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
             .setEnumeratorId(Optional.of(1L))
             .build();
 
-    Optional<Question> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
 
     assertThat(maybeConflict).contains(applicantAddress);
   }
 
   @Test
   public void findConflictingQuestion_sameQuestionPathSegment_hasConflict() throws Exception {
-    Question applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
             .setName("applicant address!")
             .build();
 
-    Optional<Question> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
 
     assertThat(maybeConflict).contains(applicantAddress);
   }
@@ -107,7 +107,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void findConflictingQuestion_sameQuestionPathSegmentButDifferentEnumeratorId_ok()
       throws Exception {
-    Question applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
@@ -115,15 +115,15 @@ public class QuestionRepositoryTest extends ResetPostgres {
             .setEnumeratorId(Optional.of(1L))
             .build();
 
-    Optional<Question> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
 
     assertThat(maybeConflict).isEmpty();
   }
 
   @Test
   public void findConflictingQuestion_sameQuestion_hasConflict() {
-    Question applicantAddress = testQuestionBank.applicantAddress();
-    Optional<Question> maybeConflict =
+    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
+    Optional<QuestionModel> maybeConflict =
         repo.findConflictingQuestion(applicantAddress.getQuestionDefinition());
 
     assertThat(maybeConflict).contains(applicantAddress);
@@ -131,11 +131,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void findConflictingQuestion_differentVersion_hasConflict() throws Exception {
-    Question applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).setId(123123L).build();
 
-    Optional<Question> maybeConflict = repo.findConflictingQuestion(questionDefinition);
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(questionDefinition);
 
     assertThat(maybeConflict).contains(applicantName);
   }
@@ -145,11 +145,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void insertingDuplicateDraftQuestions_raisesDatabaseException() throws Exception {
     var versionRepo = instanceOf(VersionRepository.class);
     var draftVersion = versionRepo.getDraftVersionOrCreate();
-    Question activeQuestion = testQuestionBank.applicantName();
+    QuestionModel activeQuestion = testQuestionBank.applicantName();
     assertThat(activeQuestion.id).isNotNull();
 
     var draftOne =
-        new Question(
+        new QuestionModel(
             new QuestionDefinitionBuilder(activeQuestion.getQuestionDefinition())
                 .setId(null)
                 .build());
@@ -157,7 +157,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
     draftOne.save();
 
     var draftTwo =
-        new Question(
+        new QuestionModel(
             new QuestionDefinitionBuilder(activeQuestion.getQuestionDefinition())
                 .setId(null)
                 .build());
@@ -178,12 +178,12 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(questionDefinition);
+    QuestionModel question = new QuestionModel(questionDefinition);
 
     repo.insertQuestion(question).toCompletableFuture().join();
 
     long id = question.id;
-    Question q = repo.lookupQuestion(id).toCompletableFuture().join().get();
+    QuestionModel q = repo.lookupQuestion(id).toCompletableFuture().join().get();
     assertThat(q.id).isEqualTo(id);
   }
 
@@ -197,7 +197,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(questionDefinition);
+    QuestionModel question = new QuestionModel(questionDefinition);
 
     repo.insertQuestionSync(question);
 
@@ -208,8 +208,8 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void getExistingQuestions() {
     resourceCreator.insertQuestion("name-question");
     resourceCreator.insertQuestion("date-question");
-    Question dateQuestionV2 = resourceCreator.insertQuestion("date-question");
-    Question nameQuestionV2 = resourceCreator.insertQuestion("name-question");
+    QuestionModel dateQuestionV2 = resourceCreator.insertQuestion("date-question");
+    QuestionModel nameQuestionV2 = resourceCreator.insertQuestion("name-question");
     Map<String, QuestionDefinition> result =
         repo.getExistingQuestions(
             ImmutableSet.of("name-question", "date-question", "other-question"));
@@ -220,27 +220,27 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void updateQuestion() throws UnsupportedQuestionTypeException {
-    Question question = resourceCreator.insertQuestion();
+    QuestionModel question = resourceCreator.insertQuestion();
     QuestionDefinition questionDefinition = question.getQuestionDefinition();
     questionDefinition =
         new QuestionDefinitionBuilder(questionDefinition).setDescription("new description").build();
 
-    repo.updateQuestion(new Question(questionDefinition)).toCompletableFuture().join();
+    repo.updateQuestion(new QuestionModel(questionDefinition)).toCompletableFuture().join();
 
-    Question q = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel q = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
     assertThat(q.getQuestionDefinition()).isEqualTo(questionDefinition);
   }
 
   @Test
   public void updateQuestionSync() throws UnsupportedQuestionTypeException {
-    Question question = resourceCreator.insertQuestion();
+    QuestionModel question = resourceCreator.insertQuestion();
     QuestionDefinition questionDefinition = question.getQuestionDefinition();
     questionDefinition =
         new QuestionDefinitionBuilder(questionDefinition).setDescription("new description").build();
 
-    repo.updateQuestionSync(new Question(questionDefinition));
+    repo.updateQuestionSync(new QuestionModel(questionDefinition));
 
-    Question q = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
+    QuestionModel q = repo.lookupQuestion(question.id).toCompletableFuture().join().get();
     assertThat(q.getQuestionDefinition()).isEqualTo(questionDefinition);
   }
 
@@ -253,7 +253,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 + " 'REPEATER');")
         .execute();
 
-    Question found =
+    QuestionModel found =
         repo.listQuestions().toCompletableFuture().join().stream()
             .filter(
                 question -> question.getQuestionDefinition().getName().equals("old schema entry"))

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import models.LifecycleStage;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class VersionRepositoryTest extends ResetPostgres {
   @Test
   public void testPublish_tombstonesProgramsAndQuestionsOnlyCreatedInTheDraftVersion()
       throws Exception {
-    Question draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
+    QuestionModel draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
     draftOnlyQuestion.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     ProgramModel draftOnlyProgram =
@@ -105,9 +105,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublish() {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel firstProgramActive =
@@ -120,7 +120,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .withBlock("Screen 1")
             .withRequiredQuestion(secondQuestion)
             .build();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     ProgramModel secondProgramDraft =
         ProgramBuilder.newDraftProgram("bar")
@@ -196,9 +196,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishWithQuestionsNotIncludedInPrograms() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel firstProgramActive =
@@ -217,7 +217,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     assertThat(
             versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
         .isTrue();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     assertThat(versionRepository.getActiveVersion().getPrograms().stream().map(p -> p.id))
@@ -235,9 +235,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishWithDraftQuestionsAndActivePrograms() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel firstProgramActive =
@@ -256,7 +256,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     assertThat(
             versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
         .isTrue();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     versionRepository.updateProgramsThatReferenceQuestion(secondQuestion.id);
 
@@ -298,9 +298,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishWithDraftQuestionsAndNoActiveOrDraftPrograms() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     VersionModel draftForTombstoning = versionRepository.getDraftVersionOrCreate();
@@ -308,7 +308,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     assertThat(
             versionRepository.addTombstoneForQuestionInVersion(firstQuestion, draftForTombstoning))
         .isTrue();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     assertThat(versionRepository.getActiveVersion().getPrograms()).isEmpty();
@@ -341,12 +341,12 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishProgram() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
     // Third question is only a draft.
-    Question thirdQuestion = resourceCreator.insertQuestion("third-question");
+    QuestionModel thirdQuestion = resourceCreator.insertQuestion("third-question");
     thirdQuestion.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     ProgramModel firstProgramActive =
@@ -366,7 +366,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .build();
 
     // secondProgramDraft and its question, secondQuestionUpdated, should be published.
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     ProgramModel secondProgramDraft =
         ProgramBuilder.newDraftProgram("bar")
@@ -421,9 +421,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishProgramWithNewProgram() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel firstProgramActive =
@@ -431,7 +431,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .withBlock("Screen 1")
             .withRequiredQuestion(firstQuestion)
             .build();
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     // Program being published has no existing active version.
@@ -466,9 +466,9 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishProgramDoesNotAllowPublishingWhenQuestionsAreShared() throws Exception {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel firstProgramActive =
@@ -484,7 +484,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .build();
 
     // firstProgram and secondProgram both reference secondQuestionUpdated.
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     ProgramModel firstProgramDraft =
         ProgramBuilder.newDraftProgram("foo")
@@ -516,7 +516,7 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void testPublishProgramDoesNotAllowPublishingNonDraftProgram() throws Exception {
-    Question question = resourceCreator.insertQuestion("first-question");
+    QuestionModel question = resourceCreator.insertQuestion("first-question");
     question.addVersion(versionRepository.getActiveVersion()).save();
 
     ProgramModel activeProgram =
@@ -538,14 +538,14 @@ public class VersionRepositoryTest extends ResetPostgres {
         .containsExactlyInAnyOrder(question.id);
   }
 
-  private Question insertActiveQuestion(String name) {
-    Question q = resourceCreator.insertQuestion(name);
+  private QuestionModel insertActiveQuestion(String name) {
+    QuestionModel q = resourceCreator.insertQuestion(name);
     q.addVersion(versionRepository.getActiveVersion()).save();
     return q;
   }
 
-  private Question insertDraftQuestion(String name) {
-    Question q = resourceCreator.insertQuestion(name);
+  private QuestionModel insertDraftQuestion(String name) {
+    QuestionModel q = resourceCreator.insertQuestion(name);
     q.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     return q;
   }
@@ -567,7 +567,7 @@ public class VersionRepositoryTest extends ResetPostgres {
                     program -> String.format("%d %s", program.id(), program.adminName()),
                     program -> program.lastModifiedTime().orElseThrow()));
 
-    ImmutableList<Question> questions =
+    ImmutableList<QuestionModel> questions =
         ImmutableList.of(
             insertActiveQuestion("active"),
             insertActiveQuestion("other_active"),
@@ -614,7 +614,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .map(
                 q ->
                     DB.getDefault()
-                        .find(Question.class)
+                        .find(QuestionModel.class)
                         .where()
                         .eq("id", q.id)
                         .findOneOrEmpty()
@@ -650,18 +650,18 @@ public class VersionRepositoryTest extends ResetPostgres {
     VersionModel active = versionRepository.getActiveVersion();
 
     // Old versions of questions
-    Question oldOne = resourceCreator.insertQuestion("one");
+    QuestionModel oldOne = resourceCreator.insertQuestion("one");
     oldOne.addVersion(active);
     oldOne.save();
-    Question oldTwo = resourceCreator.insertQuestion("two");
+    QuestionModel oldTwo = resourceCreator.insertQuestion("two");
     oldTwo.addVersion(active);
     oldTwo.save();
 
     // New versions of questions
-    Question newOne = resourceCreator.insertQuestion("one");
+    QuestionModel newOne = resourceCreator.insertQuestion("one");
     newOne.addVersion(draft);
     newOne.save();
-    Question newTwo = resourceCreator.insertQuestion("two");
+    QuestionModel newTwo = resourceCreator.insertQuestion("two");
     newTwo.addVersion(draft);
     newTwo.save();
 
@@ -715,18 +715,18 @@ public class VersionRepositoryTest extends ResetPostgres {
     VersionModel active = versionRepository.getActiveVersion();
 
     // Create some old questions
-    Question oldOne = resourceCreator.insertQuestion("one");
+    QuestionModel oldOne = resourceCreator.insertQuestion("one");
     oldOne.addVersion(active);
     oldOne.save();
-    Question oldTwo = resourceCreator.insertQuestion("two");
+    QuestionModel oldTwo = resourceCreator.insertQuestion("two");
     oldTwo.addVersion(active);
     oldTwo.save();
 
     // Create new versions of the old questions
-    Question newOne = resourceCreator.insertQuestion("one");
+    QuestionModel newOne = resourceCreator.insertQuestion("one");
     newOne.addVersion(draft);
     newOne.save();
-    Question newTwo = resourceCreator.insertQuestion("two");
+    QuestionModel newTwo = resourceCreator.insertQuestion("two");
     newTwo.addVersion(draft);
     newTwo.save();
 
@@ -886,12 +886,12 @@ public class VersionRepositoryTest extends ResetPostgres {
 
   @Test
   public void getProgramQuestionNamesInVersion() {
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(versionRepository.getActiveVersion()).save();
-    Question secondQuestion = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
     secondQuestion.addVersion(versionRepository.getActiveVersion()).save();
     // Third question is only a draft.
-    Question thirdQuestion = resourceCreator.insertQuestion("third-question");
+    QuestionModel thirdQuestion = resourceCreator.insertQuestion("third-question");
     thirdQuestion.addVersion(versionRepository.getDraftVersionOrCreate()).save();
 
     ProgramModel firstProgramActive =
@@ -905,7 +905,7 @@ public class VersionRepositoryTest extends ResetPostgres {
             .withRequiredQuestion(secondQuestion)
             .build();
 
-    Question secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
+    QuestionModel secondQuestionUpdated = resourceCreator.insertQuestion("second-question");
     secondQuestionUpdated.addVersion(versionRepository.getDraftVersionOrCreate()).save();
     ProgramModel secondProgramDraft =
         ProgramBuilder.newDraftProgram("bar")
@@ -942,7 +942,7 @@ public class VersionRepositoryTest extends ResetPostgres {
   public void previousVersion_isFound() {
     // Create first version
     VersionModel version1 = versionRepository.getDraftVersionOrCreate();
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(version1).save();
     version1.save();
     versionRepository.publishNewSynchronizedVersion();
@@ -959,11 +959,11 @@ public class VersionRepositoryTest extends ResetPostgres {
   public void getQuestionByNameForVersion_found() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionName = "question";
-    Question question = resourceCreator.insertQuestion(questionName);
+    QuestionModel question = resourceCreator.insertQuestion(questionName);
     question.addVersion(version).save();
     version.refresh();
 
-    Optional<Question> result =
+    Optional<QuestionModel> result =
         versionRepository.getQuestionByNameForVersion(questionName, version);
     assertThat(result.isPresent()).isTrue();
     assertThat(result.get().getQuestionDefinition().getName()).isEqualTo(questionName);
@@ -973,11 +973,11 @@ public class VersionRepositoryTest extends ResetPostgres {
   public void getQuestionByNameForVersion_notFound() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();
     String questionName = "question";
-    Question question = resourceCreator.insertQuestion(questionName);
+    QuestionModel question = resourceCreator.insertQuestion(questionName);
     question.addVersion(version).save();
     version.refresh();
 
-    Optional<Question> result =
+    Optional<QuestionModel> result =
         versionRepository.getQuestionByNameForVersion(questionName + "other", version);
     assertThat(result.isPresent()).isFalse();
   }
@@ -1005,10 +1005,10 @@ public class VersionRepositoryTest extends ResetPostgres {
     questionsByVersionCache.remove(version1Key);
 
     // Associate question with obsolete version
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(version1).save();
 
-    ImmutableList<Question> questionsForVersion =
+    ImmutableList<QuestionModel> questionsForVersion =
         versionRepository.getQuestionsForVersion(version1);
 
     assertThat(questionsByVersionCache.get(version1Key).get()).isEqualTo(questionsForVersion);
@@ -1026,10 +1026,10 @@ public class VersionRepositoryTest extends ResetPostgres {
     String version1Key = String.valueOf(version1.id);
 
     // Associate question with active version
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(version1).save();
 
-    ImmutableList<Question> questionsForVersion =
+    ImmutableList<QuestionModel> questionsForVersion =
         versionRepository.getQuestionsForVersion(version1);
 
     assertThat(questionsByVersionCache.get(version1Key).get()).isEqualTo(questionsForVersion);
@@ -1041,7 +1041,7 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     VersionModel version1 = versionRepository.getDraftVersionOrCreate();
     version1.save();
-    Question firstQuestion = resourceCreator.insertQuestion("first-question");
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
     firstQuestion.addVersion(version1).save();
 
     String version1Key = String.valueOf(version1.id);

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -2,7 +2,7 @@ package services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,12 +18,12 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   private ProgramBlockValidation programBlockValidation;
   private VersionRepository versionRepository;
-  private Question questionForTombstone;
+  private QuestionModel questionForTombstone;
   private QuestionService questionService;
-  private Question questionForEligible;
+  private QuestionModel questionForEligible;
   private VersionModel version;
-  private Question householdMemberQuestion;
-  private Question householdMemberNameQuestion;
+  private QuestionModel householdMemberQuestion;
+  private QuestionModel householdMemberNameQuestion;
 
   @Before
   public void setProgramBlockValidation()

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -26,7 +26,7 @@ import models.ApplicationModel;
 import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import models.StoredFile;
 import models.TrustedIntermediaryGroup;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -258,20 +258,20 @@ public class ApplicantServiceTest extends ResetPostgres {
         .contains(programDefinition.id());
   }
 
-  private Path applicantPathForQuestion(Question question) {
+  private Path applicantPathForQuestion(QuestionModel question) {
     return ApplicantData.APPLICANT_PATH.join(
         question.getQuestionDefinition().getQuestionPathSegment());
   }
 
   @Test
   public void stageAndUpdateIfvalid_invalidInputsForQuestionTypes() {
-    Question dateQuestion = testQuestionBank.applicantDate();
+    QuestionModel dateQuestion = testQuestionBank.applicantDate();
     Path datePath = applicantPathForQuestion(dateQuestion).join(Scalar.DATE);
-    Question currencyQuestion = testQuestionBank.applicantMonthlyIncome();
+    QuestionModel currencyQuestion = testQuestionBank.applicantMonthlyIncome();
     Path currencyPath = applicantPathForQuestion(currencyQuestion).join(Scalar.CURRENCY_CENTS);
-    Question numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
-    Question phoneQuestion = testQuestionBank.applicantPhone();
+    QuestionModel phoneQuestion = testQuestionBank.applicantPhone();
     Path phonePath = applicantPathForQuestion(phoneQuestion).join(Scalar.PHONE_NUMBER);
     createProgram(
         dateQuestion.getQuestionDefinition(),
@@ -3004,7 +3004,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3111,7 +3111,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3200,7 +3200,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3288,7 +3288,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3325,7 +3325,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3358,7 +3358,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -12,7 +12,7 @@ import models.ApplicantModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
@@ -55,7 +55,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   protected ProgramModel fakeProgramWithEligibility;
   protected ProgramModel fakeProgramWithOptionalFileUpload;
   protected ProgramModel fakeProgram;
-  protected ImmutableList<Question> fakeQuestions;
+  protected ImmutableList<QuestionModel> fakeQuestions;
   protected ApplicantModel applicantOne;
   protected ApplicantModel applicantFive;
   protected ApplicantModel applicantSix;
@@ -74,7 +74,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
 
   protected void answerQuestion(
       QuestionType questionType,
-      Question question,
+      QuestionModel question,
       ApplicantData applicantDataOne,
       ApplicantData applicantDataTwo) {
     Path answerPath =
@@ -236,8 +236,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   }
 
   protected void createFakeProgramWithOptionalQuestion() {
-    Question fileQuestion = testQuestionBank.applicantFile();
-    Question nameQuestion = testQuestionBank.applicantName();
+    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel nameQuestion = testQuestionBank.applicantName();
 
     fakeProgramWithOptionalFileUpload =
         ProgramBuilder.newActiveProgram()
@@ -296,8 +296,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
    * The applications have submission times one month apart starting on 2022-01-01.
    */
   protected void createFakeProgramWithEligibilityPredicate() {
-    Question nameQuestion = testQuestionBank.applicantName();
-    Question colorQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel nameQuestion = testQuestionBank.applicantName();
+    QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
 
     PredicateDefinition colorPredicate =
         PredicateDefinition.create(
@@ -373,13 +373,13 @@ public abstract class AbstractExporterTest extends ResetPostgres {
    * applications. The applications have submission times one month apart starting on 2022-01-01.
    */
   protected void createFakeProgramWithEnumeratorAndAnswerQuestions() {
-    Question nameQuestion = testQuestionBank.applicantName();
-    Question colorQuestion = testQuestionBank.applicantFavoriteColor();
-    Question monthlyIncomeQuestion = testQuestionBank.applicantMonthlyIncome();
-    Question householdMembersQuestion = testQuestionBank.applicantHouseholdMembers();
-    Question hmNameQuestion = testQuestionBank.applicantHouseholdMemberName();
-    Question hmJobsQuestion = testQuestionBank.applicantHouseholdMemberJobs();
-    Question hmNumberDaysWorksQuestion = testQuestionBank.applicantHouseholdMemberDaysWorked();
+    QuestionModel nameQuestion = testQuestionBank.applicantName();
+    QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel monthlyIncomeQuestion = testQuestionBank.applicantMonthlyIncome();
+    QuestionModel householdMembersQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel hmNameQuestion = testQuestionBank.applicantHouseholdMemberName();
+    QuestionModel hmJobsQuestion = testQuestionBank.applicantHouseholdMemberJobs();
+    QuestionModel hmNumberDaysWorksQuestion = testQuestionBank.applicantHouseholdMemberDaysWorked();
     fakeProgramWithEnumerator =
         ProgramBuilder.newActiveProgram()
             .withName("Fake Program With Enumerator")
@@ -530,7 +530,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    FakeProgramBuilder withQuestion(Question question) {
+    FakeProgramBuilder withQuestion(QuestionModel question) {
       fakeProgramBuilder.withBlock().withRequiredQuestion(question).build();
       return this;
     }

--- a/server/test/services/export/CsvExporterTest.java
+++ b/server/test/services/export/CsvExporterTest.java
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import models.Question;
+import models.QuestionModel;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -172,7 +172,7 @@ public class CsvExporterTest extends AbstractExporterTest {
         CsvExporterService.pathToHeader(nameApplicantQuestion.getFirstNamePath());
     String lastNameHeader =
         CsvExporterService.pathToHeader(nameApplicantQuestion.getLastNamePath());
-    Question phoneQuestion =
+    QuestionModel phoneQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.PHONE);
     PhoneQuestion phoneQuestion1 =
         getApplicantQuestion(phoneQuestion.getQuestionDefinition()).createPhoneQuestion();
@@ -188,7 +188,7 @@ public class CsvExporterTest extends AbstractExporterTest {
     assertThat(records.get(1).get("Status")).isEqualTo(STATUS_VALUE);
     assertThat(records.get(0).get("Submitter Type")).isEqualTo("APPLICANT");
     // Check list for multiselect in default locale
-    Question checkboxQuestion =
+    QuestionModel checkboxQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.CHECKBOX);
     MultiSelectQuestion multiSelectApplicantQuestion =
         getApplicantQuestion(checkboxQuestion.getQuestionDefinition()).createMultiSelectQuestion();
@@ -211,7 +211,7 @@ public class CsvExporterTest extends AbstractExporterTest {
                 .join("garlic_press"));
     assertThat(records.get(1).get(multiSelectHeader_3))
         .isEqualTo(MultiOptionSelectionExportType.NOT_SELECTED.toString());
-    Question fileuploadQuestion =
+    QuestionModel fileuploadQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.FILEUPLOAD);
     FileUploadQuestion fileuploadApplicantQuestion =
         getApplicantQuestion(fileuploadQuestion.getQuestionDefinition()).createFileUploadQuestion();

--- a/server/test/services/program/EligibilityDefinitionTest.java
+++ b/server/test/services/program/EligibilityDefinitionTest.java
@@ -2,7 +2,7 @@ package services.program;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import models.Question;
+import models.QuestionModel;
 import org.junit.Test;
 import services.applicant.question.Scalar;
 import services.program.predicate.LeafOperationExpressionNode;
@@ -20,7 +20,7 @@ public class EligibilityDefinitionTest {
 
   @Test
   public void setAndGet() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
 import models.DisplayMode;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Test;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
@@ -764,7 +764,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withVisibilityPredicate() throws Exception {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -795,7 +795,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withVisibilityPredicate_throwsForIllegalMove() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -825,7 +825,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicate() throws Exception {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -863,7 +863,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicate_throwsForIllegalMove() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -896,7 +896,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicateAndQuestionInSameBlock() throws Exception {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -934,7 +934,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlockDown_throwsForIllegalMove() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     // Trying to move a block after a block that depends on it throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -964,7 +964,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void hasValidPredicateOrdering() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1000,7 +1000,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void hasValidPredicateOrdering_returnsFalseIfQuestionsAreInSameBlockAsPredicate() {
-    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -29,7 +29,7 @@ import junitparams.Parameters;
 import models.AccountModel;
 import models.DisplayMode;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1487,7 +1487,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setBlockPredicate_updatesBlock() throws Exception {
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
@@ -1600,7 +1600,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setBlockEligibilityDefinition_updatesBlock() throws Exception {
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()

--- a/server/test/services/question/ActiveAndDraftQuestionsTest.java
+++ b/server/test/services/question/ActiveAndDraftQuestionsTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getQuestionNames() throws Exception {
-    Question tombstonedQuestionFromActiveVersion =
+    QuestionModel tombstonedQuestionFromActiveVersion =
         resourceCreator.insertQuestion("tombstoned-question");
 
     versionRepository
@@ -57,13 +57,14 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getActiveOrDraftQuestionDefinition() throws Exception {
-    Question tombstonedQuestionFromActiveVersion =
+    QuestionModel tombstonedQuestionFromActiveVersion =
         resourceCreator.insertQuestion("tombstoned-question");
-    Question activeAndDraftQuestion = resourceCreator.insertQuestion("active-and-draft-question");
-    Question activeOnlyQuestion = resourceCreator.insertQuestion("active-only-question");
-    Question activeAndDraftQuestionUpdated =
+    QuestionModel activeAndDraftQuestion =
         resourceCreator.insertQuestion("active-and-draft-question");
-    Question draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
+    QuestionModel activeOnlyQuestion = resourceCreator.insertQuestion("active-only-question");
+    QuestionModel activeAndDraftQuestionUpdated =
+        resourceCreator.insertQuestion("active-and-draft-question");
+    QuestionModel draftOnlyQuestion = resourceCreator.insertQuestion("draft-only-question");
 
     versionRepository
         .getActiveVersion()
@@ -143,10 +144,10 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getDeletionStatus_notReferencedByProgramButStillReferencedByVersion() {
-    Question activeVersionQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel activeVersionQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(activeVersionQuestion).save();
 
-    Question draftVersionQuestion = resourceCreator.insertQuestion("draft-version-question");
+    QuestionModel draftVersionQuestion = resourceCreator.insertQuestion("draft-version-question");
     versionRepository.getDraftVersionOrCreate().addQuestion(draftVersionQuestion).save();
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
@@ -157,7 +158,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getDeletionStatus_tombstoned() throws Exception {
-    Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(question).save();
     versionRepository
         .getDraftVersionOrCreate()
@@ -171,7 +172,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getDeletionStatus_createdAndTombstonedInDraftVersion() throws Exception {
-    Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getDraftVersionOrCreate().addQuestion(question).save();
     addTombstoneToVersion(versionRepository.getDraftVersionOrCreate(), question);
 
@@ -181,7 +182,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getDeletionStatus_stillReferencedInActiveVersion() {
-    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(questionActive).save();
     // newActiveProgram automatically adds the program to the active version.
     ProgramBuilder.newActiveProgram("foo")
@@ -198,7 +199,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     // Simulates the state where the question was created in the active version
     // and wasn't referenced. Then it was referenced by a program in the draft
     // version. In this case, the draft won't yet contain a reference to the question.
-    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(questionActive).save();
     // newDraftProgram automatically adds the program to the draft version.
     ProgramBuilder.newDraftProgram("foo")
@@ -213,7 +214,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
   @Test
   public void getDeletionStatus_noLongerReferencedInDraftVersion() {
     // Simulate the only reference to the question having been removed in an edit of the program.
-    Question questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel questionActive = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(questionActive).save();
     // newActiveProgram automatically adds the program to the active version.
     ProgramBuilder.newActiveProgram("foo")
@@ -228,7 +229,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
         .isEqualTo(DeletionStatus.DELETABLE);
 
     // Adding a draft edit of the question continues to be considered deletable.
-    Question questionDraft = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel questionDraft = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getDraftVersionOrCreate().addQuestion(questionDraft).save();
 
     assertThat(newActiveAndDraftQuestions().getDeletionStatus(TEST_QUESTION_NAME))
@@ -284,7 +285,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
 
   @Test
   public void getReferencingPrograms_multipleProgramReferencesForSameQuestionVersion() {
-    Question question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel question = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
 
     // Set up state where the question is referenced from:
     // ACTIVE version - first-program and second-program
@@ -335,7 +336,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     // DRAFT version - second-program and third-program
     // In addition, the DRAFT version references are to an edited question.
 
-    Question activeQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel activeQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getActiveVersion().addQuestion(activeQuestion).save();
     // newActiveProgram / newDraftProgram automatically adds the program to the specified version.
     ProgramModel firstProgramActive =
@@ -351,7 +352,7 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
             .build();
 
     // No longer reference the question from the first program.
-    Question draftQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
+    QuestionModel draftQuestion = resourceCreator.insertQuestion(TEST_QUESTION_NAME);
     versionRepository.getDraftVersionOrCreate().addQuestion(draftQuestion).save();
     ProgramBuilder.newDraftProgram("first-program").withBlock("Screen 1").build();
     ProgramModel secondProgramDraft =
@@ -391,7 +392,8 @@ public class ActiveAndDraftQuestionsTest extends ResetPostgres {
     return ActiveAndDraftQuestions.buildFromCurrentVersions(versionRepository);
   }
 
-  private void addTombstoneToVersion(VersionModel version, Question question) throws Exception {
+  private void addTombstoneToVersion(VersionModel version, QuestionModel question)
+      throws Exception {
     assertThat(versionRepository.addTombstoneForQuestionInVersion(question, version)).isTrue();
     version.save();
   }

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.LifecycleStage;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
@@ -181,7 +181,7 @@ public class QuestionServiceTest extends ResetPostgres {
     testQuestionBank.maybeSave(toUpdate, LifecycleStage.DRAFT);
 
     // Verify the draft is there.
-    Optional<Question> draftQuestion =
+    Optional<QuestionModel> draftQuestion =
         versionRepository.getQuestionByNameForVersion(
             nameQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(draftQuestion).isPresent();
@@ -223,7 +223,7 @@ public class QuestionServiceTest extends ResetPostgres {
     questionService.discardDraft(enumeratorDraftId);
 
     // Verify.
-    Optional<Question> dependentDraft =
+    Optional<QuestionModel> dependentDraft =
         versionRepository.getQuestionByNameForVersion(
             dependentQuestion.getName(), versionRepository.getDraftVersionOrCreate());
     assertThat(dependentDraft).isPresent();
@@ -233,7 +233,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_notReferencedSucceeds() throws Exception {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
         .doesNotContain(addressQuestion.getQuestionDefinition().getName());
@@ -244,7 +244,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_referencedFails() {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
     // Create a program that references the question.
     ProgramBuilder.newDraftProgram()
         .withBlock()
@@ -262,7 +262,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_alreadyArchivedFails() throws Exception {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
     questionService.archiveQuestion(addressQuestion.id);
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
@@ -283,7 +283,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_createsDraftIfNoneExists() throws Exception {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
 
     assertThat(
             versionRepository.getQuestionNamesForVersion(
@@ -304,7 +304,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void restoreQuestion_pendingDeletionSucceeds() throws Exception {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
     questionService.archiveQuestion(addressQuestion.id);
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
@@ -316,7 +316,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void restoreQuestion_notArchivedFails() {
-    Question addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames()).isEmpty();
     assertThatThrownBy(() -> questionService.restoreQuestion(addressQuestion.id))

--- a/server/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
@@ -2,7 +2,7 @@ package services.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
@@ -40,7 +40,7 @@ public class ReadOnlyCurrentQuestionServiceImplTest extends ResetPostgres {
   @Test
   public void getEnumeratorQuestions() {
     // The question bank initializes this question in the active version.
-    Question enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
 
     var service = new ReadOnlyCurrentQuestionServiceImpl(versionRepository);
 
@@ -55,7 +55,7 @@ public class ReadOnlyCurrentQuestionServiceImplTest extends ResetPostgres {
   @Test
   public void getQuestionDefinition_byId() throws QuestionNotFoundException {
     // The question bank initializes these in the active version.
-    Question nameQuestion = testQuestionBank.applicantName();
+    QuestionModel nameQuestion = testQuestionBank.applicantName();
     long questionId = nameQuestion.id;
 
     var service = new ReadOnlyCurrentQuestionServiceImpl(versionRepository);

--- a/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import models.LifecycleStage;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,10 +21,10 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
       new ReadOnlyVersionedQuestionServiceImpl(
           new VersionModel(LifecycleStage.OBSOLETE), instanceOf(VersionRepository.class));
   private TestQuestionBank testQuestionBank;
-  private Question nameQuestion;
-  private Question addressQuestion;
-  private Question basicQuestion;
-  private ImmutableList<Question> questions;
+  private QuestionModel nameQuestion;
+  private QuestionModel addressQuestion;
+  private QuestionModel basicQuestion;
+  private ImmutableList<QuestionModel> questions;
   private ReadOnlyQuestionService service;
 
   @Before
@@ -74,7 +74,7 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
 
   @Test
   public void getEnumeratorQuestions() {
-    Question enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
 
     VersionModel version = new VersionModel(LifecycleStage.OBSOLETE);
     addQuestionsToVersion(version, questions);
@@ -100,7 +100,7 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
   }
 
   private static void addQuestionsToVersion(
-      VersionModel version, ImmutableList<Question> questions) {
+      VersionModel version, ImmutableList<QuestionModel> questions) {
     questions.stream().forEach(version::addQuestion);
     version.save();
   }

--- a/server/test/services/seeding/DatabaseSeedTaskTest.java
+++ b/server/test/services/seeding/DatabaseSeedTaskTest.java
@@ -3,7 +3,7 @@ package services.seeding;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -35,7 +35,7 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
     assertThat(getAllQuestions().size()).isEqualTo(2);
     assertThat(
             getAllQuestions().stream()
-                .map(Question::getQuestionDefinition)
+                .map(QuestionModel::getQuestionDefinition)
                 .map(QuestionDefinition::getName))
         .containsOnly("Name", "Applicant Date of Birth");
   }
@@ -61,12 +61,12 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
     assertThat(getAllQuestions().size()).isEqualTo(2);
     assertThat(
             getAllQuestions().stream()
-                .map(Question::getQuestionDefinition)
+                .map(QuestionModel::getQuestionDefinition)
                 .map(QuestionDefinition::getName))
         .containsOnly("Name", "Applicant Date of Birth");
   }
 
-  private Set<Question> getAllQuestions() {
+  private Set<QuestionModel> getAllQuestions() {
     return questionRepository.listQuestions().toCompletableFuture().join();
   }
 }

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import play.inject.Injector;
 import repository.VersionRepository;
@@ -332,7 +332,7 @@ public class ProgramBuilder {
     }
 
     /** Add a required question to the block. */
-    public BlockBuilder withRequiredQuestion(Question question) {
+    public BlockBuilder withRequiredQuestion(QuestionModel question) {
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
               question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId)));
@@ -340,7 +340,7 @@ public class ProgramBuilder {
     }
 
     /** Add a required address question that has correction enabled to the block. */
-    public BlockBuilder withRequiredCorrectedAddressQuestion(Question question) {
+    public BlockBuilder withRequiredCorrectedAddressQuestion(QuestionModel question) {
       if (!(question.getQuestionDefinition() instanceof AddressQuestionDefinition)) {
         throw new IllegalArgumentException("Only address questions can be address corrected.");
       }
@@ -354,7 +354,7 @@ public class ProgramBuilder {
       return this;
     }
 
-    public BlockBuilder withOptionalQuestion(Question question) {
+    public BlockBuilder withOptionalQuestion(QuestionModel question) {
       return withOptionalQuestion(question.getQuestionDefinition());
     }
 
@@ -379,14 +379,14 @@ public class ProgramBuilder {
       return this;
     }
 
-    public BlockBuilder withRequiredQuestions(Question... questions) {
+    public BlockBuilder withRequiredQuestions(QuestionModel... questions) {
       return withRequiredQuestions(ImmutableList.copyOf(questions));
     }
 
-    public BlockBuilder withRequiredQuestions(ImmutableList<Question> questions) {
+    public BlockBuilder withRequiredQuestions(ImmutableList<QuestionModel> questions) {
       return withRequiredQuestionDefinitions(
           questions.stream()
-              .map(Question::getQuestionDefinition)
+              .map(QuestionModel::getQuestionDefinition)
               .collect(ImmutableList.toImmutableList()));
     }
 

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -13,7 +13,7 @@ import models.ApplicationModel;
 import models.LifecycleStage;
 import models.Models;
 import models.ProgramModel;
-import models.Question;
+import models.QuestionModel;
 import models.TrustedIntermediaryGroup;
 import play.inject.Injector;
 import services.LocalizedStrings;
@@ -61,7 +61,7 @@ public class ResourceCreator {
     injector.instanceOf(repository.VersionRepository.class).publishNewSynchronizedVersion();
   }
 
-  public Question insertQuestion(String name) {
+  public QuestionModel insertQuestion(String name) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -70,12 +70,12 @@ public class ResourceCreator {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
     question.save();
     return question;
   }
 
-  public Question insertEnum(String name) {
+  public QuestionModel insertEnum(String name) {
     QuestionDefinition enumDefinition =
         new services.question.types.EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -85,12 +85,12 @@ public class ResourceCreator {
                 .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
                 .build(),
             LocalizedStrings.empty());
-    Question enumQuestion = new Question(enumDefinition);
+    QuestionModel enumQuestion = new QuestionModel(enumDefinition);
     enumQuestion.save();
     return enumQuestion;
   }
 
-  public Question insertEnumQuestion(String enumName, Question question) {
+  public QuestionModel insertEnumQuestion(String enumName, QuestionModel question) {
     QuestionDefinition enumDefinition =
         new services.question.types.EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -101,12 +101,12 @@ public class ResourceCreator {
                 .setEnumeratorId(Optional.of(question.id))
                 .build(),
             LocalizedStrings.empty());
-    Question enumQuestion = new Question(enumDefinition);
+    QuestionModel enumQuestion = new QuestionModel(enumDefinition);
     enumQuestion.save();
     return enumQuestion;
   }
 
-  public Question insertQuestion() {
+  public QuestionModel insertQuestion() {
     String name = UUID.randomUUID().toString();
     QuestionDefinition definition =
         new TextQuestionDefinition(
@@ -116,7 +116,7 @@ public class ResourceCreator {
                 .setQuestionText(LocalizedStrings.of())
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .build());
-    Question question = new Question(definition);
+    QuestionModel question = new QuestionModel(definition);
     question.save();
     return question;
   }

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import models.LifecycleStage;
-import models.Question;
+import models.QuestionModel;
 import models.VersionModel;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -34,23 +34,23 @@ import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 /**
- * A cached {@link Question} bank for testing.
+ * A cached {@link QuestionModel} bank for testing.
  *
- * <p>The {@link Question}s in this question bank should be treated as constants, but they need to
- * be persisted in the database for some tests so they are persisted and cached. When used with
+ * <p>The {@link QuestionModel}s in this question bank should be treated as constants, but they need
+ * to be persisted in the database for some tests so they are persisted and cached. When used with
  * tests that do not have a database available (see {@link #maybeSave(QuestionDefinition)}), the
  * question IDs may not be reliable since in production, the IDs are set by the database.
  *
  * <p>The properties of these questions (e.g. question help text) are not canonical and may not be
  * representative of the properties defined by CiviForm administrators.
  *
- * <p>To add a new {@link Question} to the question bank: create a {@link QuestionEnum} for it,
+ * <p>To add a new {@link QuestionModel} to the question bank: create a {@link QuestionEnum} for it,
  * create a private method to construct the question, and create a public method to retrieve the
  * cached question. Add new methods in alphabetical order by {@link QuestionType}, grouping those
  * methods with the same type together.
  */
 public class TestQuestionBank {
-  private final Map<QuestionEnum, Question> questionCache = new ConcurrentHashMap<>();
+  private final Map<QuestionEnum, QuestionModel> questionCache = new ConcurrentHashMap<>();
   private final AtomicLong nextId = new AtomicLong(1L);
 
   private final boolean canSave;
@@ -74,8 +74,8 @@ public class TestQuestionBank {
    *
    * @return an ImmutableMap of QuestionType to Questions
    */
-  public ImmutableMap<QuestionType, Question> getSampleQuestionsForAllTypes() {
-    return new ImmutableMap.Builder<QuestionType, Question>()
+  public ImmutableMap<QuestionType, QuestionModel> getSampleQuestionsForAllTypes() {
+    return new ImmutableMap.Builder<QuestionType, QuestionModel>()
         .put(QuestionType.ADDRESS, applicantAddress())
         .put(QuestionType.CHECKBOX, applicantKitchenTools())
         .put(QuestionType.CURRENCY, applicantMonthlyIncome())
@@ -94,82 +94,82 @@ public class TestQuestionBank {
         .build();
   }
 
-  public Question applicantPhone() {
+  public QuestionModel applicantPhone() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_PHONE, this::applicantPhone);
   }
 
   // Address
-  public Question applicantAddress() {
+  public QuestionModel applicantAddress() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ADDRESS, this::applicantAddress);
   }
 
   // Address
-  public Question applicantSecondaryAddress() {
+  public QuestionModel applicantSecondaryAddress() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_SECONDARY_ADDRESS, this::applicantSecondaryAddress);
   }
 
   // Checkbox
-  public Question applicantKitchenTools() {
+  public QuestionModel applicantKitchenTools() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_KITCHEN_TOOLS, this::applicantKitchenTools);
   }
 
   // Date
-  public Question applicantDate() {
+  public QuestionModel applicantDate() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_BIRTHDATE, this::applicantDate);
   }
 
   // Dropdown
-  public Question applicantIceCream() {
+  public QuestionModel applicantIceCream() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ICE_CREAM, this::applicantIceCream);
   }
 
   // Email
-  public Question applicantEmail() {
+  public QuestionModel applicantEmail() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_EMAIL, this::applicantEmail);
   }
 
   // Enumerator
-  public Question applicantHouseholdMembers() {
+  public QuestionModel applicantHouseholdMembers() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, this::applicantHouseholdMembers);
   }
 
   // Nested Enumerator
-  public Question applicantHouseholdMemberJobs() {
+  public QuestionModel applicantHouseholdMemberJobs() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOBS, this::applicantHouseholdMemberJobs);
   }
 
   // File upload
-  public Question applicantFile() {
+  public QuestionModel applicantFile() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_FILE, this::applicantFile);
   }
 
   // Currency
-  public Question applicantMonthlyIncome() {
+  public QuestionModel applicantMonthlyIncome() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_MONTHLY_INCOME, this::applicantMonthlyIncome);
   }
 
   // Id
-  public Question applicantId() {
+  public QuestionModel applicantId() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ID, this::applicantId);
   }
 
   // Name
-  public Question applicantName() {
+  public QuestionModel applicantName() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_NAME, this::applicantName);
   }
 
   // Name
-  public Question nullQuestion() {
+  public QuestionModel nullQuestion() {
     return questionCache.computeIfAbsent(QuestionEnum.NULL_QUESTION, this::nullQuestion);
   }
 
   // Repeated name
-  public Question applicantHouseholdMemberName() {
+  public QuestionModel applicantHouseholdMemberName() {
     // Make sure the next call will have the question ready
     applicantHouseholdMembers();
     return questionCache.computeIfAbsent(
@@ -177,7 +177,7 @@ public class TestQuestionBank {
   }
 
   // Repeated test
-  public Question applicantHouseholdMemberFavoriteShape() {
+  public QuestionModel applicantHouseholdMemberFavoriteShape() {
     // Make sure the next call will have the question ready
     applicantHouseholdMembers();
     return questionCache.computeIfAbsent(
@@ -186,36 +186,36 @@ public class TestQuestionBank {
   }
 
   // Number
-  public Question applicantJugglingNumber() {
+  public QuestionModel applicantJugglingNumber() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_JUGGLING_NUMBER, this::applicantJugglingNumber);
   }
 
   // Deeply nested Number
-  public Question applicantHouseholdMemberDaysWorked() {
+  public QuestionModel applicantHouseholdMemberDaysWorked() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
         this::applicantHouseholdMemberDaysWorked);
   }
 
   // Radio button
-  public Question applicantSeason() {
+  public QuestionModel applicantSeason() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_SEASON, this::applicantSeason);
   }
 
   // Text
-  public Question applicantFavoriteColor() {
+  public QuestionModel applicantFavoriteColor() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_FAVORITE_COLOR, this::applicantFavoriteColor);
   }
 
   // Text
-  public Question staticContent() {
+  public QuestionModel staticContent() {
     return questionCache.computeIfAbsent(QuestionEnum.STATIC_CONTENT, this::staticContent);
   }
 
   // Address
-  private Question applicantAddress(QuestionEnum ignore) {
+  private QuestionModel applicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -227,7 +227,7 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private Question applicantPhone(QuestionEnum ignore) {
+  private QuestionModel applicantPhone(QuestionEnum ignore) {
     QuestionDefinition definition =
         new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -240,7 +240,7 @@ public class TestQuestionBank {
   }
 
   // Address
-  private Question applicantSecondaryAddress(QuestionEnum ignore) {
+  private QuestionModel applicantSecondaryAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -253,7 +253,7 @@ public class TestQuestionBank {
   }
 
   // Checkbox
-  private Question applicantKitchenTools(QuestionEnum ignore) {
+  private QuestionModel applicantKitchenTools(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("kitchen tools")
@@ -277,7 +277,7 @@ public class TestQuestionBank {
   }
 
   // Dropdown
-  private Question applicantIceCream(QuestionEnum ignore) {
+  private QuestionModel applicantIceCream(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("applicant ice cream")
@@ -301,7 +301,7 @@ public class TestQuestionBank {
   }
 
   // Enumerator
-  private Question applicantHouseholdMembers(QuestionEnum ignore) {
+  private QuestionModel applicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -315,8 +315,8 @@ public class TestQuestionBank {
   }
 
   // Nested Enumerator
-  private Question applicantHouseholdMemberJobs(QuestionEnum ignore) {
-    Question householdMembers = applicantHouseholdMembers();
+  private QuestionModel applicantHouseholdMemberJobs(QuestionEnum ignore) {
+    QuestionModel householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -331,7 +331,7 @@ public class TestQuestionBank {
   }
 
   // File upload
-  private Question applicantFile(QuestionEnum ignore) {
+  private QuestionModel applicantFile(QuestionEnum ignore) {
     QuestionDefinition definition =
         new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -345,7 +345,7 @@ public class TestQuestionBank {
   }
 
   // Currency
-  private Question applicantMonthlyIncome(QuestionEnum ignore) {
+  private QuestionModel applicantMonthlyIncome(QuestionEnum ignore) {
     QuestionDefinition definition =
         new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -358,7 +358,7 @@ public class TestQuestionBank {
   }
 
   // Id
-  private Question applicantId(QuestionEnum ignore) {
+  private QuestionModel applicantId(QuestionEnum ignore) {
     QuestionDefinition definition =
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -371,7 +371,7 @@ public class TestQuestionBank {
   }
 
   // Name
-  private Question applicantName(QuestionEnum ignore) {
+  private QuestionModel applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -383,14 +383,14 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private Question nullQuestion(QuestionEnum ignore) {
+  private QuestionModel nullQuestion(QuestionEnum ignore) {
     QuestionDefinition definition = new NullQuestionDefinition(9999L);
-    return new Question(definition);
+    return new QuestionModel(definition);
   }
 
   // Repeated name
-  private Question applicantHouseholdMemberName(QuestionEnum ignore) {
-    Question householdMembers = applicantHouseholdMembers();
+  private QuestionModel applicantHouseholdMemberName(QuestionEnum ignore) {
+    QuestionModel householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -406,8 +406,8 @@ public class TestQuestionBank {
   }
 
   // Repeated text
-  private Question applicantHouseholdMemberFavoriteShape(QuestionEnum ignore) {
-    Question householdMembers = applicantHouseholdMembers();
+  private QuestionModel applicantHouseholdMemberFavoriteShape(QuestionEnum ignore) {
+    QuestionModel householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -421,7 +421,7 @@ public class TestQuestionBank {
   }
 
   // Number
-  private Question applicantJugglingNumber(QuestionEnum ignore) {
+  private QuestionModel applicantJugglingNumber(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -435,7 +435,7 @@ public class TestQuestionBank {
   }
 
   // Date
-  private Question applicantDate(QuestionEnum ignore) {
+  private QuestionModel applicantDate(QuestionEnum ignore) {
     QuestionDefinition definition =
         new DateQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -448,7 +448,7 @@ public class TestQuestionBank {
   }
 
   // Email
-  private Question applicantEmail(QuestionEnum ignore) {
+  private QuestionModel applicantEmail(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EmailQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -461,8 +461,8 @@ public class TestQuestionBank {
   }
 
   // Deeply Nested Number
-  private Question applicantHouseholdMemberDaysWorked(QuestionEnum ignore) {
-    Question householdMemberJobs = applicantHouseholdMemberJobs();
+  private QuestionModel applicantHouseholdMemberDaysWorked(QuestionEnum ignore) {
+    QuestionModel householdMemberJobs = applicantHouseholdMemberJobs();
     QuestionDefinition definition =
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -481,7 +481,7 @@ public class TestQuestionBank {
   }
 
   // Radio button
-  private Question applicantSeason(QuestionEnum ignore) {
+  private QuestionModel applicantSeason(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("applicant favorite season")
@@ -502,7 +502,7 @@ public class TestQuestionBank {
   }
 
   // Static
-  private Question staticContent(QuestionEnum ignore) {
+  private QuestionModel staticContent(QuestionEnum ignore) {
     QuestionDefinition definition =
         new StaticContentQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -514,7 +514,7 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
   // Text
-  private Question applicantFavoriteColor(QuestionEnum ignore) {
+  private QuestionModel applicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -526,12 +526,13 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private Question maybeSave(QuestionDefinition questionDefinition) {
+  private QuestionModel maybeSave(QuestionDefinition questionDefinition) {
     return maybeSave(questionDefinition, LifecycleStage.ACTIVE);
   }
 
-  public Question maybeSave(QuestionDefinition questionDefinition, LifecycleStage desiredStage) {
-    Question question = new Question(questionDefinition);
+  public QuestionModel maybeSave(
+      QuestionDefinition questionDefinition, LifecycleStage desiredStage) {
+    QuestionModel question = new QuestionModel(questionDefinition);
     if (canSave) {
       // This odd way of finding the active version is because this class
       // doesn't have access to the Version repository, because it needs to

--- a/server/test/support/TestQuestionBankTest.java
+++ b/server/test/support/TestQuestionBankTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import models.Question;
+import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,7 +22,7 @@ public class TestQuestionBankTest {
 
   @Test
   public void withoutDatabase_canGetQuestion() {
-    Question question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.applicantAddress();
 
     assertThat(question.id).isEqualTo(1L);
   }
@@ -30,7 +30,7 @@ public class TestQuestionBankTest {
   @Test
   public void withoutDatabase_setsId() {
     testQuestionBank.applicantAddress();
-    Question question = testQuestionBank.applicantName();
+    QuestionModel question = testQuestionBank.applicantName();
 
     assertThat(question.id).isEqualTo(2L);
   }


### PR DESCRIPTION
### Description

Refactor the "Question" class to be "QuestionModel", so it is clear when we may be accessing the database.

We'll do this to the other Models as well as a follow up.

Similar to https://github.com/civiform/civiform/pull/5960

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes
 
#5961
