### PR TITLE
Refactor question.getQuestionDefinition to be called from questionRepository

### DIFF
--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Optional;
 import java.util.function.Function;
-import models.QuestionModel;
 import models.VersionModel;
 import repository.VersionRepository;
 import services.DeletionStatus;
@@ -48,14 +47,12 @@ public final class ActiveAndDraftQuestions {
     VersionModel draft = repository.getDraftVersionOrCreate();
     VersionModel withDraftEdits = repository.previewPublishNewSynchronizedVersion();
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
-        repository.getQuestionsForVersion(active).stream()
-            .map(QuestionModel::getQuestionDefinition)
+        repository.getQuestionDefinitionsForVersion(active).stream()
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.activeQuestions = activeNameToQuestion.values().asList();
 
     ImmutableMap<String, QuestionDefinition> draftNameToQuestion =
-        repository.getQuestionsForVersion(draft).stream()
-            .map(QuestionModel::getQuestionDefinition)
+        repository.getQuestionDefinitionsForVersion(draft).stream()
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, Function.identity()));
     this.draftQuestions = draftNameToQuestion.values().asList();
 

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import models.QuestionModel;
 import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +36,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
     ImmutableSet.Builder<QuestionDefinition> upToDateBuilder = ImmutableSet.builder();
     Set<String> namesFoundInDraft = new HashSet<>();
     for (QuestionDefinition qd :
-        repository.getQuestionsForVersion(draftVersion).stream()
-            .map(QuestionModel::getQuestionDefinition)
+        repository.getQuestionDefinitionsForVersion(draftVersion).stream()
             .collect(Collectors.toList())) {
       if (!draftVersion.getTombstonedQuestionNames().contains(qd.getName())) {
         // If the question is about to be deleted, it is not "up to date."
@@ -48,8 +46,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
       namesFoundInDraft.add(qd.getName());
     }
     for (QuestionDefinition qd :
-        repository.getQuestionsForVersion(activeVersion).stream()
-            .map(QuestionModel::getQuestionDefinition)
+        repository.getQuestionDefinitionsForVersion(activeVersion).stream()
             .collect(Collectors.toList())) {
 
       questionIdMap.put(qd.getId(), qd);

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import models.QuestionModel;
 import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +26,7 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
   public ReadOnlyVersionedQuestionServiceImpl(
       VersionModel version, VersionRepository versionRepository) {
     questionsById =
-        versionRepository.getQuestionsForVersion(version).stream()
-            .map(QuestionModel::getQuestionDefinition)
+        versionRepository.getQuestionDefinitionsForVersion(version).stream()
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
   }
 

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -51,6 +51,7 @@ public class VersionRepositoryTest extends ResetPostgres {
     versionRepository =
         new VersionRepository(
             instanceOf(ProgramRepository.class),
+            instanceOf(QuestionRepository.class),
             instanceOf(DatabaseExecutionContext.class),
             mockSettingsManifest,
             questionsByVersionCache,

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -11,6 +11,7 @@ import models.ProgramModel;
 import models.QuestionModel;
 import models.VersionModel;
 import play.inject.Injector;
+import repository.QuestionRepository;
 import repository.VersionRepository;
 import services.LocalizedStrings;
 import services.program.BlockDefinition;
@@ -333,21 +334,25 @@ public class ProgramBuilder {
 
     /** Add a required question to the block. */
     public BlockBuilder withRequiredQuestion(QuestionModel question) {
+      QuestionRepository questionRepository = injector.instanceOf(QuestionRepository.class);
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
-              question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId)));
+              questionRepository.getQuestionDefinition(question),
+              Optional.of(programBuilder.programDefinitionId)));
       return this;
     }
 
     /** Add a required address question that has correction enabled to the block. */
     public BlockBuilder withRequiredCorrectedAddressQuestion(QuestionModel question) {
-      if (!(question.getQuestionDefinition() instanceof AddressQuestionDefinition)) {
+      QuestionRepository questionRepository = injector.instanceOf(QuestionRepository.class);
+      if (!(questionRepository.getQuestionDefinition(question)
+          instanceof AddressQuestionDefinition)) {
         throw new IllegalArgumentException("Only address questions can be address corrected.");
       }
 
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
-              question.getQuestionDefinition(),
+              questionRepository.getQuestionDefinition(question),
               Optional.of(programBuilder.programDefinitionId),
               /* optional= */ true,
               /* addressCorrectionEnabled= */ true));
@@ -355,7 +360,8 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withOptionalQuestion(QuestionModel question) {
-      return withOptionalQuestion(question.getQuestionDefinition());
+      QuestionRepository questionRepository = injector.instanceOf(QuestionRepository.class);
+      return withOptionalQuestion(questionRepository.getQuestionDefinition(question));
     }
 
     public BlockBuilder withOptionalQuestion(QuestionDefinition question) {
@@ -384,9 +390,10 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withRequiredQuestions(ImmutableList<QuestionModel> questions) {
+      QuestionRepository questionRepository = injector.instanceOf(QuestionRepository.class);
       return withRequiredQuestionDefinitions(
           questions.stream()
-              .map(QuestionModel::getQuestionDefinition)
+              .map(q -> questionRepository.getQuestionDefinition(q))
               .collect(ImmutableList.toImmutableList()));
     }
 


### PR DESCRIPTION
### Description

Refactors places that call `question.getQuestionDefinition()` to use a new function `getQuestionDefinition()`. The new function calls `question.getQuestionDefinition()` for now, but in the future we can set up caching for non-draft questions within that function. For now, no functionality is updated with this change. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release | database >

### Issue(s) this completes

#6263 