### PR TITLE
[Program Card Images] Remove double "/" from program image URL

### DIFF
--- a/server/app/services/cloud/aws/AwsApplicantStorage.java
+++ b/server/app/services/cloud/aws/AwsApplicantStorage.java
@@ -109,6 +109,7 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
 
     S3Presigner getPresigner();
 
+    /** Returns the action link that applicant files should be sent to. Must end in a `/`. */
     String actionLink();
 
     void close();
@@ -140,7 +141,7 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
 
     @Override
     public String actionLink() {
-      return "fake-action-link";
+      return "fake-action-link/";
     }
 
     @Override

--- a/server/app/services/cloud/aws/AwsPublicStorage.java
+++ b/server/app/services/cloud/aws/AwsPublicStorage.java
@@ -63,13 +63,14 @@ public final class AwsPublicStorage extends PublicStorageClient {
   }
 
   interface Client {
+    /** Returns the action link that public files should be sent to. Must end in a `/`. */
     String actionLink();
   }
 
   static class NullClient implements Client {
     @Override
     public String actionLink() {
-      return "fake-action-link";
+      return "fake-action-link/";
     }
   }
 

--- a/server/app/services/cloud/aws/AwsPublicStorage.java
+++ b/server/app/services/cloud/aws/AwsPublicStorage.java
@@ -59,7 +59,7 @@ public final class AwsPublicStorage extends PublicStorageClient {
   /** Returns a direct cloud storage URL to the file with the given key. */
   @Override
   protected String getPublicDisplayUrlInternal(String fileKey) {
-    return client.actionLink() + "/" + fileKey;
+    return client.actionLink() + fileKey;
   }
 
   interface Client {

--- a/server/app/services/cloud/aws/AwsStorageUtils.java
+++ b/server/app/services/cloud/aws/AwsStorageUtils.java
@@ -71,13 +71,17 @@ public final class AwsStorageUtils {
   /** Returns the action link to use when uploading or downloading to LocalStack. */
   public String localStackActionLink(Config config, String bucketName, Region region) {
     try {
-      String url = S3EndpointProvider.defaultProvider()
-          .resolveEndpoint(
-              (builder) ->
-                  builder.endpoint(localStackEndpoint(config)).bucket(bucketName).region(region))
-          .get()
-          .url()
-          .toString();
+      String url =
+          S3EndpointProvider.defaultProvider()
+              .resolveEndpoint(
+                  (builder) ->
+                      builder
+                          .endpoint(localStackEndpoint(config))
+                          .bucket(bucketName)
+                          .region(region))
+              .get()
+              .url()
+              .toString();
       // The prod AWS action links end with a "/", so have our localstack action links do the same.
       return url + "/";
     } catch (ExecutionException | InterruptedException e) {

--- a/server/app/services/cloud/aws/AwsStorageUtils.java
+++ b/server/app/services/cloud/aws/AwsStorageUtils.java
@@ -71,13 +71,15 @@ public final class AwsStorageUtils {
   /** Returns the action link to use when uploading or downloading to LocalStack. */
   public String localStackActionLink(Config config, String bucketName, Region region) {
     try {
-      return S3EndpointProvider.defaultProvider()
+      String url = S3EndpointProvider.defaultProvider()
           .resolveEndpoint(
               (builder) ->
                   builder.endpoint(localStackEndpoint(config)).bucket(bucketName).region(region))
           .get()
           .url()
           .toString();
+      // The prod AWS action links end with a "/", so have our localstack action links do the same.
+      return url + "/";
     } catch (ExecutionException | InterruptedException e) {
       logger.warn("Unable to create a Localstack action link. Returning empty string");
       return "";

--- a/server/app/services/cloud/aws/AwsStorageUtils.java
+++ b/server/app/services/cloud/aws/AwsStorageUtils.java
@@ -82,7 +82,7 @@ public final class AwsStorageUtils {
               .get()
               .url()
               .toString();
-      // The prod AWS action links end with a "/", so have our localstack action links do the same.
+      // The prod AWS action links end with `/`, so our LocalStack action links should do the same.
       return url + "/";
     } catch (ExecutionException | InterruptedException e) {
       logger.warn("Unable to create a Localstack action link. Returning empty string");

--- a/server/test/services/cloud/aws/AwsApplicantStorageTest.java
+++ b/server/test/services/cloud/aws/AwsApplicantStorageTest.java
@@ -31,6 +31,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
         awsApplicantStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
+    assertThat(uploadRequest.actionLink()).endsWith("/");
   }
 
   @Test
@@ -49,6 +50,7 @@ public class AwsApplicantStorageTest extends ResetPostgres {
 
     assertThat(uploadRequest.actionLink()).contains("localstack");
     assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
+    assertThat(uploadRequest.actionLink()).endsWith("/");
   }
 
   @Test

--- a/server/test/services/cloud/aws/AwsPublicStorageTest.java
+++ b/server/test/services/cloud/aws/AwsPublicStorageTest.java
@@ -30,6 +30,7 @@ public class AwsPublicStorageTest extends ResetPostgres {
         awsPublicStorage.getSignedUploadRequest("fileKey", "redirect");
 
     assertThat(uploadRequest.actionLink()).contains("amazonaws.com");
+    assertThat(uploadRequest.actionLink()).endsWith("/");
   }
 
   @Test
@@ -47,6 +48,7 @@ public class AwsPublicStorageTest extends ResetPostgres {
 
     assertThat(uploadRequest.actionLink()).contains("localstack");
     assertThat(uploadRequest.actionLink()).doesNotContain("amazonaws.com");
+    assertThat(uploadRequest.actionLink()).endsWith("/");
   }
 
   @Test


### PR DESCRIPTION
### Description

After I got the new AWS bucket for program images working on a staging deployment, I noticed a bug with the formatting of the program image URL.

The image URL should be something like:

```
https://caitlinshk-test-permissions-bucket.s3.amazonaws.com/program-summary-image/program-1/my-program-image.png
```

but the actual URL getting created was:

```
https://caitlinshk-test-permissions-bucket.s3.amazonaws.com//program-summary-image/program-1/my-program-image.png
```

Notice the two `/`s after `amazonaws.com`. This is incorrect and causes the program image to not load. Removing one of the `/`s makes the image load correctly.

It looks like our fake version of AWS for local development (LocalStack) does *not* contain a `/` at the end of its base URL, whereas the prod version of AWS *does* include a `/` at the end, which is why program images were working locally but not on a staging deployment. This PR fixes these base URLs to always end in `/` for all versions.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Enable the PROGRAM_CARD_IMAGES flag.
2. On the admin side, edit a program then click "Edit program image" then upload an image. Verify the program card preview shows the image correctly.
3. Publish the program, then log out to view the homepage as an applicant. Verify the program card shows the image correctly for the applicant as well.

### Issue(s) this completes

Epic #5676
