### PR TITLE
Remove applicant id from URLs for confirm address action

### DIFF
--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -139,6 +139,8 @@ public final class ApplicantRoutes {
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).
    * @param applicantId - ID of applicant for whom the action should be performed.
    * @param programId - ID of program to review
+   * @param blockId - ID of the block to edit
+   * @param questionName - Name of question being edited, if applicable
    * @return Route for the applicant block edit action
    */
   public Call blockEdit(
@@ -161,6 +163,8 @@ public final class ApplicantRoutes {
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).
    * @param applicantId - ID of applicant for whom the action should be performed.
    * @param programId - ID of program to review
+   * @param blockId - ID of block to review
+   * @param questionName - Name of the question being reviewed, if applicable.
    * @return Route for the applicant block review action
    */
   public Call blockReview(
@@ -174,6 +178,26 @@ public final class ApplicantRoutes {
           applicantId, programId, blockId, questionName);
     } else {
       return routes.ApplicantProgramBlocksController.review(programId, blockId, questionName);
+    }
+  }
+
+  /**
+   * Returns the route corresponding to the applicant confirm address action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @param blockId - ID of the block containing the address
+   * @param inReview - true if executing the review action (as opposed to edit)
+   * @return Route for the applicant confirm address action
+   */
+  public Call confirmAddress(
+      CiviFormProfile profile, long applicantId, long programId, String blockId, boolean inReview) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+          applicantId, programId, blockId, inReview);
+    } else {
+      return routes.ApplicantProgramBlocksController.confirmAddress(programId, blockId, inReview);
     }
   }
 }

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -10,7 +10,6 @@ import static j2html.TagCreator.label;
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.ApplicantRoutes;
-import controllers.applicant.routes;
 import j2html.TagCreator;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
@@ -92,8 +91,13 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
       ImmutableList<AddressSuggestion> suggestions,
       Boolean isEligibilityEnabled) {
     String formAction =
-        routes.ApplicantProgramBlocksController.confirmAddress(
-                params.applicantId(), params.programId(), params.block().getId(), params.inReview())
+        applicantRoutes
+            .confirmAddress(
+                params.profile(),
+                params.applicantId(),
+                params.programId(),
+                params.block().getId(),
+                params.inReview())
             .url();
 
     FormTag form =

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -154,6 +154,7 @@ GET     /programs/:programId/review controllers.applicant.ApplicantProgramReview
 POST    /programs/:programId/submit controllers.applicant.ApplicantProgramReviewController.submit(request: Request, programId: Long)
 GET     /programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
 GET     /programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
+POST    /programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, programId: Long, blockId: String, inReview: Boolean)
 
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
@@ -174,7 +175,7 @@ GET     /applicants/:applicantId/programs/:programId/review                     
 POST    /applicants/:applicantId/programs/:programId/submit                                    controllers.applicant.ApplicantProgramReviewController.submitWithApplicantId(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit                      controllers.applicant.ApplicantProgramBlocksController.editWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
-POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
+POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddressWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previous(request: Request, applicantId: Long, programId: Long, previousBlockIndex: Int, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)


### PR DESCRIPTION
### Description

Remove applicant id from applicant confirm address URL.

This is done in the usual way: 
* define a new `ApplicantProgramBlocksController.confirmAddress()` method that delegates to the existing method, 
* which is renamed to `confirmAddressWithApplicantId()`.
* Create a new `ApplicantRoutes.confirmAddress()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 