### PR TITLE
Update cache clearing behavior

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -134,7 +134,16 @@ public class DevDatabaseSeedController extends Controller {
     return ok("The cache has been cleared");
   }
 
+  /**
+   * Clear cache if it is enabled in settings.
+   *
+   * <p>Note: this is not safe to do in most deployed instances, because there may be multiple
+   * tasks, but we assume all dev instances only have one task.
+   */
   private void clearCacheIfEnabled() {
+    if (!isDevOrStaging) {
+      return;
+    }
     if (settingsManifest.getVersionCacheEnabled()) {
       programsByVersionCache.removeAll().toCompletableFuture().join();
       questionsByVersionCache.removeAll().toCompletableFuture().join();

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -18,7 +18,6 @@ import io.ebean.Transaction;
 import io.ebean.TxScope;
 import io.ebean.annotation.TxIsolation;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -608,15 +607,14 @@ public final class VersionRepository {
         .anyMatch(activeProgram -> activeProgram.id.equals(program.id));
   }
 
-  /** Returns true if the program contains a version in draft. */
+  public boolean isDraft(QuestionModel question) {
+    return getQuestionsForVersion(getDraftVersion()).stream()
+        .anyMatch(draftQuestion -> draftQuestion.id.equals(question.id));
+  }
+
+  /** Returns true if the program is a member of the current draft version. */
   public boolean isDraft(ProgramModel program) {
-    VersionModel activeVersion = getActiveVersion();
-    VersionModel maxVersionForProgram =
-      programRepository.getVersionsForProgram(program).stream()
-        .max(Comparator.comparingLong(p -> p.id))
-        .orElseThrow();
-    // If the max version ID is larger than the active version ID, the program contains a version in draft.
-    return maxVersionForProgram.id > activeVersion.id;
+    return isDraftProgram(program.id);
   }
 
   /** Returns true if the program with the provided id is a member of the current draft version. */

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -18,6 +18,7 @@ import io.ebean.Transaction;
 import io.ebean.TxScope;
 import io.ebean.annotation.TxIsolation;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -607,14 +608,15 @@ public final class VersionRepository {
         .anyMatch(activeProgram -> activeProgram.id.equals(program.id));
   }
 
-  public boolean isDraft(QuestionModel question) {
-    return getQuestionsForVersion(getDraftVersion()).stream()
-        .anyMatch(draftQuestion -> draftQuestion.id.equals(question.id));
-  }
-
-  /** Returns true if the program is a member of the current draft version. */
+  /** Returns true if the program contains a version in draft. */
   public boolean isDraft(ProgramModel program) {
-    return isDraftProgram(program.id);
+    VersionModel activeVersion = getActiveVersion();
+    VersionModel maxVersionForProgram =
+      programRepository.getVersionsForProgram(program).stream()
+        .max(Comparator.comparingLong(p -> p.id))
+        .orElseThrow();
+    // If the max version ID is larger than the active version ID, the program contains a version in draft.
+    return maxVersionForProgram.id > activeVersion.id;
   }
 
   /** Returns true if the program with the provided id is a member of the current draft version. */

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import controllers.BadRequestException;
 import forms.BlockForm;
@@ -226,9 +225,9 @@ public final class ProgramService {
   private CompletionStage<ProgramDefinition> syncProgramAssociations(ProgramModel program) {
     VersionModel activeVersion = versionRepository.getActiveVersion();
     VersionModel maxVersionForProgram =
-      programRepository.getVersionsForProgram(program).stream()
-        .max(Comparator.comparingLong(p -> p.id))
-        .orElseThrow();
+        programRepository.getVersionsForProgram(program).stream()
+            .max(Comparator.comparingLong(p -> p.id))
+            .orElseThrow();
     // If the max version is greater than the active version, it is a draft
     if (maxVersionForProgram.id > activeVersion.id) {
       // This method makes multiple calls to get questions for the active and
@@ -1652,9 +1651,9 @@ public final class ProgramService {
    */
   private CompletionStage<ProgramDefinition> syncProgramDefinitionQuestions(
       ProgramDefinition programDefinition) {
-    // Note: This method is also used for non question updates.  We should
-    // have a focused method for that because getReadOnlyQuestionService() makes
-    // multiple calls to get question data for the active and draft versions.
+    // Note: This method is also used for non question updates.
+    // TODO(#6249) We should have a focused method for that because getReadOnlyQuestionService()
+    // makes multiple calls to get question data for the active and draft versions.
     return questionService
         .getReadOnlyQuestionService()
         .thenApplyAsync(

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import controllers.BadRequestException;
 import forms.BlockForm;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -223,25 +224,24 @@ public final class ProgramService {
   }
 
   private CompletionStage<ProgramDefinition> syncProgramAssociations(ProgramModel program) {
-    if (isActiveOrDraftProgram(program)) {
+    VersionModel activeVersion = versionRepository.getActiveVersion();
+    VersionModel maxVersionForProgram =
+      programRepository.getVersionsForProgram(program).stream()
+        .max(Comparator.comparingLong(p -> p.id))
+        .orElseThrow();
+    // If the max version is greater than the active version, it is a draft
+    if (maxVersionForProgram.id > activeVersion.id) {
+      // This method makes multiple calls to get questions for the active and
+      // draft versions, so we should only call it if we're syncing program
+      // associations for a draft program (which means we're in the admin flow).
       return syncProgramDefinitionQuestions(program.getProgramDefinition())
           .thenApply(ProgramDefinition::orderBlockDefinitions);
     }
 
-    // Any version that the program is in has all the questions the program has.
-    VersionModel version =
-        programRepository.getVersionsForProgram(program).stream().findAny().get();
     ProgramDefinition programDefinition =
-        syncProgramDefinitionQuestions(program.getProgramDefinition(), version);
+        syncProgramDefinitionQuestions(program.getProgramDefinition(), maxVersionForProgram);
 
     return CompletableFuture.completedStage(programDefinition.orderBlockDefinitions());
-  }
-
-  private boolean isActiveOrDraftProgram(ProgramModel program) {
-    return Streams.concat(
-            versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream(),
-            versionRepository.getProgramsForVersion(versionRepository.getDraftVersion()).stream())
-        .anyMatch(p -> p.id.equals(program.id));
   }
 
   /**
@@ -1652,8 +1652,9 @@ public final class ProgramService {
    */
   private CompletionStage<ProgramDefinition> syncProgramDefinitionQuestions(
       ProgramDefinition programDefinition) {
-    // Note: This method is also used for non question updates.  It'd likely be
-    // good to have a focused method for that.
+    // Note: This method is also used for non question updates.  We should
+    // have a focused method for that because getReadOnlyQuestionService() makes
+    // multiple calls to get question data for the active and draft versions.
     return questionService
         .getReadOnlyQuestionService()
         .thenApplyAsync(

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -41,9 +41,6 @@ public class VersionRepositoryTest extends ResetPostgres {
   private VersionRepository versionRepository;
   private SyncCacheApi questionsByVersionCache;
   private SyncCacheApi programsByVersionCache;
-  private SyncCacheApi programCache;
-  private SyncCacheApi versionsByProgramCache;
-
   private SettingsManifest mockSettingsManifest;
 
   @Before
@@ -51,17 +48,13 @@ public class VersionRepositoryTest extends ResetPostgres {
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     questionsByVersionCache = instanceOf(SyncCacheApi.class);
     programsByVersionCache = instanceOf(SyncCacheApi.class);
-    programCache = instanceOf(SyncCacheApi.class);
-    versionsByProgramCache = instanceOf(SyncCacheApi.class);
     versionRepository =
         new VersionRepository(
             instanceOf(ProgramRepository.class),
             instanceOf(DatabaseExecutionContext.class),
             mockSettingsManifest,
             questionsByVersionCache,
-            programsByVersionCache,
-            programCache,
-            versionsByProgramCache);
+            programsByVersionCache);
   }
 
   @Test
@@ -999,10 +992,6 @@ public class VersionRepositoryTest extends ResetPostgres {
     version2.refresh();
 
     String version1Key = String.valueOf(version1.id);
-
-    // Remove the questionCache for this version, since it is cached in
-    // publishNewSynchronizedVersion, but we're associating questions with it later.
-    questionsByVersionCache.remove(version1Key);
 
     // Associate question with obsolete version
     QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -836,6 +836,9 @@ public class ApplicantServiceTest extends ResetPostgres {
                         .build()))
             .getResult();
 
+    // Publish version and fetch results
+    versionRepository.publishNewSynchronizedVersion();
+
     ProgramModel firstProgram =
         ProgramBuilder.newActiveProgram("first test program", "desc")
             .withBlock()
@@ -2567,8 +2570,6 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    // Publish version and fetch results
-    versionRepository.publishNewSynchronizedVersion();
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2587,7 +2588,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
-    System.out.println("reemax setting up pqs");
     // Set up program and questions
     NameQuestionDefinition eligibleQuestion =
         createNameQuestion("question_with_matching_eligibility");
@@ -2619,7 +2619,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .build();
     programWithEligibleAndIneligibleAnswers.save();
     versionRepository.publishNewSynchronizedVersion();
-    System.out.println("published 1");
 
     // Fill out application
     answerNameQuestion(
@@ -2634,7 +2633,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .id(),
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
-    System.out.println("answered 1");
     answerNameQuestion(
         ineligibleQuestion,
         "Solána",
@@ -2648,18 +2646,12 @@ public class ApplicantServiceTest extends ResetPostgres {
         applicant.id,
         programWithEligibleAndIneligibleAnswers.id);
 
-    System.out.println("answered 2");
-
     applicationRepository
         .submitApplication(
             applicant.id, programWithEligibleAndIneligibleAnswers.id, Optional.empty())
         .toCompletableFuture()
         .join();
-    System.out.println("submitted ");
 
-    // Publish version and fetch results
-    versionRepository.publishNewSynchronizedVersion();
-    System.out.println("publish2");
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2714,8 +2706,6 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    // Publish version and fetch results
-    versionRepository.publishNewSynchronizedVersion();
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)
@@ -2763,8 +2753,6 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    // Publish version and fetch results
-    versionRepository.publishNewSynchronizedVersion();
     var result =
         subject
             .maybeEligibleProgramsForApplicant(applicant.id, trustedIntermediaryProfile)


### PR DESCRIPTION
### Description

Remove cases where we're clearing the cache when we don't need to. We thought this was needed, but really we were making unnecessary calls to create and drafts when we didn't need to. Since we aren't doing that anymore after https://github.com/civiform/civiform/pull/6244, we can remove this here. Additionally, we should never clear the cache outside of the dev instance because if there is more than one task, this wouldn't work as intended (entity may exist in one cache even if it was cleared in another). Added a comment to make that clear.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
