### PR TITLE
Enable new applicant URL schema for dev servers

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -46,3 +46,4 @@ application_exportable = true
 applicant_info_questions = true
 universal_questions = true
 program_card_images = false
+new_applicant_url_schema_enabled = true

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -538,8 +538,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
-        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
+        routes.ApplicantProgramBlocksController.edit(
+                program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);
   }
@@ -584,9 +584,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // check that the address correction screen is skipped and the user is redirected to the review
     // screen
-    String reviewRoute =
-        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
-            .url();
+    String reviewRoute = routes.ApplicantProgramReviewController.review(program.id).url();
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
@@ -623,9 +621,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
-    String reviewRoute =
-        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
-            .url();
+    String reviewRoute = routes.ApplicantProgramReviewController.review(program.id).url();
 
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
   }
@@ -837,8 +833,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     String nextBlockEditRoute =
-        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                applicant.id, program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
+        routes.ApplicantProgramBlocksController.edit(
+                program.id, /* blockId= */ "2", /* questionName= */ Optional.empty())
             .url();
     assertThat(result.redirectLocation()).hasValue(nextBlockEditRoute);
   }
@@ -870,9 +866,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
 
-    String reviewRoute =
-        routes.ApplicantProgramReviewController.reviewWithApplicantId(applicant.id, program.id)
-            .url();
+    String reviewRoute = routes.ApplicantProgramReviewController.review(program.id).url();
 
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
   }

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -155,9 +155,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains(
-            routes.ApplicantProgramsController.showWithApplicantId(currentApplicant.id, program.id)
-                .url());
+        .contains(routes.ApplicantProgramsController.show(String.valueOf(program.id)).url());
   }
 
   @Test
@@ -171,9 +169,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains(
-            routes.ApplicantProgramsController.showWithApplicantId(currentApplicant.id, program.id)
-                .url());
+        .contains(routes.ApplicantProgramsController.show(String.valueOf(program.id)).url());
   }
 
   @Test
@@ -223,10 +219,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains(
-            routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    currentApplicant.id, program.id)
-                .url());
+        .contains(routes.ApplicantProgramReviewController.review(program.id).url());
   }
 
   @Test
@@ -258,10 +251,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
-        .contains(
-            routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    currentApplicant.id, program.id)
-                .url());
+        .contains(routes.ApplicantProgramReviewController.review(program.id).url());
   }
 
   @Test
@@ -359,8 +349,8 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.ApplicantProgramBlocksController.editWithApplicantId(
-                    currentApplicant.id, program.id, "1", /* questionName= */ Optional.empty())
+            routes.ApplicantProgramBlocksController.edit(
+                    program.id, "1", /* questionName= */ Optional.empty())
                 .url());
   }
 
@@ -392,8 +382,8 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.ApplicantProgramBlocksController.editWithApplicantId(
-                    currentApplicant.id, program.id, "2", /* questionName= */ Optional.empty())
+            routes.ApplicantProgramBlocksController.edit(
+                    program.id, "2", /* questionName= */ Optional.empty())
                 .url());
   }
 

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -63,8 +63,8 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    applicant.id, programDefinition.id())
+            controllers.applicant.routes.ApplicantProgramReviewController.review(
+                    programDefinition.id())
                 .url());
   }
 
@@ -148,7 +148,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   public void programBySlug_testLanguageSelectorNotShownOneLanguage() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
-    ApplicantModel applicant = createApplicantWithMockedProfile();
+    createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
@@ -175,8 +175,8 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .join();
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    applicant.id, programDefinition.id())
+            controllers.applicant.routes.ApplicantProgramReviewController.review(
+                    programDefinition.id())
                 .url());
   }
 
@@ -184,7 +184,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   public void programBySlug_testLanguageSelectorNotShownNoLanguage() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
-    ApplicantModel applicant = createApplicantWithMockedProfile();
+    createApplicantWithMockedProfile();
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of());
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
@@ -211,8 +211,8 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .join();
     assertThat(result.redirectLocation())
         .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    applicant.id, programDefinition.id())
+            controllers.applicant.routes.ApplicantProgramReviewController.review(
+                    programDefinition.id())
                 .url());
   }
 }


### PR DESCRIPTION
### Description

Enable the new applicant URL schema for dev servers.

This also modifies behavior of unit tests, so a number of test cases were modified to reflect the schema revisions to date.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Relates to #5576 