### PR TITLE
Add main page text revisions to messages file for translation

### DIFF
--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -47,6 +47,8 @@ button.guestLogin=Continue as guest
 content.loginDisabledPrompt=Account login currently disabled
 content.adminLoginPrompt=Looking for something else?
 content.adminFooterPrompt=Are you a benefits administrator?
+# Text at the bottom of the home page to prompt administrators to go to the administrator login page
+content.adminFooterPromptNew=Are you an administrator?
 link.adminLogin=Admin login
 
 #--------------------------------------------------------------------------#
@@ -81,13 +83,23 @@ button.editCommonIntakeSr=Edit submitted information for {0}
 button.continueCommonIntakeSr=Continue filling out {0}
 content.submittedDate=Submitted {0}
 content.benefits=Get benefits
+# Title of the page where applicants can go to find programs
+content.findPrograms=Find programs
 content.description=CiviForm helps you find benefits you may be eligible for in {0}. Get started by choosing an application below.
+# Content that explains the benefit of using CiviForm. We'll fill in the name of the city or state.
+content.findProgramsDescription=CiviForm helps you find programs you may be eligible for in {0}. Get started by choosing an application below.
 content.saveTime=Save time when applying for benefits
+# Content on the home page to describe the benefit of CiviForm
+content.saveTimeServices=Save time applying for programs and services
 content.guestDescription=Log in to your {0} account or create an account and apply for many benefits without having to enter the same information again. You can also edit applications at any time and check your application statuses.
+# Content explaining the benefits of creating an account, with the authentication provider filled in.
+content.guestDescriptionNew=Log in to your {0} account or create an account and apply to programs without having to enter the same information again. You can also edit applications at any time and check your application statuses.
 link.programDetails=Program details
 link.programDetailsSr=Program details for {0}, opens in a new tab
 title.programs=Programs & services
 title.findServicesSection=Find services that can help you
+# A section of the site that the users should start with
+title.getStartedSection=Get Started
 title.allProgramsSection=All programs ({0})
 title.status=Status
 title.inProgressProgramsUpdated=In progress
@@ -144,14 +156,30 @@ content.confirmed=Thank you for applying to {0}.  Your application has been rece
 title.createAnAccount=Create an account or sign in
 content.pleaseCreateAccount=Log in to your {0} account or create an account to have your information saved. You''ll be able to return at any time to complete future applications. If you do not already have an account, the login page will allow you to sign up and you won''t lose any data you''ve already entered.
 content.generalLoginModalPrompt=You are not logged in to an account. Without an account you will not be able to edit an application, check the status of your application, or apply for other benefits quickly.
+# Content explaining the benefits of being logged into your account.
+content.generalLoginModalPromptNew=You are not logged in to an account. Without an account you will not be able to edit an application, check the status of your application, or apply for other programs quickly.
 content.initialLoginModalPrompt=Before you continue, log in to your {0} account or create an account. You''ll be able to apply for many benefits without having to enter the same information again. You can also edit applications and check your application statuses.
+# Content explaining the benefits of being logged into your account, with {0} as the authentication provider.
+content.initialLoginModalPromptNew=Before you continue, log in to your {0} account or create an account. You''ll be able to apply for multiple programs without having to enter the same information again. You can also edit applications and check your application statuses.
 button.continueWithoutAnAccount=Continue without an account
 title.commonIntakeConfirmation=Benefits you may qualify for
+# Title of the section containing programs the applicant may qualify for.
+title.commonIntakeConfirmationNew=Programs you may qualify for
 title.commonIntakeConfirmationTi=Benefits your client may qualify for
+# Title of the section containing programs the applicant may qualify for, when someone is filling out the application on behalf of their client.
+title.commonIntakeConfirmationTiNew=Programs your client may qualify for 
 content.commonIntakeConfirmation=You may be able to get these benefits if you apply through the online application by clicking ''Apply to programs''.
+# Text explaining next steps in order to enroll in programs
+content.commonIntakeConfirmationNew=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 content.commonIntakeConfirmationTi=Your client may be able to get these benefits if you apply through the online application by clicking ''Apply to programs''.
+# Text explaining next steps in order to enroll in programs, when filling out the application on behalf of a client
+content.commonIntakeConfirmationTiNew=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 content.commonIntakeNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for benefits at any time, by clicking ''Apply to programs''.  Or to view additional benefit programs you can visit {0}
+# Content explaining that the screener application couldn't find eligible programs, but allows users to find other programs through another website (substituted for {0})
+content.commonIntakeNoMatchingProgramsNew=The pre-screener could not find programs you may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''.  Or to view additional programs you can visit {0}
 content.commonIntakeNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for benefits at any time, by clicking ''Apply to programs''.  Or to view additional benefit programs you can visit {0}
+# Content explaining that the screener application couldn't find eligible programs, but allows users to find other programs on behalf of their client through another website (substituted for {0})
+content.commonIntakeNoMatchingProgramsTiNew=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''.  Or to view additional programs you can visit {0}
 content.commonIntakeNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
 button.downloadPdf=Download PDF
 button.applyToPrograms=Apply to programs

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -134,7 +134,7 @@ public class MessagesTest {
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
     // TODO(#5893) remove when translations are completed.
-    Stream.of(
+    ImmutableList<String> messageKeysAndUntranslatedKeys = Stream.of(
             messageKeys,
             ImmutableList.of(
                 "content.adminFooterPromptNew",
@@ -153,7 +153,7 @@ public class MessagesTest {
                 "title.getStartedSection"))
         .collect(toImmutableList());
 
-    assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
+    assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);
   }
 
   private static Set<String> keysInFile(String filePath) throws Exception {

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -133,6 +133,24 @@ public class MessagesTest {
     ImmutableList<String> messageKeys =
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
+    // TODO(#5893) remove when translations are completed.
+    messageKeys.concat(
+        ImmutableList.of(
+            "content.adminFooterPromptNew",
+            "content.commonIntakeConfirmationNew",
+            "content.commonIntakeConfirmationTiNew",
+            "content.commonIntakeNoMatchingProgramsNew",
+            "content.commonIntakeNoMatchingProgramsTiNew",
+            "content.findPrograms",
+            "content.findProgramsDescription",
+            "content.generalLoginModalPromptNew",
+            "content.guestDescriptionNew",
+            "content.initialLoginModalPromptNew",
+            "content.saveTimeServices",
+            "title.commonIntakeConfirmationNew",
+            "title.commonIntakeConfirmationTiNew",
+            "title.getStartedSection"));
+
     assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
   }
 

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -134,7 +134,7 @@ public class MessagesTest {
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
     // TODO(#5893) remove when translations are completed.
-    messageKeys.concat(
+    Stream.of(messageKeys,
         ImmutableList.of(
             "content.adminFooterPromptNew",
             "content.commonIntakeConfirmationNew",
@@ -149,7 +149,7 @@ public class MessagesTest {
             "content.saveTimeServices",
             "title.commonIntakeConfirmationNew",
             "title.commonIntakeConfirmationTiNew",
-            "title.getStartedSection"));
+            "title.getStartedSection")).collect(toImmutableList());
 
     assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
   }

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -134,22 +134,24 @@ public class MessagesTest {
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
     // TODO(#5893) remove when translations are completed.
-    Stream.of(messageKeys,
-        ImmutableList.of(
-            "content.adminFooterPromptNew",
-            "content.commonIntakeConfirmationNew",
-            "content.commonIntakeConfirmationTiNew",
-            "content.commonIntakeNoMatchingProgramsNew",
-            "content.commonIntakeNoMatchingProgramsTiNew",
-            "content.findPrograms",
-            "content.findProgramsDescription",
-            "content.generalLoginModalPromptNew",
-            "content.guestDescriptionNew",
-            "content.initialLoginModalPromptNew",
-            "content.saveTimeServices",
-            "title.commonIntakeConfirmationNew",
-            "title.commonIntakeConfirmationTiNew",
-            "title.getStartedSection")).collect(toImmutableList());
+    Stream.of(
+            messageKeys,
+            ImmutableList.of(
+                "content.adminFooterPromptNew",
+                "content.commonIntakeConfirmationNew",
+                "content.commonIntakeConfirmationTiNew",
+                "content.commonIntakeNoMatchingProgramsNew",
+                "content.commonIntakeNoMatchingProgramsTiNew",
+                "content.findPrograms",
+                "content.findProgramsDescription",
+                "content.generalLoginModalPromptNew",
+                "content.guestDescriptionNew",
+                "content.initialLoginModalPromptNew",
+                "content.saveTimeServices",
+                "title.commonIntakeConfirmationNew",
+                "title.commonIntakeConfirmationTiNew",
+                "title.getStartedSection"))
+        .collect(toImmutableList());
 
     assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
   }

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -133,26 +133,25 @@ public class MessagesTest {
     ImmutableList<String> messageKeys =
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
+    ImmutableList<String> untranslatedKeys =
+        ImmutableList.of(
+            "content.adminFooterPromptNew",
+            "content.commonIntakeConfirmationNew",
+            "content.commonIntakeConfirmationTiNew",
+            "content.commonIntakeNoMatchingProgramsNew",
+            "content.commonIntakeNoMatchingProgramsTiNew",
+            "content.findPrograms",
+            "content.findProgramsDescription",
+            "content.generalLoginModalPromptNew",
+            "content.guestDescriptionNew",
+            "content.initialLoginModalPromptNew",
+            "content.saveTimeServices",
+            "title.commonIntakeConfirmationNew",
+            "title.commonIntakeConfirmationTiNew",
+            "title.getStartedSection");
+
     // TODO(#5893) remove when translations are completed.
-    ImmutableList<String> messageKeysAndUntranslatedKeys =
-        Stream.of(
-                messageKeys,
-                ImmutableList.of(
-                    "content.adminFooterPromptNew",
-                    "content.commonIntakeConfirmationNew",
-                    "content.commonIntakeConfirmationTiNew",
-                    "content.commonIntakeNoMatchingProgramsNew",
-                    "content.commonIntakeNoMatchingProgramsTiNew",
-                    "content.findPrograms",
-                    "content.findProgramsDescription",
-                    "content.generalLoginModalPromptNew",
-                    "content.guestDescriptionNew",
-                    "content.initialLoginModalPromptNew",
-                    "content.saveTimeServices",
-                    "title.commonIntakeConfirmationNew",
-                    "title.commonIntakeConfirmationTiNew",
-                    "title.getStartedSection"))
-            .collect(toImmutableList());
+    ImmutableList<String> messageKeysAndUntranslatedKeys = Stream.of(messageKeys, untranslatedKeys);
 
     assertThat(keysInPrimaryFile)
         .containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -151,7 +151,10 @@ public class MessagesTest {
             "title.getStartedSection");
 
     // TODO(#5893) remove when translations are completed.
-    ImmutableList<String> messageKeysAndUntranslatedKeys = Stream.of(messageKeys, untranslatedKeys);
+    ImmutableList<String> messageKeysAndUntranslatedKeys =
+        Stream.of(messageKeys, untranslatedKeys)
+            .flatMap(ImmutableList::stream)
+            .collect(toImmutableList());
 
     assertThat(keysInPrimaryFile)
         .containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -134,26 +134,28 @@ public class MessagesTest {
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
     // TODO(#5893) remove when translations are completed.
-    ImmutableList<String> messageKeysAndUntranslatedKeys = Stream.of(
-            messageKeys,
-            ImmutableList.of(
-                "content.adminFooterPromptNew",
-                "content.commonIntakeConfirmationNew",
-                "content.commonIntakeConfirmationTiNew",
-                "content.commonIntakeNoMatchingProgramsNew",
-                "content.commonIntakeNoMatchingProgramsTiNew",
-                "content.findPrograms",
-                "content.findProgramsDescription",
-                "content.generalLoginModalPromptNew",
-                "content.guestDescriptionNew",
-                "content.initialLoginModalPromptNew",
-                "content.saveTimeServices",
-                "title.commonIntakeConfirmationNew",
-                "title.commonIntakeConfirmationTiNew",
-                "title.getStartedSection"))
-        .collect(toImmutableList());
+    ImmutableList<String> messageKeysAndUntranslatedKeys =
+        Stream.of(
+                messageKeys,
+                ImmutableList.of(
+                    "content.adminFooterPromptNew",
+                    "content.commonIntakeConfirmationNew",
+                    "content.commonIntakeConfirmationTiNew",
+                    "content.commonIntakeNoMatchingProgramsNew",
+                    "content.commonIntakeNoMatchingProgramsTiNew",
+                    "content.findPrograms",
+                    "content.findProgramsDescription",
+                    "content.generalLoginModalPromptNew",
+                    "content.guestDescriptionNew",
+                    "content.initialLoginModalPromptNew",
+                    "content.saveTimeServices",
+                    "title.commonIntakeConfirmationNew",
+                    "title.commonIntakeConfirmationTiNew",
+                    "title.getStartedSection"))
+            .collect(toImmutableList());
 
-    assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);
+    assertThat(keysInPrimaryFile)
+        .containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);
   }
 
   private static Set<String> keysInFile(String filePath) throws Exception {


### PR DESCRIPTION
### Description

Add text to the messages file that we plan to use, based on suggestions from Leslie https://github.com/civiform/civiform/issues/5893. 

See full before and after text [here](https://docs.google.com/spreadsheets/d/1KkGB8AsvxuSEJipVXnZIuXqshMUSh6KjBldr-Zv_gkI/edit#gid=0)

These will be swapped in for the "before" texts once we get the translations back (likely in early - mid January)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
