### PR TITLE
Only validate new admin names

### DIFF
--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -150,7 +150,7 @@ public final class AdminQuestionController extends CiviFormController {
 
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = getBuilder(Optional.empty(), questionForm).build();
+      questionDefinition = questionForm.getBuilder().build();
     } catch (UnsupportedQuestionTypeException e) {
       // Valid question type that is not yet fully supported.
       return badRequest(e.getMessage());
@@ -290,7 +290,7 @@ public final class AdminQuestionController extends CiviFormController {
 
     ErrorAnd<QuestionDefinition, CiviFormError> errorAndUpdatedQuestionDefinition;
     try {
-      errorAndUpdatedQuestionDefinition = service.update(questionDefinition);
+      errorAndUpdatedQuestionDefinition = service.update(maybeExisting, questionDefinition);
     } catch (InvalidUpdateException e) {
       // Ill-formed update request.
       return badRequest(e.toString());

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -40,6 +40,7 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
     this.questionOptions = questionOptions;
     this.multiOptionQuestionType = multiOptionQuestionType;
   }
+
   // If we are using a dropdown or radio button, set the SINGLE_SELECT_PREDICATE to ensure
   // only one selection can be made.
   private static QuestionDefinitionConfig fixValidationPredicates(

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -1,6 +1,7 @@
 package services.question.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableList;
@@ -476,6 +477,92 @@ public class QuestionDefinitionTest {
             CiviFormError.of(
                 "Multi-option admin names can only contain letters, numbers, underscores, and"
                     + " dashes"));
+  }
+
+  @Test
+  public void
+      validate_multiOptionQuestion_withInvalidOptionAdminNameInPreviousDefinition_doesNotReturnError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "c_valid", LocalizedStrings.withDefaultValue("c")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion))).isEmpty();
+  }
+
+  @Test
+  public void
+      validate_multiOptionQuestion_withInvalidOptionAdminNameInPreviousAndUpdatedDefinition_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "c invalid", LocalizedStrings.withDefaultValue("c")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
+        .containsOnly(
+            CiviFormError.of(
+                "Multi-option admin names can only contain letters, numbers, underscores, and"
+                    + " dashes"));
+  }
+
+  @Test
+  public void validate_throwsExceptionWhenQuestionTypesMismatched() {
+    QuestionDefinitionConfig config = configBuilder.build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a_one-1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_two-2", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.DROPDOWN);
+
+    var throwableAssert =
+        assertThatThrownBy(() -> question.validate(Optional.of(previousQuestion)))
+            .isInstanceOf(IllegalArgumentException.class);
+    throwableAssert.hasMessage(
+        "The previous version of the question definition must be of the same question type as the"
+            + " updated version.");
   }
 
   private static ImmutableList<Object[]> getMultiOptionQuestionValidationTestData() {


### PR DESCRIPTION
### Description

Updates option admin name validation to only validate _new_ option admin names, so existing admin names don't have to be changed when updating a question.

Details:
- Updates `QuestionDefintion#validate()` to optionally take the previous question definition
- Only validates that new option admin names match the requirements in #5839, allowing existing admin names to be saved when the question is updated

## Release notes

Updates option admin name validation to only validate _new_ option admin names, so existing admin names don't have to be changed when updating a question.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

- Manually create a question option with an invalid admin name (either via the DB or disabling the checking code)
- Try updating the question and ensure the validation doesn't catch the existing invalid admin name.

### Issue(s) this completes

Fixes #6103
