### PR TITLE
Introduce ProfileUtils.currentProfileOrThrow()

### DIFF
--- a/server/app/auth/ProfileUtils.java
+++ b/server/app/auth/ProfileUtils.java
@@ -1,5 +1,6 @@
 package auth;
 
+import auth.controllers.MissingOptionalException;
 import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.Optional;
@@ -33,6 +34,17 @@ public class ProfileUtils {
   public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
     PlayWebContext webContext = new PlayWebContext(request);
     return currentUserProfile(webContext);
+  }
+
+  /**
+   * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
+   * request's cookies, using the injected session store to decrypt it.
+   *
+   * @throws MissingOptionalException if we can't find the profile from the request
+   */
+  public CiviFormProfile currentUserProfileOrThrow(Http.RequestHeader request) {
+    return currentUserProfile(request)
+        .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
   }
 
   /**

--- a/server/app/controllers/admin/AdminProgramPreviewController.java
+++ b/server/app/controllers/admin/AdminProgramPreviewController.java
@@ -5,10 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import auth.Authorizers;
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.controllers.MissingOptionalException;
 import controllers.CiviFormController;
 import controllers.applicant.ApplicantRoutes;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
@@ -37,17 +35,10 @@ public final class AdminProgramPreviewController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result preview(Request request, long programId) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
-    if (profile.isEmpty()) {
-      throw new RuntimeException("Unable to resolve profile.");
-    }
+    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
 
     try {
-      return redirect(
-          applicantRoutes.review(
-              profile.orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class)),
-              profile.get().getApplicant().get().id,
-              programId));
+      return redirect(applicantRoutes.review(profile, profile.getApplicant().get().id, programId));
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.controllers.MissingOptionalException;
 import controllers.CiviFormController;
 import forms.ApplicantInformationForm;
 import java.util.Locale;
@@ -96,10 +95,7 @@ public final class ApplicantInformationController extends CiviFormController {
                             /* page= */ Optional.of(1))
                         .url();
               } else {
-                CiviFormProfile profile =
-                    profileUtils
-                        .currentUserProfile(request)
-                        .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
                 redirectLink = applicantRoutes.index(profile, applicantId).url();
               }
 
@@ -139,10 +135,7 @@ public final class ApplicantInformationController extends CiviFormController {
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
     String redirectLocation;
     Session session;
-    CiviFormProfile profile =
-        profileUtils
-            .currentUserProfile(request)
-            .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
 
     if (infoForm.getRedirectLink().isEmpty()) {
       redirectLocation = applicantRoutes.index(profile, applicantId).url();

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -7,7 +7,6 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -242,10 +241,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         .thenComposeAsync(
             roApplicantProgramService -> {
               removeAddressJsonFromSession(request);
-              CiviFormProfile profile =
-                  profileUtils
-                      .currentUserProfile(request)
-                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
               return renderErrorOrRedirectToNextBlock(
                   request,
                   profile,
@@ -286,10 +282,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 httpExecutionContext.current())
             .toCompletableFuture();
 
-    CiviFormProfile profile =
-        profileUtils
-            .currentUserProfile(request)
-            .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
 
     CompletableFuture<ReadOnlyApplicantProgramService> applicantProgramServiceCompletableFuture =
         applicantStage
@@ -373,10 +366,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
 
               if (block.isPresent()) {
                 ApplicantPersonalInfo personalInfo = applicantStage.toCompletableFuture().join();
-                CiviFormProfile profile =
-                    profileUtils
-                        .currentUserProfile(request)
-                        .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
                 return ok(
                     editView.render(
                         applicationBaseViewParamsBuilder(
@@ -488,10 +478,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             httpExecutionContext.current())
         .thenComposeAsync(
             (roApplicantProgramService) -> {
-              CiviFormProfile profile =
-                  profileUtils
-                      .currentUserProfile(request)
-                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
               return renderErrorOrRedirectToNextBlock(
                   request,
                   profile,
@@ -546,10 +533,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             httpExecutionContext.current())
         .thenComposeAsync(
             roApplicantProgramService -> {
-              CiviFormProfile profile =
-                  profileUtils
-                      .currentUserProfile(request)
-                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
               return renderErrorOrRedirectToNextBlock(
                   request,
                   profile,
@@ -735,10 +719,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       Boolean isEligibilityEnabledOnThisBlock =
           thisBlockUpdated.getLeafAddressNodeServiceAreaIds().isPresent();
 
-      CiviFormProfile profile =
-          profileUtils
-              .currentUserProfile(request)
-              .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+      CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
 
       return CompletableFuture.completedFuture(
           ok(addressCorrectionBlockView.render(

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -364,10 +364,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           roApplicantProgramService,
                           messagesApi.preferred(request),
                           applicantId,
-                          profileUtils
-                              .currentUserProfile(request)
-                              .orElseThrow(
-                                  () -> new MissingOptionalException(CiviFormProfile.class))));
+                          profileUtils.currentUserProfileOrThrow(request)));
                 }
                 throw new RuntimeException(cause);
               }

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -160,10 +160,7 @@ public final class ApplicantProgramsController extends CiviFormController {
                       .map(ApplicantProgramData::program)
                       .filter(program -> program.id() == programId)
                       .findFirst();
-              CiviFormProfile profile =
-                  profileUtils
-                      .currentUserProfile(request)
-                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
               if (programDefinition.isPresent()) {
                 return ok(
                     programInfoView.render(
@@ -237,10 +234,7 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenApplyAsync(
             roApplicantService -> {
               Optional<Block> blockMaybe = roApplicantService.getFirstIncompleteOrStaticBlock();
-              CiviFormProfile profile =
-                  profileUtils
-                      .currentUserProfile(request)
-                      .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
+              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
               return blockMaybe.flatMap(
                   block ->
                       Optional.of(
@@ -256,14 +250,9 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenComposeAsync(
             resultMaybe -> {
               if (resultMaybe.isEmpty()) {
+                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
                 return supplyAsync(
-                    () ->
-                        redirect(
-                            applicantRoutes.review(
-                                requesterProfile.orElseThrow(
-                                    () -> new MissingOptionalException(CiviFormProfile.class)),
-                                applicantId,
-                                programId)));
+                    () -> redirect(applicantRoutes.review(profile, applicantId, programId)));
               }
               return supplyAsync(resultMaybe::get);
             },

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -143,5 +143,6 @@ public class WithMockedProfiles {
   private void mockProfile(CiviFormProfile profile) {
     when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile()))))
         .thenReturn(Optional.of(profile));
+    when(MOCK_UTILS.currentUserProfileOrThrow(not(argThat(skipUserProfile())))).thenReturn(profile);
   }
 }


### PR DESCRIPTION
### Description

Introduce a convenience method to `ProfileUtils` to reduce code noise.

Note that this doesn't remove *all* existing cases of `profile.orElseThrow(() -> ...)`. There are places where a controller has already retrieved an `Optional<CiviFormProfile>` and redirected the user to the home page for the empty case. Since we've already gone to the trouble to locate the profile at that point, it didn't seem worth it to use the new convenience method.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
