### PR TITLE
Remove applicant id from URLs for block edit action

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -133,6 +133,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
    * <p>`edit` takes the applicant to the next in-progress block, see {@link
    * ReadOnlyApplicantProgramService#getInProgressBlocks()}. If there are no more blocks, summary
    * page is shown.
+   *
+   * <p>`questionName` is present when answering a question or reviewing an answer.
    */
   @Secure
   public CompletionStage<Result> editWithApplicantId(
@@ -153,6 +155,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
    * <p>`edit` takes the applicant to the next in-progress block, see {@link
    * ReadOnlyApplicantProgramService#getInProgressBlocks()}. If there are no more blocks, summary
    * page is shown.
+   *
+   * <p>`questionName` is present when answering a question or reviewing an answer.
    */
   @Secure
   public CompletionStage<Result> edit(

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -237,11 +237,16 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenApplyAsync(
             roApplicantService -> {
               Optional<Block> blockMaybe = roApplicantService.getFirstIncompleteOrStaticBlock();
+              CiviFormProfile profile =
+                  profileUtils
+                      .currentUserProfile(request)
+                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
               return blockMaybe.flatMap(
                   block ->
                       Optional.of(
                           found(
-                              routes.ApplicantProgramBlocksController.edit(
+                              applicantRoutes.blockEdit(
+                                  profile,
                                   applicantId,
                                   programId,
                                   block.getId(),

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -6,6 +6,7 @@ import auth.CiviFormProfile;
 import auth.ProfileFactory;
 import com.google.inject.Inject;
 import io.prometheus.client.Counter;
+import java.util.Optional;
 import play.api.mvc.Call;
 import services.settings.SettingsManifest;
 
@@ -129,6 +130,28 @@ public final class ApplicantRoutes {
       return routes.ApplicantProgramReviewController.submitWithApplicantId(applicantId, programId);
     } else {
       return routes.ApplicantProgramReviewController.submit(programId);
+    }
+  }
+
+  /**
+   * Returns the route corresponding to the applicant block edit action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @return Route for the applicant block edit action
+   */
+  public Call blockEdit(
+      CiviFormProfile profile,
+      long applicantId,
+      long programId,
+      String blockId,
+      Optional<String> questionName) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramBlocksController.editWithApplicantId(
+          applicantId, programId, blockId, questionName);
+    } else {
+      return routes.ApplicantProgramBlocksController.edit(programId, blockId, questionName);
     }
   }
 }

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -94,7 +94,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
           && currentRepeatedEntity.isPresent()) {
         applicationSummary.with(renderRepeatedEntitySection(currentRepeatedEntity.get(), messages));
       }
-      applicationSummary.with(renderQuestionSummary(answerData, messages, params.applicantId()));
+      applicationSummary.with(
+          renderQuestionSummary(answerData, messages, params.applicantId(), params.profile()));
       previousRepeatedEntity = currentRepeatedEntity;
     }
 
@@ -165,7 +166,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
   }
 
   /** Renders {@code data} including the question and any existing answer to it. */
-  private DivTag renderQuestionSummary(AnswerData data, Messages messages, long applicantId) {
+  private DivTag renderQuestionSummary(
+      AnswerData data, Messages messages, long applicantId, CiviFormProfile profile) {
     DivTag questionContent =
         div(div()
                 .with(
@@ -243,8 +245,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     } else {
       editElement
           .setHref(
-              routes.ApplicantProgramBlocksController.edit(
-                      applicantId, data.programId(), data.blockId(), questionName)
+              applicantRoutes
+                  .blockEdit(profile, applicantId, data.programId(), data.blockId(), questionName)
                   .url())
           .setText(messages.at(MessageKey.LINK_ANSWER.getKeyName()))
           .setIcon(Icons.ARROW_FORWARD, LinkElement.IconPosition.END);

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -152,6 +152,8 @@ GET     /programs                   controllers.applicant.ApplicantProgramsContr
 GET     /programs/:programId/edit   controllers.applicant.ApplicantProgramsController.edit(request: Request, programId: Long)
 GET     /programs/:programId/review controllers.applicant.ApplicantProgramReviewController.review(request: Request, programId: Long)
 POST    /programs/:programId/submit controllers.applicant.ApplicantProgramReviewController.submit(request: Request, programId: Long)
+GET     /programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
+
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
 # the path parameter as a string and decide how to handle it in the
@@ -169,7 +171,7 @@ GET     /applicants/:applicantId/programs/:programId                            
 GET     /applicants/:applicantId/programs/:programId/edit                                      controllers.applicant.ApplicantProgramsController.editWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submitWithApplicantId(request: Request, applicantId: Long, programId: Long)
-GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
+GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.editWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previous(request: Request, applicantId: Long, programId: Long, previousBlockIndex: Int, inReview: Boolean)

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -57,13 +57,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badApplicantId = applicant.id + 1000;
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.edit(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
                     badApplicantId, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
 
     Result result =
         subject
-            .edit(request, badApplicantId, program.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, badApplicantId, program.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -81,12 +82,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.edit(
+                    routes.ApplicantProgramBlocksController.editWithApplicantId(
                         applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -106,12 +108,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.edit(
+                    routes.ApplicantProgramBlocksController.editWithApplicantId(
                         applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -125,12 +128,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.edit(
+                    routes.ApplicantProgramBlocksController.editWithApplicantId(
                         applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
-            .edit(
+            .editWithApplicantId(
                 request,
                 applicant.id,
                 obsoleteProgram.id,
@@ -147,7 +150,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.edit(
+                    routes.ApplicantProgramBlocksController.editWithApplicantId(
                         applicant.id,
                         program.id + 1000,
                         "1",
@@ -156,7 +159,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .edit(
+            .editWithApplicantId(
                 request, applicant.id, program.id + 1000, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
@@ -169,13 +172,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.edit(
+                    routes.ApplicantProgramBlocksController.editWithApplicantId(
                         applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
 
     Result result =
         subject
-            .edit(request, applicant.id, program.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, program.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -186,13 +190,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void edit_toABlockThatDoesNotExist_returns404() {
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.edit(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
                     applicant.id, program.id, "9999", /* questionName= */ Optional.empty()))
             .build();
 
     Result result =
         subject
-            .edit(request, applicant.id, program.id, "9999", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, program.id, "9999", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -204,14 +209,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                        routes.ApplicantProgramBlocksController.edit(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
                             applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
                     .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()))
             .build();
 
     Result result =
         subject
-            .edit(request, applicant.id, program.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, program.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -250,7 +256,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -275,7 +282,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -294,7 +302,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(
+            .editWithApplicantId(
                 request,
                 applicant.id,
                 obsoleteProgram.id,
@@ -340,7 +348,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -365,7 +374,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -384,7 +394,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(
+            .editWithApplicantId(
                 request,
                 applicant.id,
                 obsoleteProgram.id,
@@ -528,7 +538,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
-        routes.ApplicantProgramBlocksController.edit(
+        routes.ApplicantProgramBlocksController.editWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);
@@ -659,7 +669,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -684,7 +695,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
+            .editWithApplicantId(
+                request, applicant.id, draftProgram.id, "1", /* questionName= */ Optional.empty())
             .toCompletableFuture()
             .join();
 
@@ -703,7 +715,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .edit(
+            .editWithApplicantId(
                 request,
                 applicant.id,
                 obsoleteProgram.id,
@@ -825,7 +837,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
-        routes.ApplicantProgramBlocksController.edit(
+        routes.ApplicantProgramBlocksController.editWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -359,7 +359,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.ApplicantProgramBlocksController.edit(
+            routes.ApplicantProgramBlocksController.editWithApplicantId(
                     currentApplicant.id, program.id, "1", /* questionName= */ Optional.empty())
                 .url());
   }
@@ -392,7 +392,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.ApplicantProgramBlocksController.edit(
+            routes.ApplicantProgramBlocksController.editWithApplicantId(
                     currentApplicant.id, program.id, "2", /* questionName= */ Optional.empty())
                 .url());
   }

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -11,6 +11,7 @@ import auth.Role;
 import io.prometheus.client.Collector.MetricFamilySamples;
 import io.prometheus.client.CollectorRegistry;
 import java.util.Collections;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
@@ -23,6 +24,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   private static long applicantAccountId = 456L;
   private static long tiAccountId = 789L;
   private static long programId = 321L;
+  private static String blockId = "test_block";
   private static SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
 
   // Class to hold counter values.
@@ -495,6 +497,98 @@ public class ApplicantRoutesTest extends ResetPostgres {
                 .submit(tiProfile, applicantId, programId)
                 .url())
         .isEqualTo(expectedSubmitUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testBlockEditRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockEditUrl = String.format("/programs/%d/blocks/%s/edit", programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testBlockEditRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockEditUrl =
+        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testBlockEditRoute_forApplicantWithoutIdInProfile() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockEditUrl =
+        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testBlockRoute_forTrustedIntermediary() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockEditUrl =
+        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockEdit(tiProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockEditUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);


### PR DESCRIPTION
### Description

Remove applicant id from application program block edit URL.

This is done in the usual way: 
* define a new `ApplicantProgramBlockController.edit()` method that delegates to the existing method, 
* which is renamed to `editWithApplicantId()`.
* Create a new `ApplicantRoutes.blockEdit()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 