### PR TITLE
Refactor SettingsGroup to SettingsGroupModel

### DIFF
--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -20,7 +20,7 @@ public final class Models {
           StoredFile.class,
           TrustedIntermediaryGroup.class,
           VersionModel.class,
-          SettingsGroup.class);
+          SettingsGroupModel.class);
 
   /** Get the complete list of ebean models to truncate. */
   public static void truncate(Database database) {

--- a/server/app/models/SettingsGroupModel.java
+++ b/server/app/models/SettingsGroupModel.java
@@ -19,7 +19,7 @@ import play.data.validation.Constraints;
  */
 @Entity
 @Table(name = "civiform_settings")
-public class SettingsGroup extends BaseModel {
+public class SettingsGroupModel extends BaseModel {
 
   @DbJsonB private ImmutableMap<String, String> settings;
 
@@ -40,12 +40,12 @@ public class SettingsGroup extends BaseModel {
   }
 
   @VisibleForTesting
-  public SettingsGroup setCreateTimeForTest(String createTimeString) {
+  public SettingsGroupModel setCreateTimeForTest(String createTimeString) {
     this.createTime = Instant.parse(createTimeString);
     return this;
   }
 
-  public SettingsGroup(ImmutableMap<String, String> settings, String createdBy) {
+  public SettingsGroupModel(ImmutableMap<String, String> settings, String createdBy) {
     this.settings = checkNotNull(settings);
     this.createdBy = createdBy;
   }

--- a/server/app/repository/SettingsGroupRepository.java
+++ b/server/app/repository/SettingsGroupRepository.java
@@ -8,7 +8,7 @@ import io.ebean.Database;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import models.SettingsGroup;
+import models.SettingsGroupModel;
 
 /** Contains queries related to the server settings system. */
 public final class SettingsGroupRepository {
@@ -24,16 +24,16 @@ public final class SettingsGroupRepository {
     this.databaseExecutionContext = checkNotNull(databaseExecutionContext);
   }
 
-  /** Get the most recently created {@link SettingsGroup}. */
-  public CompletionStage<Optional<SettingsGroup>> getCurrentSettings() {
+  /** Get the most recently created {@link SettingsGroupModel}. */
+  public CompletionStage<Optional<SettingsGroupModel>> getCurrentSettings() {
     return supplyAsync(
         () ->
             database
-                .find(SettingsGroup.class)
+                .find(SettingsGroupModel.class)
                 .orderBy()
                 .desc("create_time")
                 .setMaxRows(1)
-                .setLabel("SettingsGroup.findOne")
+                .setLabel("SettingsGroupModel.findOne")
                 .setProfileLocation(queryProfileLocationBuilder.create("getCurrentSettings"))
                 .findOneOrEmpty(),
         databaseExecutionContext);

--- a/server/app/services/applicant/AnswerData.java
+++ b/server/app/services/applicant/AnswerData.java
@@ -3,8 +3,6 @@ package services.applicant;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
-import models.ProgramModel;
-import models.QuestionModel;
 import services.Path;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Question;
@@ -23,7 +21,7 @@ public abstract class AnswerData {
     return new AutoValue_AnswerData.Builder();
   }
 
-  /** The {@link ProgramModel} id that this is currently in the context of. */
+  /** The {@link models.ProgramModel} id that this is currently in the context of. */
   public abstract Long programId();
 
   /** The {@link Block} id for where this question resides within the current program. */
@@ -41,7 +39,10 @@ public abstract class AnswerData {
   /** The repeated entity if this is an answer to a repeated question. Otherwise, empty. */
   public abstract Optional<RepeatedEntity> repeatedEntity();
 
-  /** The index of the {@link QuestionModel} this is an answer for in the block it appeared in. */
+  /**
+   * The index of the {@link models.QuestionModel} this is an answer for in the block it appeared
+   * in.
+   */
   public abstract int questionIndex();
 
   /** The localized question text */

--- a/server/app/services/settings/SettingsService.java
+++ b/server/app/services/settings/SettingsService.java
@@ -15,7 +15,7 @@ import controllers.BadRequestException;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
-import models.SettingsGroup;
+import models.SettingsGroupModel;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -26,7 +26,7 @@ import play.mvc.Http;
 import repository.SettingsGroupRepository;
 
 /**
- * Service management of the resource backed by {@link models.SettingsGroup}.
+ * Service management of the resource backed by {@link SettingsGroupModel}.
  *
  * <p>Each time an admin updates the server settings using the admin UI, a SettingsGroup is saved.
  * The latest snapshot is used to provide settings for a given request to the server.
@@ -60,7 +60,7 @@ public final class SettingsService {
   public CompletionStage<Optional<ImmutableMap<String, String>>> loadSettings() {
     return settingsGroupRepository
         .getCurrentSettings()
-        .thenApply(maybeSettingsGroup -> maybeSettingsGroup.map(SettingsGroup::getSettings));
+        .thenApply(maybeSettingsGroup -> maybeSettingsGroup.map(SettingsGroupModel::getSettings));
   }
 
   /**
@@ -91,9 +91,9 @@ public final class SettingsService {
   }
 
   /**
-   * Store a new {@link SettingsGroup} in the DB and returns {@code true} if the new settings are
-   * different from the current settings. Otherwise returns {@code false} and does NOT insert a new
-   * row.
+   * Store a new {@link SettingsGroupModel} in the DB and returns {@code true} if the new settings
+   * are different from the current settings. Otherwise returns {@code false} and does NOT insert a
+   * new row.
    */
   public SettingsGroupUpdateResult updateSettings(
       ImmutableMap<String, String> newSettings, String papertrail) {
@@ -111,7 +111,7 @@ public final class SettingsService {
       }
     }
 
-    var newSettingsGroup = new SettingsGroup(newSettings, papertrail);
+    var newSettingsGroup = new SettingsGroupModel(newSettings, papertrail);
     newSettingsGroup.save();
 
     return SettingsGroupUpdateResult.success();
@@ -238,14 +238,14 @@ public final class SettingsService {
   }
 
   /**
-   * Inserts a new {@link SettingsGroup} if it finds admin writeable settings in the {@link
-   * SettingsManifest} that are not in the current {@link SettingsGroup}.
+   * Inserts a new {@link SettingsGroupModel} if it finds admin writeable settings in the {@link
+   * SettingsManifest} that are not in the current {@link SettingsGroupModel}.
    */
-  public SettingsGroup migrateConfigValuesToSettingsGroup() {
-    Optional<SettingsGroup> maybeExistingSettingsGroup =
+  public SettingsGroupModel migrateConfigValuesToSettingsGroup() {
+    Optional<SettingsGroupModel> maybeExistingSettingsGroup =
         settingsGroupRepository.getCurrentSettings().toCompletableFuture().join();
     Optional<ImmutableMap<String, String>> maybeExistingSettings =
-        maybeExistingSettingsGroup.map(SettingsGroup::getSettings);
+        maybeExistingSettingsGroup.map(SettingsGroupModel::getSettings);
 
     ImmutableMap.Builder<String, String> settingsBuilder = ImmutableMap.builder();
 
@@ -267,7 +267,7 @@ public final class SettingsService {
       return maybeExistingSettingsGroup.get();
     }
 
-    var group = new SettingsGroup(settings, "system");
+    var group = new SettingsGroupModel(settings, "system");
     group.save();
 
     LOGGER.info("Migrated {} settings from config to database.", settings.size());
@@ -296,15 +296,17 @@ public final class SettingsService {
   @AutoValue
   public abstract static class SettingsGroupUpdateResult {
 
-    /** Creates a result representing success, where a new {@link SettingsGroup} was inserted. */
+    /**
+     * Creates a result representing success, where a new {@link SettingsGroupModel} was inserted.
+     */
     public static SettingsGroupUpdateResult success() {
       return new AutoValue_SettingsService_SettingsGroupUpdateResult(
           /* errorMessages= */ Optional.empty(), /* updated= */ true);
     }
 
     /**
-     * Creates a result representing validation failure, where a new {@link SettingsGroup} was NOT
-     * inserted and the admin should address the errors.
+     * Creates a result representing validation failure, where a new {@link SettingsGroupModel} was
+     * NOT inserted and the admin should address the errors.
      */
     public static SettingsGroupUpdateResult withErrors(
         ImmutableMap<String, UpdateError> errorMessages) {
@@ -313,8 +315,8 @@ public final class SettingsService {
     }
 
     /**
-     * Creates a result representing failure where a new {@link SettingsGroup} was NOT inserted due
-     * to the admin not changing any values.
+     * Creates a result representing failure where a new {@link SettingsGroupModel} was NOT inserted
+     * due to the admin not changing any values.
      */
     public static SettingsGroupUpdateResult noChange() {
       return new AutoValue_SettingsService_SettingsGroupUpdateResult(
@@ -324,7 +326,7 @@ public final class SettingsService {
     /** Validation error messages for the attempted update. */
     public abstract Optional<ImmutableMap<String, UpdateError>> errorMessages();
 
-    /** True if the update completed successfully, inserting a new {@link SettingsGroup}. */
+    /** True if the update completed successfully, inserting a new {@link SettingsGroupModel}. */
     public abstract boolean updated();
 
     /** True if there are validation error messages. */

--- a/server/test/repository/SettingsGroupRepositoryTest.java
+++ b/server/test/repository/SettingsGroupRepositoryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.ebean.DB;
-import models.SettingsGroup;
+import models.SettingsGroupModel;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,18 +19,18 @@ public class SettingsGroupRepositoryTest extends ResetPostgres {
 
   @Test
   public void getCurrentSettings_returnsTheMostRecentGroup() {
-    DB.getDefault().truncate(SettingsGroup.class);
+    DB.getDefault().truncate(SettingsGroupModel.class);
 
-    var groupA = new SettingsGroup(ImmutableMap.of("TEST", "true"), "test");
+    var groupA = new SettingsGroupModel(ImmutableMap.of("TEST", "true"), "test");
     groupA.save();
     groupA.setCreateTimeForTest("2040-01-01T00:00:00Z").save();
 
-    var groupB = new SettingsGroup(ImmutableMap.of("TEST", "false"), "test");
+    var groupB = new SettingsGroupModel(ImmutableMap.of("TEST", "false"), "test");
     groupB.save();
 
     groupB.setCreateTimeForTest("2041-01-01T00:00:00Z").save();
 
-    SettingsGroup result =
+    SettingsGroupModel result =
         settingsGroupRepository.getCurrentSettings().toCompletableFuture().join().get();
 
     assertThat(result.getSettings()).isEqualTo(groupB.getSettings());

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -13,7 +13,7 @@ import io.ebean.DB;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
-import models.SettingsGroup;
+import models.SettingsGroupModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http;
@@ -154,7 +154,7 @@ public class SettingsServiceTest extends ResetPostgres {
 
   @Test
   public void applySettingsToRequest_doesNotAlterAttributesIfNoSettingsFound() {
-    DB.getDefault().truncate(SettingsGroup.class);
+    DB.getDefault().truncate(SettingsGroupModel.class);
     Http.Request request = Helpers.fakeRequest().build();
 
     settingsService.applySettingsToRequest(request).toCompletableFuture().join();
@@ -218,20 +218,20 @@ public class SettingsServiceTest extends ResetPostgres {
   @Test
   public void
       migrateConfigValuesToSettingsGroup_migratesSettingsFromHoconUnlessNoChangesAreFound() {
-    DB.getDefault().truncate(SettingsGroup.class);
+    DB.getDefault().truncate(SettingsGroupModel.class);
 
     assertThat(getCurrentSettingsGroup()).isEmpty();
     settingsService.migrateConfigValuesToSettingsGroup();
 
-    SettingsGroup settings = getCurrentSettingsGroup().get();
+    SettingsGroupModel settings = getCurrentSettingsGroup().get();
     assertThat(settings.getSettings()).isEqualTo(TEST_SETTINGS);
 
     settingsService.migrateConfigValuesToSettingsGroup();
-    SettingsGroup settingsAfterSecondMigration = getCurrentSettingsGroup().get();
+    SettingsGroupModel settingsAfterSecondMigration = getCurrentSettingsGroup().get();
     assertThat(settingsAfterSecondMigration.id).isEqualTo(settings.id);
   }
 
-  private Optional<SettingsGroup> getCurrentSettingsGroup() {
+  private Optional<SettingsGroupModel> getCurrentSettingsGroup() {
     return instanceOf(SettingsGroupRepository.class)
         .getCurrentSettings()
         .toCompletableFuture()
@@ -248,6 +248,6 @@ public class SettingsServiceTest extends ResetPostgres {
       throw new RuntimeException(e);
     }
 
-    new SettingsGroup(TEST_SETTINGS, "test").save();
+    new SettingsGroupModel(TEST_SETTINGS, "test").save();
   }
 }


### PR DESCRIPTION
### Description

Refactor the "SettingsGroup" class to be "SettingsGroupModel", so it is clear when we may be accessing the database.

We'll do this to the other Models as well as a follow up.

Similar to https://github.com/civiform/civiform/pull/5960

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes
 
#5961
