### PR TITLE
Re-add last workdir to server folder

### DIFF
--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -36,6 +36,7 @@ RUN cd $FORMATTER_DIR && \
     cd $SERVER_DIR && \
     npm install
 
+WORKDIR $SERVER_DIR
 
 ENTRYPOINT ["/code/formatter/fmt"]
 


### PR DESCRIPTION
### Description

Re-adding the `WORKDIR` command back before the `ENTRYPOINT` pointing at the `server` folder. I believe this is why prettier is crawling the `.git` directory in some cases.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
