### PR TITLE
Fix issue with prometheus metrics

### DIFF
--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -107,8 +107,6 @@ public final class MetricsController extends CiviFormController {
 
   @VisibleForTesting
   static void initializeCounters() {
-    CollectorRegistry.defaultRegistry.clear();
-
     QUERY_METRIC_COUNT =
         Counter.build()
             .name("ebean_queries_total")

--- a/server/test/controllers/monitoring/MetricsControllerTest.java
+++ b/server/test/controllers/monitoring/MetricsControllerTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import controllers.WithMockedProfiles;
+import io.prometheus.client.CollectorRegistry;
 import java.util.Locale;
 import models.ApplicantModel;
 import models.ApplicationModel;
@@ -23,6 +24,8 @@ public class MetricsControllerTest extends WithMockedProfiles {
   @Before
   public void setUp() {
     resetDatabase();
+    CollectorRegistry.defaultRegistry.clear();
+    // TODO(#5933) initializing counters causes the test to fail in bin/sbt-test
     MetricsController.initializeCounters();
   }
 


### PR DESCRIPTION
It looks like we were clearing the default prometheus metrics by adding the clear method in the MetricsController

Reverts civiform/civiform#6010