### PR TITLE
Fix text overflow issue on question title

### DIFF
--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -84,6 +84,22 @@ describe('Admin question list', () => {
     ])
   })
 
+  it('displays the question with long title wrapped', async () => {
+    const {page, adminQuestions} = ctx
+    await loginAsAdmin(page)
+    await adminQuestions.addTextQuestion({
+      questionName: 'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      questionText: 'first question',
+    })
+
+    await adminQuestions.gotoAdminQuestionsPage()
+
+    await page.locator('#question-bank-filter').fill('first')
+    expect(await adminQuestions.questionBankNames()).toEqual(['first question'])
+    await page.locator('#question-bank-filter').fill('')
+    await validateScreenshot(page, 'question-list-long-title')
+  })
+
   it('filters question list with search query', async () => {
     const {page, adminQuestions} = ctx
     await loginAsAdmin(page)

--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -85,18 +85,23 @@ describe('Admin question list', () => {
   })
 
   it('displays the question with long title wrapped', async () => {
-    const {page, adminQuestions} = ctx
+    const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
+    // Set the questionText to the same as questionName to make validation easier since questionBankNames()
+    // returns the questionText. The questionText is not actually used to sort.
     await adminQuestions.addTextQuestion({
-      questionName: 'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      questionText: 'first question',
+      questionName:
+        'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      questionText: 'a',
     })
+    await adminPrograms.addAndPublishProgramWithQuestions(
+      [
+        'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ],
+      'program-one',
+    )
 
     await adminQuestions.gotoAdminQuestionsPage()
-
-    await page.locator('#question-bank-filter').fill('first')
-    expect(await adminQuestions.questionBankNames()).toEqual(['first question'])
-    await page.locator('#question-bank-filter').fill('')
     await validateScreenshot(page, 'question-list-long-title')
   })
 

--- a/browser-test/src/civiform_admin_question_list.test.ts
+++ b/browser-test/src/civiform_admin_question_list.test.ts
@@ -84,27 +84,6 @@ describe('Admin question list', () => {
     ])
   })
 
-  it('displays the question with long title wrapped', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
-    await loginAsAdmin(page)
-    // Set the questionText to the same as questionName to make validation easier since questionBankNames()
-    // returns the questionText. The questionText is not actually used to sort.
-    await adminQuestions.addTextQuestion({
-      questionName:
-        'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      questionText: 'a',
-    })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      [
-        'https://civiformstage.somecity.gov/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      ],
-      'program-one',
-    )
-
-    await adminQuestions.gotoAdminQuestionsPage()
-    await validateScreenshot(page, 'question-list-long-title')
-  })
-
   it('filters question list with search query', async () => {
     const {page, adminQuestions} = ctx
     await loginAsAdmin(page)

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -244,7 +244,8 @@ public final class ProgramQuestionBank {
             .withClasses("ml-4", "grow")
             .with(
                 p(definition.getQuestionText().getDefault())
-                    .withClasses(ReferenceClasses.ADMIN_QUESTION_TITLE, "font-bold", "w-3/5"),
+                    .withClasses(
+                        ReferenceClasses.ADMIN_QUESTION_TITLE, "font-bold", "w-3/5", "break-all"),
                 p(questionHelpText).withClasses("mt-1", "text-sm", "line-clamp-2"),
                 p(String.format("Admin ID: %s", definition.getName()))
                     .withClasses("mt-1", "text-sm"),


### PR DESCRIPTION
### Description

Made question title break into next line when it is long and overflow, so we can see `Add` button on the screen.

<img width="1149" alt="Screenshot 2023-12-12 at 5 22 18 PM" src="https://github.com/civiform/civiform/assets/149536150/1c32ebc3-f333-4eab-84f7-66fc5ad05ec7">


## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes ##5975
