### PR TITLE
Remove applicant id from URLs for update block action

### DIFF
--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -245,4 +245,24 @@ public final class ApplicantRoutes {
       return routes.ApplicantProgramBlocksController.updateFile(programId, blockId, inReview);
     }
   }
+
+  /**
+   * Returns the route corresponding to the applicant update block action.
+   *
+   * @param profile - Profile corresponding to the logged-in user (applicant or TI).
+   * @param applicantId - ID of applicant for whom the action should be performed.
+   * @param programId - ID of program to review
+   * @param blockId - ID of the block to be updated
+   * @param inReview - true if executing the review action (as opposed to edit)
+   * @return Route for the applicant update block action
+   */
+  public Call updateBlock(
+      CiviFormProfile profile, long applicantId, long programId, String blockId, boolean inReview) {
+    if (includeApplicantIdInRoute(profile)) {
+      return routes.ApplicantProgramBlocksController.updateWithApplicantId(
+          applicantId, programId, blockId, inReview);
+    } else {
+      return routes.ApplicantProgramBlocksController.update(programId, blockId, inReview);
+    }
+  }
 }

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -10,7 +10,6 @@ import static j2html.TagCreator.p;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.ApplicantRoutes;
-import controllers.applicant.routes;
 import j2html.TagCreator;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -233,8 +232,13 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
    */
   private DivTag renderDeleteAndContinueFileUploadForms(Params params) {
     String formAction =
-        routes.ApplicantProgramBlocksController.update(
-                params.applicantId(), params.programId(), params.block().getId(), params.inReview())
+        applicantRoutes
+            .updateBlock(
+                params.profile(),
+                params.applicantId(),
+                params.programId(),
+                params.block().getId(),
+                params.inReview())
             .url();
     ApplicantQuestionRendererParams rendererParams =
         ApplicantQuestionRendererParams.builder()

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -8,7 +8,7 @@ import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMo
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.assistedinject.Assisted;
-import controllers.applicant.routes;
+import controllers.applicant.ApplicantRoutes;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -37,15 +37,18 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
   private final ApplicantLayout layout;
   private final ApplicantFileUploadRenderer applicantFileUploadRenderer;
   private final ApplicantQuestionRendererFactory applicantQuestionRendererFactory;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   ApplicantProgramBlockEditView(
       ApplicantLayout layout,
       ApplicantFileUploadRenderer applicantFileUploadRenderer,
-      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory) {
+      @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory,
+      ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
     this.applicantFileUploadRenderer = checkNotNull(applicantFileUploadRenderer);
     this.applicantQuestionRendererFactory = checkNotNull(applicantQuestionRendererFactory);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   public Content render(Params params) {
@@ -142,8 +145,13 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
     }
 
     String formAction =
-        routes.ApplicantProgramBlocksController.update(
-                params.applicantId(), params.programId(), params.block().getId(), params.inReview())
+        applicantRoutes
+            .updateBlock(
+                params.profile(),
+                params.applicantId(),
+                params.programId(),
+                params.block().getId(),
+                params.inReview())
             .url();
 
     AtomicInteger ordinalErrorCount = new AtomicInteger(0);

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -157,6 +157,7 @@ GET     /programs/:programId/blocks/:blockId/review                    controlle
 POST    /programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddress(request: Request, programId: Long, blockId: String, inReview: Boolean)
 GET     /programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previous(request: Request, programId: Long, previousBlockIndex: Int, inReview: Boolean)
 GET     /programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, programId: Long, blockId: String, inReview: Boolean)
+POST    /programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.update(request: Request, programId: Long, blockId: String, inReview: Boolean)
 
 # This route is special. It may specify a program by id or by program
 # slug. Since Play doesn't allow overloaded controller methods, accept
@@ -180,7 +181,7 @@ GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review     
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/confirmAddress/:inReview  controllers.applicant.ApplicantProgramBlocksController.confirmAddressWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:previousBlockIndex/previous/:inReview     controllers.applicant.ApplicantProgramBlocksController.previousWithApplicantId(request: Request, applicantId: Long, programId: Long, previousBlockIndex: Int, inReview: Boolean)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFileWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
-POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
+POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.updateWithApplicantId(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 
 # API
 GET     /api/v1/checkAuth                                   controllers.api.CiviFormApiController.checkAuth()

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -322,13 +322,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badApplicantId = applicant.id + 1000;
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     badApplicantId, program.id, /* blockId= */ "1", /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(request, badApplicantId, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, badApplicantId, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -346,7 +347,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.update(
+                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -372,7 +373,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.update(
+                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -392,7 +393,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.update(
+                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
                         applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)))
             .build();
     Result result =
@@ -414,13 +415,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badProgramId = program.id + 1000;
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, badProgramId, /* blockId= */ "1", /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, badProgramId, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, badProgramId, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -432,13 +434,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String badBlockId = "1000";
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, program.id, badBlockId, /* inReview= */ false))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, badBlockId, /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, badBlockId, /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -449,14 +452,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_invalidPathsInRequest_returnsBadRequest() {
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(ImmutableMap.of("fake.path", "value"))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -468,14 +472,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String reservedPath = Path.create("metadata").join(Scalar.PROGRAM_UPDATED_IN).toString();
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(ImmutableMap.of(reservedPath, "value"))
             .build();
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -487,7 +492,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                        routes.ApplicantProgramBlocksController.update(
+                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
                     .bodyForm(
                         ImmutableMap.of(
@@ -503,7 +508,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -523,7 +529,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
@@ -535,7 +541,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -557,7 +564,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     Request request =
         addCSRFToken(
                 requestBuilderWithSettings(
-                        routes.ApplicantProgramBlocksController.update(
+                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id, program.id, "1", false))
                     .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
                     .bodyForm(
@@ -581,7 +588,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 
@@ -606,7 +614,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
@@ -618,7 +626,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Result result =
         subject
-            .update(request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -307,7 +307,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   private void answer(long programId) {
     Request request =
         requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.update(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id, programId, /* blockId= */ "1", /* inReview= */ false))
             .bodyForm(
                 ImmutableMap.of(
@@ -319,7 +319,8 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
     Result result =
         blockController
-            .update(request, applicant.id, programId, /* blockId= */ "1", /* inReview= */ false)
+            .updateWithApplicantId(
+                request, applicant.id, programId, /* blockId= */ "1", /* inReview= */ false)
             .toCompletableFuture()
             .join();
 

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -1034,4 +1034,107 @@ public class ApplicantRoutesTest extends ResetPostgres {
     assertThat(after.present).isEqualTo(before.present);
     assertThat(after.absent).isEqualTo(before.absent + 1);
   }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateBlockRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateBlockUrl =
+        String.format("/programs/%d/blocks/%s/%s", programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateBlock(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateBlockUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateBlockRoute_forApplicantWithIdInProfile_newSchemaDisabled(String inReview) {
+    disableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateBlockUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateBlock(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateBlockUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present + 1);
+    assertThat(after.absent).isEqualTo(before.absent);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateBlockRoute_forApplicantWithoutIdInProfile(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateBlockUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateBlock(
+                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateBlockUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void testUpdateBlockRoute_forTrustedIntermediary(String inReview) {
+    enableNewApplicantUrlSchema();
+    Counts before = getApplicantIdInProfileCounts();
+
+    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    profileData.addRole(Role.ROLE_TI.toString());
+    CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedUpdateBlockUrl =
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
+    assertThat(
+            new ApplicantRoutes(mockSettingsManifest)
+                .updateBlock(tiProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                .url())
+        .isEqualTo(expectedUpdateBlockUrl);
+
+    Counts after = getApplicantIdInProfileCounts();
+    assertThat(after.present).isEqualTo(before.present);
+    assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
 }

--- a/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
+++ b/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
@@ -1,15 +1,19 @@
 package views.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_ERROR;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.NONE;
 
+import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import repository.ResetPostgres;
 import services.question.types.QuestionDefinition;
+import services.settings.SettingsManifest;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 import views.questiontypes.ApplicantQuestionRendererParams;
 
@@ -17,15 +21,20 @@ public class ApplicantProgramBlockEditViewTest extends ResetPostgres {
 
   private static QuestionDefinition ADDRESS_QD =
       testQuestionBank.applicantAddress().getQuestionDefinition();
-  // While mocking is generally discouraged, some tests in this file don't need c'tor so mocking
-  // them is a
-  // convenient way to construct an instance of the class under test. The mocks are
-  // not otherwise used.
+  private static SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+  private static ApplicantRoutes applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+
   private static ApplicantProgramBlockEditView EMPTY_VIEW =
       new ApplicantProgramBlockEditView(
           Mockito.mock(ApplicantLayout.class),
           Mockito.mock(ApplicantFileUploadRenderer.class),
-          Mockito.mock(ApplicantQuestionRendererFactory.class));
+          Mockito.mock(ApplicantQuestionRendererFactory.class),
+          applicantRoutes);
+
+  @BeforeClass
+  public static void setupMock() {
+    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
+  }
 
   @Test
   public void


### PR DESCRIPTION
### Description

Remove applicant id from applicant update block URL.

This is done in the usual way: 
* define a new `ApplicantProgramBlocksController.update()` method that delegates to the existing method, 
* which is renamed to `updateWithApplicantId()`.
* Create a new `ApplicantRoutes.updateBlock()` method which determines which controller method to invoke, and
* revise the callsites to use the new applicant route method.

Here is a [cookbook](https://docs.google.com/document/d/1s9I6YLOSisCHpG9DrjSDgWsVsfnVTcXNTq73mftGjLM/edit?usp=sharing) for these changes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Relates to #5576 