### PR TITLE
Fix edit dob flow

### DIFF
--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -159,7 +159,12 @@ public class ApplicantData extends CfJsonDocumentContext {
   }
 
   public void setDateOfBirth(String dateOfBirth) {
-    putDate(WellKnownPaths.APPLICANT_DOB, dateOfBirth);
+    Path deprecatedDobPath = WellKnownPaths.APPLICANT_DOB_DEPRECATED;
+    if (hasPath(deprecatedDobPath)) {
+      putDate(deprecatedDobPath, dateOfBirth);
+    } else {
+      putDate(WellKnownPaths.APPLICANT_DOB, dateOfBirth);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description

This PR fixes a bug that was introduced in https://github.com/civiform/civiform/pull/5956 where editing an applicant's date of birth as a TI results in an error.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing
1. Comment out the code inside the `setDateOfBirth` method and add the line `putDate(WellKnownPaths.APPLICANT_DOB_DEPRECATED, dateOfBirth);`
2. As a TI, add a client. 
3. Set the code inside of `setDateOfBirth` back to what it was before
4. As a TI, attempt to edit the date of birth for the client you added. It should work!


### Issue(s) this completes

Fixes #6072 
