### PR TITLE
Refactor StoredFile to StoredFileModel

### DIFF
--- a/server/app/auth/StoredFileAcls.java
+++ b/server/app/auth/StoredFileAcls.java
@@ -10,7 +10,7 @@ import models.AccountModel;
 import services.program.ProgramDefinition;
 
 /**
- * Stores access control state for {@link models.StoredFile}s.
+ * Stores access control state for {@link models.StoredFileModel}s.
  *
  * <p>Program admins may read a file if they are an admin for a program included in the {@code
  * programReadAcls} for that file.

--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.AccountModel;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.pac4j.play.java.Secure;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http.Request;
@@ -98,7 +98,7 @@ public class FileController extends CiviFormController {
   private Result adminShowInternal(Request request, String fileKey) {
     String decodedFileKey = URLDecoder.decode(fileKey, StandardCharsets.UTF_8);
 
-    Optional<StoredFile> maybeFile =
+    Optional<StoredFileModel> maybeFile =
         storedFileRepository.lookupFile(decodedFileKey).toCompletableFuture().join();
 
     if (maybeFile.isEmpty()) {

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.pac4j.play.java.Secure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -422,7 +422,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
 
               return ensureFileRecord(key.get(), originalFileName)
                   .thenComposeAsync(
-                      (StoredFile unused) ->
+                      (StoredFileModel unused) ->
                           applicantService.stageAndUpdateIfValid(
                               applicantId,
                               programId,
@@ -758,12 +758,12 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         .build();
   }
 
-  private CompletionStage<StoredFile> ensureFileRecord(
+  private CompletionStage<StoredFileModel> ensureFileRecord(
       String key, Optional<String> originalFileName) {
     return storedFileRepository
         .lookupFile(key)
         .thenComposeAsync(
-            (Optional<StoredFile> maybeStoredFile) -> {
+            (Optional<StoredFileModel> maybeStoredFile) -> {
               // If there is already a stored file with this key in the database, then
               // the applicant has uploaded a file with the same name for the same
               // block and question, overwriting the original in file storage.
@@ -771,7 +771,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 return completedFuture(maybeStoredFile.get());
               }
 
-              var storedFile = new StoredFile();
+              var storedFile = new StoredFileModel();
               storedFile.setName(key);
               originalFileName.ifPresent(storedFile::setOriginalFileName);
 

--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -17,7 +17,7 @@ public final class Models {
           PersistedDurableJobModel.class,
           ProgramModel.class,
           QuestionModel.class,
-          StoredFile.class,
+          StoredFileModel.class,
           TrustedIntermediaryGroup.class,
           VersionModel.class,
           SettingsGroupModel.class);

--- a/server/app/models/StoredFileModel.java
+++ b/server/app/models/StoredFileModel.java
@@ -12,17 +12,17 @@ import play.data.validation.Constraints;
 /** The EBean mapped class for a file stored in AWS S3 */
 @Entity
 @Table(name = "files")
-public class StoredFile extends BaseModel {
+public class StoredFileModel extends BaseModel {
   private static final long serialVersionUID = 1L;
 
   /** ACLs for accessing this file. */
   @DbJsonB private StoredFileAcls acls;
 
-  public StoredFile(StoredFileAcls acls) {
+  public StoredFileModel(StoredFileAcls acls) {
     this.acls = checkNotNull(acls);
   }
 
-  public StoredFile() {
+  public StoredFileModel() {
     this(new StoredFileAcls());
   }
 
@@ -30,7 +30,7 @@ public class StoredFile extends BaseModel {
     return acls;
   }
 
-  public StoredFile setAcls(StoredFileAcls acls) {
+  public StoredFileModel setAcls(StoredFileAcls acls) {
     this.acls = acls;
     return this;
   }
@@ -39,7 +39,7 @@ public class StoredFile extends BaseModel {
     return name;
   }
 
-  public StoredFile setName(String name) {
+  public StoredFileModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -48,7 +48,7 @@ public class StoredFile extends BaseModel {
     return Optional.ofNullable(originalFileName);
   }
 
-  public StoredFile setOriginalFileName(String originalFileName) {
+  public StoredFileModel setOriginalFileName(String originalFileName) {
     this.originalFileName = originalFileName;
     return this;
   }

--- a/server/app/repository/StoredFileRepository.java
+++ b/server/app/repository/StoredFileRepository.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import models.StoredFile;
+import models.StoredFileModel;
 
 /**
- * StoredFileRepository performs complicated operations on {@link StoredFile} that involve
+ * StoredFileRepository performs complicated operations on {@link StoredFileModel} that involve
  * asynchronous handling.
  */
 public final class StoredFileRepository {
@@ -31,22 +31,22 @@ public final class StoredFileRepository {
   }
 
   /** Return all files in a set. */
-  public CompletionStage<Set<StoredFile>> list() {
+  public CompletionStage<Set<StoredFileModel>> list() {
     return supplyAsync(
         () ->
             database
-                .find(StoredFile.class)
+                .find(StoredFileModel.class)
                 .setLabel("StoredFile.findSet")
                 .setProfileLocation(queryProfileLocationBuilder.create("list"))
                 .findSet(),
         executionContext);
   }
 
-  public CompletionStage<List<StoredFile>> lookupFiles(ImmutableList<String> keyNames) {
+  public CompletionStage<List<StoredFileModel>> lookupFiles(ImmutableList<String> keyNames) {
     return supplyAsync(
         () ->
             database
-                .find(StoredFile.class)
+                .find(StoredFileModel.class)
                 .setLabel("StoredFile.findList")
                 .setProfileLocation(queryProfileLocationBuilder.create("lookupFiles"))
                 .where()
@@ -55,12 +55,12 @@ public final class StoredFileRepository {
         executionContext);
   }
 
-  public CompletionStage<Optional<StoredFile>> lookupFile(String keyName) {
+  public CompletionStage<Optional<StoredFileModel>> lookupFile(String keyName) {
     return supplyAsync(
         () ->
             Optional.ofNullable(
                 database
-                    .find(StoredFile.class)
+                    .find(StoredFileModel.class)
                     .setLabel("StoredFile.findByName")
                     .setProfileLocation(queryProfileLocationBuilder.create("lookupFile"))
                     .where()
@@ -69,12 +69,12 @@ public final class StoredFileRepository {
         executionContext);
   }
 
-  public CompletionStage<Optional<StoredFile>> lookupFile(Long id) {
+  public CompletionStage<Optional<StoredFileModel>> lookupFile(Long id) {
     return supplyAsync(
         () ->
             Optional.ofNullable(
                 database
-                    .find(StoredFile.class)
+                    .find(StoredFileModel.class)
                     .setLabel("StoredFile.findOne")
                     .setProfileLocation(queryProfileLocationBuilder.create("lookupFile"))
                     .setId(id)
@@ -82,7 +82,7 @@ public final class StoredFileRepository {
         executionContext);
   }
 
-  public CompletionStage<Void> update(StoredFile storedFile) {
+  public CompletionStage<Void> update(StoredFileModel storedFile) {
     return supplyAsync(
         () -> {
           database.update(storedFile);
@@ -91,7 +91,7 @@ public final class StoredFileRepository {
         executionContext);
   }
 
-  public CompletionStage<StoredFile> insert(StoredFile file) {
+  public CompletionStage<StoredFileModel> insert(StoredFileModel file) {
     return supplyAsync(
         () -> {
           database.insert(file);

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -35,7 +35,7 @@ import models.ApplicationModel;
 import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.i18n.Lang;
@@ -560,7 +560,7 @@ public final class ApplicantService {
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
         programService.getProgramDefinitionAsync(programId).toCompletableFuture();
 
-    CompletableFuture<List<StoredFile>> storedFilesFuture =
+    CompletableFuture<List<StoredFileModel>> storedFilesFuture =
         getReadOnlyApplicantProgramService(applicantId, programId)
             .thenApplyAsync(
                 ReadOnlyApplicantProgramService::getStoredFileKeys, httpExecutionContext.current())
@@ -570,11 +570,11 @@ public final class ApplicantService {
     return CompletableFuture.allOf(programDefinitionCompletableFuture, storedFilesFuture)
         .thenComposeAsync(
             (ignoreVoid) -> {
-              List<StoredFile> storedFiles = storedFilesFuture.join();
+              List<StoredFileModel> storedFiles = storedFilesFuture.join();
               ProgramDefinition programDefinition = programDefinitionCompletableFuture.join();
               CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
 
-              for (StoredFile file : storedFiles) {
+              for (StoredFileModel file : storedFiles) {
                 file.getAcls().addProgramToReaders(programDefinition);
                 future =
                     CompletableFuture.allOf(

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -10,7 +10,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import models.ApplicantModel;
 import models.ProgramModel;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
@@ -186,7 +186,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   private void createStoredFileWithProgramAccess(String fileKey, ProgramModel program) {
-    var file = new StoredFile().setName(fileKey);
+    var file = new StoredFileModel().setName(fileKey);
     file.getAcls().addProgramToReaders(program.getProgramDefinition());
     file.save();
   }

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import models.AccountModel;
 import models.ApplicantModel;
 import models.ProgramModel;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
@@ -879,7 +879,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     var fileKey = "fake-key";
-    var storedFile = new StoredFile();
+    var storedFile = new StoredFileModel();
     storedFile.setName(fileKey);
     storedFile.save();
 

--- a/server/test/repository/StoredFileRepositoryTest.java
+++ b/server/test/repository/StoredFileRepositoryTest.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
 import io.ebean.Database;
 import java.util.List;
-import models.StoredFile;
+import models.StoredFileModel;
 import org.junit.Before;
 import org.junit.Test;
 import support.ProgramBuilder;
@@ -15,12 +15,12 @@ import support.ProgramBuilder;
 public class StoredFileRepositoryTest extends ResetPostgres {
 
   private StoredFileRepository repo;
-  private StoredFile file;
+  private StoredFileModel file;
 
   @Before
   public void setUp() {
     repo = instanceOf(StoredFileRepository.class);
-    file = new StoredFile().setName("file name");
+    file = new StoredFileModel().setName("file name");
   }
 
   @Test
@@ -48,10 +48,10 @@ public class StoredFileRepositoryTest extends ResetPostgres {
   @Test
   public void lookupFiles() {
     file.save();
-    var fileTwo = new StoredFile().setName("file-two");
+    var fileTwo = new StoredFileModel().setName("file-two");
     fileTwo.save();
 
-    List<StoredFile> result =
+    List<StoredFileModel> result =
         repo.lookupFiles(ImmutableList.of(file.getName(), fileTwo.getName()))
             .toCompletableFuture()
             .join();
@@ -63,7 +63,7 @@ public class StoredFileRepositoryTest extends ResetPostgres {
   public void lookupFile() {
     file.save();
 
-    StoredFile result = repo.lookupFile(file.getName()).toCompletableFuture().join().get();
+    StoredFileModel result = repo.lookupFile(file.getName()).toCompletableFuture().join().get();
 
     assertThat(result).isEqualTo(file);
   }
@@ -81,7 +81,7 @@ public class StoredFileRepositoryTest extends ResetPostgres {
         .setParameter("name", fileName)
         .execute();
 
-    StoredFile result = repo.lookupFile(fileName).toCompletableFuture().join().get();
+    StoredFileModel result = repo.lookupFile(fileName).toCompletableFuture().join().get();
 
     assertThat(result.getName()).isEqualTo(fileName);
     assertThat(result.getAcls()).isInstanceOf(StoredFileAcls.class);

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -27,7 +27,7 @@ import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
 import models.QuestionModel;
-import models.StoredFile;
+import models.StoredFileModel;
 import models.TrustedIntermediaryGroup;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Before;
@@ -855,7 +855,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    var storedFile = new StoredFile().setName(fileKey);
+    var storedFile = new StoredFileModel().setName(fileKey);
     storedFile.save();
 
     subject


### PR DESCRIPTION
### Description

Refactor the "StoredFile" class to be "StoredFileModel", so it is clear when we may be accessing the database.

We'll do this to the other Models as well as a follow up.

Similar to https://github.com/civiform/civiform/pull/5960

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes
 
#5961
