### PR TITLE
Use regex instead of glob for URL pattern

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -383,7 +383,7 @@ async function loginAsTestUserAwsStaging(
   await page.fill('input[name=username]', TEST_USER_LOGIN)
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await Promise.all([
-    page.waitForURL(isTi ? '**/admin/**' : '**/programs**', {
+    page.waitForURL(isTi ? '**/admin/**' : '.*/programs.*', {
       waitUntil: 'networkidle',
     }),
     // Auth0 has an additional hidden "Continue" button that does nothing for some reason


### PR DESCRIPTION
### Description

Replace (invalid) glob with regex.

The globstar pattern (`**`) only applies to path components (before or after a `/`).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
