### PR TITLE
Add /metrics to exclusion list for SessionIdFilter

### DIFF
--- a/server/app/filters/SessionIdFilter.java
+++ b/server/app/filters/SessionIdFilter.java
@@ -14,11 +14,13 @@ import play.mvc.Http;
 import play.mvc.Result;
 
 /** Filter that ensures all sessions have have a unique ID. */
+
+// TODO(#6113): Remove this filter in favor of populating a pac4j profile attribute.
 public final class SessionIdFilter extends Filter {
   public static final String SESSION_ID = "sessionId";
 
   private static final ImmutableSet<String> excludedPrefixes =
-      ImmutableSet.of("/api/", "/assets/", "/dev/", "/favicon", "/playIndex");
+      ImmutableSet.of("/api/", "/assets/", "/dev/", "/favicon", "/playIndex", "/metrics");
 
   @Inject
   public SessionIdFilter(Materializer mat) {

--- a/server/test/filters/SessionIdFilterTest.java
+++ b/server/test/filters/SessionIdFilterTest.java
@@ -32,11 +32,31 @@ public class SessionIdFilterTest extends WithApplication {
   }
 
   @Test
-  public void testSessionIdIsNotCreatedForExcludedRoute() throws Exception {
+  public void testSessionIdIsNotCreatedForPlayIndex() throws Exception {
     SessionIdFilter filter = new SessionIdFilter(mat);
 
     // The request is for /playIndex and has no session id.
     Http.RequestBuilder request = fakeRequest("GET", "/playIndex");
+    assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
+
+    CompletionStage<Result> stage =
+        filter.apply(
+            header -> {
+              return CompletableFuture.completedFuture(play.mvc.Results.ok());
+            },
+            request.build());
+
+    Result result = stage.toCompletableFuture().get();
+    // The session has no session id. In fact, it has no session.
+    assertThat(result.session()).isNull();
+  }
+
+  @Test
+  public void testSessionIdIsNotCreatedForMetrics() throws Exception {
+    SessionIdFilter filter = new SessionIdFilter(mat);
+
+    // The request is for /metrics and has no session id.
+    Http.RequestBuilder request = fakeRequest("GET", "/metrics");
     assertThat(request.session().containsKey(SessionIdFilter.SESSION_ID)).isFalse();
 
     CompletionStage<Result> stage =


### PR DESCRIPTION
### Description

Add /metrics to exclusion list for SessionIdFilter, since the client does not support redirects.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
### Issue(s) this completes

Fixes #6112
