### PR TITLE
Replace TODO with explanatory comment

### DIFF
--- a/browser-test/src/profile_stability.test.ts
+++ b/browser-test/src/profile_stability.test.ts
@@ -15,7 +15,13 @@ describe('user HTTP sessions', () => {
   //
   // This guards against changes that unexpectedly affect serialization.
   it('recognizes the profile from a frozen cookie', async () => {
-    // TODO(#6069): Get this to work as a prober test.
+    // Play encrypts cookies with the server secret:
+    // https://www.playframework.com/documentation/2.8.x/ApplicationSecret
+    //
+    // For this test to run as a prober, we would need to provision one frozen
+    // cookie value per environment and pass that in. That is more trouble than
+    // it is worth, since the hermetic test (which relies on using the default
+    // server secret) will detect any breaking changes to profile serialization.
     if (isHermeticTestEnvironment()) {
       const {hostname} = new URL(BASE_URL)
       const frozenCookie = {


### PR DESCRIPTION
### Description

The profile stability test works in the hermetic environment. However, running as a prober causes complications because a custom serialized cookie value is required for each environment (because cookies are [encrypted](https://www.playframework.com/documentation/2.8.x/ApplicationSecret#Requirements-for-an-application-secret) with the Play server secret).

Abandon the idea of running the test as a prober, since the test provides as much value when run as a hermetic test (using the default server secret).

### Issue(s) this completes

Fixes #6069 
