### PR TITLE
[Program Card Images] Add alt text when rendering program cards with images.

### DIFF
--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -252,7 +252,7 @@ describe('applicant program index page', () => {
 })
 
 // TODO(#5676): Re-enable once the deployment scripts are correctly updated.
-describe('applicant program index page with images', () => {
+xdescribe('applicant program index page with images', () => {
   const ctx = createTestContext()
 
   it('shows program with wide image', async () => {
@@ -268,7 +268,7 @@ describe('applicant program index page with images', () => {
     await adminPrograms.publishAllDrafts()
     await logout(page)
 
- //   await validateScreenshot(page, 'program-image-wide')
+    await validateScreenshot(page, 'program-image-wide')
     await validateAccessibility(page)
   })
 
@@ -285,7 +285,7 @@ describe('applicant program index page with images', () => {
     await adminPrograms.publishAllDrafts()
     await logout(page)
 
-   // await validateScreenshot(page, 'program-image-tall')
+    await validateScreenshot(page, 'program-image-tall')
   })
 
   it('no program image if flag off', async () => {
@@ -305,7 +305,7 @@ describe('applicant program index page with images', () => {
     await logout(page)
 
     // Verify the user doesn't see the image
-    //await validateScreenshot(page, 'program-image-flag-off')
+    await validateScreenshot(page, 'program-image-flag-off')
   })
 
   it('shows program with image and status', async () => {
@@ -331,7 +331,7 @@ describe('applicant program index page with images', () => {
 
     // Verify program card shows both the Accepted status and image
     await loginAsTestUser(page)
-  //  await validateScreenshot(page, 'program-image-with-status')
+    await validateScreenshot(page, 'program-image-with-status')
   })
 
   // This test puts programs with different specs in the different sections of the homepage
@@ -480,7 +480,7 @@ describe('applicant program index page with images', () => {
 
     // Verify homepage
     await loginAsTestUser(page)
-  //  await validateScreenshot(page, 'program-image-all-types')
+    await validateScreenshot(page, 'program-image-all-types')
     await validateAccessibility(page)
   })
 

--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -252,7 +252,7 @@ describe('applicant program index page', () => {
 })
 
 // TODO(#5676): Re-enable once the deployment scripts are correctly updated.
-xdescribe('applicant program index page with images', () => {
+describe('applicant program index page with images', () => {
   const ctx = createTestContext()
 
   it('shows program with wide image', async () => {
@@ -269,6 +269,7 @@ xdescribe('applicant program index page with images', () => {
     await logout(page)
 
     await validateScreenshot(page, 'program-image-wide')
+    await validateAccessibility(page)
   })
 
   it('shows program with tall image', async () => {
@@ -480,10 +481,10 @@ xdescribe('applicant program index page with images', () => {
     // Verify homepage
     await loginAsTestUser(page)
     await validateScreenshot(page, 'program-image-all-types')
+    await validateAccessibility(page)
   })
 
   // TODO(#5676): Test with a very small image.
-  // TODO(#5676): Add validateAccessibility tests once the alt-text is added.
 
   async function submitApplicationAndApplyStatus(
     page: Page,

--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -268,7 +268,7 @@ describe('applicant program index page with images', () => {
     await adminPrograms.publishAllDrafts()
     await logout(page)
 
-    await validateScreenshot(page, 'program-image-wide')
+ //   await validateScreenshot(page, 'program-image-wide')
     await validateAccessibility(page)
   })
 
@@ -285,7 +285,7 @@ describe('applicant program index page with images', () => {
     await adminPrograms.publishAllDrafts()
     await logout(page)
 
-    await validateScreenshot(page, 'program-image-tall')
+   // await validateScreenshot(page, 'program-image-tall')
   })
 
   it('no program image if flag off', async () => {
@@ -305,7 +305,7 @@ describe('applicant program index page with images', () => {
     await logout(page)
 
     // Verify the user doesn't see the image
-    await validateScreenshot(page, 'program-image-flag-off')
+    //await validateScreenshot(page, 'program-image-flag-off')
   })
 
   it('shows program with image and status', async () => {
@@ -331,7 +331,7 @@ describe('applicant program index page with images', () => {
 
     // Verify program card shows both the Accepted status and image
     await loginAsTestUser(page)
-    await validateScreenshot(page, 'program-image-with-status')
+  //  await validateScreenshot(page, 'program-image-with-status')
   })
 
   // This test puts programs with different specs in the different sections of the homepage
@@ -480,7 +480,7 @@ describe('applicant program index page with images', () => {
 
     // Verify homepage
     await loginAsTestUser(page)
-    await validateScreenshot(page, 'program-image-all-types')
+  //  await validateScreenshot(page, 'program-image-all-types')
     await validateAccessibility(page)
   })
 

--- a/server/app/views/applicant/ProgramCardViewRenderer.java
+++ b/server/app/views/applicant/ProgramCardViewRenderer.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
 import play.mvc.Http;
-import services.LocalizedStrings;
 import services.MessageKey;
 import services.applicant.ApplicantPersonalInfo;
 import services.applicant.ApplicantService;
@@ -239,20 +238,21 @@ public final class ProgramCardViewRenderer {
     // TODO(#5676): Can we detect if the image URL is invalid and then not show it?
     // TODO(#5676): Include a placeholder while the image is loading.
 
-    LocalizedStrings altText;
-    if (program.localizedSummaryImageDescription().isPresent()
-        && program.localizedSummaryImageDescription().get().hasTranslationFor(preferredLocale)) {
-      altText = program.localizedSummaryImageDescription().get();
-    } else {
-      // Fall back to the program name if the description hasn't been set
-      altText = program.localizedName();
-    }
-
     return Optional.of(
         img()
             .withSrc(publicStorageClient.getPublicDisplayUrl(program.summaryImageFileKey().get()))
-            .withAlt(altText.getOrDefault(preferredLocale))
+            .withAlt(getProgramImageAltText(program, preferredLocale))
             .withClasses("w-full", "aspect-video", "object-cover", "rounded-b-lg"));
+  }
+
+  private static String getProgramImageAltText(ProgramDefinition program, Locale preferredLocale) {
+    if (program.localizedSummaryImageDescription().isPresent()
+        && program.localizedSummaryImageDescription().get().hasTranslationFor(preferredLocale)) {
+      return program.localizedSummaryImageDescription().get().getOrDefault(preferredLocale);
+    } else {
+      // Fall back to the program name if the description hasn't been set.
+      return program.localizedName().getOrDefault(preferredLocale);
+    }
   }
 
   /**

--- a/server/app/views/applicant/ProgramCardViewRenderer.java
+++ b/server/app/views/applicant/ProgramCardViewRenderer.java
@@ -106,7 +106,8 @@ public final class ProgramCardViewRenderer {
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
 
     Optional<ImgTag> programImage =
-        createProgramImage(request, program, preferredLocale, settingsManifest, publicStorageClient);
+        createProgramImage(
+            request, program, preferredLocale, settingsManifest, publicStorageClient);
 
     ContainerTag title =
         nestedUnderSubheading
@@ -239,7 +240,8 @@ public final class ProgramCardViewRenderer {
     // TODO(#5676): Include a placeholder while the image is loading.
 
     LocalizedStrings altText;
-    if (program.localizedSummaryImageDescription().isPresent() && program.localizedSummaryImageDescription().get().hasTranslationFor(preferredLocale)) {
+    if (program.localizedSummaryImageDescription().isPresent()
+        && program.localizedSummaryImageDescription().get().hasTranslationFor(preferredLocale)) {
       altText = program.localizedSummaryImageDescription().get();
     } else {
       // Fall back to the program name if the description hasn't been set
@@ -249,7 +251,7 @@ public final class ProgramCardViewRenderer {
     return Optional.of(
         img()
             .withSrc(publicStorageClient.getPublicDisplayUrl(program.summaryImageFileKey().get()))
-                .withAlt(altText.getOrDefault(preferredLocale))
+            .withAlt(altText.getOrDefault(preferredLocale))
             .withClasses("w-full", "aspect-video", "object-cover", "rounded-b-lg"));
   }
 


### PR DESCRIPTION
### Description

This PR uses the `ProgramDefinition.localizedSummaryImageDescription` field as the program image's alt-text if that description is set for the user's language. If not, we fall back to using the program name as the alt-text.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method -- **I specifically verified that the tests now fail if the alt-text isn't set.**
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

### Issue(s) this completes

Epic #5676 

Fixes #6003 (sub task)
