### PR TITLE
Make bin/help more helpful

### DIFF
--- a/bin/help
+++ b/bin/help
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # DOC: Print descriptions of each bin script.
-# DOC: Use --help for optional usage flags
+# DOC: Use -h for help to show optional usage flags
 
 source bin/lib.sh
 
@@ -10,38 +10,26 @@ function print_help {
   ${0} [options] 
 
 OPTIONS
-  -h, --help          show list of command-line options
-  -n, --no-color      disable colorized output 
-  -s, --single-line   print file name and help text on the same line (useful for grep)"
+  -h    shows help 
+  -n    disable colorized output 
+  -s    print file name and help text on the same line (useful for grep)"
 }
 
 # Get arguments
-opts="$(getopt \
-  --options "hns" \
-  --longoptions "help,no-color,single-line" \
-  -- "${@}"
-)" || exit
-
-# Required for getopt to safely and correctly parse
-eval set -- "${opts}"
-
 NO_COLOR_OUTPUT="false"
 SINGLE_LINE_OUTPUT="false"
 
-while [[ "${#}" -gt 0 ]]; do
-  case "${1}" in 
-    -h | --help)
+while getopts "hns" opt; do
+  case "${opt}" in 
+    h)
       print_help
       exit 0;;
-    -n | --no-color)
-      NO_COLOR_OUTPUT="true"
-      shift 1;;
-    -s | --single-line)
-      SINGLE_LINE_OUTPUT="true"
-      shift 1;;
+    n)
+      NO_COLOR_OUTPUT="true";;
+    s)
+      SINGLE_LINE_OUTPUT="true";;
     *)
-      break
-      ;;
+      break;;
   esac
 done
 

--- a/bin/help
+++ b/bin/help
@@ -86,7 +86,7 @@ while read -r HELP_FILE; do
   if [[ -n "${HELP_TEXT}" ]]; then
     printf "%b%s\n\n" "${COLOR_FILENAME}${HELP_FILE}${COLOR_RESET}${FILENAME_SEPARATOR}" "${HELP_TEXT}"
   else
-    FILES_MISSING_DOCSTRING+=("$HELP_FILE")
+    FILES_MISSING_DOCSTRING+=("${HELP_FILE}")
   fi
 done <<< "${HELP_FILES}"
 

--- a/bin/help
+++ b/bin/help
@@ -1,36 +1,114 @@
 #! /usr/bin/env bash
 
 # DOC: Print descriptions of each bin script.
+# DOC: Use --help for optional usage flags
 
 source bin/lib.sh
 
-missing=""
+function print_help {
+  echo "Usage: 
+  ${0} [options] 
 
-for f in bin/* bin/**/*; do
-  # Files containing library code for scripts have .sh or .py file extension,
-  # don't include those or directories.
-  if [[ -d "${f}" || "${f}" =~ .+\.sh || "${f}" =~ .+\.py ]]; then
-    continue
-  fi
+OPTIONS
+  -h, --help          show list of command-line options
+  -n, --no-color      disable colorized output 
+  -s, --single-line   print file name and help text on the same line (useful for grep)"
+}
 
-  help=$(cat $f | { grep "DOC\:" || true; })
+# Get arguments
+opts="$(getopt \
+  --options "hns" \
+  --longoptions "help,no-color,single-line" \
+  -- "${@}"
+)" || exit
 
-  if [[ -z $help ]]; then
-    out::column_print 40 "$f" "MISSING DOCSTRING"
-    missing="${f}"
-    continue
-  fi
+# Required for getopt to safely and correctly parse
+eval set -- "${opts}"
 
-  help_without_prefix=$(echo "$help" | sed -e "s/^\# DOC\: //")
+NO_COLOR_OUTPUT="false"
+SINGLE_LINE_OUTPUT="false"
 
-  out::column_print 40 "$f" "$help_without_prefix"
+while [[ "${#}" -gt 0 ]]; do
+  case "${1}" in 
+    -h | --help)
+      print_help
+      exit 0;;
+    -n | --no-color)
+      NO_COLOR_OUTPUT="true"
+      shift 1;;
+    -s | --single-line)
+      SINGLE_LINE_OUTPUT="true"
+      shift 1;;
+    *)
+      break
+      ;;
+  esac
 done
 
-if [[ -z "${missing}" ]]; then
-  exit 0
+
+# Set up variables
+FILENAME_SEPARATOR="\n"
+
+if [[ "${SINGLE_LINE_OUTPUT}" == "true" ]]; then
+  FILENAME_SEPARATOR=" "
 fi
 
-echo
-out::error "${missing} is missing a docstring. Please fix."
+# Define variables with ANSI color codes to enable color output
+COLOR_FILENAME="\033[0;35m" # 35 is magenta unless the pc overrides the color
+COLOR_ERROR="\033[0;31m"    # 31 is red unless the pc overrides the color
+COLOR_RESET="\033[0m"       # This is the reset code to set output back to default color
 
-exit 1
+# Set the ANSI color code variables to nothing in order to print without color
+if [[ "${NO_COLOR_OUTPUT}" == "true" ]]; then
+  COLOR_FILENAME=""
+  COLOR_ERROR=""
+  COLOR_RESET=""
+fi
+
+# Make variables readonly
+readonly NO_COLOR_OUTPUT
+readonly SINGLE_LINE_OUTPUT
+readonly COLOR_FILENAME
+readonly COLOR_ERROR
+readonly COLOR_RESET
+
+# Begin work
+FILES_MISSING_DOCSTRING=()
+
+# Get a sort list of potential files with help text
+HELP_FILES="$(find bin \
+  -type f \
+  -not -iname '*.sh' \
+  -not -iname "*.py" \
+  -not -iname "*.pyc" \
+  | sort)"
+
+while read -r HELP_FILE; do
+  # Pull the help text from the file and remove the doc string token for easier reading
+  HELP_TEXT="$(grep --regexp "^# DOC\:" "${HELP_FILE}" \
+    | sed --expression "s/^\# DOC\: //")"
+
+  # Remove extra lines break when in single line mode
+  if [[ "${SINGLE_LINE_OUTPUT}" == "true" ]]; then
+    HELP_TEXT="$(echo "${HELP_TEXT}" | awk 1 ORS=" ")"
+  fi
+
+  # Print formatted string of file name and help text when there is help text found or
+  # store the file in the missing list
+  if [[ -n "${HELP_TEXT}" ]]; then
+    printf "%b%s\n\n" "${COLOR_FILENAME}${HELP_FILE}${COLOR_RESET}${FILENAME_SEPARATOR}" "${HELP_TEXT}"
+  else
+    FILES_MISSING_DOCSTRING+=("$HELP_FILE")
+  fi
+done <<< "${HELP_FILES}"
+
+# Print a full list of files that are missing help text
+if [[ "${#FILES_MISSING_DOCSTRING[@]}" -gt 0 ]]; then
+  printf "%b\n" "${COLOR_ERROR}----------------------------------------------------------${COLOR_RESET}"
+  printf "%b\n" "${COLOR_ERROR}The following file(s) are missing a docstring. Please fix.${COLOR_RESET}"
+  printf "%b\n" "${COLOR_ERROR}----------------------------------------------------------${COLOR_RESET}"
+  printf "* %s\n" "${FILES_MISSING_DOCSTRING[@]}"
+  exit 1
+fi
+
+exit 0

--- a/bin/help
+++ b/bin/help
@@ -20,19 +20,22 @@ NO_COLOR_OUTPUT="false"
 SINGLE_LINE_OUTPUT="false"
 
 while getopts "hns" opt; do
-  case "${opt}" in 
+  case "${opt}" in
     h)
       print_help
-      exit 0;;
+      exit 0
+      ;;
     n)
-      NO_COLOR_OUTPUT="true";;
+      NO_COLOR_OUTPUT="true"
+      ;;
     s)
-      SINGLE_LINE_OUTPUT="true";;
+      SINGLE_LINE_OUTPUT="true"
+      ;;
     *)
-      break;;
+      break
+      ;;
   esac
 done
-
 
 # Set up variables
 FILENAME_SEPARATOR="\n"
@@ -88,7 +91,7 @@ while read -r HELP_FILE; do
   else
     FILES_MISSING_DOCSTRING+=("${HELP_FILE}")
   fi
-done <<< "${HELP_FILES}"
+done <<<"${HELP_FILES}"
 
 # Print a full list of files that are missing help text
 if [[ "${#FILES_MISSING_DOCSTRING[@]}" -gt 0 ]]; then

--- a/bin/help
+++ b/bin/help
@@ -10,7 +10,7 @@ function print_help {
   ${0} [options] 
 
 OPTIONS
-  -h    shows help 
+  -h    shows this help message
   -n    disable colorized output 
   -s    print file name and help text on the same line (useful for grep)"
 }

--- a/bin/help
+++ b/bin/help
@@ -86,7 +86,7 @@ HELP_FILES="$(find bin \
 while read -r HELP_FILE; do
   # Pull the help text from the file and remove the doc string token for easier reading
   HELP_TEXT="$(grep --regexp "^# DOC\:" "${HELP_FILE}" \
-    | sed --expression "s/^\# DOC\: //")"
+    | sed -e "s/^\# DOC\: //")"
 
   # Remove extra lines break when in single line mode
   if [[ "${SINGLE_LINE_OUTPUT}" == "true" ]]; then

--- a/bin/help
+++ b/bin/help
@@ -63,7 +63,7 @@ readonly COLOR_RESET
 # Begin work
 FILES_MISSING_DOCSTRING=()
 
-# Get a sort list of potential files with help text
+# Get a sorted list of potential files with help text
 HELP_FILES="$(find bin \
   -type f \
   -not -iname '*.sh' \


### PR DESCRIPTION
### Description

The previous `bin/help` was getting crufty. 
- The formatting wasn't aligning if a file had multiple `#DOC` tokens
- Grepping wouldn't always show the filename
- Only one filename would be printed if there were multiple files with no `#DOC` help text

This replacement to `bin/help` now defaults to printing like this:
![image](https://github.com/civiform/civiform/assets/195162/4f64ff46-3797-45c0-a662-0905cbbd694f)


*Colors and fonts are subject to the system they are run on and may not match these screenshots*

Additionally the optional flags will allow:
- `-n` to not print colors
- `-s` to print the file name and help text on the same line
- `-h` prints info on these flags

Using `-n` prints in boring black and white. 

Using `-s` will allow for grepping (searching) the help text and have the file name always included. Files missing help text are not display when using this so excess noise isn't included in matches from grep.

![image](https://github.com/civiform/civiform/assets/195162/1b4af8d6-4e14-4f20-a0b6-9447c337c569)

All filenames missing help text will now be printed when not in `-s` mode
![image](https://github.com/civiform/civiform/assets/195162/0ce7734b-5966-4973-bec7-afc7f57441cf)