### PR TITLE
Avoid creating a draft program when we don't need to

### DIFF
--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -144,9 +144,7 @@ public final class QuestionRepository {
     // TODO: This seems error prone as a question could be present as a DRAFT and ACTIVE.
     // Investigate further.
     Stream.concat(
-            versionRepository
-                .getQuestionsForVersion(versionRepository.getDraftVersion())
-                .stream(),
+            versionRepository.getQuestionsForVersion(versionRepository.getDraftVersion()).stream(),
             versionRepository.getQuestionsForVersion(versionRepository.getActiveVersion()).stream())
         // Find questions that reference the old enumerator ID.
         .filter(

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -145,7 +145,7 @@ public final class QuestionRepository {
     // Investigate further.
     Stream.concat(
             versionRepository
-                .getQuestionsForVersion(versionRepository.getDraftVersionOrCreate())
+                .getQuestionsForVersion(versionRepository.getDraftVersion())
                 .stream(),
             versionRepository.getQuestionsForVersion(versionRepository.getActiveVersion()).stream())
         // Find questions that reference the old enumerator ID.

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -469,9 +469,8 @@ public final class VersionRepository {
     }
     return getQuestionsForVersionWithoutCache(version);
   }
-  /**
-   * Returns the questions for a version if the version is present.
-   */
+
+  /** Returns the questions for a version if the version is present. */
   public ImmutableList<QuestionModel> getQuestionsForVersion(Optional<VersionModel> maybeVersion) {
     return maybeVersion.isPresent()
         ? getQuestionsForVersion(maybeVersion.get())
@@ -492,11 +491,12 @@ public final class VersionRepository {
         .filter(p -> p.getProgramDefinition().adminName().equals(name))
         .findAny();
   }
-  
-  public Optional<ProgramModel> getProgramByNameForVersion(String name, Optional<VersionModel> maybeVersion) {
+
+  public Optional<ProgramModel> getProgramByNameForVersion(
+      String name, Optional<VersionModel> maybeVersion) {
     return getProgramsForVersion(maybeVersion).stream()
-      .filter(p -> p.getProgramDefinition().adminName().equals(name))
-      .findAny();
+        .filter(p -> p.getProgramDefinition().adminName().equals(name))
+        .findAny();
   }
 
   /** Returns the names of all the programs. */
@@ -521,10 +521,8 @@ public final class VersionRepository {
     }
     return getProgramsForVersionWithoutCache(version);
   }
-  /**
-   * Returns the programs for a version if the version is present.
-   */
 
+  /** Returns the programs for a version if the version is present. */
   public ImmutableList<ProgramModel> getProgramsForVersion(Optional<VersionModel> version) {
     return version.isPresent() ? getProgramsForVersion(version.get()) : ImmutableList.of();
   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -240,9 +240,7 @@ public final class ProgramService {
   private boolean isActiveOrDraftProgram(ProgramModel program) {
     return Streams.concat(
             versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream(),
-            versionRepository
-                .getProgramsForVersion(versionRepository.getDraftVersion())
-                .stream())
+            versionRepository.getProgramsForVersion(versionRepository.getDraftVersion()).stream())
         .anyMatch(p -> p.id.equals(program.id));
   }
 

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -241,7 +241,7 @@ public final class ProgramService {
     return Streams.concat(
             versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream(),
             versionRepository
-                .getProgramsForVersion(versionRepository.getDraftVersionOrCreate())
+                .getProgramsForVersion(versionRepository.getDraftVersion())
                 .stream())
         .anyMatch(p -> p.id.equals(program.id));
   }


### PR DESCRIPTION
### Description

There are places we are calling getDraftVersionOrCreate when we really don't need to create a draft version, we just need to get it if it exists. This causes extra versions to be created unnecessarily.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
