### PR TITLE
Added dev/seed/data page to avoid loading data in dev/seed page

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -74,12 +74,17 @@ public class DevDatabaseSeedController extends Controller {
     if (!isDevOrStaging) {
       return notFound();
     }
+    return ok(view.render(request, request.flash().get("success")));
+  }
+
+  public Result data(Request request) {
+    if (!isDevOrStaging) {
+      return notFound();
+    }
     ActiveAndDraftPrograms activeAndDraftPrograms = programService.getActiveAndDraftPrograms();
     ImmutableList<QuestionDefinition> questionDefinitions =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join().getAllQuestions();
-    return ok(
-        view.render(
-            request, activeAndDraftPrograms, questionDefinitions, request.flash().get("success")));
+    return ok(view.SeedDataView(request, activeAndDraftPrograms, questionDefinitions));
   }
 
   public Result seedQuestions() {

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -84,7 +84,7 @@ public class DevDatabaseSeedController extends Controller {
     ActiveAndDraftPrograms activeAndDraftPrograms = programService.getActiveAndDraftPrograms();
     ImmutableList<QuestionDefinition> questionDefinitions =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join().getAllQuestions();
-    return ok(view.SeedDataView(request, activeAndDraftPrograms, questionDefinitions));
+    return ok(view.seedDataView(request, activeAndDraftPrograms, questionDefinitions));
   }
 
   public Result seedQuestions() {

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -56,8 +56,7 @@ public class DatabaseSeedView extends BaseHtmlView {
                 div()
                     .with(
                         form()
-                            .with(makeCsrfTokenInputTag(request))
-                            .with(submitButton("index", "Go to index page"))
+                            .with(submitButton("index", "Go to dev database seeder page"))
                             .withMethod("get")
                             .withAction(routes.DevDatabaseSeedController.index().url())))
             .with(
@@ -112,13 +111,13 @@ public class DatabaseSeedView extends BaseHtmlView {
                             .with(makeCsrfTokenInputTag(request))
                             .with(submitButton("index", "Go to index page"))
                             .withMethod("get")
-                            .withAction(routes.DevDatabaseSeedController.index().url())))
-            .with(
-                form()
-                    .with(makeCsrfTokenInputTag(request))
-                    .with(submitButton("data", "Go to seed data page"))
-                    .withMethod("get")
-                    .withAction(routes.DevDatabaseSeedController.data().url()));
+                            .withAction(controllers.routes.HomeController.index().url()))
+                    .with(
+                        form()
+                            .with(makeCsrfTokenInputTag(request))
+                            .with(submitButton("data", "Go to seed data page"))
+                            .withMethod("get")
+                            .withAction(routes.DevDatabaseSeedController.data().url())));
 
     HtmlBundle bundle = layout.getBundle(request).setTitle(title).addMainContent(content);
     return layout.render(bundle);

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -70,7 +70,6 @@ public class DatabaseSeedView extends BaseHtmlView {
             .with(indexLinkTag)
             .with(
                 div()
-                    .with(makeCsrfTokenInputTag(request))
                     .withClasses("grid", "grid-cols-2")
                     .with(div().with(h2("Current Draft Programs:")).with(pre(prettyDraftPrograms)))
                     .with(

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -43,6 +43,9 @@ public class DatabaseSeedView extends BaseHtmlView {
       Request request,
       ActiveAndDraftPrograms activeAndDraftPrograms,
       ImmutableList<QuestionDefinition> questionDefinitions) {
+
+    String title = "Dev database seed data";
+
     ImmutableList<ProgramDefinition> draftPrograms = activeAndDraftPrograms.getDraftPrograms();
     ImmutableList<ProgramDefinition> activePrograms = activeAndDraftPrograms.getActivePrograms();
 
@@ -52,15 +55,18 @@ public class DatabaseSeedView extends BaseHtmlView {
 
     DivTag content =
         div()
+            .with(h1(title))
             .with(
                 div()
                     .with(
                         form()
+                            .with(makeCsrfTokenInputTag(request))
                             .with(submitButton("index", "Go to dev database seeder page"))
                             .withMethod("get")
                             .withAction(routes.DevDatabaseSeedController.index().url())))
             .with(
                 form()
+                    .with(makeCsrfTokenInputTag(request))
                     .withClasses("grid", "grid-cols-2")
                     .with(div().with(h2("Current Draft Programs:")).with(pre(prettyDraftPrograms)))
                     .with(

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -69,7 +69,7 @@ public class DatabaseSeedView extends BaseHtmlView {
             .with(h1(title))
             .with(indexLinkTag)
             .with(
-                form()
+                div()
                     .with(makeCsrfTokenInputTag(request))
                     .withClasses("grid", "grid-cols-2")
                     .with(div().with(h2("Current Draft Programs:")).with(pre(prettyDraftPrograms)))

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -1,6 +1,7 @@
 package views.dev;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
 import controllers.dev.seeding.routes;
+import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -43,7 +45,7 @@ public class DatabaseSeedView extends BaseHtmlView {
    * Renders a page for a developer to view seeded data. This is only available in non-prod
    * environments.
    */
-  public Content SeedDataView(
+  public Content seedDataView(
       Request request,
       ActiveAndDraftPrograms activeAndDraftPrograms,
       ImmutableList<QuestionDefinition> questionDefinitions) {
@@ -57,17 +59,15 @@ public class DatabaseSeedView extends BaseHtmlView {
     String prettyActivePrograms = getPrettyJson(activePrograms);
     String prettyQuestions = getPrettyJson(questionDefinitions);
 
+    ATag indexLinkTag =
+        a().withHref(routes.DevDatabaseSeedController.index().url())
+            .withId("index")
+            .with(submitButton("index", "Go to dev database seeder page"));
+
     DivTag content =
         div()
             .with(h1(title))
-            .with(
-                div()
-                    .with(
-                        form()
-                            .with(makeCsrfTokenInputTag(request))
-                            .with(submitButton("index", "Go to dev database seeder page"))
-                            .withMethod("get")
-                            .withAction(routes.DevDatabaseSeedController.index().url())))
+            .with(indexLinkTag)
             .with(
                 form()
                     .with(makeCsrfTokenInputTag(request))
@@ -85,6 +85,10 @@ public class DatabaseSeedView extends BaseHtmlView {
   public Content render(Request request, Optional<String> maybeFlash) {
 
     String title = "Dev database seeder";
+
+    ATag datalinkTag =
+        a().withHref(routes.DevDatabaseSeedController.data().url())
+            .with(submitButton("data", "Go to seed data page"));
 
     DivTag content =
         div()
@@ -122,12 +126,7 @@ public class DatabaseSeedView extends BaseHtmlView {
                             .with(submitButton("index", "Go to index page"))
                             .withMethod("get")
                             .withAction(controllers.routes.HomeController.index().url()))
-                    .with(
-                        form()
-                            .with(makeCsrfTokenInputTag(request))
-                            .with(submitButton("data", "Go to seed data page"))
-                            .withMethod("get")
-                            .withAction(routes.DevDatabaseSeedController.data().url())));
+                    .with(datalinkTag));
 
     HtmlBundle bundle = layout.getBundle(request).setTitle(title).addMainContent(content);
     return layout.render(bundle);

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -39,18 +39,41 @@ public class DatabaseSeedView extends BaseHtmlView {
     this.objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }
 
-  public Content render(
+  public Content SeedDataView(
       Request request,
       ActiveAndDraftPrograms activeAndDraftPrograms,
-      ImmutableList<QuestionDefinition> questionDefinitions,
-      Optional<String> maybeFlash) {
-
+      ImmutableList<QuestionDefinition> questionDefinitions) {
     ImmutableList<ProgramDefinition> draftPrograms = activeAndDraftPrograms.getDraftPrograms();
     ImmutableList<ProgramDefinition> activePrograms = activeAndDraftPrograms.getActivePrograms();
 
     String prettyDraftPrograms = getPrettyJson(draftPrograms);
     String prettyActivePrograms = getPrettyJson(activePrograms);
     String prettyQuestions = getPrettyJson(questionDefinitions);
+
+    DivTag content =
+        div()
+            .with(
+                div()
+                    .with(
+                        form()
+                            .with(makeCsrfTokenInputTag(request))
+                            .with(submitButton("index", "Go to index page"))
+                            .withMethod("get")
+                            .withAction(routes.DevDatabaseSeedController.index().url())))
+            .with(
+                form()
+                    .withClasses("grid", "grid-cols-2")
+                    .with(div().with(h2("Current Draft Programs:")).with(pre(prettyDraftPrograms)))
+                    .with(
+                        div().with(h2("Current Active Programs:")).with(pre(prettyActivePrograms)))
+                    .with(div().with(h2("Current Questions:")).with(pre(prettyQuestions))))
+            .withClasses("px-6", "py-6");
+
+    HtmlBundle bundle = layout.getBundle(request).addMainContent(content);
+    return layout.render(bundle);
+  }
+
+  public Content render(Request request, Optional<String> maybeFlash) {
 
     String title = "Dev database seeder";
 
@@ -89,15 +112,13 @@ public class DatabaseSeedView extends BaseHtmlView {
                             .with(makeCsrfTokenInputTag(request))
                             .with(submitButton("index", "Go to index page"))
                             .withMethod("get")
-                            .withAction(controllers.routes.HomeController.index().url())))
+                            .withAction(routes.DevDatabaseSeedController.index().url())))
             .with(
-                div()
-                    .withClasses("grid", "grid-cols-2")
-                    .with(div().with(h2("Current Draft Programs:")).with(pre(prettyDraftPrograms)))
-                    .with(
-                        div().with(h2("Current Active Programs:")).with(pre(prettyActivePrograms)))
-                    .with(div().with(h2("Current Questions:")).with(pre(prettyQuestions))))
-            .withClasses("px-6", "py-6");
+                form()
+                    .with(makeCsrfTokenInputTag(request))
+                    .with(submitButton("data", "Go to seed data page"))
+                    .withMethod("get")
+                    .withAction(routes.DevDatabaseSeedController.data().url()));
 
     HtmlBundle bundle = layout.getBundle(request).setTitle(title).addMainContent(content);
     return layout.render(bundle);

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -39,6 +39,10 @@ public class DatabaseSeedView extends BaseHtmlView {
     this.objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }
 
+  /**
+   * Renders a page for a developer to view seeded data. This is only available in non-prod
+   * environments.
+   */
   public Content SeedDataView(
       Request request,
       ActiveAndDraftPrograms activeAndDraftPrograms,
@@ -74,7 +78,7 @@ public class DatabaseSeedView extends BaseHtmlView {
                     .with(div().with(h2("Current Questions:")).with(pre(prettyQuestions))))
             .withClasses("px-6", "py-6");
 
-    HtmlBundle bundle = layout.getBundle(request).addMainContent(content);
+    HtmlBundle bundle = layout.getBundle(request).setTitle(title).addMainContent(content);
     return layout.render(bundle);
   }
 

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -231,6 +231,7 @@ GET     /logout                      @org.pac4j.play.LogoutController.logout(req
 ## Methods for development
 # Seed the database with test content to develop against, and clear the database
 GET     /dev/seed                        controllers.dev.seeding.DevDatabaseSeedController.index(request: Request)
+GET     /dev/seed/data                   controllers.dev.seeding.DevDatabaseSeedController.data(request: Request)
 POST    /dev/seedQuestions               controllers.dev.seeding.DevDatabaseSeedController.seedQuestions()
 POST    /dev/seedPrograms                controllers.dev.seeding.DevDatabaseSeedController.seedPrograms()
 POST    /dev/seed/clear                  controllers.dev.seeding.DevDatabaseSeedController.clear()

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
@@ -51,6 +51,13 @@ public class DevDatabaseSeedControllerTest {
     assertThat(result.flash().get("success")).hasValue("The database has been seeded");
     result = controller.index(addCSRFToken(fakeRequest()).build());
     assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
+
+    // Go to seed data display page.
+    result = controller.data();
+    assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.data().url());
+    result = controller.data(addCSRFToken(fakeRequest()).build());
+    assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("comprehensive-sample-program");
 
     // Clear the data.
@@ -84,7 +91,7 @@ public class DevDatabaseSeedControllerTest {
     assertThat(result.flash().get("success")).hasValue("The database has been seeded");
     result = controller.index(addCSRFToken(fakeRequest()).build());
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("comprehensive-sample-program");
+    assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
     // Load the data, which sets the cache and ensure it is present
     VersionModel activeVersion = versionRepo.getActiveVersion();
@@ -101,6 +108,15 @@ public class DevDatabaseSeedControllerTest {
   public void index_inNonDevMode_returnsNotFound() {
     setupControllerInMode(Mode.TEST);
     Result result = controller.index(fakeRequest().build());
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void data_inNonDevMode_returnsNotFound() {
+
+    setupControllerInMode(Mode.TEST);
+    Result result = controller.data(fakeRequest().build());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
@@ -54,8 +54,6 @@ public class DevDatabaseSeedControllerTest {
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
     // Go to seed data display page.
-    result = controller.data();
-    assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.data().url());
     result = controller.data(addCSRFToken(fakeRequest()).build());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("comprehensive-sample-program");


### PR DESCRIPTION
### Description

Changes with this PR:
1. Created a new page - dev/seed/data where we load seed data
2. Added a button on dev/seed page to direct user(devs) to dev/seed/data page
3. Added a button on dev/seed/data page to direct user(devs) back to dev/seed page

dev/seed page
<img width="606" alt="Screenshot 2023-12-31 at 4 46 21 PM" src="https://github.com/civiform/civiform/assets/149536150/966859e3-8372-424a-a9ac-81c3dc16c420">

dev/seed/data page
<img width="1172" alt="Screenshot 2024-01-02 at 1 16 54 PM" src="https://github.com/civiform/civiform/assets/149536150/dee7a086-3bf6-4bf5-957b-a5d4b9bab76c">

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5210
