### PR TITLE
Match full URL in loginAsTestUserAwsStaging()

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -383,7 +383,7 @@ async function loginAsTestUserAwsStaging(
   await page.fill('input[name=username]', TEST_USER_LOGIN)
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await Promise.all([
-    page.waitForURL(isTi ? '**/admin/**' : '/programs', {
+    page.waitForURL(isTi ? '**/admin/**' : '**/programs', {
       waitUntil: 'networkidle',
     }),
     // Auth0 has an additional hidden "Continue" button that does nothing for some reason


### PR DESCRIPTION
### Description

Revise `loginAsTestUserAwsStaging()` to match a full URL, not just a path.

The Playwright [docs](https://playwright.dev/docs/api/class-page#page-wait-for-url) for `Page.waitForUrl()` indicate that a full URL is expected. This test doesn't run in hermetic environments, so we only saw the failure when it ran as a prober test against AWS staging.

Tested via:
```
$ BASE_URL=https://staging-aws.civiform.dev bin/run-browser-tests admin_application_statuses.test.ts
```
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

