### PR TITLE
Add AwsApplicantStorageTest

### DIFF
--- a/server/test/services/cloud/aws/ApplicantSimpleStorageTest.java
+++ b/server/test/services/cloud/aws/ApplicantSimpleStorageTest.java
@@ -5,48 +5,45 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.typesafe.config.Config;
-import org.junit.Before;
+import java.io.File;
 import org.junit.Test;
 import play.Environment;
 import play.Mode;
 import play.inject.ApplicationLifecycle;
 import repository.ResetPostgres;
-import services.cloud.StorageUploadRequest;
-import services.cloud.azure.ApplicantBlobStorage;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
-import java.io.File;
-
 public class ApplicantSimpleStorageTest extends ResetPostgres {
-
 
   @Test
   public void getSignedUploadRequest_prodEnv_actionLinkIsProdAws() {
-    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
-      instanceOf(AwsRegion.class),
-      instanceOf(Credentials.class),
-      instanceOf(Config.class),
-      new Environment(new File("."), Environment.class.getClassLoader(), Mode.PROD),
-      instanceOf(ApplicationLifecycle.class)
-    );
+    ApplicantSimpleStorage applicantSimpleStorage =
+        new ApplicantSimpleStorage(
+            instanceOf(AwsRegion.class),
+            instanceOf(Credentials.class),
+            instanceOf(Config.class),
+            new Environment(new File("."), Environment.class.getClassLoader(), Mode.PROD),
+            instanceOf(ApplicationLifecycle.class));
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
   }
 
   @Test
   public void getSignedUploadRequest_devEnv_actionLinkIsLocalStack() {
-    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
-      instanceOf(AwsRegion.class),
-      instanceOf(Credentials.class),
-      instanceOf(Config.class),
-      new Environment(new File("."), Environment.class.getClassLoader(), Mode.DEV),
-      instanceOf(ApplicationLifecycle.class)
-    );
+    ApplicantSimpleStorage applicantSimpleStorage =
+        new ApplicantSimpleStorage(
+            instanceOf(AwsRegion.class),
+            instanceOf(Credentials.class),
+            instanceOf(Config.class),
+            new Environment(new File("."), Environment.class.getClassLoader(), Mode.DEV),
+            instanceOf(ApplicationLifecycle.class));
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("localstack");
     assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
@@ -56,27 +53,28 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
   public void getSignedUploadRequest_hasCredentialsAndRegion() {
     AwsRegion region = instanceOf(AwsRegion.class);
     Credentials credentials = instanceOf(Credentials.class);
-    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
-      region,
-      credentials,
-      instanceOf(Config.class),
-      instanceOf(Environment.class),
-      instanceOf(ApplicationLifecycle.class)
-    );
+    ApplicantSimpleStorage applicantSimpleStorage =
+        new ApplicantSimpleStorage(
+            region,
+            credentials,
+            instanceOf(Config.class),
+            instanceOf(Environment.class),
+            instanceOf(ApplicationLifecycle.class));
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.accessKey()).isEqualTo(credentials.getCredentials().accessKeyId());
     assertThat(uploadRequest.secretKey()).isEqualTo(credentials.getCredentials().secretAccessKey());
     assertThat(uploadRequest.regionName()).isEqualTo(region.get().id());
   }
 
-
   @Test
   public void getSignedUploadRequest_hasFileKey() {
     ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
 
     assertThat(uploadRequest.key()).isEqualTo("test/fake/fakeFile.png");
   }
@@ -85,11 +83,11 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
   public void getSignedUploadRequest_hasSuccessRedirect() {
     ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
 
     assertThat(uploadRequest.successActionRedirect()).isEqualTo("http://redirect.to.here");
   }
-
 
   @Test
   public void getSignedUploadRequest_sessionCredentials_hasSecurityToken() {
@@ -100,15 +98,16 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
 
     when(credentials.getCredentials()).thenReturn(sessionCredentials);
     when(sessionCredentials.sessionToken()).thenReturn("testSessionToken");
-    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
-      instanceOf(AwsRegion.class),
-      credentials,
-      instanceOf(Config.class),
-      instanceOf(Environment.class),
-      instanceOf(ApplicationLifecycle.class)
-    );
+    ApplicantSimpleStorage applicantSimpleStorage =
+        new ApplicantSimpleStorage(
+            instanceOf(AwsRegion.class),
+            credentials,
+            instanceOf(Config.class),
+            instanceOf(Environment.class),
+            instanceOf(ApplicationLifecycle.class));
 
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEqualTo("testSessionToken");
   }
@@ -121,16 +120,16 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
     when(notSessionCredentials.secretAccessKey()).thenReturn("secretKey");
     when(credentials.getCredentials()).thenReturn(notSessionCredentials);
 
+    ApplicantSimpleStorage applicantSimpleStorage =
+        new ApplicantSimpleStorage(
+            instanceOf(AwsRegion.class),
+            credentials,
+            instanceOf(Config.class),
+            instanceOf(Environment.class),
+            instanceOf(ApplicationLifecycle.class));
 
-    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
-      instanceOf(AwsRegion.class),
-      credentials,
-      instanceOf(Config.class),
-      instanceOf(Environment.class),
-      instanceOf(ApplicationLifecycle.class)
-    );
-
-    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+    SignedS3UploadRequest uploadRequest =
+        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEmpty();
   }

--- a/server/test/services/cloud/aws/ApplicantSimpleStorageTest.java
+++ b/server/test/services/cloud/aws/ApplicantSimpleStorageTest.java
@@ -1,0 +1,137 @@
+package services.cloud.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import org.junit.Before;
+import org.junit.Test;
+import play.Environment;
+import play.Mode;
+import play.inject.ApplicationLifecycle;
+import repository.ResetPostgres;
+import services.cloud.StorageUploadRequest;
+import services.cloud.azure.ApplicantBlobStorage;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+import java.io.File;
+
+public class ApplicantSimpleStorageTest extends ResetPostgres {
+
+
+  @Test
+  public void getSignedUploadRequest_prodEnv_actionLinkIsProdAws() {
+    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
+      instanceOf(AwsRegion.class),
+      instanceOf(Credentials.class),
+      instanceOf(Config.class),
+      new Environment(new File("."), Environment.class.getClassLoader(), Mode.PROD),
+      instanceOf(ApplicationLifecycle.class)
+    );
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+
+    assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
+  }
+
+  @Test
+  public void getSignedUploadRequest_devEnv_actionLinkIsLocalStack() {
+    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
+      instanceOf(AwsRegion.class),
+      instanceOf(Credentials.class),
+      instanceOf(Config.class),
+      new Environment(new File("."), Environment.class.getClassLoader(), Mode.DEV),
+      instanceOf(ApplicationLifecycle.class)
+    );
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+
+    assertThat(uploadRequest.actionLink()).contains("localstack");
+    assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
+  }
+
+  @Test
+  public void getSignedUploadRequest_hasCredentialsAndRegion() {
+    AwsRegion region = instanceOf(AwsRegion.class);
+    Credentials credentials = instanceOf(Credentials.class);
+    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
+      region,
+      credentials,
+      instanceOf(Config.class),
+      instanceOf(Environment.class),
+      instanceOf(ApplicationLifecycle.class)
+    );
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+
+    assertThat(uploadRequest.accessKey()).isEqualTo(credentials.getCredentials().accessKeyId());
+    assertThat(uploadRequest.secretKey()).isEqualTo(credentials.getCredentials().secretAccessKey());
+    assertThat(uploadRequest.regionName()).isEqualTo(region.get().id());
+  }
+
+
+  @Test
+  public void getSignedUploadRequest_hasFileKey() {
+    ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
+
+    assertThat(uploadRequest.key()).isEqualTo("test/fake/fakeFile.png");
+  }
+
+  @Test
+  public void getSignedUploadRequest_hasSuccessRedirect() {
+    ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
+
+    assertThat(uploadRequest.successActionRedirect()).isEqualTo("http://redirect.to.here");
+  }
+
+
+  @Test
+  public void getSignedUploadRequest_sessionCredentials_hasSecurityToken() {
+    Credentials credentials = mock(Credentials.class);
+    AwsSessionCredentials sessionCredentials = mock(AwsSessionCredentials.class);
+    when(sessionCredentials.accessKeyId()).thenReturn("accessKeyId");
+    when(sessionCredentials.secretAccessKey()).thenReturn("secretKey");
+
+    when(credentials.getCredentials()).thenReturn(sessionCredentials);
+    when(sessionCredentials.sessionToken()).thenReturn("testSessionToken");
+    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
+      instanceOf(AwsRegion.class),
+      credentials,
+      instanceOf(Config.class),
+      instanceOf(Environment.class),
+      instanceOf(ApplicationLifecycle.class)
+    );
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+
+    assertThat(uploadRequest.securityToken()).isEqualTo("testSessionToken");
+  }
+
+  @Test
+  public void getSignedUploadRequest_noSessionCredentials_noSecurityToken() {
+    Credentials credentials = mock(Credentials.class);
+    AwsCredentials notSessionCredentials = mock(AwsCredentials.class);
+    when(notSessionCredentials.accessKeyId()).thenReturn("accessKeyId");
+    when(notSessionCredentials.secretAccessKey()).thenReturn("secretKey");
+    when(credentials.getCredentials()).thenReturn(notSessionCredentials);
+
+
+    ApplicantSimpleStorage applicantSimpleStorage = new ApplicantSimpleStorage(
+      instanceOf(AwsRegion.class),
+      credentials,
+      instanceOf(Config.class),
+      instanceOf(Environment.class),
+      instanceOf(ApplicationLifecycle.class)
+    );
+
+    SignedS3UploadRequest uploadRequest = applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+
+    assertThat(uploadRequest.securityToken()).isEmpty();
+  }
+}

--- a/server/test/services/cloud/aws/AwsApplicantStorageTest.java
+++ b/server/test/services/cloud/aws/AwsApplicantStorageTest.java
@@ -27,7 +27,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
   }
@@ -35,7 +35,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
   @Test
   public void getSignedUploadRequest_devEnv_actionLinkIsLocalStack() {
     AwsApplicantStorage awsApplicantStorage =
-      new AwsApplicantStorage(
+        new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
             instanceOf(Config.class),
@@ -43,7 +43,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("localstack");
     assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
@@ -54,7 +54,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
     AwsRegion region = instanceOf(AwsRegion.class);
     Credentials credentials = instanceOf(Credentials.class);
     AwsApplicantStorage awsApplicantStorage =
-      new AwsApplicantStorage(
+        new AwsApplicantStorage(
             region,
             credentials,
             instanceOf(Config.class),
@@ -62,7 +62,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.accessKey()).isEqualTo(credentials.getCredentials().accessKeyId());
     assertThat(uploadRequest.secretKey()).isEqualTo(credentials.getCredentials().secretAccessKey());
@@ -74,7 +74,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
     AwsApplicantStorage awsApplicantStorage = instanceOf(AwsApplicantStorage.class);
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
 
     assertThat(uploadRequest.key()).isEqualTo("test/fake/fakeFile.png");
   }
@@ -84,7 +84,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
     AwsApplicantStorage awsApplicantStorage = instanceOf(AwsApplicantStorage.class);
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
 
     assertThat(uploadRequest.successActionRedirect()).isEqualTo("http://redirect.to.here");
   }
@@ -99,7 +99,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
     when(credentials.getCredentials()).thenReturn(sessionCredentials);
     when(sessionCredentials.sessionToken()).thenReturn("testSessionToken");
     AwsApplicantStorage awsApplicantStorage =
-      new AwsApplicantStorage(
+        new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             credentials,
             instanceOf(Config.class),
@@ -107,7 +107,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEqualTo("testSessionToken");
   }
@@ -129,7 +129,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
+        awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEmpty();
   }

--- a/server/test/services/cloud/aws/AwsApplicantStorageTest.java
+++ b/server/test/services/cloud/aws/AwsApplicantStorageTest.java
@@ -14,12 +14,12 @@ import repository.ResetPostgres;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
-public class ApplicantSimpleStorageTest extends ResetPostgres {
+public class AwsApplicantStorageTest extends ResetPostgres {
 
   @Test
   public void getSignedUploadRequest_prodEnv_actionLinkIsProdAws() {
-    ApplicantSimpleStorage applicantSimpleStorage =
-        new ApplicantSimpleStorage(
+    AwsApplicantStorage awsApplicantStorage =
+        new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
             instanceOf(Config.class),
@@ -27,15 +27,15 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
   }
 
   @Test
   public void getSignedUploadRequest_devEnv_actionLinkIsLocalStack() {
-    ApplicantSimpleStorage applicantSimpleStorage =
-        new ApplicantSimpleStorage(
+    AwsApplicantStorage awsApplicantStorage =
+      new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
             instanceOf(Config.class),
@@ -43,7 +43,7 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("localstack");
     assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
@@ -53,8 +53,8 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
   public void getSignedUploadRequest_hasCredentialsAndRegion() {
     AwsRegion region = instanceOf(AwsRegion.class);
     Credentials credentials = instanceOf(Credentials.class);
-    ApplicantSimpleStorage applicantSimpleStorage =
-        new ApplicantSimpleStorage(
+    AwsApplicantStorage awsApplicantStorage =
+      new AwsApplicantStorage(
             region,
             credentials,
             instanceOf(Config.class),
@@ -62,7 +62,7 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.accessKey()).isEqualTo(credentials.getCredentials().accessKeyId());
     assertThat(uploadRequest.secretKey()).isEqualTo(credentials.getCredentials().secretAccessKey());
@@ -71,20 +71,20 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
 
   @Test
   public void getSignedUploadRequest_hasFileKey() {
-    ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
+    AwsApplicantStorage awsApplicantStorage = instanceOf(AwsApplicantStorage.class);
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("test/fake/fakeFile.png", "redirect");
 
     assertThat(uploadRequest.key()).isEqualTo("test/fake/fakeFile.png");
   }
 
   @Test
   public void getSignedUploadRequest_hasSuccessRedirect() {
-    ApplicantSimpleStorage applicantSimpleStorage = instanceOf(ApplicantSimpleStorage.class);
+    AwsApplicantStorage awsApplicantStorage = instanceOf(AwsApplicantStorage.class);
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "http://redirect.to.here");
 
     assertThat(uploadRequest.successActionRedirect()).isEqualTo("http://redirect.to.here");
   }
@@ -98,8 +98,8 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
 
     when(credentials.getCredentials()).thenReturn(sessionCredentials);
     when(sessionCredentials.sessionToken()).thenReturn("testSessionToken");
-    ApplicantSimpleStorage applicantSimpleStorage =
-        new ApplicantSimpleStorage(
+    AwsApplicantStorage awsApplicantStorage =
+      new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             credentials,
             instanceOf(Config.class),
@@ -107,7 +107,7 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEqualTo("testSessionToken");
   }
@@ -120,8 +120,8 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
     when(notSessionCredentials.secretAccessKey()).thenReturn("secretKey");
     when(credentials.getCredentials()).thenReturn(notSessionCredentials);
 
-    ApplicantSimpleStorage applicantSimpleStorage =
-        new ApplicantSimpleStorage(
+    AwsApplicantStorage awsApplicantStorage =
+        new AwsApplicantStorage(
             instanceOf(AwsRegion.class),
             credentials,
             instanceOf(Config.class),
@@ -129,7 +129,7 @@ public class ApplicantSimpleStorageTest extends ResetPostgres {
             instanceOf(ApplicationLifecycle.class));
 
     SignedS3UploadRequest uploadRequest =
-        applicantSimpleStorage.getSignedUploadRequest("fileKey", "redirect");
+      awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.securityToken()).isEmpty();
   }

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - 9100:9000
       - 8459:8459
     environment:
+      - AWS_ACCESS_KEY_ID=testAccessKey
+      - AWS_SECRET_ACCESS_KEY=testSecretKey
+      - AWS_SESSION_TOKEN=testSession
       - IDCS_CLIENT_ID=idcs-fake-oidc-client
       - IDCS_SECRET=idcs-fake-oidc-secret
       - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration


### PR DESCRIPTION
### Description

Adds a test for the `AwsApplicantStorage` class. This will be useful because the program images feature will be making some changes to applicant file upload storage (to share code when possible), so this test can try and catch regressions.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

#5676 
