### PR TITLE
Remove applicant id from URLs for block review action

### DIFF
--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -154,4 +154,26 @@ public final class ApplicantRoutes {
       return routes.ApplicantProgramBlocksController.edit(programId, blockId, questionName);
     }
   }
+
+  /**
+   * Returns the route corresponding to the applicant block review action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @return Route for the applicant block review action
+   */
+  public Call blockReview(
+      CiviFormProfile profile,
+      long applicantId,
+      long programId,
+      String blockId,
+      Optional<String> questionName) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramBlocksController.reviewWithApplicantId(
+          applicantId, programId, blockId, questionName);
+    } else {
+      return routes.ApplicantProgramBlocksController.review(programId, blockId, questionName);
+    }
+  }
 }

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -7,7 +7,9 @@ import static j2html.TagCreator.h2;
 import static j2html.TagCreator.h3;
 import static j2html.TagCreator.label;
 
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.TagCreator;
 import j2html.tags.specialized.ATag;
@@ -44,10 +46,12 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
   public static final String USER_KEEPING_ADDRESS_VALUE = "USER_KEEPING_ADDRESS_VALUE";
   public static final String SELECTED_ADDRESS_NAME = "selectedAddress";
   private final ApplicantLayout layout;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
-  AddressCorrectionBlockView(ApplicantLayout layout) {
+  AddressCorrectionBlockView(ApplicantLayout layout, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public Content render(
@@ -116,7 +120,11 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
               .withClasses("mb-8")
               .with(
                   renderAsEnteredHeading(
-                      params.applicantId(), params.programId(), params.block().getId(), messages),
+                      params.applicantId(),
+                      params.programId(),
+                      params.block().getId(),
+                      messages,
+                      params.profile()),
                   renderAddress(
                       addressAsEntered,
                       /* selected= */ !anySuggestions,
@@ -140,7 +148,11 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
   }
 
   private DivTag renderAsEnteredHeading(
-      long applicantId, long programId, String blockId, Messages messages) {
+      long applicantId,
+      long programId,
+      String blockId,
+      Messages messages,
+      CiviFormProfile profile) {
     DivTag containerDiv = div().withClass("flex flex-nowrap mb-2");
 
     ATag editElement =
@@ -148,8 +160,13 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
             .setStyles(
                 "bottom-0", "right-0", "text-blue-600", StyleUtils.hover("text-blue-700"), "mb-2")
             .setHref(
-                routes.ApplicantProgramBlocksController.review(
-                        applicantId, programId, blockId, /* questionName= */ Optional.empty())
+                applicantRoutes
+                    .blockReview(
+                        profile,
+                        applicantId,
+                        programId,
+                        blockId,
+                        /* questionName= */ Optional.empty())
                     .url())
             .setText(messages.at(MessageKey.LINK_EDIT.getKeyName()))
             .setIcon(Icons.EDIT, LinkElement.IconPosition.START)

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -12,7 +12,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import controllers.applicant.ApplicantRoutes;
-import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
 import java.time.LocalDate;
@@ -237,8 +236,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     if (data.isAnswered()) {
       editElement
           .setHref(
-              routes.ApplicantProgramBlocksController.review(
-                      applicantId, data.programId(), data.blockId(), questionName)
+              applicantRoutes
+                  .blockReview(profile, applicantId, data.programId(), data.blockId(), questionName)
                   .url())
           .setText(messages.at(MessageKey.LINK_EDIT.getKeyName()))
           .setIcon(Icons.EDIT, LinkElement.IconPosition.START);

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -153,6 +153,7 @@ GET     /programs/:programId/edit   controllers.applicant.ApplicantProgramsContr
 GET     /programs/:programId/review controllers.applicant.ApplicantProgramReviewController.review(request: Request, programId: Long)
 POST    /programs/:programId/submit controllers.applicant.ApplicantProgramReviewController.submit(request: Request, programId: Long)
 GET     /programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
+GET     /programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
 
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
@@ -172,7 +173,7 @@ GET     /applicants/:applicantId/programs/:programId/edit                       
 GET     /applicants/:applicantId/programs/:programId/review                                    controllers.applicant.ApplicantProgramReviewController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long)
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submitWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.editWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
-GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
+GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previous(request: Request, applicantId: Long, programId: Long, previousBlockIndex: Int, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -574,7 +574,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testBlockRoute_forTrustedIntermediary() {
+  public void testBlockEditRoute_forTrustedIntermediary() {
     enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
@@ -589,6 +589,102 @@ public class ApplicantRoutesTest extends ResetPostgres {
                 .blockEdit(tiProfile, applicantId, programId, blockId, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockEditUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testBlockReviewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockReviewUrl =
+        String.format("/programs/%d/blocks/%s/review", programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testBlockReviewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockReviewUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  public void testBlockReviewRoute_forApplicantWithoutIdInProfile() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockReviewUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockReviewUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testBlockReviewRoute_forTrustedIntermediary() {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedBlockReviewUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .blockReview(tiProfile, applicantId, programId, blockId, Optional.empty())
+                .url())
+        .isEqualTo(expectedBlockReviewUrl);
 
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);


### PR DESCRIPTION
### Description

Remove applicant id from applicant block review URL.

This is done in the usual way: 
* define a new `ApplicantProgramBlocksController.review()` method that delegates to the existing method, 
* which is renamed to `reviewWithApplicantId()`.
* Create a new `ApplicantRoutes.blockReview()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 