### PR TITLE
Handle missing groups attribute in OIDC profile

### DIFF
--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -54,7 +54,7 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
   private boolean isGlobalAdmin(OidcProfile profile) {
     @SuppressWarnings("unchecked")
     List<String> groups = (List) profile.getAttribute(this.groupsAttributeName);
-    return groups.contains(this.adminGroupName);
+    return groups != null && groups.contains(this.adminGroupName);
   }
 
   @Override

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -86,6 +86,22 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
   }
 
   @Test
+  public void mergeCiviFormProfile_noGroupsInProfileDoesNotThrow() {
+    OidcProfile profile = new OidcProfile();
+    profile.addAttribute("email", "email@example.com");
+    profile.removeAttribute("groups");
+    // Required for OIDC profiles.
+    profile.addAttribute("iss", "issuer");
+    profile.setId("subject");
+
+    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    CiviFormProfileData profileData =
+        genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
+
+    assertThat(profileData.getRoles()).doesNotContain("ROLE_CIVIFORM_ADMIN");
+  }
+
+  @Test
   public void genericOidcProfileCreator_identityProviderTypeIsCorrect() {
     assertThat(genericOidcProfileCreator.identityProviderType())
         .isEqualTo(IdentityProviderType.ADMIN_IDENTITY_PROVIDER);


### PR DESCRIPTION
### Description

Before this change, `isGlobalAdmin()` would throw a `NullPointerException` if the OIDC profile did not contain the `groups` claim. Now we handle that case and return `false`.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

