### PR TITLE
Shrink Formatter Image Size

### DIFF
--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -8,46 +8,33 @@ FROM bellsoft/liberica-openjdk-alpine:11.0.19-7 as arm64
 
 FROM ${TARGETARCH}
 
-ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
-RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
-
-RUN apk update && apk add --no-cache --update \
-  openjdk11 bash wget npm shfmt git py3-pip terraform
-
-RUN pip install yapf
-
-COPY .prettier* /
-COPY .editorconfig* /
+ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/v1.18.1/google-java-format-1.18.1-all-deps.jar"
+RUN wget $JAVA_FORMATTER_URL -O /fmt.jar && \
+    apk update && \
+    apk add --no-cache --update bash wget npm shfmt git py3-pip terraform && \
+    pip install yapf && \
+    apk cache clean
 
 # Below we pre-install nodejs depdendencies for various
 # TS codebases we have. We need all dependencies in order to
 # run type-based checks with eslint. For each directory that
 # contains package.json we run npm install and save resulted `node_modules`
 # directory as volume.
-
-# Fetch node js dependencies for `formatter` directory.
 ENV FORMATTER_DIR /code/formatter
-RUN mkdir -p $FORMATTER_DIR
-COPY formatter/package.json $FORMATTER_DIR
-COPY formatter/package-lock.json $FORMATTER_DIR
-WORKDIR $FORMATTER_DIR
-RUN npm install
-
-# Fetch node js dependencies for `browser-test` directory.
 ENV BROWSER_TEST_DIR /code/browser-test
-RUN mkdir -p $BROWSER_TEST_DIR
-COPY browser-test/package.json $BROWSER_TEST_DIR
-COPY browser-test/package-lock.json $BROWSER_TEST_DIR
-WORKDIR $BROWSER_TEST_DIR
-RUN npm install
-
-# Fetch node js dependencies for `server` directory.
 ENV SERVER_DIR /code/server
-RUN mkdir -p $SERVER_DIR
-COPY server/package.json $SERVER_DIR
-COPY server/package-lock.json $SERVER_DIR
-WORKDIR $SERVER_DIR
-RUN npm install
+
+COPY .prettier* .editorconfig* /
+COPY formatter/package.json formatter/package-lock.json $FORMATTER_DIR/
+COPY browser-test/package.json browser-test/package-lock.json $BROWSER_TEST_DIR/
+COPY server/package.json server/package-lock.json $SERVER_DIR/
+
+RUN cd $FORMATTER_DIR && \
+    npm install && \
+    cd $BROWSER_TEST_DIR && \
+    npm install && \
+    cd $SERVER_DIR && \
+    npm install
 
 
 ENTRYPOINT ["/code/formatter/fmt"]

--- a/server/app/auth/saml/SamlProfileCreator.java
+++ b/server/app/auth/saml/SamlProfileCreator.java
@@ -36,6 +36,7 @@ public class SamlProfileCreator extends AuthenticatorProfileCreator {
   protected final ProfileFactory profileFactory;
   protected final Provider<AccountRepository> applicantRepositoryProvider;
   protected final SAML2Configuration saml2Configuration;
+
   // TODO(#3856): Update with a non deprecated saml impl.
   @SuppressWarnings("deprecation")
   protected final SAML2Client saml2Client;

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -333,7 +333,9 @@ public final class AdminApplicationController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result updateStatus(Http.Request request, long programId, long applicationId)
-      throws ProgramNotFoundException, StatusEmailNotFoundException, StatusNotFoundException,
+      throws ProgramNotFoundException,
+          StatusEmailNotFoundException,
+          StatusNotFoundException,
           AccountHasNoEmailException {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     String programName = program.adminName();

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -140,8 +140,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 Modal loginPromptModal =
                     createLoginPromptModal(
                             messages,
-                            /*postLoginRedirectTo=*/ controllers.applicant.routes.DeepLinkController
-                                .programBySlug(
+                            /* postLoginRedirectTo= */ controllers.applicant.routes
+                                .DeepLinkController.programBySlug(
                                     request.flash().get("redirected-from-program-slug").get())
                                 .url(),
                             messages.at(

--- a/server/app/models/ApplicationEventModel.java
+++ b/server/app/models/ApplicationEventModel.java
@@ -21,10 +21,12 @@ public final class ApplicationEventModel extends BaseModel {
   @ManyToOne private ApplicationModel application;
   // The {@code ApplicationEventDetails.Type} of the event.
   @Constraints.Required private ApplicationEventDetails.Type eventType;
+
   // The Account that triggered the event.
   @ManyToOne
   @JoinColumn(name = "creator_id")
   private AccountModel creator;
+
   // Details of the event specific to the eventType.
   @Constraints.Required @DbJson private ApplicationEventDetails details;
   @WhenCreated private Instant createTime;

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -71,6 +71,7 @@ public class ProgramModel extends BaseModel {
   @DbJsonB private LocalizedStrings localizedName;
 
   @DbJsonB private ProgramAcls acls;
+
   /**
    * legacyLocalizedName is the legacy storage column for program name translations. Programs
    * created before early May 2021 may use this, but all other programs should not.

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -22,6 +22,7 @@ public final class ProgramBlockValidation {
     this.version = checkNotNull(version);
     this.activeAndDraftQuestions = checkNotNull(activeAndDraftQuestions);
   }
+
   /**
    * Result of checking whether a question can be added to a specific block. Only ELIGIBLE means
    * that question can be added. All other states indicate that question is not eligible for the

--- a/server/app/services/ProgramBlockValidationFactory.java
+++ b/server/app/services/ProgramBlockValidationFactory.java
@@ -25,6 +25,7 @@ public final class ProgramBlockValidationFactory {
     this.versionRepository = checkNotNull(versionRepository);
     this.questionService = checkNotNull(questionService);
   }
+
   /** Creating a ProgramBlockValidation object with version(DB object) as its member variable */
   public ProgramBlockValidation create() {
     VersionModel version = versionRepository.getDraftVersionOrCreate();

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -1096,7 +1096,8 @@ public final class ProgramService {
       long programId,
       long blockDefinitionId,
       ImmutableList<ProgramQuestionDefinition> programQuestionDefinitions)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
           IllegalPredicateOrderingException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
@@ -1123,7 +1124,9 @@ public final class ProgramService {
    */
   public ProgramDefinition addQuestionsToBlock(
       long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
-      throws CantAddQuestionToBlockException, QuestionNotFoundException, ProgramNotFoundException,
+      throws CantAddQuestionToBlockException,
+          QuestionNotFoundException,
+          ProgramNotFoundException,
           ProgramBlockDefinitionNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
@@ -1184,8 +1187,10 @@ public final class ProgramService {
    */
   public ProgramDefinition removeQuestionsFromBlock(
       long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
-      throws QuestionNotFoundException, ProgramNotFoundException,
-          ProgramBlockDefinitionNotFoundException, IllegalPredicateOrderingException {
+      throws QuestionNotFoundException,
+          ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
+          IllegalPredicateOrderingException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
     for (long questionId : questionIds) {
@@ -1225,7 +1230,8 @@ public final class ProgramService {
    */
   public ProgramDefinition setBlockVisibilityPredicate(
       long programId, long blockDefinitionId, Optional<PredicateDefinition> predicate)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
           IllegalPredicateOrderingException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
@@ -1254,8 +1260,10 @@ public final class ProgramService {
    */
   public ProgramDefinition setBlockEligibilityDefinition(
       long programId, long blockDefinitionId, Optional<EligibilityDefinition> eligibility)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
-          IllegalPredicateOrderingException, EligibilityNotValidForProgramTypeException {
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
+          IllegalPredicateOrderingException,
+          EligibilityNotValidForProgramTypeException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
     if (programDefinition.isCommonIntakeForm() && eligibility.isPresent()) {
@@ -1326,7 +1334,8 @@ public final class ProgramService {
    *     this program
    */
   public ProgramDefinition deleteBlock(long programId, long blockDefinitionId)
-      throws ProgramNotFoundException, ProgramNeedsABlockException,
+      throws ProgramNotFoundException,
+          ProgramNeedsABlockException,
           IllegalPredicateOrderingException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 
@@ -1419,7 +1428,8 @@ public final class ProgramService {
    */
   public ProgramDefinition setProgramQuestionDefinitionOptionality(
       long programId, long blockDefinitionId, long questionDefinitionId, boolean optional)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
           ProgramQuestionDefinitionNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
@@ -1469,8 +1479,10 @@ public final class ProgramService {
       long blockDefinitionId,
       long questionDefinitionId,
       boolean addressCorrectionEnabled)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
@@ -1532,8 +1544,10 @@ public final class ProgramService {
    */
   public ProgramDefinition setProgramQuestionDefinitionPosition(
       long programId, long blockDefinitionId, long questionDefinitionId, int newPosition)
-      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, InvalidQuestionPositionException {
+      throws ProgramNotFoundException,
+          ProgramBlockDefinitionNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          InvalidQuestionPositionException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -934,9 +934,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "IDCS_SECRET",
                                       "A secret known only to the client (Civiform) and"
                                           + " authorization server, specifically for IDCS OIDC"
-                                          + " systems. This secret essentially acts as the"
-                                          + " client’s “password” for accessing data from the auth"
-                                          + " server.",
+                                          + " systems. This secret essentially acts as the client’s"
+                                          + " “password” for accessing data from the auth server.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.SECRET),
@@ -962,8 +961,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "LOGIN_RADIUS_METADATA_URI",
-                                      "The base URL to construct SAML endpoints, based on the"
-                                          + " SAML2 spec.",
+                                      "The base URL to construct SAML endpoints, based on the SAML2"
+                                          + " spec.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1010,11 +1009,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_OVERRIDE_LOGOUT_URL",
-                                      "By default the 'end_session_endpoint' from the auth"
-                                          + " provider discovery metadata file is used as the"
-                                          + " logout endpoint. However for some integrations that"
-                                          + " standard flow might not work and we need to override"
-                                          + " logout URL.",
+                                      "By default the 'end_session_endpoint' from the auth provider"
+                                          + " discovery metadata file is used as the logout"
+                                          + " endpoint. However for some integrations that standard"
+                                          + " flow might not work and we need to override logout"
+                                          + " URL.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1022,12 +1021,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "APPLICANT_OIDC_POST_LOGOUT_REDIRECT_PARAM",
                                       "URL param used to pass the post logout redirect url in the"
                                           + " logout request to the auth provider. It defaults to"
-                                          + " 'post_logout_redirect_uri' if this variable is"
-                                          + " unset. If this variable is set to the empty string,"
-                                          + " the post logout redirect url is not passed at all"
-                                          + " and instead it needs to be hardcoded on the the auth"
-                                          + " provider (otherwise the user won't be redirected"
-                                          + " back to civiform after logout).",
+                                          + " 'post_logout_redirect_uri' if this variable is unset."
+                                          + " If this variable is set to the empty string, the post"
+                                          + " logout redirect url is not passed at all and instead"
+                                          + " it needs to be hardcoded on the the auth provider"
+                                          + " (otherwise the user won't be redirected back to"
+                                          + " civiform after logout).",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1049,9 +1048,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_CLIENT_SECRET",
                                       "A secret known only to the client (Civiform) and"
-                                          + " authorization server. This secret essentially acts"
-                                          + " as the client’s “password” for accessing data from"
-                                          + " the auth server.",
+                                          + " authorization server. This secret essentially acts as"
+                                          + " the client’s “password” for accessing data from the"
+                                          + " auth server.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.SECRET),
@@ -1064,8 +1063,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_RESPONSE_MODE",
-                                      "Informs the auth server of the desired auth processing"
-                                          + " flow, based on the OpenID Connect spec.",
+                                      "Informs the auth server of the desired auth processing flow,"
+                                          + " based on the OpenID Connect spec.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1126,8 +1125,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       "LOGIN_GOV_CLIENT_ID",
                                       "An opaque public identifier for apps that use OIDC (OpenID"
                                           + " Connect) to request data from authorization servers,"
-                                          + " specifically communicating with Login.gov. A"
-                                          + " Civiform instance is always the client.",
+                                          + " specifically communicating with Login.gov. A Civiform"
+                                          + " instance is always the client.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1142,8 +1141,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "LOGIN_GOV_ADDITIONAL_SCOPES",
                                       "Scopes the client (CiviForm) is requesting in addition to"
-                                          + " the standard scopes the OpenID Connect spec"
-                                          + " provides. Scopes should be separated by a space.",
+                                          + " the standard scopes the OpenID Connect spec provides."
+                                          + " Scopes should be separated by a space.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1210,9 +1209,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "ADFS_SECRET",
                                       "A secret known only to the client (Civiform) and"
-                                          + " authorization server. This secret essentially acts"
-                                          + " as the client’s “password” for accessing data from"
-                                          + " the auth server.",
+                                          + " authorization server. This secret essentially acts as"
+                                          + " the client’s “password” for accessing data from the"
+                                          + " auth server.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.SECRET),
@@ -1233,15 +1232,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "ADFS_ADDITIONAL_SCOPES",
                                       "Scopes the client (CiviForm) is requesting in addition to"
-                                          + " the standard scopes the OpenID Connect spec"
-                                          + " provides. Scopes should be separated by a space.",
+                                          + " the standard scopes the OpenID Connect spec provides."
+                                          + " Scopes should be separated by a space.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "AD_GROUPS_ATTRIBUTE_NAME",
-                                      "The attribute name for looking up the groups associated"
-                                          + " with a particular user.",
+                                      "The attribute name for looking up the groups associated with"
+                                          + " a particular user.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN))),
@@ -1270,9 +1269,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "ADMIN_OIDC_CLIENT_SECRET",
                                       "A secret known only to the client (Civiform) and"
-                                          + " authorization server. This secret essentially acts"
-                                          + " as the client’s “password” for accessing data from"
-                                          + " the auth server.",
+                                          + " authorization server. This secret essentially acts as"
+                                          + " the client’s “password” for accessing data from the"
+                                          + " auth server.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1285,8 +1284,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                       SettingMode.HIDDEN),
                                   SettingDescription.create(
                                       "ADMIN_OIDC_RESPONSE_MODE",
-                                      "Informs the auth server of the desired auth processing"
-                                          + " flow, based on the OpenID Connect spec.",
+                                      "Informs the auth server of the desired auth processing flow,"
+                                          + " based on the OpenID Connect spec.",
                                       /* isRequired= */ false,
                                       SettingType.STRING,
                                       SettingMode.HIDDEN),
@@ -1399,8 +1398,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               SettingMode.HIDDEN),
                           SettingDescription.create(
                               "FORK_JOIN_PARALLELISM_FACTOR",
-                              "The parallelism factor is used to determine thread pool size for"
-                                  + " the 'fork-join-executor' using the following formula:"
+                              "The parallelism factor is used to determine thread pool size for the"
+                                  + " 'fork-join-executor' using the following formula:"
                                   + " ceil(available processors * factor). Resulting size is then"
                                   + " bounded by the parallelism-min and parallelism-max values.",
                               /* isRequired= */ false,
@@ -1630,10 +1629,10 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "A cryptographic [secret"
                           + " salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) used for"
                           + " salting API keys before storing their hash values in the database."
-                          + " This value should be kept strictly secret. If one suspects the"
-                          + " secret has been leaked or otherwise comprised it should be changed"
-                          + " and all active API keys should be retired and reissued. Default"
-                          + " value is 'changeme'.",
+                          + " This value should be kept strictly secret. If one suspects the secret"
+                          + " has been leaked or otherwise comprised it should be changed and all"
+                          + " active API keys should be retired and reissued. Default value is"
+                          + " 'changeme'.",
                       /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.SECRET),
@@ -1677,9 +1676,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "DURABLE_JOBS_THREAD_POOL_SIZE",
-                      "The number of server threads available for the durable job runner. More"
-                          + " than a single thread will the server execute multiple jobs in"
-                          + " parallel. Default value is 1.",
+                      "The number of server threads available for the durable job runner. More than"
+                          + " a single thread will the server execute multiple jobs in parallel."
+                          + " Default value is 1.",
                       /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.HIDDEN))),
@@ -1691,8 +1690,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
               ImmutableList.of(
                   SettingDescription.create(
                       "APPLICATION_EXPORTABLE",
-                      "Enables the feature that allows completed applications to be downloadable"
-                          + " by PDF.",
+                      "Enables the feature that allows completed applications to be downloadable by"
+                          + " PDF.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
@@ -1785,8 +1784,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "APPLICANT_OIDC_ENHANCED_LOGOUT_ENABLED",
-                      "Enables populating more fields in OIDC logout requests to applicant"
-                          + " identity provider.",
+                      "Enables populating more fields in OIDC logout requests to applicant identity"
+                          + " provider.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
@@ -1840,9 +1839,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                   SettingDescription.create(
                       "CIVIFORM_SUPPORTED_LANGUAGES",
                       "The full list of languages available to CiviForm. These are the language"
-                          + " that admins can choose from when adding translations for programs"
-                          + " and applications, as well as the default list that applicants can"
-                          + " choose from when specifying their language preference. See"
+                          + " that admins can choose from when adding translations for programs and"
+                          + " applications, as well as the default list that applicants can choose"
+                          + " from when specifying their language preference. See"
                           + " CIVIFORM_APPLICANT_ENABLED_LANGUAGES for further control over"
                           + " languages available to applicants.",
                       /* isRequired= */ false,
@@ -1871,17 +1870,17 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "CIVIFORM_IMAGE_TAG",
                       "The tag of the docker image this server is running inside. Is added as a"
                           + " HTML meta tag with name 'civiform-build-tag'. If"
-                          + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
-                          + " shown on the login page if CIVIFORM_VERSION is the empty string or"
-                          + " set to 'latest'.",
+                          + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown"
+                          + " on the login page if CIVIFORM_VERSION is the empty string or set to"
+                          + " 'latest'.",
                       /* isRequired= */ false,
                       SettingType.STRING,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "CIVIFORM_VERSION",
                       "The release version of CiviForm. For example: v1.18.0. If"
-                          + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
-                          + " shown on the login page if it a value other than the empty string or"
+                          + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown"
+                          + " on the login page if it a value other than the empty string or"
                           + " 'latest'.",
                       /* isRequired= */ false,
                       SettingType.STRING,
@@ -1889,8 +1888,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                   SettingDescription.create(
                       "CLIENT_IP_TYPE",
                       "Where to find the IP address for incoming requests. Default is \"DIRECT\""
-                          + " where the IP address of the request is the originating IP address."
-                          + " If \"FORWARDED\" then request has been reverse proxied and the"
+                          + " where the IP address of the request is the originating IP address. If"
+                          + " \"FORWARDED\" then request has been reverse proxied and the"
                           + " originating IP address is stored in the X-Forwarded-For header.",
                       /* isRequired= */ false,
                       SettingType.ENUM,

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -169,7 +169,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
     String redirectUrl =
         routes.AdminApplicationController.index(
                 program.id(),
-                /* search = */ Optional.empty(),
+                /* search= */ Optional.empty(),
                 /* page= */ Optional.empty(),
                 /* fromDate= */ Optional.empty(),
                 /* untilDate= */ Optional.empty(),
@@ -183,7 +183,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
         .withAction(
             routes.AdminApplicationController.index(
                     program.id(),
-                    /* search = */ Optional.empty(),
+                    /* search= */ Optional.empty(),
                     /* page= */ Optional.empty(),
                     /* fromDate= */ Optional.empty(),
                     /* untilDate= */ Optional.empty(),

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -89,8 +89,8 @@ abstract class ProgramBaseView extends BaseHtmlView {
             .with(
                 TextFormatter.formatText(
                     programDefinition.localizedDescription().getDefault(),
-                    /*preserveEmptyLines=*/ false,
-                    /*addRequiredIndicator=*/ false))
+                    /* preserveEmptyLines= */ false,
+                    /* addRequiredIndicator= */ false))
             .withClasses("text-sm");
     DivTag adminNote =
         div()

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -181,10 +181,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
                                 iff(
                                     malformedQuestionDefinition,
                                     div(
-                                        p("If you see this file a bug with the CiviForm"
-                                              + " development team. Some questions are not"
-                                              + " pointing at the latest version. Edit the program"
-                                              + " and try republishing. ")
+                                        p("If you see this file a bug with the CiviForm development"
+                                                + " team. Some questions are not pointing at the"
+                                                + " latest version. Edit the program and try"
+                                                + " republishing. ")
                                             .withClasses("text-center", "text-red-500")))),
                         div()
                             .withClasses("flex", "flex-grow", "-mx-2")

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -78,8 +78,8 @@ public class CiviFormProfileMergerTest {
   public void mergeProfiles_succeeds_noExistingApplicantAndNoExistingProfile() {
     var merged =
         civiFormProfileMerger.mergeProfiles(
-            /* applicantInDatabase = */ Optional.empty(),
-            /* existingProfile = */ Optional.empty(),
+            /* applicantInDatabase= */ Optional.empty(),
+            /* existingProfile= */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
@@ -94,7 +94,7 @@ public class CiviFormProfileMergerTest {
     var merged =
         civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
-            /* existingProfile = */ Optional.empty(),
+            /* existingProfile= */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -128,7 +128,7 @@ public class CiviFormProfileMergerTest {
   public void mergeProfiles_succeeds_noExistingApplicant() {
     var merged =
         civiFormProfileMerger.mergeProfiles(
-            /* applicantInDatabase = */ Optional.empty(),
+            /* applicantInDatabase= */ Optional.empty(),
             Optional.of(civiFormProfile),
             oidcProfile,
             (civiFormProfile, profile) -> {

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -38,7 +38,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void index_withInvalidProgram_notFound() {
-    Result result = controller.index(/*programId =*/ 1L);
+    Result result = controller.index(/* programId= */ 1L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -52,7 +52,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlocksController.edit(program.id, /*blockDefinitionId =*/ 1L).url());
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 1L)
+                .url());
   }
 
   @Test
@@ -64,13 +65,14 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlocksController.show(program.id, /*blockDefinitionId =*/ 1L).url());
+            routes.AdminProgramBlocksController.show(program.id, /* blockDefinitionId= */ 1L)
+                .url());
   }
 
   @Test
   public void create_withInvalidProgram_notFound() {
     Request request = requestBuilderWithSettings().build();
-    assertThatThrownBy(() -> controller.create(request, /*programId =*/ 1L))
+    assertThatThrownBy(() -> controller.create(request, /* programId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -83,7 +85,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlocksController.edit(program.id, /*blockDefinitionId =*/ 2L).url());
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 2L)
+                .url());
 
     program.refresh();
     assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(2);
@@ -107,7 +110,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     // block in the program (see issue #1885).
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlocksController.edit(program.id, /*blockDefinitionId =*/ 3L).url());
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 3L)
+                .url());
 
     program.refresh();
     assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(3);
@@ -118,14 +122,14 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     ProgramModel program = ProgramBuilder.newDraftProgram("test program").build();
 
-    assertThatThrownBy(() -> controller.show(request, program.id, /*blockId =*/ 1L))
+    assertThatThrownBy(() -> controller.show(request, program.id, /* blockId= */ 1L))
         .isInstanceOf(NotViewableException.class);
   }
 
   @Test
   public void show_withInvalidProgram_notFound() {
     Request request = requestBuilderWithSettings().build();
-    assertThatThrownBy(() -> controller.show(request, /*programId =*/ 1L, /*blockId =*/ 1L))
+    assertThatThrownBy(() -> controller.show(request, /* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotViewableException.class);
   }
 
@@ -133,7 +137,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   public void show_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newActiveProgram().build();
     Request request = requestBuilderWithSettings().build();
-    Result result = controller.show(request, program.id, /*blockId =*/ 2L);
+    Result result = controller.show(request, program.id, /* blockId= */ 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -150,7 +154,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    Result result = controller.show(request, program.id, /*blockId =*/ 1L);
+    Result result = controller.show(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String html = Helpers.contentAsString(result);
@@ -168,7 +172,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void edit_withInvalidProgram_notFound() {
     Request request = requestBuilderWithSettings().build();
-    assertThatThrownBy(() -> controller.edit(request, /*programId =*/ 1L, /*blockId =*/ 1L))
+    assertThatThrownBy(() -> controller.edit(request, /* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -176,7 +180,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   public void edit_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     Request request = requestBuilderWithSettings().build();
-    Result result = controller.edit(request, program.id, /*blockId =*/ 2L);
+    Result result = controller.edit(request, program.id, /* blockId= */ 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -193,7 +197,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    Result result = controller.edit(request, program.id, /*blockId =*/ 1L);
+    Result result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String html = Helpers.contentAsString(result);
@@ -215,7 +219,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
     questionService.update(otherQuestionDef);
     request = addCSRFToken(requestBuilderWithSettings()).build();
-    result = controller.edit(request, program.id, /*blockId =*/ 1L);
+    result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(Helpers.contentAsString(result))
@@ -231,7 +235,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
-    assertThatThrownBy(() -> controller.update(request, /*programId =*/ 1L, /*blockId =*/ 1L))
+    assertThatThrownBy(() -> controller.update(request, /* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -243,7 +247,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
-    Result result = controller.update(request, program.id, /*blockId =*/ 2L);
+    Result result = controller.update(request, program.id, /* blockId= */ 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -260,33 +264,33 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
         controller.update(
             request,
             program.id(),
-            program.getBlockDefinitionByIndex(/*blockIndex =*/ 0).get().id());
+            program.getBlockDefinitionByIndex(/* blockIndex= */ 0).get().id());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
             routes.AdminProgramBlocksController.edit(
-                    program.id(), program.getBlockDefinitionByIndex(/*blockIndex =*/ 0).get().id())
+                    program.id(), program.getBlockDefinitionByIndex(/* blockIndex= */ 0).get().id())
                 .url());
 
     Result redirectResult =
         controller.edit(
             addCSRFToken(requestBuilderWithSettings()).build(),
             program.id(),
-            program.getBlockDefinitionByIndex(/*blockIndex =*/ 0).get().id());
+            program.getBlockDefinitionByIndex(/* blockIndex= */ 0).get().id());
     assertThat(contentAsString(redirectResult)).contains("updated name");
   }
 
   @Test
   public void destroy_withInvalidProgram_notFound() {
-    assertThatThrownBy(() -> controller.destroy(/*programId =*/ 1L, /*blockId =*/ 1L))
+    assertThatThrownBy(() -> controller.destroy(/* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void destroy_programWithTwoBlocks_redirects() {
     ProgramModel program = ProgramBuilder.newDraftProgram().withBlock().withBlock().build();
-    Result result = controller.destroy(program.id, /*blockId =*/ 1L);
+    Result result = controller.destroy(program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
@@ -296,7 +300,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void destroy_lastBlock_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
-    Result result = controller.destroy(program.id, /*blockId =*/ 1L);
+    Result result = controller.destroy(program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -312,13 +312,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    badApplicantId, program.id, /* blockId = */ "1", /* inReview = */ false))
+                    badApplicantId, program.id, /* blockId= */ "1", /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(
-                request, badApplicantId, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, badApplicantId, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -337,7 +336,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.update(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -362,7 +361,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.update(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -381,7 +380,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.update(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -403,13 +402,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, badProgramId, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, badProgramId, /* blockId= */ "1", /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(
-                request, applicant.id, badProgramId, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, badProgramId, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -422,12 +420,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, program.id, badBlockId, /* inReview = */ false))
+                    applicant.id, program.id, badBlockId, /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, badBlockId, /* inReview = */ false)
+            .update(request, applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -439,13 +437,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(ImmutableMap.of("fake.path", "value"))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -458,13 +456,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(ImmutableMap.of(reservedPath, "value"))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -477,7 +475,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                         routes.ApplicantProgramBlocksController.update(
-                            applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false))
+                            applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
                     .bodyForm(
                         ImmutableMap.of(
                             Path.create("applicant.applicant_name")
@@ -492,7 +490,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -513,7 +511,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
                     Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
@@ -524,14 +522,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
         routes.ApplicantProgramBlocksController.edit(
-                applicant.id, program.id, /* blockId = */ "2", /* questionName= */ Optional.empty())
+                applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);
   }
@@ -570,7 +568,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -597,7 +595,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
                     Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
@@ -608,7 +606,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -626,7 +624,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                badApplicantId, program.id, /* blockId = */ "2", /* inReview = */ false));
+                badApplicantId, program.id, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -635,8 +633,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 badApplicantId,
                 program.id,
-                /* blockId = */ "2",
-                /* inReview = */ false)
+                /* blockId= */ "2",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -655,7 +653,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.updateFile(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -680,7 +678,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.updateFile(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -699,7 +697,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addCSRFToken(
                 requestBuilderWithSettings(
                     routes.ApplicantProgramBlocksController.updateFile(
-                        applicant.id, program.id, /*blockId=*/ "1", /*inReview=*/ false)))
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -721,7 +719,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, badProgramId, /* blockId = */ "2", /* inReview = */ false));
+                applicant.id, badProgramId, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -730,8 +728,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 applicant.id,
                 badProgramId,
-                /* blockId = */ "2",
-                /* inReview = */ false)
+                /* blockId= */ "2",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -744,13 +742,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, badBlockId, /* inReview = */ false));
+                applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
             .updateFile(
-                request.build(), applicant.id, program.id, badBlockId, /* inReview = */ false)
+                request.build(), applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -763,13 +761,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, badBlockId, /* inReview = */ false));
+                applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
             .updateFile(
-                request.build(), applicant.id, program.id, badBlockId, /* inReview = */ false)
+                request.build(), applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -781,7 +779,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, /* blockId = */ "2", /* inReview = */ false));
+                applicant.id, program.id, /* blockId= */ "2", /* inReview= */ false));
 
     Result result =
         subject
@@ -789,8 +787,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 applicant.id,
                 program.id,
-                /* blockId = */ "2",
-                /* inReview = */ false)
+                /* blockId= */ "2",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -809,7 +807,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false));
+                applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -818,15 +816,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 applicant.id,
                 program.id,
-                /* blockId = */ "1",
-                /* inReview = */ false)
+                /* blockId= */ "1",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
         routes.ApplicantProgramBlocksController.edit(
-                applicant.id, program.id, /* blockId = */ "2", /* questionName= */ Optional.empty())
+                applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);
   }
@@ -842,7 +840,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false));
+                applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -851,8 +849,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 applicant.id,
                 program.id,
-                /* blockId = */ "1",
-                /* inReview = */ false)
+                /* blockId= */ "1",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -886,7 +884,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     RequestBuilder request =
         requestBuilderWithSettings(
             routes.ApplicantProgramBlocksController.updateFile(
-                applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false));
+                applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", fileKey, "bucket", "fake-bucket"));
 
     Result result =
@@ -895,8 +893,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 request.build(),
                 applicant.id,
                 program.id,
-                /* blockId = */ "1",
-                /* inReview = */ false)
+                /* blockId= */ "1",
+                /* inReview= */ false)
             .toCompletableFuture()
             .join();
 

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -300,7 +300,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     Request request =
         requestBuilderWithSettings(
                 routes.ApplicantProgramBlocksController.update(
-                    applicant.id, programId, /* blockId = */ "1", /* inReview = */ false))
+                    applicant.id, programId, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
                     Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
@@ -311,7 +311,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
     Result result =
         blockController
-            .update(request, applicant.id, programId, /* blockId = */ "1", /* inReview = */ false)
+            .update(request, applicant.id, programId, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2997,9 +2997,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getCorrectedAddress_whenSuccessfullyApplyingACorrectedAddress()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException,
-          ExecutionException, InterruptedException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException,
+          ExecutionException,
+          InterruptedException {
     // Arrange
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
@@ -3104,9 +3107,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getCorrectedAddress_whenUserChooseToKeepTheAddressOriginallyEntered()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException,
-          ExecutionException, InterruptedException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException,
+          ExecutionException,
+          InterruptedException {
     // Arrange
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
@@ -3193,9 +3199,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getCorrectedAddress_whenExternalCorrectionFails()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException,
-          ExecutionException, InterruptedException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException,
+          ExecutionException,
+          InterruptedException {
     // Arrange
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
@@ -3282,8 +3291,10 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getFirstAddressCorrectionEnabledApplicantQuestion_isSuccessful()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     // Arrange
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
@@ -3353,8 +3364,10 @@ public class ApplicantServiceTest extends ResetPostgres {
    * the block for use in getAddressSuggestionGroup.
    */
   public Block createProgramAndBlockWithAddress(String address)
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
@@ -3407,8 +3420,10 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getAddressSuggestionGroup_isSuccessful()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     Block block = createProgramAndBlockWithAddress("Legit Address");
     AddressSuggestionGroup addressSuggestionGroup =
         subject.getAddressSuggestionGroup(block).toCompletableFuture().join();
@@ -3417,8 +3432,10 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getAddressSuggestionGroup_noSuggestions()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     Block block = createProgramAndBlockWithAddress("Bogus Address");
     AddressSuggestionGroup addressSuggestionGroup =
         subject.getAddressSuggestionGroup(block).toCompletableFuture().join();
@@ -3427,8 +3444,10 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getAddressSuggestionGroup_errorFromService()
-      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException,
-          ProgramQuestionDefinitionNotFoundException, ProgramQuestionDefinitionInvalidException {
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          ProgramQuestionDefinitionNotFoundException,
+          ProgramQuestionDefinitionInvalidException {
     Block block = createProgramAndBlockWithAddress("Error Address");
     AddressSuggestionGroup addressSuggestionGroup =
         subject.getAddressSuggestionGroup(block).toCompletableFuture().join();

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -368,6 +368,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
         "2022-03-01T00:00:00Z", () -> applicationThree.setSubmitTimeToNow());
     applicationThree.save();
   }
+
   /**
    * Creates a program that has an enumerator question with children, three applicants, and three
    * applications. The applications have submission times one month apart starting on 2022-01-01.

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -402,6 +402,7 @@ public class ProgramBuilder {
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
       return this;
     }
+
     /**
      * Adds this {@link support.ProgramBuilder.BlockBuilder} to the {@link ProgramBuilder} and
      * starts a new {@link support.ProgramBuilder.BlockBuilder} with an empty name and description.

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -513,6 +513,7 @@ public class TestQuestionBank {
                 .build());
     return maybeSave(definition);
   }
+
   // Text
   private QuestionModel applicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =


### PR DESCRIPTION
### Description

This reduces the on disk size of the image from `1.16 GB` to `892 MB`.

And the size on DockerHub

arch|old size|new size
-|-|-
linux/amd64|474.8 MB|337.34 MB
linux/arm64|405.4 MB|267.6 MB

Changes:
* Base image is Temurin Alpine JDK, removed unneeded secondary java install via `apk`.
* Cleaning apk cache.
* Merging steps to reduce layers.
* Not size related, but also updated the google-java-format version from 1.9 to 1.18.1. The java files in the pr are due to minor changes in how the formatter formats.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing 
