### PR TITLE
Honor BASE_URL from environment in run-browser-tests-local

### DIFF
--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -7,7 +7,7 @@ source bin/lib.sh
 # machine which can be different from the browser used by browser-test docker
 # image and produce different screenshots.
 export DISABLE_SCREENSHOTS=true
-export BASE_URL=http://localhost:9999
+export BASE_URL="${BASE_URL:-http://localhost:9999}"
 export LOCALSTACK_URL=http://localhost.localstack.cloud:6645
 
 cd browser-test


### PR DESCRIPTION
### Description

Remove unconditional setting of `BASE_URL` from `run-browser-tests-local`.

Before this change, the script would overwrite the value of `BASE_URL` in the environment. Instead, we set it to a default value if it is unset.