### PR TITLE
Add "opens in new tab" string to be translated for aria labels

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -129,6 +129,7 @@ public enum MessageKey {
   LINK_CREATE_ACCOUNT_OR_SIGN_IN("link.createAccountOrSignIn"),
   LINK_EDIT("link.edit"),
   LINK_ANSWER("link.answer"),
+  LINK_OPENS_NEW_TAB_SR("link.opensNewTabSr"),
   LINK_PROGRAM_DETAILS("link.programDetails"),
   LINK_PROGRAM_DETAILS_SR("link.programDetailsSr"),
   MOBILE_FILE_UPLOAD_HELP("content.mobileFileUploadHelp"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -28,6 +28,7 @@ content.mobileFileUploadHelp=On your phone? "Choose File" also allows you to use
 toast.errorMessageOutline=Error: {0}
 # Description for an "X" button that will close a dialog, modal, or page.
 button.close=Close
+# Indicator for screen readers that a link will open in a new tab. Mean to be used with aria label text eg. "Program details, opens in a new tab"
 link.opensNewTabSr=opens in a new tab
 
 #-------------------------------------------------------------#

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -28,7 +28,7 @@ content.mobileFileUploadHelp=On your phone? "Choose File" also allows you to use
 toast.errorMessageOutline=Error: {0}
 # Description for an "X" button that will close a dialog, modal, or page.
 button.close=Close
-# Indicator for screen readers that a link will open in a new tab. Mean to be used with aria label text eg. "Program details, opens in a new tab"
+# Indicator for screen readers that a link will open in a new tab. Meant to be used with aria label text eg. "Program details, opens in a new tab"
 link.opensNewTabSr=opens in a new tab
 
 #-------------------------------------------------------------#

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -28,6 +28,7 @@ content.mobileFileUploadHelp=On your phone? "Choose File" also allows you to use
 toast.errorMessageOutline=Error: {0}
 # Description for an "X" button that will close a dialog, modal, or page.
 button.close=Close
+link.opensNewTabSr=opens in a new tab
 
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #
@@ -83,7 +84,7 @@ content.description=CiviForm helps you find benefits you may be eligible for in 
 content.saveTime=Save time when applying for benefits
 content.guestDescription=Log in to your {0} account or create an account and apply for many benefits without having to enter the same information again. You can also edit applications at any time and check your application statuses.
 link.programDetails=Program details
-link.programDetailsSr=Program details for {0}
+link.programDetailsSr=Program details for {0}, opens in a new tab
 title.programs=Programs & services
 title.findServicesSection=Find services that can help you
 title.allProgramsSection=All programs ({0})


### PR DESCRIPTION
### Description

This PR adds text to be included in aria labels on links that open in a new tab.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).


### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/5534
