### PR TITLE
Add serialVersionUID to CiviFormProfileData

### DIFF
--- a/server/app/auth/CiviFormProfileData.java
+++ b/server/app/auth/CiviFormProfileData.java
@@ -18,6 +18,17 @@ import repository.DatabaseExecutionContext;
  */
 public class CiviFormProfileData extends CommonProfile {
 
+  // It is crucial that serialization of this class does not change, so that user profiles continue
+  // to be honored and in-progress applications are not lost.
+  //
+  // However, serialization is highly sensitive to details of the class, well beyond the actual data
+  // being serialized: see https://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html
+  //
+  // The value below corresponds to the value computed by the compiler for the current version of
+  // the class. Specifying this value will prevent us from introducing changes that break
+  // serialization.
+  private static final long serialVersionUID = 3142603030317816700L;
+
   public CiviFormProfileData() {
     super();
   }


### PR DESCRIPTION
### Description

It is crucial that the serialization format of `CiviFormProfileData` does not change, so that existing user profiles continue to be honored and in-progress applications are not lost.

However, serialization is apparently quite sensitive to details of the class, beyond the actual data being serialized: see [Serializable (Java Platform SE 7)](https://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html).

The value below corresponds to the value computed by the compiler for the current version of the class. Specifying this value will prevent us from introducing changes that break (de)serialization.

Relates to #5576, #6069