### PR TITLE
Remove applicant id from URLs for update file action

### DIFF
--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -225,4 +225,24 @@ public final class ApplicantRoutes {
           programId, previousBlockIndex, inReview);
     }
   }
+
+  /**
+   * Returns the route corresponding to the applicant update file action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @param blockId - ID of the block containing file upload question
+   * @param inReview - true if executing the review action (as opposed to edit)
+   * @return Route for the applicant update file action
+   */
+  public Call updateFile(
+      CiviFormProfile profile, long applicantId, long programId, String blockId, boolean inReview) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+          applicantId, programId, blockId, inReview);
+    } else {
+      return routes.ApplicantProgramBlocksController.updateFile(programId, blockId, inReview);
+    }
+  }
 }

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -1,5 +1,6 @@
 package views.applicant;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
@@ -8,6 +9,7 @@ import static j2html.TagCreator.p;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import controllers.applicant.ApplicantRoutes;
 import controllers.applicant.routes;
 import j2html.TagCreator;
 import j2html.tags.specialized.ButtonTag;
@@ -46,10 +48,13 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
   private static final String FILEUPLOAD_CONTINUE_BUTTON_ID = "fileupload-continue-button";
 
   private final FileUploadViewStrategy fileUploadViewStrategy;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
-  public ApplicantFileUploadRenderer(FileUploadViewStrategy fileUploadViewStrategy) {
-    this.fileUploadViewStrategy = fileUploadViewStrategy;
+  public ApplicantFileUploadRenderer(
+      FileUploadViewStrategy fileUploadViewStrategy, ApplicantRoutes applicantRoutes) {
+    this.fileUploadViewStrategy = checkNotNull(fileUploadViewStrategy);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   /**
@@ -107,7 +112,9 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
       Params params, ApplicantQuestionRendererFactory applicantQuestionRendererFactory) {
     String onSuccessRedirectUrl =
         params.baseUrl()
-            + routes.ApplicantProgramBlocksController.updateFile(
+            + applicantRoutes
+                .updateFile(
+                    params.profile(),
                     params.applicantId(),
                     params.programId(),
                     params.block().getId(),

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -156,6 +156,7 @@ GET     /programs/:programId/blocks/:blockId/edit                      controlle
 GET     /programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.review(request: Request, programId: Long, blockId: String, questionName: java.util.Optional[String])
 POST    /programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, programId: Long, blockId: String, inReview: Boolean)
 GET     /programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previous(request: Request, programId: Long, previousBlockIndex: Int, inReview: Boolean)
+GET     /programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, programId: Long, blockId: String, inReview: Boolean)
 
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
@@ -178,7 +179,7 @@ GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit       
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                    controllers.applicant.ApplicantProgramBlocksController.reviewWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, questionName: java.util.Optional[String])
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddressWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previousWithApplicantId(request: Request, applicantId: Long, programId: Long, previousBlockIndex: Int, inReview: Boolean)
-GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
+GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFileWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 
 # API

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -634,13 +634,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badApplicantId = applicant.id + 1000;
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 badApplicantId, program.id, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 badApplicantId,
                 program.id,
@@ -663,7 +663,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateFile(
+                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -689,7 +689,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateFile(
+                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -709,7 +709,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateFile(
+                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -731,13 +731,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badProgramId = program.id + 1000;
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, badProgramId, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 applicant.id,
                 badProgramId,
@@ -754,13 +754,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String badBlockId = "1000";
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(), applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
@@ -773,13 +773,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String badBlockId = "1";
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(), applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
@@ -791,12 +791,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void updateFile_missingFileKeyAndBucket_returnsBadRequest() {
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "2", /* inReview= */ false));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 applicant.id,
                 program.id,
@@ -819,13 +819,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 applicant.id,
                 program.id,
@@ -852,13 +852,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 applicant.id,
                 program.id,
@@ -895,13 +895,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFile(
+            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
                 applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", fileKey, "bucket", "fake-bucket"));
 
     Result result =
         subject
-            .updateFile(
+            .updateFileWithApplicantId(
                 request.build(),
                 applicant.id,
                 program.id,

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -928,4 +928,110 @@ public class ApplicantRoutesTest extends ResetPostgres {
     assertThat(after.present).isEqualTo(before.present);
     assertThat(after.absent).isEqualTo(before.absent + 1);
   }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateFileRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateFileUrl =
+        String.format("/programs/%d/blocks/%s/updateFile/%s", programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateFile(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateFileUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateFileRoute_forApplicantWithIdInProfile_newSchemaDisabled(String inReview) {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateFileUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
+            applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateFile(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateFileUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateFileRoute_forApplicantWithoutIdInProfile(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateFileUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
+            applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateFile(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateFileUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateFileRoute_forTrustedIntermediary(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateFileUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
+            applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateFile(tiProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateFileUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
 }

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -3,18 +3,23 @@ package views.questiontypes;
 import static j2html.TagCreator.document;
 import static j2html.TagCreator.html;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static play.test.Helpers.stubMessagesApi;
 
 import com.google.common.collect.ImmutableSet;
+import controllers.applicant.ApplicantRoutes;
 import j2html.tags.specialized.DivTag;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionType;
+import services.settings.SettingsManifest;
 import views.applicant.ApplicantFileUploadRenderer;
 import views.fileupload.AwsFileUploadViewStrategy;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
@@ -30,6 +35,13 @@ public class ApplicantQuestionRendererFactoryTest {
           .setErrorDisplayMode(ErrorDisplayMode.HIDE_ERRORS)
           .build();
 
+  private final SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+
+  @Before
+  public void setupMock() {
+    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
+  }
+
   @Test
   @Parameters(source = QuestionType.class)
   public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
@@ -38,9 +50,11 @@ public class ApplicantQuestionRendererFactoryTest {
       return;
     }
 
+    var applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+
     ApplicantQuestionRendererFactory factory =
         new ApplicantQuestionRendererFactory(
-            new ApplicantFileUploadRenderer(new AwsFileUploadViewStrategy()));
+            new ApplicantFileUploadRenderer(new AwsFileUploadViewStrategy(), applicantRoutes));
 
     ApplicantQuestionRenderer sampleRenderer = factory.getSampleRenderer(type);
 
@@ -59,10 +73,12 @@ public class ApplicantQuestionRendererFactoryTest {
       return;
     }
 
+    var applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+
     // Multi-input questions should be wrapped in fieldsets for screen reader users.
     ApplicantQuestionRendererFactory factory =
         new ApplicantQuestionRendererFactory(
-            new ApplicantFileUploadRenderer(new AwsFileUploadViewStrategy()));
+            new ApplicantFileUploadRenderer(new AwsFileUploadViewStrategy(), applicantRoutes));
 
     ApplicantQuestionRenderer sampleRenderer = factory.getSampleRenderer(type);
 


### PR DESCRIPTION
### Description

Remove applicant id from applicant update file URL.

This is done in the usual way: 
* define a new `ApplicantProgramBlocksController.updateFile()` method that delegates to the existing method, 
* which is renamed to `updateFileWithApplicantId()`.
* Create a new `ApplicantRoutes.updateFile()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 