### PR TITLE
Added character length limit of program status

### DIFF
--- a/browser-test/src/civiform_admin_program_statuses.test.ts
+++ b/browser-test/src/civiform_admin_program_statuses.test.ts
@@ -82,6 +82,18 @@ describe('modify program statuses', () => {
       await dismissModal(page)
     })
 
+    it('fails to create status exceeding 35 character limit', async () => {
+      const {page, adminProgramStatuses} = ctx
+      await adminProgramStatuses.createStatus(
+        'looooooooooooooooooooooooooooooooooog',
+      )
+      await adminProgramStatuses.expectProgramManageStatusesPage(programName)
+      await adminProgramStatuses.expectCreateStatusModalWithError(
+        'This field is limited to 35 characters.',
+      )
+      await dismissModal(page)
+    })
+
     it('fails to create status with an existing name', async () => {
       const {page, adminProgramStatuses} = ctx
       await adminProgramStatuses.createStatus('Existing status')

--- a/server/app/forms/admin/ProgramStatusesForm.java
+++ b/server/app/forms/admin/ProgramStatusesForm.java
@@ -98,6 +98,10 @@ public final class ProgramStatusesForm implements Validatable<List<ValidationErr
     if (Strings.isNullOrEmpty(statusText)) {
       return ImmutableList.of(new ValidationError("statusText", "This field is required."));
     }
+    if (statusText.trim().length() > 35) {
+      return ImmutableList.of(
+          new ValidationError("statusText", "This field is limited to 35 characters."));
+    }
     return ImmutableList.of();
   }
 }

--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -76,7 +76,7 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
     // "Markdown" the program description.
     ImmutableList<DomContent> items =
         TextFormatter.formatText(
-            programInfo, /*preserveEmptyLines= */ true, /*addRequiredIndicator= */ false);
+            programInfo, /* preserveEmptyLines= */ true, /* addRequiredIndicator= */ false);
 
     DivTag descriptionDiv = div().withClasses("py-2").with(items);
 


### PR DESCRIPTION
### Description

Limiting the status of a program to 35 characters. With the change, issue #5000 will get fixed. Below is a screenshot of status being updated to a 35-character-length string not overflowing the banner.
 
<img width="550" alt="Screenshot 2023-12-20 at 11 07 20 AM" src="https://github.com/civiform/civiform/assets/149536150/0899e5c1-1652-4254-8e84-551777051037">


## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5000
