### PR TITLE
Create a cache for the full program definition

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -37,6 +37,7 @@ public class DevDatabaseSeedController extends Controller {
   private final AsyncCacheApi questionsByVersionCache;
   private final AsyncCacheApi programsByVersionCache;
   private final AsyncCacheApi programCache;
+  private final AsyncCacheApi programDefCache;
   private final AsyncCacheApi versionsByProgramCache;
 
   @Inject
@@ -51,6 +52,7 @@ public class DevDatabaseSeedController extends Controller {
       @NamedCache("version-questions") AsyncCacheApi questionsByVersionCache,
       @NamedCache("version-programs") AsyncCacheApi programsByVersionCache,
       @NamedCache("program") AsyncCacheApi programCache,
+      @NamedCache("program-definition") AsyncCacheApi programDefCache,
       @NamedCache("program-versions") AsyncCacheApi versionsByProgramCache) {
     this.devDatabaseSeedTask = checkNotNull(devDatabaseSeedTask);
     this.view = checkNotNull(view);
@@ -63,6 +65,7 @@ public class DevDatabaseSeedController extends Controller {
     this.questionsByVersionCache = checkNotNull(questionsByVersionCache);
     this.programsByVersionCache = checkNotNull(programsByVersionCache);
     this.programCache = checkNotNull(programCache);
+    this.programDefCache = checkNotNull(programDefCache);
     this.versionsByProgramCache = checkNotNull(versionsByProgramCache);
   }
 
@@ -155,6 +158,7 @@ public class DevDatabaseSeedController extends Controller {
     }
     if (settingsManifest.getProgramCacheEnabled()) {
       programCache.removeAll().toCompletableFuture().join();
+      programDefCache.removeAll().toCompletableFuture().join();
       versionsByProgramCache.removeAll().toCompletableFuture().join();
     }
   }

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -158,7 +158,6 @@ public class DevDatabaseSeedController extends Controller {
     }
     if (settingsManifest.getProgramCacheEnabled()) {
       programCache.removeAll().toCompletableFuture().join();
-      programDefCache.removeAll().toCompletableFuture().join();
       versionsByProgramCache.removeAll().toCompletableFuture().join();
     }
     if (settingsManifest.getQuestionCacheEnabled()) {

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -158,6 +158,7 @@ public class DevDatabaseSeedController extends Controller {
     }
     if (settingsManifest.getProgramCacheEnabled()) {
       programCache.removeAll().toCompletableFuture().join();
+      programDefCache.removeAll().toCompletableFuture().join();
       versionsByProgramCache.removeAll().toCompletableFuture().join();
     }
     if (settingsManifest.getQuestionCacheEnabled()) {

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -158,8 +158,10 @@ public class DevDatabaseSeedController extends Controller {
     }
     if (settingsManifest.getProgramCacheEnabled()) {
       programCache.removeAll().toCompletableFuture().join();
-      programDefCache.removeAll().toCompletableFuture().join();
       versionsByProgramCache.removeAll().toCompletableFuture().join();
+    }
+    if (settingsManifest.getQuestionCacheEnabled()) {
+      programDefCache.removeAll().toCompletableFuture().join();
     }
   }
 

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -147,8 +147,13 @@ public final class ProgramRepository {
    * <p>Draft program definition data must not be set in the cache.
    */
   public void setFullProgramDefinitionCache(long programId, ProgramDefinition programDefinition) {
-    if (settingsManifest.getQuestionCacheEnabled()) {
-      programDefCache.set(String.valueOf(programId), programDefinition);
+    if (settingsManifest.getQuestionCacheEnabled()
+        // We only set the cache if it hasn't yet been set for the ID.
+        && getFullProgramDefinitionFromCache(programId).isEmpty()) {
+      // We should never set the cache for draft programs.
+      if (!versionRepository.get().isDraftProgram(programId)) {
+        programDefCache.set(String.valueOf(programId), programDefinition);
+      }
     }
   }
 

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -130,15 +130,15 @@ public final class ProgramRepository {
    * Gets the program definition that contains the related question data from the cache (if
    * enabled).
    */
-  public Optional<ProgramDefinition> getProgramDefinitionFromCache(ProgramModel program) {
-    if (settingsManifest.getProgramCacheEnabled()) {
+  public Optional<ProgramDefinition> getFullProgramDefinitionFromCache(ProgramModel program) {
+    if (settingsManifest.getQuestionCacheEnabled()) {
       return programDefCache.get(String.valueOf(program.id));
     }
     return Optional.empty();
   }
 
-  public Optional<ProgramDefinition> getProgramDefinitionFromCache(long programId) {
-    if (settingsManifest.getProgramCacheEnabled()) {
+  public Optional<ProgramDefinition> getFullProgramDefinitionFromCache(long programId) {
+    if (settingsManifest.getQuestionCacheEnabled()) {
       return programDefCache.get(String.valueOf(programId));
     }
     return Optional.empty();
@@ -149,8 +149,8 @@ public final class ProgramRepository {
    *
    * <p>Draft program definition data must not be set in the cache.
    */
-  public void setProgramDefinitionCache(long programId, ProgramDefinition programDefinition) {
-    if (settingsManifest.getProgramCacheEnabled()) {
+  public void setFullProgramDefinitionCache(long programId, ProgramDefinition programDefinition) {
+    if (settingsManifest.getQuestionCacheEnabled()) {
       programDefCache.set(String.valueOf(programId), programDefinition);
     }
   }

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -131,10 +131,7 @@ public final class ProgramRepository {
    * enabled).
    */
   public Optional<ProgramDefinition> getFullProgramDefinitionFromCache(ProgramModel program) {
-    if (settingsManifest.getQuestionCacheEnabled()) {
-      return programDefCache.get(String.valueOf(program.id));
-    }
-    return Optional.empty();
+    return getFullProgramDefinitionFromCache(program.id);
   }
 
   public Optional<ProgramDefinition> getFullProgramDefinitionFromCache(long programId) {

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -54,6 +54,7 @@ public final class ProgramRepository {
   private final Provider<VersionRepository> versionRepository;
   private final SettingsManifest settingsManifest;
   private final SyncCacheApi programCache;
+  private final SyncCacheApi programDefCache;
   private final SyncCacheApi versionsByProgramCache;
 
   @Inject
@@ -62,12 +63,14 @@ public final class ProgramRepository {
       Provider<VersionRepository> versionRepository,
       SettingsManifest settingsManifest,
       @NamedCache("program") SyncCacheApi programCache,
+      @NamedCache("program-definition") SyncCacheApi programDefCache,
       @NamedCache("program-versions") SyncCacheApi versionsByProgramCache) {
     this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);
     this.versionRepository = checkNotNull(versionRepository);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.programCache = checkNotNull(programCache);
+    this.programDefCache = checkNotNull(programDefCache);
     this.versionsByProgramCache = checkNotNull(versionsByProgramCache);
   }
 
@@ -121,6 +124,35 @@ public final class ProgramRepository {
     }
 
     return names.build();
+  }
+
+  /**
+   * Gets the program definition that contains the related question data from the cache (if
+   * enabled).
+   */
+  public Optional<ProgramDefinition> getProgramDefinitionFromCache(ProgramModel program) {
+    if (settingsManifest.getProgramCacheEnabled()) {
+      return programDefCache.get(String.valueOf(program.id));
+    }
+    return Optional.empty();
+  }
+
+  public Optional<ProgramDefinition> getProgramDefinitionFromCache(long programId) {
+    if (settingsManifest.getProgramCacheEnabled()) {
+      return programDefCache.get(String.valueOf(programId));
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Sets the program definition that contains the related question data in the cache (if enabled).
+   *
+   * <p>Draft program definition data must not be set in the cache.
+   */
+  public void setProgramDefinitionCache(long programId, ProgramDefinition programDefinition) {
+    if (settingsManifest.getProgramCacheEnabled()) {
+      programDefCache.set(String.valueOf(programId), programDefinition);
+    }
   }
 
   /**

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -52,6 +52,7 @@ import services.question.QuestionService;
 import services.question.ReadOnlyQuestionService;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
+import services.settings.SettingsManifest;
 
 /**
  * The service responsible for accessing the Program resource. Admins create programs to represent
@@ -83,6 +84,7 @@ public final class ProgramService {
   private final HttpExecutionContext httpExecutionContext;
   private final AccountRepository accountRepository;
   private final VersionRepository versionRepository;
+  private final SettingsManifest settingsManifest;
   private final ProgramBlockValidationFactory programBlockValidationFactory;
 
   @Inject
@@ -92,12 +94,14 @@ public final class ProgramService {
       AccountRepository accountRepository,
       VersionRepository versionRepository,
       HttpExecutionContext ec,
+      SettingsManifest settingsManifest,
       ProgramBlockValidationFactory programBlockValidationFactory) {
     this.programRepository = checkNotNull(programRepository);
     this.questionService = checkNotNull(questionService);
     this.httpExecutionContext = checkNotNull(ec);
     this.accountRepository = checkNotNull(accountRepository);
     this.versionRepository = checkNotNull(versionRepository);
+    this.settingsManifest = checkNotNull(settingsManifest);
     this.programBlockValidationFactory = checkNotNull(programBlockValidationFactory);
   }
 
@@ -224,6 +228,11 @@ public final class ProgramService {
   }
 
   private CompletionStage<ProgramDefinition> syncProgramAssociations(ProgramModel program) {
+    if (settingsManifest.getProgramCacheEnabled()
+        && programRepository.getProgramDefinitionFromCache(program).isPresent()) {
+      return CompletableFuture.completedStage(
+          programRepository.getProgramDefinitionFromCache(program).get());
+    }
     VersionModel activeVersion = versionRepository.getActiveVersion();
     VersionModel maxVersionForProgram =
         programRepository.getVersionsForProgram(program).stream()
@@ -240,6 +249,13 @@ public final class ProgramService {
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(program.getProgramDefinition(), maxVersionForProgram);
+
+    if (settingsManifest.getProgramCacheEnabled()) {
+      // It is safe to set the program definition cache, since we have already checked that it is
+      // not a draft program.
+      programRepository.setProgramDefinitionCache(
+          program.id, programDefinition.orderBlockDefinitions());
+    }
 
     return CompletableFuture.completedStage(programDefinition.orderBlockDefinitions());
   }
@@ -1393,7 +1409,9 @@ public final class ProgramService {
      * eligibility state, we must sync each program with a version it
      * is associated with. This diverges from previous behavior where
      * we did not need to sync the programs because the contents of their
-     * questions was not needed in the index view.
+     * questions was not needed in the index view. Note: we only have to do this
+     * for programs with eligibility conditions if the cache is disabled or the
+     * program is not yet in the cache.
      */
 
     // Create a map of the questionService for each program and version to minimize database calls.
@@ -1403,8 +1421,10 @@ public final class ProgramService {
     for (ProgramDefinition programDef : programDefinitions) {
       ProgramModel p = programDef.toProgram();
       p.refresh();
-      // We only need to get the question data if the program has eligibility conditions.
-      if (programDef.hasEligibilityEnabled()) {
+      // We only need to get the question data if the program has eligibility conditions and the
+      // program definition is not in the cache.
+      if (programDef.hasEligibilityEnabled()
+          && !programRepository.getProgramDefinitionFromCache(p).isPresent()) {
         VersionModel v =
             programRepository.getVersionsForProgram(p).stream().findAny().orElseThrow();
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
@@ -1424,9 +1444,13 @@ public final class ProgramService {
                   if (!programDef.hasEligibilityEnabled()) {
                     return programDef;
                   }
+                  Long programId = programDef.id();
+                  if (programRepository.getProgramDefinitionFromCache(programId).isPresent()) {
+                    return programRepository.getProgramDefinitionFromCache(programId).get();
+                  }
                   try {
                     return syncProgramDefinitionQuestions(
-                        programDef, programToQuestionService.get(programDef.id()));
+                        programDef, programToQuestionService.get(programId));
                     /* END TEMP BUG FIX */
                   } catch (QuestionNotFoundException e) {
                     throw new RuntimeException(

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -1444,7 +1444,7 @@ public final class ProgramService {
                   if (!programDef.hasEligibilityEnabled()) {
                     return programDef;
                   }
-                  Long programId = programDef.id();
+                  long programId = programDef.id();
                   if (programRepository.getFullProgramDefinitionFromCache(programId).isPresent()) {
                     return programRepository.getFullProgramDefinitionFromCache(programId).get();
                   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -228,10 +228,10 @@ public final class ProgramService {
   }
 
   private CompletionStage<ProgramDefinition> syncProgramAssociations(ProgramModel program) {
-    if (settingsManifest.getProgramCacheEnabled()
-        && programRepository.getProgramDefinitionFromCache(program).isPresent()) {
+    if (settingsManifest.getQuestionCacheEnabled()
+        && programRepository.getFullProgramDefinitionFromCache(program).isPresent()) {
       return CompletableFuture.completedStage(
-          programRepository.getProgramDefinitionFromCache(program).get());
+          programRepository.getFullProgramDefinitionFromCache(program).get());
     }
     VersionModel activeVersion = versionRepository.getActiveVersion();
     VersionModel maxVersionForProgram =
@@ -250,10 +250,10 @@ public final class ProgramService {
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(program.getProgramDefinition(), maxVersionForProgram);
 
-    if (settingsManifest.getProgramCacheEnabled()) {
+    if (settingsManifest.getQuestionCacheEnabled()) {
       // It is safe to set the program definition cache, since we have already checked that it is
       // not a draft program.
-      programRepository.setProgramDefinitionCache(
+      programRepository.setFullProgramDefinitionCache(
           program.id, programDefinition.orderBlockDefinitions());
     }
 
@@ -1424,7 +1424,7 @@ public final class ProgramService {
       // We only need to get the question data if the program has eligibility conditions and the
       // program definition is not in the cache.
       if (programDef.hasEligibilityEnabled()
-          && !programRepository.getProgramDefinitionFromCache(p).isPresent()) {
+          && !programRepository.getFullProgramDefinitionFromCache(p).isPresent()) {
         VersionModel v =
             programRepository.getVersionsForProgram(p).stream().findAny().orElseThrow();
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
@@ -1445,8 +1445,8 @@ public final class ProgramService {
                     return programDef;
                   }
                   Long programId = programDef.id();
-                  if (programRepository.getProgramDefinitionFromCache(programId).isPresent()) {
-                    return programRepository.getProgramDefinitionFromCache(programId).get();
+                  if (programRepository.getFullProgramDefinitionFromCache(programId).isPresent()) {
+                    return programRepository.getFullProgramDefinitionFromCache(programId).get();
                   }
                   try {
                     return syncProgramDefinitionQuestions(

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions","program-definition"]
 }
 
 ## Security rules for play-pac4j SecurityFilter

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions","program-definition"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions", "program-definition"]
 }
 
 ## Security rules for play-pac4j SecurityFilter

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -26,6 +26,7 @@ api_generated_docs_enabled = true
 
 version_cache_enabled=true
 program_cache_enabled=true
+question_cache_enabled=true
 applicant_info_questions=false
 universal_questions=true
 program_card_images=false

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -21,3 +21,5 @@ civiform_applicant_idp = "disabled"
 # address service area validation relative path for testing
 esri_find_address_candidates_url = ""
 esri_address_service_area_validation_urls = ["/query"]
+
+question_cache_enabled=true

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -112,10 +112,23 @@ public class ProgramRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void setFullProgramDefinitionFromCache_doesNotSetWhenDraft() {
+    Mockito.when(mockSettingsManifest.getQuestionCacheEnabled()).thenReturn(true);
+    ProgramModel program = resourceCreator.insertDraftProgram("testDraftInCache");
+
+    repo.setFullProgramDefinitionCache(program.id, program.getProgramDefinition());
+    Optional<ProgramDefinition> programDefFromCache =
+        repo.getFullProgramDefinitionFromCache(program);
+
+    assertThat(programDefFromCache).isEmpty();
+  }
+
+  @Test
   public void getFullProgramDefinitionFromCache_getsFromCacheWhenPresent() {
     Mockito.when(mockSettingsManifest.getQuestionCacheEnabled()).thenReturn(true);
     ProgramModel program = resourceCreator.insertActiveProgram("testInCache");
     repo.setFullProgramDefinitionCache(program.id, program.getProgramDefinition());
+
     Optional<ProgramDefinition> programDefFromCache =
         repo.getFullProgramDefinitionFromCache(program);
 
@@ -126,8 +139,9 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
   @Test
   public void getFullProgramDefinitionFromCache_returnsEmptyOptionalWhenNotPresent() {
-    Mockito.when(mockSettingsManifest.getQuestionCacheEnabled()).thenReturn(false);
+    Mockito.when(mockSettingsManifest.getQuestionCacheEnabled()).thenReturn(true);
     ProgramModel program = resourceCreator.insertActiveProgram("testNotInCache");
+
     // We don't set the cache, but we try to get it here.
     Optional<ProgramDefinition> programDefFromCache =
         repo.getFullProgramDefinitionFromCache(program);
@@ -138,9 +152,9 @@ public class ProgramRepositoryTest extends ResetPostgres {
   @Test
   public void getFullProgramDefinitionFromCache_returnsEmptyOptionalWhenCacheDisabled() {
     Mockito.when(mockSettingsManifest.getQuestionCacheEnabled()).thenReturn(false);
-
     ProgramModel program = resourceCreator.insertActiveProgram("testCacheDisabled");
     repo.setFullProgramDefinitionCache(program.id, program.getProgramDefinition());
+
     Optional<ProgramDefinition> programDefFromCache =
         repo.getFullProgramDefinitionFromCache(program);
 

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -50,6 +50,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
   private ProgramRepository repo;
   private VersionRepository versionRepo;
   private SyncCacheApi programCache;
+  private SyncCacheApi programDefCache;
   private SyncCacheApi versionsByProgramCache;
   private SettingsManifest mockSettingsManifest;
 
@@ -58,6 +59,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
     versionRepo = instanceOf(VersionRepository.class);
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     programCache = instanceOf(SyncCacheApi.class);
+    programDefCache = instanceOf(SyncCacheApi.class);
     versionsByProgramCache = instanceOf(SyncCacheApi.class);
     repo =
         new ProgramRepository(
@@ -65,6 +67,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             Providers.of(versionRepo),
             mockSettingsManifest,
             programCache,
+            programDefCache,
             versionsByProgramCache);
   }
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2999,7 +2999,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
-        ProgramBuilder.newActiveProgram("program")
+        ProgramBuilder.newDraftProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
             .withBlock()
             .withRequiredQuestion(question)
@@ -3109,7 +3109,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
-        ProgramBuilder.newActiveProgram("program")
+        ProgramBuilder.newDraftProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
             .withBlock()
             .withRequiredQuestion(question)
@@ -3201,7 +3201,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
-        ProgramBuilder.newActiveProgram("program")
+        ProgramBuilder.newDraftProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
             .withBlock()
             .withRequiredQuestion(question)
@@ -3307,7 +3307,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
-        ProgramBuilder.newActiveProgram("program")
+        ProgramBuilder.newDraftProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
             .withBlock()
             .withRequiredQuestion(question)
@@ -3379,7 +3379,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     QuestionModel question = testQuestionBank.applicantAddress();
 
     ProgramModel program =
-        ProgramBuilder.newActiveProgram("program")
+        ProgramBuilder.newDraftProgram("program")
             .withStatusDefinitions(new StatusDefinitions(ImmutableList.of(APPROVED_STATUS)))
             .withBlock()
             .withRequiredQuestion(question)

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -1096,6 +1096,26 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void getProgramDefinitionAsync_doesNotSetCacheForDraft() throws Exception {
+    QuestionDefinition question = nameQuestion;
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestionDefinition(question)
+            .buildDefinition();
+
+    ProgramDefinition found =
+        ps.getProgramDefinitionAsync(program.id()).toCompletableFuture().join();
+    Optional<ProgramDefinition> maybeCachedProgram =
+        programDefCache.get(String.valueOf(program.id()));
+
+    QuestionDefinition foundQuestion =
+        found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
+    assertThat(foundQuestion).isInstanceOf(NameQuestionDefinition.class);
+    assertThat(maybeCachedProgram).isEmpty();
+  }
+
+  @Test
   public void getActiveProgramDefinitionAsync_getsActiveProgram() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("Test Program").buildDefinition();


### PR DESCRIPTION
### Description

The full program definition is an expensive database lookup operation, since it involves looking up question data.

We should set this program definition in the cache when the program is active or obsolete.

We can create a follow up PR to refactor programModel.getProgramDefinition() calls to use this cached program definition if it is present and also ensure syncProgramDefinitionQuestions and its callers use the cache if its available (if not a draft program).

This PR enables the question_cache_enabled feature flag in tests, and updates some tests to create draft programs instead of active ones when edits are still being made to the program (because otherwise it will be cached)

## Release notes

Get and set full program definition data from the cache (with the question data included), if the question cache feature flag is enabled.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc. (all browser tests have this feature flag enabled)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

#6466