### PR TITLE
Ignore program image tests

### DIFF
--- a/browser-test/src/admin_program_image.test.ts
+++ b/browser-test/src/admin_program_image.test.ts
@@ -112,7 +112,10 @@ describe('Admin can manage program image', () => {
     })
   })
 
-  describe('image file upload', () => {
+  // TODO(#5676): The program image files are stored in a new bucket in cloud storage,
+  // so our deploy scripts need to create that new bucket. Ignore this test until
+  // the deploy scripts are correctly updated (this test will fail otherwise).
+  xdescribe('image file upload', () => {
     const programName = 'Test program'
 
     beforeEach(async () => {


### PR DESCRIPTION
### Description

The program image tests are failing during the prober tests in a staging deploy because the program images are stored in a *new* cloud storage bucket but the deploy scripts haven't been correctly updated to create that new bucket: https://github.com/civiform/civiform-staging-deploy/actions/runs/7269688382.

Ignore the tests for now so that deploys can succeed.

### Issue(s) this completes

Epic: #5676 
