### PR TITLE
Remove applicant id from URLs for edit action

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -135,7 +135,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           ImmutableList.of(flashBanner, flashSuccessBanner, notEligibleBanner))
                       .setMessages(messages)
                       .setProgramId(programId)
-                      .setRequest(request);
+                      .setRequest(request)
+                      .setProfile(
+                          submittingProfile.orElseThrow(
+                              () -> new MissingOptionalException(CiviFormProfile.class)));
 
               // Show a login prompt on the review page if we were redirected from a program slug
               // and user is a guest.

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -82,4 +82,21 @@ public final class ApplicantRoutes {
           String.valueOf(programId));
     }
   }
+
+  /**
+   * Returns the route corresponding to the applicant edit action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to edit
+   * @return Route for the applicant action
+   */
+  public Call edit(CiviFormProfile profile, long applicantId, long programId) {
+    if (includeApplicantIdInRoute(profile)) {
+      return controllers.applicant.routes.ApplicantProgramsController.editWithApplicantId(
+          applicantId, programId);
+    } else {
+      return routes.ApplicantProgramsController.edit(programId);
+    }
+  }
 }

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -7,9 +7,11 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 
+import auth.CiviFormProfile;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
@@ -46,13 +48,18 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
   private final ApplicantLayout layout;
   private final DateConverter dateConverter;
   private final SettingsManifest settingsManifest;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ApplicantProgramSummaryView(
-      ApplicantLayout layout, DateConverter dateConverter, SettingsManifest settingsManifest) {
+      ApplicantLayout layout,
+      DateConverter dateConverter,
+      SettingsManifest settingsManifest,
+      ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
     this.dateConverter = checkNotNull(dateConverter);
     this.settingsManifest = checkNotNull(settingsManifest);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   /**
@@ -103,7 +110,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
               .withClasses(ReferenceClasses.SUBMIT_BUTTON, ButtonStyles.SOLID_BLUE, "mx-auto");
     } else {
       String applyUrl =
-          routes.ApplicantProgramsController.edit(params.applicantId(), params.programId()).url();
+          applicantRoutes.edit(params.profile(), params.applicantId(), params.programId()).url();
       continueOrSubmitButton =
           a().withHref(applyUrl)
               .withText(messages.at(MessageKey.BUTTON_CONTINUE.getKeyName()))
@@ -331,6 +338,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
     abstract Optional<Modal> loginPromptModal();
 
+    abstract CiviFormProfile profile();
+
     @AutoValue.Builder
     public abstract static class Builder {
 
@@ -357,6 +366,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       public abstract Builder setTotalBlockCount(int totalBlockCount);
 
       public abstract Builder setLoginPromptModal(Modal loginPromptModal);
+
+      public abstract Builder setProfile(CiviFormProfile profile);
 
       public abstract Params build();
     }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -149,6 +149,7 @@ POST    /applicants/:applicantId                                            cont
 
 # Program methods for applicants (new)
 GET     /programs                   controllers.applicant.ApplicantProgramsController.index(request: Request)
+GET     /programs/:programId/edit   controllers.applicant.ApplicantProgramsController.edit(request: Request, programId: Long)
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
 # the path parameter as a string and decide how to handle it in the
@@ -163,7 +164,7 @@ GET     /programs/:programParam     controllers.applicant.ApplicantProgramsContr
 # during migration.
 GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.indexWithApplicantId(request: Request, applicantId: Long)
 GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.showWithApplicantId(request: Request, applicantId: Long, programId: Long)
-GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.edit(request: Request, applicantId: Long, programId: Long)
+GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.editWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.review(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -264,7 +264,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_differentApplicant_redirectsToHome() {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id + 1, 1L).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, currentApplicant.id + 1, 1L)
+            .toCompletableFuture()
+            .join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -273,7 +276,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_applicantWithoutProfile_redirectsToHome() {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, applicantWithoutProfile.id, 1L).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, applicantWithoutProfile.id, 1L)
+            .toCompletableFuture()
+            .join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -283,7 +289,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id, draftProgram.id).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, currentApplicant.id, draftProgram.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
@@ -296,7 +305,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, adminApplicantId, draftProgram.id).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, adminApplicantId, draftProgram.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
@@ -305,7 +317,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_invalidProgram_returnsBadRequest() {
     Result result =
         controller
-            .edit(requestBuilderWithSettings().build(), currentApplicant.id, 9999L)
+            .editWithApplicantId(requestBuilderWithSettings().build(), currentApplicant.id, 9999L)
             .toCompletableFuture()
             .join();
 
@@ -318,7 +330,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
         controller
-            .edit(request, currentApplicant.id, obsoleteProgram.id)
+            .editWithApplicantId(request, currentApplicant.id, obsoleteProgram.id)
             .toCompletableFuture()
             .join();
 
@@ -335,7 +347,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id, program.id).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
@@ -365,7 +380,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id, program.id).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
@@ -383,7 +401,10 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     Request request = addCSRFToken(requestBuilderWithSettings()).build();
     Result result =
-        controller.edit(request, currentApplicant.id, program.id).toCompletableFuture().join();
+        controller
+            .editWithApplicantId(request, currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -226,4 +226,94 @@ public class ApplicantRoutesTest extends ResetPostgres {
     assertThat(after.present).isEqualTo(before.present);
     assertThat(after.absent).isEqualTo(before.absent + 1);
   }
+
+  @Test
+  public void testEditRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedEditUrl = String.format("/programs/%d/edit", programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .edit(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testEditRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedEditUrl =
+        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .edit(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testEditRoute_forApplicantWithoutIdInProfile() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedEditUrl =
+        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .edit(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testEditRoute_forTrustedIntermediary() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedEditUrl =
+        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest).edit(tiProfile, applicantId, programId).url())
+        .isEqualTo(expectedEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
 }


### PR DESCRIPTION
### Description

Remove applicant id from application programs edit URL.

This is done in the usual way: 
* define a new `ApplicantRoutes.edit()` method that delegates to the existing method, 
* which is renamed to `editWithApplicantId()`, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 