### PR TITLE
Remove applicant id from application programs view URL

### DIFF
--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import play.mvc.Controller;
 import play.mvc.Http;
+import play.mvc.Result;
 import repository.VersionRepository;
 import services.CiviFormError;
 
@@ -74,17 +75,27 @@ public class CiviFormController extends Controller {
 
   /** Retrieves the applicant id from the user profile, if present. */
   protected Optional<Long> getApplicantId(Http.Request request) {
-    CiviFormProfileData profileData =
-        profileUtils
-            .currentUserProfile(request)
-            .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class))
-            .getProfileData();
+    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    if (profile.isEmpty()) {
+      return Optional.empty();
+    }
 
+    CiviFormProfileData profileData = profile.orElseThrow().getProfileData();
     if (profileData == null) {
       return Optional.empty();
     }
 
     return Optional.ofNullable(
         profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class));
+  }
+
+  /** Returns a redirect to the home page. */
+  protected static Result redirectToHome() {
+    return redirect(controllers.routes.HomeController.index().url());
+  }
+
+  /** Returns a CompletionStage containing a redirect to the home page. */
+  protected static CompletionStage<Result> redirectToHomeCompletionStage() {
+    return CompletableFuture.completedFuture(redirectToHome());
   }
 }

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -80,7 +80,10 @@ public class CiviFormController extends Controller {
       return Optional.empty();
     }
 
-    CiviFormProfileData profileData = profile.orElseThrow().getProfileData();
+    CiviFormProfileData profileData =
+        profile
+            .orElseThrow(() -> new MissingOptionalException(CiviFormProfileData.class))
+            .getProfileData();
     return Optional.ofNullable(
         profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class));
   }

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -76,15 +76,11 @@ public class CiviFormController extends Controller {
   /** Retrieves the applicant id from the user profile, if present. */
   protected Optional<Long> getApplicantId(Http.Request request) {
     Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
-    if (profile.isEmpty()) {
+    if (profile.map(CiviFormProfile::getProfileData).isEmpty()) {
       return Optional.empty();
     }
 
     CiviFormProfileData profileData = profile.orElseThrow().getProfileData();
-    if (profileData == null) {
-      return Optional.empty();
-    }
-
     return Optional.ofNullable(
         profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class));
   }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -144,8 +144,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 Modal loginPromptModal =
                     createLoginPromptModal(
                             messages,
-                            /* postLoginRedirectTo= */ controllers.applicant.routes
-                                .DeepLinkController.programBySlug(
+                            /* postLoginRedirectTo= */ routes.ApplicantProgramsController.view(
                                     request.flash().get("redirected-from-program-slug").get())
                                 .url(),
                             messages.at(

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -144,7 +144,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 Modal loginPromptModal =
                     createLoginPromptModal(
                             messages,
-                            /* postLoginRedirectTo= */ routes.ApplicantProgramsController.view(
+                            /* postLoginRedirectTo= */ routes.ApplicantProgramsController.show(
                                     request.flash().get("redirected-from-program-slug").get())
                                 .url(),
                             messages.at(
@@ -325,9 +325,5 @@ public class ApplicantProgramReviewController extends CiviFormController {
               }
               throw new RuntimeException(ex);
             });
-  }
-
-  private static Result redirectToHome() {
-    return redirect(controllers.routes.HomeController.index().url());
   }
 }

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -132,7 +132,7 @@ public final class ApplicantProgramsController extends CiviFormController {
   }
 
   @Secure
-  public CompletionStage<Result> viewWithApplicantId(
+  public CompletionStage<Result> showWithApplicantId(
       Request request, long applicantId, long programId) {
     Optional<CiviFormProfile> requesterProfile = profileUtils.currentUserProfile(request);
 
@@ -189,16 +189,16 @@ public final class ApplicantProgramsController extends CiviFormController {
   //
   // Because the second use is public, this controller is not annotated as @Secure. For the first
   // use, the delegated-to method *is* annotated as such.
-  public CompletionStage<Result> view(Request request, String programParam) {
+  public CompletionStage<Result> show(Request request, String programParam) {
     if (StringUtils.isNumeric(programParam)) {
       // The path parameter specifies a program by (numeric) id.
 
       // The route for this action should only be computed if the applicant ID is available in the
-      // session.
+      // session, so it should not throw.
       long applicantId = getApplicantId(request).orElseThrow();
-      return viewWithApplicantId(request, applicantId, Long.parseLong(programParam));
+      return showWithApplicantId(request, applicantId, Long.parseLong(programParam));
     } else {
-      return programSlugHandler.programBySlug(this, request, programParam);
+      return programSlugHandler.showProgram(this, request, programParam);
     }
   }
 
@@ -258,9 +258,5 @@ public final class ApplicantProgramsController extends CiviFormController {
               }
               throw new RuntimeException(ex);
             });
-  }
-
-  private static Result redirectToHome() {
-    return redirect(controllers.routes.HomeController.index().url());
   }
 }

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -94,7 +94,8 @@ public final class ApplicantProgramsController extends CiviFormController {
                       applicantStage.toCompletableFuture().join(),
                       applicationPrograms,
                       banner,
-                      requesterProfile.orElseThrow()))
+                      requesterProfile.orElseThrow(
+                          () -> new MissingOptionalException(CiviFormProfile.class))))
                   // If the user has been to the index page, any existing redirects should be
                   // cleared to avoid an experience where they're unexpectedly redirected after
                   // logging in.
@@ -202,7 +203,10 @@ public final class ApplicantProgramsController extends CiviFormController {
         // gotten the URL from another source.
         return CompletableFuture.completedFuture(redirectToHome());
       }
-      return showWithApplicantId(request, applicantId.orElseThrow(), Long.parseLong(programParam));
+      return showWithApplicantId(
+          request,
+          applicantId.orElseThrow(() -> new MissingOptionalException(Long.class)),
+          Long.parseLong(programParam));
     } else {
       return programSlugHandler.showProgram(this, request, programParam);
     }

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -62,4 +62,24 @@ public final class ApplicantRoutes {
       return controllers.applicant.routes.ApplicantProgramsController.index();
     }
   }
+
+  /**
+   * Returns the route corresponding to the applicant view action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to view
+   * @return Route for the program view action
+   */
+  public Call view(CiviFormProfile profile, long applicantId, long programId) {
+    if (includeApplicantIdInRoute(profile)) {
+      return controllers.applicant.routes.ApplicantProgramsController.viewWithApplicantId(
+          applicantId, programId);
+    } else {
+      // Since this controller handles two different actions depending on whether it has an integer
+      // id or an alphanum slug, we must pass the parameter as the more general type.
+      return controllers.applicant.routes.ApplicantProgramsController.view(
+          String.valueOf(programId));
+    }
+  }
 }

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -64,21 +64,21 @@ public final class ApplicantRoutes {
   }
 
   /**
-   * Returns the route corresponding to the applicant view action.
+   * Returns the route corresponding to the applicant show action.
    *
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).
    * @param applicantId - ID of applicant for whom the action should be performed.
    * @param programId - ID of program to view
    * @return Route for the program view action
    */
-  public Call view(CiviFormProfile profile, long applicantId, long programId) {
+  public Call show(CiviFormProfile profile, long applicantId, long programId) {
     if (includeApplicantIdInRoute(profile)) {
-      return controllers.applicant.routes.ApplicantProgramsController.viewWithApplicantId(
+      return controllers.applicant.routes.ApplicantProgramsController.showWithApplicantId(
           applicantId, programId);
     } else {
       // Since this controller handles two different actions depending on whether it has an integer
       // id or an alphanum slug, we must pass the parameter as the more general type.
-      return controllers.applicant.routes.ApplicantProgramsController.view(
+      return controllers.applicant.routes.ApplicantProgramsController.show(
           String.valueOf(programId));
     }
   }

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -22,10 +22,7 @@ import services.applicant.ApplicantService.ApplicationPrograms;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
 
-/**
- * Controller for handling methods for deep links. Applicants will be asked to sign-in before they
- * can access the page.
- */
+/** Class for showing program view based on program slug. */
 public final class ProgramSlugHandler {
 
   private final HttpExecutionContext httpContext;
@@ -48,7 +45,7 @@ public final class ProgramSlugHandler {
     this.languageUtils = checkNotNull(languageUtils);
   }
 
-  public CompletionStage<Result> programBySlug(
+  public CompletionStage<Result> showProgram(
       CiviFormController controller, Http.Request request, String programSlug) {
     Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -6,7 +6,6 @@ import annotations.BindingAnnotations.ApplicantAuthProviderName;
 import annotations.BindingAnnotations.EnUsLang;
 import annotations.BindingAnnotations.Now;
 import auth.ProfileFactory;
-import auth.ProfileUtils;
 import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.github.slugify.Slugify;
@@ -14,8 +13,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.typesafe.config.Config;
-import controllers.LanguageUtils;
-import controllers.applicant.ProgramSlugHandler;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -23,10 +20,7 @@ import javax.inject.Provider;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
-import play.libs.concurrent.HttpExecutionContext;
 import repository.AccountRepository;
-import services.applicant.ApplicantService;
-import services.program.ProgramService;
 
 /**
  * This class is a Guice module that tells Guice how to bind several different types. This Guice
@@ -89,16 +83,5 @@ public class MainModule extends AbstractModule {
       Provider<AccountRepository> accountRepositoryProvider) {
     return OidcClientProviderParams.create(
         config, profileFactory, idTokensFactory, accountRepositoryProvider);
-  }
-
-  @Provides
-  public ProgramSlugHandler provideProgramSlugHandler(
-      HttpExecutionContext httpContext,
-      ApplicantService applicantService,
-      ProfileUtils profileUtils,
-      ProgramService programService,
-      LanguageUtils languageUtils) {
-    return new ProgramSlugHandler(
-        httpContext, applicantService, profileUtils, programService, languageUtils);
   }
 }

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -6,6 +6,7 @@ import annotations.BindingAnnotations.ApplicantAuthProviderName;
 import annotations.BindingAnnotations.EnUsLang;
 import annotations.BindingAnnotations.Now;
 import auth.ProfileFactory;
+import auth.ProfileUtils;
 import auth.oidc.IdTokensFactory;
 import auth.oidc.OidcClientProviderParams;
 import com.github.slugify.Slugify;
@@ -13,6 +14,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.typesafe.config.Config;
+import controllers.LanguageUtils;
+import controllers.applicant.ProgramSlugHandler;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -20,7 +23,10 @@ import javax.inject.Provider;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
+import play.libs.concurrent.HttpExecutionContext;
 import repository.AccountRepository;
+import services.applicant.ApplicantService;
+import services.program.ProgramService;
 
 /**
  * This class is a Guice module that tells Guice how to bind several different types. This Guice
@@ -83,5 +89,16 @@ public class MainModule extends AbstractModule {
       Provider<AccountRepository> accountRepositoryProvider) {
     return OidcClientProviderParams.create(
         config, profileFactory, idTokensFactory, accountRepositoryProvider);
+  }
+
+  @Provides
+  public ProgramSlugHandler provideProgramSlugHandler(
+      HttpExecutionContext httpContext,
+      ApplicantService applicantService,
+      ProfileUtils profileUtils,
+      ProgramService programService,
+      LanguageUtils languageUtils) {
+    return new ProgramSlugHandler(
+        httpContext, applicantService, profileUtils, programService, languageUtils);
   }
 }

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -115,7 +115,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
   private ButtonTag renderShareLink(ProgramDefinition program) {
     String programLink =
         baseUrl
-            + controllers.applicant.routes.ApplicantProgramsController.view(program.slug()).url();
+            + controllers.applicant.routes.ApplicantProgramsController.show(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -115,7 +115,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
   private ButtonTag renderShareLink(ProgramDefinition program) {
     String programLink =
         baseUrl
-            + controllers.applicant.routes.DeepLinkController.programBySlug(program.slug()).url();
+            + controllers.applicant.routes.ApplicantProgramsController.view(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -12,6 +12,7 @@ import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
 
 import com.typesafe.config.Config;
+import controllers.applicant.routes;
 import forms.ProgramForm;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.DivTag;
@@ -275,8 +276,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     if (editExistingProgram) {
       String programUrl =
           baseUrl
-              + controllers.applicant.routes.DeepLinkController.programBySlug(
-                      MainModule.SLUGIFIER.slugify(adminName))
+              + routes.ApplicantProgramsController.view(MainModule.SLUGIFIER.slugify(adminName))
                   .url();
       return div()
           .withClass("mb-2")

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -276,7 +276,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     if (editExistingProgram) {
       String programUrl =
           baseUrl
-              + routes.ApplicantProgramsController.view(MainModule.SLUGIFIER.slugify(adminName))
+              + routes.ApplicantProgramsController.show(MainModule.SLUGIFIER.slugify(adminName))
                   .url();
       return div()
           .withClass("mb-2")

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -532,7 +532,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   ButtonTag renderShareLink(ProgramDefinition program) {
     String programLink =
         baseUrl
-            + controllers.applicant.routes.DeepLinkController.programBySlug(program.slug()).url();
+            + controllers.applicant.routes.ApplicantProgramsController.view(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -532,7 +532,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   ButtonTag renderShareLink(ProgramDefinition program) {
     String programLink =
         baseUrl
-            + controllers.applicant.routes.ApplicantProgramsController.view(program.slug()).url();
+            + controllers.applicant.routes.ApplicantProgramsController.show(program.slug()).url();
     return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(ButtonStyles.CLEAR_WITH_ICON)
         .withData("copyable-program-link", programLink);

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -57,7 +57,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
         programDefinition.externalLink().isEmpty()
-            ? routes.ApplicantProgramsController.view(applicantId, programId).url()
+            ? applicantRoutes.view(submittingProfile, applicantId, programId).url()
             : programDefinition.externalLink();
     ATag infoLink =
         new LinkElement()

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -57,7 +57,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
         programDefinition.externalLink().isEmpty()
-            ? applicantRoutes.view(submittingProfile, applicantId, programId).url()
+            ? applicantRoutes.show(submittingProfile, applicantId, programId).url()
             : programDefinition.externalLink();
     ATag infoLink =
         new LinkElement()

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -464,7 +464,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
         program.externalLink().isEmpty()
-            ? applicantRoutes.view(profile, applicantId, program.id()).url()
+            ? applicantRoutes.show(profile, applicantId, program.id()).url()
             : program.externalLink();
     ATag infoLink =
         new LinkElement()

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -22,6 +22,7 @@ import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import controllers.applicant.ApplicantRoutes;
 import controllers.routes;
 import j2html.TagCreator;
 import j2html.tags.ContainerTag;
@@ -74,6 +75,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   private final ProfileUtils profileUtils;
   private final String authProviderName;
   private final ZoneId zoneId;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ProgramIndexView(
@@ -81,11 +83,13 @@ public final class ProgramIndexView extends BaseHtmlView {
       ZoneId zoneId,
       SettingsManifest settingsManifest,
       ProfileUtils profileUtils,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName) {
+      @BindingAnnotations.ApplicantAuthProviderName String authProviderName,
+      ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.profileUtils = checkNotNull(profileUtils);
     this.authProviderName = checkNotNull(authProviderName);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
     this.zoneId = checkNotNull(zoneId);
   }
 
@@ -105,7 +109,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       long applicantId,
       ApplicantPersonalInfo personalInfo,
       ApplicantService.ApplicationPrograms applicationPrograms,
-      Optional<ToastMessage> bannerMessage) {
+      Optional<ToastMessage> bannerMessage,
+      CiviFormProfile profile) {
     HtmlBundle bundle = layout.getBundle(request);
     bundle.setTitle(messages.at(MessageKey.CONTENT_GET_BENEFITS.getKeyName()));
     bannerMessage.ifPresent(bundle::addToastMessages);
@@ -125,10 +130,11 @@ public final class ProgramIndexView extends BaseHtmlView {
             applicationPrograms,
             applicantId,
             messages.lang().toLocale(),
-            bundle));
+            bundle,
+            profile));
 
     return layout.renderWithNav(
-        request, personalInfo, messages, bundle, /*includeAdminLogin=*/ true, applicantId);
+        request, personalInfo, messages, bundle, /* includeAdminLogin= */ true, applicantId);
   }
 
   private DivTag topContent(
@@ -214,7 +220,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       ApplicantService.ApplicationPrograms relevantPrograms,
       long applicantId,
       Locale preferredLocale,
-      HtmlBundle bundle) {
+      HtmlBundle bundle,
+      CiviFormProfile profile) {
     DivTag content =
         div()
             .withId("main-content")
@@ -239,7 +246,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               cardContainerStyles,
               applicantId,
               preferredLocale,
-              bundle),
+              bundle,
+              profile),
           div().withClass("mb-12"),
           programSectionTitle(
               messages.at(
@@ -264,7 +272,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               relevantPrograms.inProgress(),
               MessageKey.BUTTON_CONTINUE,
               MessageKey.BUTTON_CONTINUE_SR,
-              bundle));
+              bundle,
+              profile));
     }
     if (!relevantPrograms.submitted().isEmpty()) {
       content.with(
@@ -279,7 +288,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               relevantPrograms.submitted(),
               MessageKey.BUTTON_EDIT,
               MessageKey.BUTTON_EDIT_SR,
-              bundle));
+              bundle,
+              profile));
     }
     if (!relevantPrograms.unapplied().isEmpty()) {
       content.with(
@@ -294,7 +304,8 @@ public final class ProgramIndexView extends BaseHtmlView {
               relevantPrograms.unapplied(),
               MessageKey.BUTTON_APPLY,
               MessageKey.BUTTON_APPLY_SR,
-              bundle));
+              bundle,
+              profile));
     }
 
     return div().withClasses("flex", "flex-col", "place-items-center").with(content);
@@ -308,7 +319,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       String cardContainerStyles,
       long applicantId,
       Locale preferredLocale,
-      HtmlBundle bundle) {
+      HtmlBundle bundle,
+      CiviFormProfile profile) {
     Optional<LifecycleStage> commonIntakeFormApplicationStatus =
         relevantPrograms.commonIntakeForm().get().latestApplicationLifecycleStage();
     MessageKey buttonText = MessageKey.BUTTON_START_HERE;
@@ -342,7 +354,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                 ImmutableList.of(relevantPrograms.commonIntakeForm().get()),
                 buttonText,
                 buttonScreenReaderText,
-                bundle));
+                bundle,
+                profile));
   }
 
   /**
@@ -370,7 +383,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       ImmutableList<ApplicantService.ApplicantProgramData> cards,
       MessageKey buttonTitle,
       MessageKey buttonSrText,
-      HtmlBundle bundle) {
+      HtmlBundle bundle,
+      CiviFormProfile profile) {
     String sectionHeaderId = Modal.randomModalId();
     DivTag div = div().withClass(ReferenceClasses.APPLICATION_PROGRAM_SECTION);
     if (sectionTitle.isPresent()) {
@@ -396,7 +410,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                             buttonTitle,
                             buttonSrText,
                             sectionTitle.isPresent(),
-                            bundle))));
+                            bundle,
+                            profile))));
   }
 
   private LiTag programCard(
@@ -409,7 +424,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       MessageKey buttonTitle,
       MessageKey buttonSrText,
       boolean nestedUnderSubheading,
-      HtmlBundle bundle) {
+      HtmlBundle bundle,
+      CiviFormProfile profile) {
     ProgramDefinition program = cardData.program();
 
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
@@ -425,8 +441,8 @@ public final class ProgramIndexView extends BaseHtmlView {
     ImmutableList<DomContent> descriptionContent =
         TextFormatter.formatText(
             program.localizedDescription().getOrDefault(preferredLocale),
-            /*preserveEmptyLines= */ false,
-            /*addRequiredIndicator= */ false);
+            /* preserveEmptyLines= */ false,
+            /* addRequiredIndicator= */ false);
     DivTag description =
         div()
             .withId(baseId + "-description")
@@ -448,9 +464,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     // Use external link if it is present else use the default Program details page
     String programDetailsLink =
         program.externalLink().isEmpty()
-            ? controllers.applicant.routes.ApplicantProgramsController.view(
-                    applicantId, program.id())
-                .url()
+            ? applicantRoutes.view(profile, applicantId, program.id()).url()
             : program.externalLink();
     ATag infoLink =
         new LinkElement()

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -149,6 +149,11 @@ POST    /applicants/:applicantId                                            cont
 
 # Program methods for applicants (new)
 GET     /programs                   controllers.applicant.ApplicantProgramsController.index(request: Request)
+# This route is special. It may specify a program by id or by program
+# slug. Since Play doesn't allow overloaded controller methods, accept
+# the path parameter as a string and decide how to handle it in the
+# controller.
+GET     /programs/:programParam     controllers.applicant.ApplicantProgramsController.view(request: Request, programParam: String)
 
 # Program methods for TI actions on behalf of applicants.
 #
@@ -157,7 +162,7 @@ GET     /programs                   controllers.applicant.ApplicantProgramsContr
 # do not yet contain the applicant id, so we maintain these routes
 # during migration.
 GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.indexWithApplicantId(request: Request, applicantId: Long)
-GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.view(request: Request, applicantId: Long, programId: Long)
+GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.viewWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.edit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.review(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submit(request: Request, applicantId: Long, programId: Long)
@@ -181,9 +186,6 @@ GET     /support/unsupportedBrowser    controllers.SupportController.handleUnsup
 
 # Methods for program admins
 GET     /programAdmin       controllers.admin.ProgramAdminController.index(request: Request)
-
-# Deep-link methods
-GET     /programs/:programSlug      controllers.applicant.DeepLinkController.programBySlug(request: Request, programSlug: String)
 
 # Upsell methods
 GET     /download                   controllers.applicant.UpsellController.download(request: Request, applicationId: Long, applicantId: Long)

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -153,7 +153,7 @@ GET     /programs                   controllers.applicant.ApplicantProgramsContr
 # slug. Since Play doesn't allow overloaded controller methods, accept
 # the path parameter as a string and decide how to handle it in the
 # controller.
-GET     /programs/:programParam     controllers.applicant.ApplicantProgramsController.view(request: Request, programParam: String)
+GET     /programs/:programParam     controllers.applicant.ApplicantProgramsController.show(request: Request, programParam: String)
 
 # Program methods for TI actions on behalf of applicants.
 #
@@ -162,7 +162,7 @@ GET     /programs/:programParam     controllers.applicant.ApplicantProgramsContr
 # do not yet contain the applicant id, so we maintain these routes
 # during migration.
 GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.indexWithApplicantId(request: Request, applicantId: Long)
-GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.viewWithApplicantId(request: Request, applicantId: Long, programId: Long)
+GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.showWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.edit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.review(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submit(request: Request, applicantId: Long, programId: Long)

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -156,7 +156,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
         .contains(
-            routes.ApplicantProgramsController.viewWithApplicantId(currentApplicant.id, program.id)
+            routes.ApplicantProgramsController.showWithApplicantId(currentApplicant.id, program.id)
                 .url());
   }
 
@@ -172,7 +172,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
         .contains(
-            routes.ApplicantProgramsController.viewWithApplicantId(currentApplicant.id, program.id)
+            routes.ApplicantProgramsController.showWithApplicantId(currentApplicant.id, program.id)
                 .url());
   }
 
@@ -211,15 +211,12 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void view_includesApplyButton() {
+  public void show_includesApplyButton() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller
-            .viewWithApplicantId(request, currentApplicant.id, program.id)
-            .toCompletableFuture()
-            .join();
+        controller.show(request, String.valueOf(program.id)).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -228,40 +225,23 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void view_invalidProgram_returnsBadRequest() {
+  public void show_invalidProgram_returnsBadRequest() {
     Result result =
-        controller
-            .viewWithApplicantId(requestBuilderWithSettings().build(), currentApplicant.id, 9999L)
-            .toCompletableFuture()
-            .join();
+        controller.show(requestBuilderWithSettings().build(), "9999").toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
-  public void view_applicantWithoutProfile_redirectsToHome() {
-    ProgramModel program = resourceCreator().insertActiveProgram("program");
-
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    Result result =
-        controller
-            .viewWithApplicantId(request, applicantWithoutProfile.id, program.id)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation()).hasValue("/");
-  }
-
-  @Test
-  // Tests the behavior of the `view()` method when the parameter contains a numeric value,
-  // representing a program id.
-  public void view_withNumericProgramParam_viewsById() {
+  // Tests the behavior of the `show()` method when
+  // - the parameter contains a numeric value, representing a program id
+  // - the applicant id is present in the profile
+  public void show_withNumericProgramParam_idInProfile_viewsById() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     String numericProgramParam = String.valueOf(program.id);
-    Result result = controller.view(request, numericProgramParam).toCompletableFuture().join();
+    Result result = controller.show(request, numericProgramParam).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -270,9 +250,9 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  // Tests the behavior of the `view()` method when the parameter contains an alphanumeric value,
+  // Tests the behavior of the `show()` method when the parameter contains an alphanumeric value,
   // representing a program slug.
-  public void view_withStringProgramParam_viewsByProgramSlug() {
+  public void show_withStringProgramParam_showsByProgramSlug() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
     // Set preferred locale so that browser doesn't get redirected to set it. This way we get a
@@ -283,7 +263,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
 
     String alphaNumProgramParam = program.getSlug();
-    Result result = controller.view(request, alphaNumProgramParam).toCompletableFuture().join();
+    Result result = controller.show(request, alphaNumProgramParam).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -211,12 +211,15 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void show_includesApplyButton() {
+  public void showWithApplicantId_includesApplyButton() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.show(request, String.valueOf(program.id)).toCompletableFuture().join();
+        controller
+            .showWithApplicantId(request, currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -225,28 +228,14 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void show_invalidProgram_returnsBadRequest() {
+  public void showWithApplicantId_invalidProgram_returnsBadRequest() {
     Result result =
-        controller.show(requestBuilderWithSettings().build(), "9999").toCompletableFuture().join();
+        controller
+            .showWithApplicantId(requestBuilderWithSettings().build(), currentApplicant.id, 9999)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
-  }
-
-  @Test
-  // Tests the behavior of the `show()` method when
-  // - the parameter contains a numeric value, representing a program id
-  // - the applicant id is present in the profile
-  public void show_withNumericProgramParam_idInProfile_viewsById() {
-    ProgramModel program = resourceCreator().insertActiveProgram("program");
-
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
-    String numericProgramParam = String.valueOf(program.id);
-    Result result = controller.show(request, numericProgramParam).toCompletableFuture().join();
-
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result))
-        .contains(
-            routes.ApplicantProgramReviewController.review(currentApplicant.id, program.id).url());
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -141,7 +141,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testViewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+  public void testShowRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -151,9 +151,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
         ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedViewUrl = String.format("/programs/%d", programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
-        .isEqualTo(expectedViewUrl);
+    String expectedShowUrl = String.format("/programs/%d", programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
+        .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present + 1);
@@ -161,7 +161,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testViewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+  public void testShowRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
     disableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -171,9 +171,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
       ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
-      .isEqualTo(expectedViewUrl);
+    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
+      .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present + 1);
@@ -181,7 +181,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testViewRoute_forApplicantWithoutIdInProfile() {
+  public void testShowRoute_forApplicantWithoutIdInProfile() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -190,9 +190,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
-        .isEqualTo(expectedViewUrl);
+    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
+        .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);
@@ -200,7 +200,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testViewRoute_forTrustedIntermediary() {
+  public void testShowRoute_forTrustedIntermediary() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -208,9 +208,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).view(tiProfile, applicantId, programId).url())
-        .isEqualTo(expectedViewUrl);
+    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).show(tiProfile, applicantId, programId).url())
+        .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -22,6 +22,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   private static long applicantId = 123L;
   private static long applicantAccountId = 456L;
   private static long tiAccountId = 789L;
+  private static long programId = 321L;
   private static SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
 
   // Class to hold counter values.
@@ -65,11 +66,12 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testIndexRouteForApplicantWithIdInProfile_newSchemaEnabled() {
+  public void testIndexRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
     CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
         ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
@@ -83,7 +85,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testIndexRouteForApplicantWithIdInProfile_newSchemaDisabled() {
+  public void testIndexRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
     disableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -102,11 +104,12 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testIndexRouteForApplicantWithoutIdInProfile() {
+  public void testIndexRoute_forApplicantWithoutIdInProfile() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
     CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
@@ -120,7 +123,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testIndexRouteForTrustedIntermediary() {
+  public void testIndexRoute_forTrustedIntermediary() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -131,6 +134,83 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
     assertThat(new ApplicantRoutes(mockSettingsManifest).index(tiProfile, applicantId).url())
         .isEqualTo(expectedIndexUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testViewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedViewUrl = String.format("/programs/%d", programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
+        .isEqualTo(expectedViewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testViewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+      ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
+      .isEqualTo(expectedViewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testViewRoute_forApplicantWithoutIdInProfile() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).view(applicantProfile, applicantId, programId).url())
+        .isEqualTo(expectedViewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testViewRoute_forTrustedIntermediary() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedViewUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
+    assertThat(new ApplicantRoutes(mockSettingsManifest).view(tiProfile, applicantId, programId).url())
+        .isEqualTo(expectedViewUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -152,7 +152,10 @@ public class ApplicantRoutesTest extends ResetPostgres {
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedShowUrl = String.format("/programs/%d", programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .show(applicantProfile, applicantId, programId)
+                .url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -168,12 +171,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
     CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-      ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
-      .isEqualTo(expectedShowUrl);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .show(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present + 1);
@@ -191,7 +197,10 @@ public class ApplicantRoutesTest extends ResetPostgres {
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).show(applicantProfile, applicantId, programId).url())
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .show(applicantProfile, applicantId, programId)
+                .url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -209,7 +218,8 @@ public class ApplicantRoutesTest extends ResetPostgres {
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).show(tiProfile, applicantId, programId).url())
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest).show(tiProfile, applicantId, programId).url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -8,6 +8,7 @@ import static support.CfTestHelpers.requestBuilderWithSettings;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
+import controllers.CiviFormController;
 import controllers.LanguageUtils;
 import controllers.WithMockedProfiles;
 import java.util.Locale;
@@ -29,7 +30,7 @@ import services.program.ProgramService;
 import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 
-public class DeepLinkControllerTest extends WithMockedProfiles {
+public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
   @Before
   public void setUp() {
@@ -50,10 +51,13 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     resourceCreator().insertDraftProgram(programDefinition.adminName());
     versionRepository.publishNewSynchronizedVersion();
 
+    CiviFormController controller = instanceOf(CiviFormController.class);
     Result result =
-        instanceOf(DeepLinkController.class)
+        instanceOf(ProgramSlugHandler.class)
             .programBySlug(
-                addCSRFToken(requestBuilderWithSettings()).build(), programDefinition.slug())
+                controller,
+                addCSRFToken(requestBuilderWithSettings()).build(),
+                programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -75,9 +79,12 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     resourceCreator().insertDraftProgram(programDefinition.adminName());
     versionRepository.publishNewSynchronizedVersion();
 
+    CiviFormController controller = instanceOf(CiviFormController.class);
+
     Result result =
-        instanceOf(DeepLinkController.class)
+        instanceOf(ProgramSlugHandler.class)
             .programBySlug(
+                controller,
                 addCSRFToken(
                         requestBuilderWithSettings()
                             .session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
@@ -95,9 +102,12 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     applicant.getApplicantData().setPreferredLocale(Locale.ENGLISH);
     applicant.save();
 
+    CiviFormController controller = instanceOf(CiviFormController.class);
+
     Result result =
-        instanceOf(DeepLinkController.class)
+        instanceOf(ProgramSlugHandler.class)
             .programBySlug(
+                controller,
                 addCSRFToken(
                         requestBuilderWithSettings()
                             .session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
@@ -114,11 +124,16 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
     ApplicantModel applicant = createApplicantWithMockedProfile();
-    DeepLinkController controller = instanceOf(DeepLinkController.class);
+    CiviFormController controller = instanceOf(CiviFormController.class);
+
+    ProgramSlugHandler handler = instanceOf(ProgramSlugHandler.class);
+
     Result result =
-        controller
+        handler
             .programBySlug(
-                addCSRFToken(requestBuilderWithSettings()).build(), programDefinition.slug())
+                controller,
+                addCSRFToken(requestBuilderWithSettings()).build(),
+                programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -139,19 +154,21 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
+    CiviFormController controller = instanceOf(CiviFormController.class);
 
-    DeepLinkController controller =
-        new DeepLinkController(
+    ProgramSlugHandler handler =
+        new ProgramSlugHandler(
             instanceOf(HttpExecutionContext.class),
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
             instanceOf(ProgramService.class),
-            instanceOf(VersionRepository.class),
             languageUtils);
     Result result =
-        controller
+        handler
             .programBySlug(
-                addCSRFToken(requestBuilderWithSettings()).build(), programDefinition.slug())
+                controller,
+                addCSRFToken(requestBuilderWithSettings()).build(),
+                programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())
@@ -171,19 +188,21 @@ public class DeepLinkControllerTest extends WithMockedProfiles {
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
+    CiviFormController controller = instanceOf(CiviFormController.class);
 
-    DeepLinkController controller =
-        new DeepLinkController(
+    ProgramSlugHandler handler =
+        new ProgramSlugHandler(
             instanceOf(HttpExecutionContext.class),
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
             instanceOf(ProgramService.class),
-            instanceOf(VersionRepository.class),
             languageUtils);
     Result result =
-        controller
+        handler
             .programBySlug(
-                addCSRFToken(requestBuilderWithSettings()).build(), programDefinition.slug())
+                controller,
+                addCSRFToken(requestBuilderWithSettings()).build(),
+                programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -54,7 +54,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     CiviFormController controller = instanceOf(CiviFormController.class);
     Result result =
         instanceOf(ProgramSlugHandler.class)
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(requestBuilderWithSettings()).build(),
                 programDefinition.slug())
@@ -83,7 +83,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     Result result =
         instanceOf(ProgramSlugHandler.class)
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(
                         requestBuilderWithSettings()
@@ -106,7 +106,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     Result result =
         instanceOf(ProgramSlugHandler.class)
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(
                         requestBuilderWithSettings()
@@ -130,7 +130,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     Result result =
         handler
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(requestBuilderWithSettings()).build(),
                 programDefinition.slug())
@@ -165,7 +165,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             languageUtils);
     Result result =
         handler
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(requestBuilderWithSettings()).build(),
                 programDefinition.slug())
@@ -199,7 +199,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             languageUtils);
     Result result =
         handler
-            .programBySlug(
+            .showProgram(
                 controller,
                 addCSRFToken(requestBuilderWithSettings()).build(),
                 programDefinition.slug())


### PR DESCRIPTION
### Description

Remove applicant id from application programs view URL.

This is done in the usual way: 
* define a new `ApplicantRoutes.view()` method that delegates to the existing method, 
* which is renamed to `viewWithApplicantId()`, and
* revise the callsites to use the new applicant route method.

This PR has a complication. Before this PR, the existing route was:

```
/applicants/:applicantId/programs/:programId
```

Since Play does not permit overloaded controller methods, when we remove the leading `/applicants/:applicantId` path components, that results in a conflict with this route:

```
/programs/:programSlug
```

Therefore the new `ApplicantProgramsController.view()` method needs to disambiguate between the two cases. At this point, we no longer need a separate `DeepLinkController`, so this class has been transformed into a `ProgramSlugHandler` that is created by injection.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 
