### PR TITLE
Retire new_applicant_url_schema_enabled feature flag

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -49,8 +49,7 @@ public class CiviFormProfile {
 
   /** Get the latest {@link ApplicantModel} associated with the profile. */
   public CompletableFuture<ApplicantModel> getApplicant() {
-    if (settingsManifest.getNewApplicantUrlSchemaEnabled()
-        && profileData.containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
+    if (profileData.containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
       long applicantId =
           profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class);
       return accountRepository
@@ -296,10 +295,6 @@ public class CiviFormProfile {
    * looking up the account each time and finding the corresponding applicant id.
    */
   void storeApplicantIdInProfile(Long applicantId) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      return;
-    }
-
     if (!profileData.containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
       profileData.addAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, applicantId);
     }
@@ -312,10 +307,6 @@ public class CiviFormProfile {
    * looking up the account each time and finding the corresponding applicant id.
    */
   void storeApplicantIdInProfile(AccountModel account) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      return;
-    }
-
     Long applicantId =
         getApplicantForAccount(account)
             .orElseThrow(() -> new MissingOptionalException(ApplicantModel.class))

--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -52,14 +52,12 @@ public final class ProfileFactory {
   public CiviFormProfileData createNewApplicant() {
     CiviFormProfileData profileData = create(new Role[] {Role.ROLE_APPLICANT});
 
-    if (settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // Store the applicant id in the profile.
-      //
-      // The profile ID corresponds to the *account* id, but controllers need the applicant id. We
-      // store it in the profile for easy retrieval without a db lookup.
-      CiviFormProfile profile = wrapProfileData(profileData);
-      profile.getAccount().thenAccept(account -> profile.storeApplicantIdInProfile(account)).join();
-    }
+    // Store the applicant id in the profile.
+    //
+    // The profile ID corresponds to the *account* id, but controllers need the applicant id. We
+    // store it in the profile for easy retrieval without a db lookup.
+    CiviFormProfile profile = wrapProfileData(profileData);
+    profile.getAccount().thenAccept(account -> profile.storeApplicantIdInProfile(account)).join();
 
     return profileData;
   }

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -160,11 +160,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> edit(
       Request request, long programId, String blockId, Optional<String> questionName) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -210,11 +205,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> review(
       Request request, long programId, String blockId, Optional<String> questionName) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -245,11 +235,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> confirmAddress(
       Request request, long programId, String blockId, boolean inReview) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -393,11 +378,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> previous(
       Request request, long programId, int previousBlockIndex, boolean inReview) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -571,11 +551,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> updateFile(
       Request request, long programId, String blockId, boolean inReview) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -656,11 +631,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
   @Secure
   public CompletionStage<Result> update(
       Request request, long programId, String blockId, boolean inReview) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -186,11 +186,6 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
   @Secure
   public CompletionStage<Result> review(Request request, long programId) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -245,11 +240,6 @@ public class ApplicantProgramReviewController extends CiviFormController {
    */
   @Secure
   public CompletionStage<Result> submit(Request request, long programId) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -26,7 +26,6 @@ import services.applicant.ApplicantService.ApplicantProgramData;
 import services.applicant.Block;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
-import services.settings.SettingsManifest;
 import views.applicant.ApplicantProgramInfoView;
 import views.applicant.ProgramIndexView;
 import views.components.ToastMessage;
@@ -43,7 +42,6 @@ public final class ApplicantProgramsController extends CiviFormController {
   private final MessagesApi messagesApi;
   private final ProgramIndexView programIndexView;
   private final ApplicantProgramInfoView programInfoView;
-  private final SettingsManifest settingsManifest;
   private final ProgramSlugHandler programSlugHandler;
   private final ApplicantRoutes applicantRoutes;
 
@@ -56,7 +54,6 @@ public final class ApplicantProgramsController extends CiviFormController {
       ApplicantProgramInfoView programInfoView,
       ProfileUtils profileUtils,
       VersionRepository versionRepository,
-      SettingsManifest settingsManifest,
       ProgramSlugHandler programSlugHandler,
       ApplicantRoutes applicantRoutes) {
     super(profileUtils, versionRepository);
@@ -65,7 +62,6 @@ public final class ApplicantProgramsController extends CiviFormController {
     this.messagesApi = checkNotNull(messagesApi);
     this.programIndexView = checkNotNull(programIndexView);
     this.programInfoView = checkNotNull(programInfoView);
-    this.settingsManifest = checkNotNull(settingsManifest);
     this.programSlugHandler = checkNotNull(programSlugHandler);
     this.applicantRoutes = checkNotNull(applicantRoutes);
   }
@@ -120,11 +116,6 @@ public final class ApplicantProgramsController extends CiviFormController {
 
   @Secure
   public CompletionStage<Result> index(Request request) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have
@@ -197,10 +188,6 @@ public final class ApplicantProgramsController extends CiviFormController {
   public CompletionStage<Result> show(Request request, String programParam) {
     if (StringUtils.isNumeric(programParam)) {
       // The path parameter specifies a program by (numeric) id.
-      if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-        // This route is only operative for the new URL schema, so send the user home.
-        return CompletableFuture.completedFuture(redirectToHome());
-      }
       Optional<Long> applicantId = getApplicantId(request);
       if (applicantId.isEmpty()) {
         // This route should not have been computed for the user in this case, but they may have
@@ -277,11 +264,6 @@ public final class ApplicantProgramsController extends CiviFormController {
 
   @Secure
   public CompletionStage<Result> edit(Request request, long programId) {
-    if (!settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      // This route is only operative for the new URL schema, so send the user home.
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
     Optional<Long> applicantId = getApplicantId(request);
     if (applicantId.isEmpty()) {
       // This route should not have been computed for the user in this case, but they may have

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -1,27 +1,16 @@
 package controllers.applicant;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
-import com.google.inject.Inject;
 import io.prometheus.client.Counter;
 import java.util.Optional;
 import play.api.mvc.Call;
-import services.settings.SettingsManifest;
 
 /**
  * Class that computes routes for applicant actions. The route for an applicant may be different
  * from that for a TI taking action on behalf of an applicant.
  */
 public final class ApplicantRoutes {
-  private final SettingsManifest settingsManifest;
-
-  @Inject
-  public ApplicantRoutes(SettingsManifest settingsManifest) {
-    this.settingsManifest = checkNotNull(settingsManifest);
-  }
-
   private static final Counter APPLICANT_ID_IN_PROFILE_COUNT =
       Counter.build()
           .name("applicant_id_in_profile")
@@ -29,13 +18,11 @@ public final class ApplicantRoutes {
           .labelNames("existence")
           .register();
 
-  // There are three cases where we want to use the URL that contains the applicant id:
-  // - The new schema is /not/ active yet.
+  // There are two cases where we want to use the URL that contains the applicant id:
   // - TIs performing actions on behalf of applicants.
   // - The applicant has a profile that does /not/ (yet) include the applicant id.
   //   This case will eventually go away once existing profiles have expired and been replaced.
   private boolean includeApplicantIdInRoute(CiviFormProfile profile) {
-    boolean newUrlSchemaEnabled = settingsManifest.getNewApplicantUrlSchemaEnabled();
     boolean isTi = profile.isTrustedIntermediary();
     boolean applicantIdInProfile =
         profile.getProfileData().containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
@@ -45,7 +32,7 @@ public final class ApplicantRoutes {
     String existence = applicantIdInProfile ? "present" : "absent";
     APPLICANT_ID_IN_PROFILE_COUNT.labels(existence).inc();
 
-    return !newUrlSchemaEnabled || isTi || !applicantIdInProfile;
+    return isTi || !applicantIdInProfile;
   }
 
   /**

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -895,11 +895,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE", request);
   }
 
-  /** Enables new URL schema that removes applicant ID from applicant actions. */
-  public boolean getNewApplicantUrlSchemaEnabled() {
-    return getBool("NEW_APPLICANT_URL_SCHEMA_ENABLED");
-  }
-
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.of(
           "Branding",
@@ -1862,13 +1857,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " finishing an application.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.ADMIN_WRITEABLE),
-                  SettingDescription.create(
-                      "NEW_APPLICANT_URL_SCHEMA_ENABLED",
-                      "Enables new URL schema that removes applicant ID from applicant actions.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
-                      SettingMode.HIDDEN))),
+                      SettingMode.ADMIN_WRITEABLE))),
           "Miscellaneous",
           SettingsSection.create(
               "Miscellaneous",

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -29,4 +29,3 @@ program_cache_enabled=true
 applicant_info_questions=false
 universal_questions=true
 program_card_images=false
-new_applicant_url_schema_enabled=true

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -46,4 +46,3 @@ application_exportable = true
 applicant_info_questions = true
 universal_questions = true
 program_card_images = false
-new_applicant_url_schema_enabled = true

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -752,11 +752,6 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "Add programs cards to the confirmation screen that an applicant sees after finishing an application.",
         "type": "bool"
-      },
-      "NEW_APPLICANT_URL_SCHEMA_ENABLED": {
-        "mode": "HIDDEN",
-        "description": "Enables new URL schema that removes applicant ID from applicant actions.",
-        "type": "bool"
       }
     }
   }

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -65,6 +65,3 @@ program_card_images = ${?PROGRAM_CARD_IMAGES}
 suggest_programs_on_application_confirmation_page = false
 suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE}
 
-# New Applicant URL Schema
-new_applicant_url_schema_enabled = true
-new_applicant_url_schema_enabled = ${?NEW_APPLICANT_URL_SCHEMA_ENABLED}

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -5,24 +5,15 @@ import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.ResetPostgres;
-import services.settings.SettingsManifest;
 import support.CfTestHelpers;
 import support.CfTestHelpers.ResultWithFinalRequestUri;
 
 public class HomeControllerTest extends ResetPostgres {
-  private SettingsManifest settingsManifest;
-
-  @Before
-  public void setup() {
-    settingsManifest = instanceOf(SettingsManifest.class);
-  }
-
   @Test
   public void testUnauthenticatedSecurePage() {
     Http.RequestBuilder request =
@@ -32,11 +23,7 @@ public class HomeControllerTest extends ResetPostgres {
         CfTestHelpers.doRequestWithInternalRedirects(app, request);
 
     assertThat(resultWithFinalRequestUri.getResult().status()).isEqualTo(HttpConstants.OK);
-    if (settingsManifest.getNewApplicantUrlSchemaEnabled()) {
-      assertThat(resultWithFinalRequestUri.getFinalRequestUri()).isEqualTo("/programs");
-    } else {
-      assertThat(resultWithFinalRequestUri.getFinalRequestUri()).endsWith("/programs");
-    }
+    assertThat(resultWithFinalRequestUri.getFinalRequestUri()).isEqualTo("/programs");
   }
 
   @Test

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -46,7 +46,6 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
     Langs mockLangs = Mockito.mock(Langs.class);
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
     SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
     LanguageUtils languageUtils =
         new LanguageUtils(instanceOf(AccountRepository.class), mockLangs, mockSettingsManifest);
 
@@ -57,7 +56,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             instanceOf(MessagesApi.class),
             instanceOf(HttpExecutionContext.class),
             languageUtils,
-            new ApplicantRoutes(mockSettingsManifest));
+            new ApplicantRoutes());
     Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
     assertThat(result.redirectLocation()).isNotEmpty();
     assertThat(

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -1,8 +1,6 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -18,19 +16,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import repository.ResetPostgres;
-import services.settings.SettingsManifest;
 
 @RunWith(JUnitParamsRunner.class)
 public class ApplicantRoutesTest extends ResetPostgres {
 
   private ProfileFactory profileFactory;
-  private static long applicantId = 123L;
-  private static long applicantAccountId = 456L;
-  private static long tiAccountId = 789L;
-  private static long programId = 321L;
-  private static String blockId = "test_block";
-  private static int previousBlockIndex = 7;
-  private static SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
+  private static long APPLICANT_ID = 123L;
+  private static long APPLICANT_ACCOUNT_ID = 456L;
+  private static long TI_ACCOUNT_ID = 789L;
+  private static long PROGRAM_ID = 321L;
+  private static String BLOCK_ID = "test_block";
+  private static int PREVIOUS_BLOCK_INDEX = 7;
 
   // Class to hold counter values.
   static class Counts {
@@ -55,18 +51,6 @@ public class ApplicantRoutesTest extends ResetPostgres {
     return counts;
   }
 
-  private void setNewApplicantUrlSchemaEnabled(boolean enabled) {
-    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenAnswer(invocation -> enabled);
-  }
-
-  private void enableNewApplicantUrlSchema() {
-    setNewApplicantUrlSchemaEnabled(true);
-  }
-
-  private void disableNewApplicantUrlSchema() {
-    setNewApplicantUrlSchemaEnabled(false);
-  }
-
   @Before
   public void setup() {
     profileFactory = instanceOf(ProfileFactory.class);
@@ -74,16 +58,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testIndexRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    assertThat(new ApplicantRoutes(mockSettingsManifest).index(applicantProfile, applicantId).url())
+    assertThat(new ApplicantRoutes().index(applicantProfile, APPLICANT_ID).url())
         .isEqualTo("/programs");
 
     Counts after = getApplicantIdInProfileCounts();
@@ -92,36 +75,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
   }
 
   @Test
-  public void testIndexRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).index(applicantProfile, applicantId).url())
-        .isEqualTo(expectedIndexUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
   public void testIndexRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).index(applicantProfile, applicantId).url())
+    String expectedIndexUrl = String.format("/applicants/%d/programs", APPLICANT_ID);
+    assertThat(new ApplicantRoutes().index(applicantProfile, APPLICANT_ID).url())
         .isEqualTo(expectedIndexUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -131,15 +94,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testIndexRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedIndexUrl = String.format("/applicants/%d/programs", applicantId);
-    assertThat(new ApplicantRoutes(mockSettingsManifest).index(tiProfile, applicantId).url())
+    String expectedIndexUrl = String.format("/applicants/%d/programs", APPLICANT_ID);
+    assertThat(new ApplicantRoutes().index(tiProfile, APPLICANT_ID).url())
         .isEqualTo(expectedIndexUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -149,43 +111,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testShowRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedShowUrl = String.format("/programs/%d", programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .show(applicantProfile, applicantId, programId)
-                .url())
-        .isEqualTo(expectedShowUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testShowRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .show(applicantProfile, applicantId, programId)
-                .url())
+    String expectedShowUrl = String.format("/programs/%d", PROGRAM_ID);
+    assertThat(new ApplicantRoutes().show(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -195,19 +130,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testShowRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .show(applicantProfile, applicantId, programId)
-                .url())
+    String expectedShowUrl = String.format("/applicants/%d/programs/%d", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().show(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -217,16 +148,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testShowRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedShowUrl = String.format("/applicants/%d/programs/%d", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest).show(tiProfile, applicantId, programId).url())
+    String expectedShowUrl = String.format("/applicants/%d/programs/%d", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().show(tiProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedShowUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -236,44 +165,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testEditRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedEditUrl = String.format("/programs/%d/edit", programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .edit(applicantProfile, applicantId, programId)
-                .url())
-        .isEqualTo(expectedEditUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testEditRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedEditUrl =
-        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .edit(applicantProfile, applicantId, programId)
-                .url())
+    String expectedEditUrl = String.format("/programs/%d/edit", PROGRAM_ID);
+    assertThat(new ApplicantRoutes().edit(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedEditUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -283,20 +184,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testEditRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedEditUrl =
-        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .edit(applicantProfile, applicantId, programId)
-                .url())
+        String.format("/applicants/%d/programs/%d/edit", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().edit(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedEditUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -306,17 +203,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testEditRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedEditUrl =
-        String.format("/applicants/%d/programs/%d/edit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest).edit(tiProfile, applicantId, programId).url())
+        String.format("/applicants/%d/programs/%d/edit", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().edit(tiProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedEditUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -326,44 +221,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testReviewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedReviewUrl = String.format("/programs/%d/review", programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .review(applicantProfile, applicantId, programId)
-                .url())
-        .isEqualTo(expectedReviewUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testReviewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedReviewUrl =
-        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .review(applicantProfile, applicantId, programId)
-                .url())
+    String expectedReviewUrl = String.format("/programs/%d/review", PROGRAM_ID);
+    assertThat(new ApplicantRoutes().review(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedReviewUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -373,20 +240,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testReviewRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedReviewUrl =
-        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .review(applicantProfile, applicantId, programId)
-                .url())
+        String.format("/applicants/%d/programs/%d/review", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().review(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedReviewUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -396,19 +259,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testReviewRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedReviewUrl =
-        String.format("/applicants/%d/programs/%d/review", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .review(tiProfile, applicantId, programId)
-                .url())
+        String.format("/applicants/%d/programs/%d/review", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().review(tiProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedReviewUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -418,44 +277,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testSubmitRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
-    String expectedSubmitUrl = String.format("/programs/%d/submit", programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .submit(applicantProfile, applicantId, programId)
-                .url())
-        .isEqualTo(expectedSubmitUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testSubmitRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedSubmitUrl =
-        String.format("/applicants/%d/programs/%d/submit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .submit(applicantProfile, applicantId, programId)
-                .url())
+    String expectedSubmitUrl = String.format("/programs/%d/submit", PROGRAM_ID);
+    assertThat(new ApplicantRoutes().submit(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedSubmitUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -465,20 +296,16 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testSubmitRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedSubmitUrl =
-        String.format("/applicants/%d/programs/%d/submit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .submit(applicantProfile, applicantId, programId)
-                .url())
+        String.format("/applicants/%d/programs/%d/submit", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().submit(applicantProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedSubmitUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -488,19 +315,15 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testSubmitRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedSubmitUrl =
-        String.format("/applicants/%d/programs/%d/submit", applicantId, programId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .submit(tiProfile, applicantId, programId)
-                .url())
+        String.format("/applicants/%d/programs/%d/submit", APPLICANT_ID, PROGRAM_ID);
+    assertThat(new ApplicantRoutes().submit(tiProfile, APPLICANT_ID, PROGRAM_ID).url())
         .isEqualTo(expectedSubmitUrl);
 
     Counts after = getApplicantIdInProfileCounts();
@@ -510,43 +333,19 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockEditRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedBlockEditUrl = String.format("/programs/%d/blocks/%s/edit", programId, blockId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
-                .url())
-        .isEqualTo(expectedBlockEditUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testBlockEditRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockEditUrl =
-        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+        String.format("/programs/%d/blocks/%s/edit", PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockEdit(applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockEditUrl);
 
@@ -557,19 +356,19 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockEditRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockEditUrl =
-        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/edit", APPLICANT_ID, PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockEdit(applicantProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockEdit(applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockEditUrl);
 
@@ -580,18 +379,18 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockEditRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockEditUrl =
-        String.format("/applicants/%d/programs/%d/blocks/%s/edit", applicantId, programId, blockId);
+        String.format(
+            "/applicants/%d/programs/%d/blocks/%s/edit", APPLICANT_ID, PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockEdit(tiProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockEdit(tiProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockEditUrl);
 
@@ -602,45 +401,19 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockReviewRoute_forApplicantWithIdInProfile_newSchemaEnabled() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockReviewUrl =
-        String.format("/programs/%d/blocks/%s/review", programId, blockId);
+        String.format("/programs/%d/blocks/%s/review", PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
-                .url())
-        .isEqualTo(expectedBlockReviewUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  public void testBlockReviewRoute_forApplicantWithIdInProfile_newSchemaDisabled() {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedBlockReviewUrl =
-        String.format(
-            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockReview(applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockReviewUrl);
 
@@ -651,20 +424,19 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockReviewRoute_forApplicantWithoutIdInProfile() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockReviewUrl =
         String.format(
-            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
+            "/applicants/%d/programs/%d/blocks/%s/review", APPLICANT_ID, PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockReview(applicantProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockReview(applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockReviewUrl);
 
@@ -675,19 +447,18 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   public void testBlockReviewRoute_forTrustedIntermediary() {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedBlockReviewUrl =
         String.format(
-            "/applicants/%d/programs/%d/blocks/%s/review", applicantId, programId, blockId);
+            "/applicants/%d/programs/%d/blocks/%s/review", APPLICANT_ID, PROGRAM_ID, BLOCK_ID);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockReview(tiProfile, applicantId, programId, blockId, Optional.empty())
+            new ApplicantRoutes()
+                .blockReview(tiProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Optional.empty())
                 .url())
         .isEqualTo(expectedBlockReviewUrl);
 
@@ -700,50 +471,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Parameters({"true", "false"})
   public void testConfirmAddressRoute_forApplicantWithIdInProfile_newSchemaEnabled(
       String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedConfirmAddressUrl =
-        String.format("/programs/%d/blocks/%s/confirmAddress/%s", programId, blockId, inReview);
+        String.format("/programs/%d/blocks/%s/confirmAddress/%s", PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .confirmAddress(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
-                .url())
-        .isEqualTo(expectedConfirmAddressUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  public void testConfirmAddressRoute_forApplicantWithIdInProfile_newSchemaDisabled(
-      String inReview) {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedConfirmAddressUrl =
-        String.format(
-            "/applicants/%d/programs/%d/blocks/%s/confirmAddress/%s",
-            applicantId, programId, blockId, inReview);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .confirmAddress(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedConfirmAddressUrl);
 
@@ -755,10 +496,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testConfirmAddressRoute_forApplicantWithoutIdInProfile(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
@@ -766,11 +506,11 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedConfirmAddressUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%s/confirmAddress/%s",
-            applicantId, programId, blockId, inReview);
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .confirmAddress(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedConfirmAddressUrl);
 
@@ -782,21 +522,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testConfirmAddressRoute_forTrustedIntermediary(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedConfirmAddressUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%s/confirmAddress/%s",
-            applicantId, programId, blockId, inReview);
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .confirmAddress(
-                    tiProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    tiProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedConfirmAddressUrl);
 
@@ -808,57 +547,24 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testPreviousRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedPreviousUrl =
         String.format(
-            "/programs/%d/blocks/%d/previous/%s", programId, previousBlockIndex, inReview);
+            "/programs/%d/blocks/%d/previous/%s", PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .blockPrevious(
                     applicantProfile,
-                    applicantId,
-                    programId,
-                    previousBlockIndex,
-                    Boolean.valueOf(inReview))
-                .url())
-        .isEqualTo(expectedPreviousUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  public void testPreviousRoute_forApplicantWithIdInProfile_newSchemaDisabled(String inReview) {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedPreviousUrl =
-        String.format(
-            "/applicants/%d/programs/%d/blocks/%d/previous/%s",
-            applicantId, programId, previousBlockIndex, inReview);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .blockPrevious(
-                    applicantProfile,
-                    applicantId,
-                    programId,
-                    previousBlockIndex,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    PREVIOUS_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -871,10 +577,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testPreviousRoute_forApplicantWithoutIdInProfile(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
@@ -882,14 +587,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedPreviousUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%d/previous/%s",
-            applicantId, programId, previousBlockIndex, inReview);
+            APPLICANT_ID, PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .blockPrevious(
                     applicantProfile,
-                    applicantId,
-                    programId,
-                    previousBlockIndex,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    PREVIOUS_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -902,24 +607,23 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testPreviousRoute_forTrustedIntermediary(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedPreviousUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%d/previous/%s",
-            applicantId, programId, previousBlockIndex, inReview);
+            APPLICANT_ID, PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .blockPrevious(
                     tiProfile,
-                    applicantId,
-                    programId,
-                    previousBlockIndex,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    PREVIOUS_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -932,49 +636,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateFileRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedUpdateFileUrl =
-        String.format("/programs/%d/blocks/%s/updateFile/%s", programId, blockId, inReview);
+        String.format("/programs/%d/blocks/%s/updateFile/%s", PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .updateFile(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
-                .url())
-        .isEqualTo(expectedUpdateFileUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  public void testUpdateFileRoute_forApplicantWithIdInProfile_newSchemaDisabled(String inReview) {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedUpdateFileUrl =
-        String.format(
-            "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
-            applicantId, programId, blockId, inReview);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .updateFile(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateFileUrl);
 
@@ -986,10 +661,9 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateFileRoute_forApplicantWithoutIdInProfile(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
@@ -997,11 +671,11 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedUpdateFileUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
-            applicantId, programId, blockId, inReview);
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .updateFile(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateFileUrl);
 
@@ -1013,20 +687,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateFileRoute_forTrustedIntermediary(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedUpdateFileUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%s/updateFile/%s",
-            applicantId, programId, blockId, inReview);
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .updateFile(tiProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+            new ApplicantRoutes()
+                .updateFile(
+                    tiProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateFileUrl);
 
@@ -1038,48 +712,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateBlockRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedUpdateBlockUrl =
-        String.format("/programs/%d/blocks/%s/%s", programId, blockId, inReview);
+        String.format("/programs/%d/blocks/%s/%s", PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .updateBlock(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
-                .url())
-        .isEqualTo(expectedUpdateBlockUrl);
-
-    Counts after = getApplicantIdInProfileCounts();
-    assertThat(after.present).isEqualTo(before.present + 1);
-    assertThat(after.absent).isEqualTo(before.absent);
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  public void testUpdateBlockRoute_forApplicantWithIdInProfile_newSchemaDisabled(String inReview) {
-    disableNewApplicantUrlSchema();
-    Counts before = getApplicantIdInProfileCounts();
-
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
-    profileData.addRole(Role.ROLE_APPLICANT.toString());
-    profileData.addAttribute(
-        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(applicantId));
-    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
-
-    String expectedUpdateBlockUrl =
-        String.format(
-            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
-    assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .updateBlock(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateBlockUrl);
 
@@ -1091,21 +737,21 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateBlockRoute_forApplicantWithoutIdInProfile(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(applicantAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_APPLICANT.toString());
     profileData.removeAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME);
     CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedUpdateBlockUrl =
         String.format(
-            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
+            "/applicants/%d/programs/%d/blocks/%s/%s",
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
+            new ApplicantRoutes()
                 .updateBlock(
-                    applicantProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+                    applicantProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateBlockUrl);
 
@@ -1117,19 +763,20 @@ public class ApplicantRoutesTest extends ResetPostgres {
   @Test
   @Parameters({"true", "false"})
   public void testUpdateBlockRoute_forTrustedIntermediary(String inReview) {
-    enableNewApplicantUrlSchema();
     Counts before = getApplicantIdInProfileCounts();
 
-    CiviFormProfileData profileData = new CiviFormProfileData(tiAccountId);
+    CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
     profileData.addRole(Role.ROLE_TI.toString());
     CiviFormProfile tiProfile = profileFactory.wrapProfileData(profileData);
 
     String expectedUpdateBlockUrl =
         String.format(
-            "/applicants/%d/programs/%d/blocks/%s/%s", applicantId, programId, blockId, inReview);
+            "/applicants/%d/programs/%d/blocks/%s/%s",
+            APPLICANT_ID, PROGRAM_ID, BLOCK_ID, inReview);
     assertThat(
-            new ApplicantRoutes(mockSettingsManifest)
-                .updateBlock(tiProfile, applicantId, programId, blockId, Boolean.valueOf(inReview))
+            new ApplicantRoutes()
+                .updateBlock(
+                    tiProfile, APPLICANT_ID, PROGRAM_ID, BLOCK_ID, Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedUpdateBlockUrl);
 

--- a/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
+++ b/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
@@ -1,19 +1,16 @@
 package views.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_ERROR;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD;
 import static views.questiontypes.ApplicantQuestionRendererParams.AutoFocusTarget.NONE;
 
 import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import repository.ResetPostgres;
 import services.question.types.QuestionDefinition;
-import services.settings.SettingsManifest;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 import views.questiontypes.ApplicantQuestionRendererParams;
 
@@ -21,8 +18,7 @@ public class ApplicantProgramBlockEditViewTest extends ResetPostgres {
 
   private static QuestionDefinition ADDRESS_QD =
       testQuestionBank.applicantAddress().getQuestionDefinition();
-  private static SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-  private static ApplicantRoutes applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+  private static ApplicantRoutes applicantRoutes = new ApplicantRoutes();
 
   private static ApplicantProgramBlockEditView EMPTY_VIEW =
       new ApplicantProgramBlockEditView(
@@ -30,11 +26,6 @@ public class ApplicantProgramBlockEditViewTest extends ResetPostgres {
           Mockito.mock(ApplicantFileUploadRenderer.class),
           Mockito.mock(ApplicantQuestionRendererFactory.class),
           applicantRoutes);
-
-  @BeforeClass
-  public static void setupMock() {
-    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
-  }
 
   @Test
   public void

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -3,7 +3,6 @@ package views.questiontypes;
 import static j2html.TagCreator.document;
 import static j2html.TagCreator.html;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 import static play.test.Helpers.stubMessagesApi;
 
 import com.google.common.collect.ImmutableSet;
@@ -11,15 +10,12 @@ import controllers.applicant.ApplicantRoutes;
 import j2html.tags.specialized.DivTag;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionType;
-import services.settings.SettingsManifest;
 import views.applicant.ApplicantFileUploadRenderer;
 import views.fileupload.AwsFileUploadViewStrategy;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
@@ -35,13 +31,6 @@ public class ApplicantQuestionRendererFactoryTest {
           .setErrorDisplayMode(ErrorDisplayMode.HIDE_ERRORS)
           .build();
 
-  private final SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-
-  @Before
-  public void setupMock() {
-    when(mockSettingsManifest.getNewApplicantUrlSchemaEnabled()).thenReturn(true);
-  }
-
   @Test
   @Parameters(source = QuestionType.class)
   public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
@@ -50,7 +39,7 @@ public class ApplicantQuestionRendererFactoryTest {
       return;
     }
 
-    var applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+    var applicantRoutes = new ApplicantRoutes();
 
     ApplicantQuestionRendererFactory factory =
         new ApplicantQuestionRendererFactory(
@@ -73,7 +62,7 @@ public class ApplicantQuestionRendererFactoryTest {
       return;
     }
 
-    var applicantRoutes = new ApplicantRoutes(mockSettingsManifest);
+    var applicantRoutes = new ApplicantRoutes();
 
     // Multi-input questions should be wrapped in fieldsets for screen reader users.
     ApplicantQuestionRendererFactory factory =


### PR DESCRIPTION
### Description

Retire new_applicant_url_schema_enabled feature flag. The default flag value was set to `true` in #6253.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

Relates to #6270
