### PR TITLE
Enable new applicant URL schema

### DIFF
--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -66,5 +66,5 @@ suggest_programs_on_application_confirmation_page = false
 suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE}
 
 # New Applicant URL Schema
-new_applicant_url_schema_enabled = false
+new_applicant_url_schema_enabled = true
 new_applicant_url_schema_enabled = ${?NEW_APPLICANT_URL_SCHEMA_ENABLED}


### PR DESCRIPTION
### Description

Enable new applicant URL schema everywhere. Applicant URLs will no longer contain the leading `/applicants/:id` portion of the URL path.

The new schema is already enabled in staging (AWS and Seattle).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #5576 
