### PR TITLE
Remove applicant id from URL for review action

### DIFF
--- a/server/app/controllers/admin/AdminProgramPreviewController.java
+++ b/server/app/controllers/admin/AdminProgramPreviewController.java
@@ -1,9 +1,13 @@
 package controllers.admin;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import auth.Authorizers;
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import auth.controllers.MissingOptionalException;
 import controllers.CiviFormController;
+import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -16,11 +20,15 @@ import repository.VersionRepository;
 
 /** Controller for admins previewing a program as an applicant. */
 public final class AdminProgramPreviewController extends CiviFormController {
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public AdminProgramPreviewController(
-      ProfileUtils profileUtils, VersionRepository versionRepository) {
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
+      ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   /**
@@ -36,8 +44,10 @@ public final class AdminProgramPreviewController extends CiviFormController {
 
     try {
       return redirect(
-          controllers.applicant.routes.ApplicantProgramReviewController.review(
-              profile.get().getApplicant().get().id, programId));
+          applicantRoutes.review(
+              profile.orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class)),
+              profile.get().getApplicant().get().id,
+              programId));
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -89,7 +89,7 @@ public final class ApplicantRoutes {
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).
    * @param applicantId - ID of applicant for whom the action should be performed.
    * @param programId - ID of program to edit
-   * @return Route for the applicant action
+   * @return Route for the applicant edit action
    */
   public Call edit(CiviFormProfile profile, long applicantId, long programId) {
     if (includeApplicantIdInRoute(profile)) {
@@ -97,6 +97,22 @@ public final class ApplicantRoutes {
           applicantId, programId);
     } else {
       return routes.ApplicantProgramsController.edit(programId);
+    }
+  }
+
+  /**
+   * Returns the route corresponding to the applicant review action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @return Route for the applicant review action
+   */
+  public Call review(CiviFormProfile profile, long applicantId, long programId) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramReviewController.reviewWithApplicantId(applicantId, programId);
+    } else {
+      return routes.ApplicantProgramReviewController.review(programId);
     }
   }
 }

--- a/server/app/views/ApplicationBaseView.java
+++ b/server/app/views/ApplicationBaseView.java
@@ -5,7 +5,9 @@ import static j2html.TagCreator.p;
 import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.span;
 
+import auth.CiviFormProfile;
 import com.google.auto.value.AutoValue;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.PTag;
@@ -26,9 +28,9 @@ public class ApplicationBaseView extends BaseHtmlView {
   final String REVIEW_APPLICATION_BUTTON_ID = "review-application-button";
 
   protected ATag renderReviewButton(ApplicationBaseView.Params params) {
+    ApplicantRoutes applicantRoutes = params.applicantRoutes();
     String reviewUrl =
-        routes.ApplicantProgramReviewController.review(params.applicantId(), params.programId())
-            .url();
+        applicantRoutes.review(params.profile(), params.applicantId(), params.programId()).url();
     return a().withHref(reviewUrl)
         .withText(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
         .withId(REVIEW_APPLICATION_BUTTON_ID)
@@ -45,9 +47,9 @@ public class ApplicationBaseView extends BaseHtmlView {
                   params.applicantId(), params.programId(), previousBlockIndex, params.inReview())
               .url();
     } else {
+      ApplicantRoutes applicantRoutes = params.applicantRoutes();
       redirectUrl =
-          routes.ApplicantProgramReviewController.review(params.applicantId(), params.programId())
-              .url();
+          applicantRoutes.review(params.profile(), params.applicantId(), params.programId()).url();
     }
     return a().withHref(redirectUrl)
         .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
@@ -95,6 +97,10 @@ public class ApplicationBaseView extends BaseHtmlView {
 
     public abstract Optional<String> applicantSelectedQuestionName();
 
+    public abstract ApplicantRoutes applicantRoutes();
+
+    public abstract CiviFormProfile profile();
+
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setRequest(Http.Request request);
@@ -130,6 +136,10 @@ public class ApplicationBaseView extends BaseHtmlView {
       public abstract Builder setApplicantPersonalInfo(ApplicantPersonalInfo personalInfo);
 
       public abstract Builder setApplicantSelectedQuestionName(Optional<String> questionName);
+
+      public abstract Builder setApplicantRoutes(ApplicantRoutes applicantRoutes);
+
+      public abstract Builder setProfile(CiviFormProfile profile);
 
       public abstract Params build();
     }

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
@@ -80,9 +80,7 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
           redirectButton(
                   "go-back-and-edit",
                   messages.at(MessageKey.BUTTON_GO_BACK_AND_EDIT.getKeyName()),
-                  controllers.applicant.routes.ApplicantProgramReviewController.review(
-                          applicantId, programId)
-                      .url())
+                  applicantRoutes.review(profile, applicantId, programId).url())
               .withClasses(ButtonStyles.OUTLINED_TRANSPARENT));
     }
 

--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -6,8 +6,10 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.span;
 
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import controllers.applicant.ApplicantRoutes;
 import controllers.routes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
@@ -31,10 +33,12 @@ import views.style.ReferenceClasses;
 public class ApplicantProgramInfoView extends BaseHtmlView {
 
   private final ApplicantLayout layout;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
-  public ApplicantProgramInfoView(ApplicantLayout layout) {
+  public ApplicantProgramInfoView(ApplicantLayout layout, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public Content render(
@@ -42,7 +46,8 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
       ProgramDefinition program,
       Http.Request request,
       long applicantId,
-      ApplicantPersonalInfo personalInfo) {
+      ApplicantPersonalInfo personalInfo,
+      CiviFormProfile profile) {
 
     Locale preferredLocale = messages.lang().toLocale();
     String programTitle = program.localizedName().getOrDefault(preferredLocale);
@@ -53,7 +58,7 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
             .getBundle(request)
             .addMainStyles("mx-12", "my-8")
             .addMainContent(topContent(programTitle, programInfo, messages))
-            .addMainContent(createButtons(applicantId, program.id(), messages));
+            .addMainContent(createButtons(applicantId, program.id(), messages, profile));
 
     return layout.renderWithNav(request, personalInfo, messages, bundle, applicantId);
   }
@@ -76,17 +81,16 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
     // "Markdown" the program description.
     ImmutableList<DomContent> items =
         TextFormatter.formatText(
-            programInfo, /*preserveEmptyLines= */ true, /*addRequiredIndicator= */ false);
+            programInfo, /* preserveEmptyLines= */ true, /* addRequiredIndicator= */ false);
 
     DivTag descriptionDiv = div().withClasses("py-2").with(items);
 
     return div(allProgramsDiv, titleDiv, descriptionDiv);
   }
 
-  private DivTag createButtons(Long applicantId, Long programId, Messages messages) {
-    String applyUrl =
-        controllers.applicant.routes.ApplicantProgramReviewController.review(applicantId, programId)
-            .url();
+  private DivTag createButtons(
+      Long applicantId, Long programId, Messages messages, CiviFormProfile profile) {
+    String applyUrl = applicantRoutes.review(profile, applicantId, programId).url();
     ATag applyLink =
         a().withText(messages.at(MessageKey.BUTTON_APPLY.getKeyName()))
             .withHref(applyUrl)

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -10,7 +10,6 @@ import static j2html.TagCreator.ul;
 
 import auth.CiviFormProfile;
 import controllers.applicant.ApplicantRoutes;
-import controllers.applicant.routes;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.UlTag;
@@ -111,8 +110,8 @@ public final class IneligibleBlockView extends ApplicationBaseView {
                     .with(
                         new LinkElement()
                             .setHref(
-                                routes.ApplicantProgramReviewController.review(
-                                        applicantId, programId)
+                                applicantRoutes
+                                    .review(submittingProfile, applicantId, programId)
                                     .url())
                             .setText(messages.at(MessageKey.BUTTON_GO_BACK_AND_EDIT.getKeyName()))
                             .asButton()

--- a/server/app/views/applicant/PreventDuplicateSubmissionView.java
+++ b/server/app/views/applicant/PreventDuplicateSubmissionView.java
@@ -8,7 +8,6 @@ import static j2html.TagCreator.p;
 
 import auth.CiviFormProfile;
 import controllers.applicant.ApplicantRoutes;
-import controllers.applicant.routes;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -64,8 +63,11 @@ public final class PreventDuplicateSubmissionView extends ApplicationBaseView {
                         redirectButton(
                                 "continue-editing-button",
                                 messages.at(MessageKey.BUTTON_CONTINUE_EDITING.getKeyName()),
-                                routes.ApplicantProgramReviewController.review(
-                                        applicantId, roApplicantProgramService.getProgramId())
+                                applicantRoutes
+                                    .review(
+                                        profile,
+                                        applicantId,
+                                        roApplicantProgramService.getProgramId())
                                     .url())
                             .withClasses(ButtonStyles.SOLID_BLUE),
                         redirectButton(

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -487,10 +487,7 @@ public final class ProgramIndexView extends BaseHtmlView {
           programCardSubmittedDate(messages, cardData.latestSubmittedApplicationTime().get()));
     }
 
-    String actionUrl =
-        controllers.applicant.routes.ApplicantProgramReviewController.review(
-                applicantId, program.id())
-            .url();
+    String actionUrl = applicantRoutes.review(profile, applicantId, program.id()).url();
 
     Modal loginPromptModal =
         createLoginPromptModal(

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -150,6 +150,7 @@ POST    /applicants/:applicantId                                            cont
 # Program methods for applicants (new)
 GET     /programs                   controllers.applicant.ApplicantProgramsController.index(request: Request)
 GET     /programs/:programId/edit   controllers.applicant.ApplicantProgramsController.edit(request: Request, programId: Long)
+GET     /programs/:programId/review controllers.applicant.ApplicantProgramReviewController.review(request: Request, programId: Long)
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
 # the path parameter as a string and decide how to handle it in the
@@ -165,7 +166,7 @@ GET     /programs/:programParam     controllers.applicant.ApplicantProgramsContr
 GET     /applicants/:applicantId/programs                                                      controllers.applicant.ApplicantProgramsController.indexWithApplicantId(request: Request, applicantId: Long)
 GET     /applicants/:applicantId/programs/:programId                                           controllers.applicant.ApplicantProgramsController.showWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.editWithApplicantId(request: Request, applicantId: Long, programId: Long)
-GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.review(request: Request, applicantId: Long, programId: Long)
+GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])

--- a/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
@@ -29,7 +29,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
-            controllers.applicant.routes.ApplicantProgramReviewController.review(
+            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
                     adminAccount.ownedApplicantIds().get(0), programId)
                 .url());
   }

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -575,7 +575,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // check that the address correction screen is skipped and the user is redirected to the review
     // screen
     String reviewRoute =
-        routes.ApplicantProgramReviewController.review(applicant.id, program.id).url();
+        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
+            .url();
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
@@ -613,7 +614,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     String reviewRoute =
-        routes.ApplicantProgramReviewController.review(applicant.id, program.id).url();
+        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
+            .url();
 
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
   }
@@ -857,7 +859,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     String reviewRoute =
-        routes.ApplicantProgramReviewController.review(applicant.id, program.id).url();
+        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
+            .url();
 
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
   }

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -279,10 +279,14 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                        routes.ApplicantProgramReviewController.review(applicantId, programId))
+                        routes.ApplicantProgramReviewController.reviewWithApplicantId(
+                            applicantId, programId))
                     .header(skipUserProfile, shouldSkipUserProfile.toString()))
             .build();
-    return subject.review(request, applicantId, programId).toCompletableFuture().join();
+    return subject
+        .reviewWithApplicantId(request, applicantId, programId)
+        .toCompletableFuture()
+        .join();
   }
 
   public Result submit(long applicantId, long programId) {

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -224,7 +224,9 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
         .contains(
-            routes.ApplicantProgramReviewController.review(currentApplicant.id, program.id).url());
+            routes.ApplicantProgramReviewController.reviewWithApplicantId(
+                    currentApplicant.id, program.id)
+                .url());
   }
 
   @Test
@@ -257,7 +259,9 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .contains(
-            routes.ApplicantProgramReviewController.review(currentApplicant.id, program.id).url());
+            routes.ApplicantProgramReviewController.reviewWithApplicantId(
+                    currentApplicant.id, program.id)
+                .url());
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -316,4 +316,96 @@ public class ApplicantRoutesTest extends ResetPostgres {
     assertThat(after.present).isEqualTo(before.present);
     assertThat(after.absent).isEqualTo(before.absent + 1);
   }
+
+  @Test
+  public void testReviewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl = String.format("/programs/%d/review", programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .review(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testReviewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl =
+        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .review(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testReviewRoute_forApplicantWithoutIdInProfile() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl =
+        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .review(applicantProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testReviewRoute_forTrustedIntermediary() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl =
+        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .review(tiProfile, applicantId, programId)
+                .url())
+        .isEqualTo(expectedReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
 }

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -63,7 +63,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.review(
+            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
                     applicant.id, programDefinition.id())
                 .url());
   }
@@ -155,6 +155,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
     CiviFormController controller = instanceOf(CiviFormController.class);
+    ApplicantRoutes applicantRoutes = instanceOf(ApplicantRoutes.class);
 
     ProgramSlugHandler handler =
         new ProgramSlugHandler(
@@ -162,7 +163,8 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
             instanceOf(ProgramService.class),
-            languageUtils);
+            languageUtils,
+            applicantRoutes);
     Result result =
         handler
             .showProgram(
@@ -173,7 +175,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .join();
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.review(
+            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
                     applicant.id, programDefinition.id())
                 .url());
   }
@@ -189,6 +191,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
     CiviFormController controller = instanceOf(CiviFormController.class);
+    ApplicantRoutes applicantRoutes = instanceOf(ApplicantRoutes.class);
 
     ProgramSlugHandler handler =
         new ProgramSlugHandler(
@@ -196,7 +199,8 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             instanceOf(ApplicantService.class),
             instanceOf(ProfileUtils.class),
             instanceOf(ProgramService.class),
-            languageUtils);
+            languageUtils,
+            applicantRoutes);
     Result result =
         handler
             .showProgram(
@@ -207,7 +211,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .join();
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.review(
+            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
                     applicant.id, programDefinition.id())
                 .url());
   }


### PR DESCRIPTION
### Description

Remove applicant id from application programs review URL.

This is done in the usual way: 
* define a new `ApplicantProgramReviewController.review()` method that delegates to the existing method, 
* which is renamed to `reviewWithApplicantId()`.
* Create a new `ApplicantRoutes.review()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 