### PR TITLE
Fix single program publish bug

### DIFF
--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -173,12 +173,12 @@ describe('Program list page.', () => {
     await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
 
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#program-one-publish-modal-button')
-    expect(await page.innerText('#program-one-publish-modal')).toContain(
+    await page.click('#publish-modal-program-one-button')
+    expect(await page.innerText('#publish-modal-program-one')).toContain(
       'Are you sure you want to publish program one and all of its draft questions?',
     )
     // Warning should not show because there are no universal questions
-    expect(await page.innerText('#program-one-publish-modal')).not.toContain(
+    expect(await page.innerText('#publish-modal-program-one')).not.toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await validateScreenshot(page, 'publish-single-program-modal-no-warning')
@@ -192,9 +192,9 @@ describe('Program list page.', () => {
       universal: true,
     })
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#program-one-publish-modal-button')
+    await page.click('#publish-modal-program-one-button')
     // Warning should show because there is a universal question that is not used in this program
-    expect(await page.innerText('#program-one-publish-modal')).toContain(
+    expect(await page.innerText('#publish-modal-program-one')).toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await validateScreenshot(page, 'publish-single-program-modal-with-warning')
@@ -205,9 +205,9 @@ describe('Program list page.', () => {
     await adminPrograms.gotoEditDraftProgramPage(programOne)
     await adminPrograms.addQuestionFromQuestionBank(textQuestion)
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#program-one-publish-modal-button')
+    await page.click('#publish-modal-program-one-button')
     // Warning should not show because the program uses all universal questions
-    expect(await page.innerText('#program-one-publish-modal')).not.toContain(
+    expect(await page.innerText('#publish-modal-program-one')).not.toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await adminQuestions.clickSubmitButtonAndNavigate('Publish program')

--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -172,13 +172,16 @@ describe('Program list page.', () => {
     await adminPrograms.gotoEditDraftProgramPage(programOne)
     await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
 
+    const publishProgramOneModalButton = '#publish-modal-program-one-button'
+    const publishProgramOneModal = '#publish-modal-program-one'
+
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#publish-modal-program-one-button')
-    expect(await page.innerText('#publish-modal-program-one')).toContain(
+    await page.click(publishProgramOneModalButton)
+    expect(await page.innerText(publishProgramOneModal)).toContain(
       'Are you sure you want to publish program one and all of its draft questions?',
     )
     // Warning should not show because there are no universal questions
-    expect(await page.innerText('#publish-modal-program-one')).not.toContain(
+    expect(await page.innerText(publishProgramOneModal)).not.toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await validateScreenshot(page, 'publish-single-program-modal-no-warning')
@@ -192,9 +195,9 @@ describe('Program list page.', () => {
       universal: true,
     })
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#publish-modal-program-one-button')
+    await page.click(publishProgramOneModalButton)
     // Warning should show because there is a universal question that is not used in this program
-    expect(await page.innerText('#publish-modal-program-one')).toContain(
+    expect(await page.innerText(publishProgramOneModal)).toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await validateScreenshot(page, 'publish-single-program-modal-with-warning')
@@ -205,9 +208,9 @@ describe('Program list page.', () => {
     await adminPrograms.gotoEditDraftProgramPage(programOne)
     await adminPrograms.addQuestionFromQuestionBank(textQuestion)
     await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#publish-modal-program-one-button')
+    await page.click(publishProgramOneModalButton)
     // Warning should not show because the program uses all universal questions
-    expect(await page.innerText('#publish-modal-program-one')).not.toContain(
+    expect(await page.innerText(publishProgramOneModal)).not.toContain(
       'Warning: This program does not use all recommended universal questions.',
     )
     await adminQuestions.clickSubmitButtonAndNavigate('Publish program')

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -263,7 +263,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                           "flex", "flex-col", StyleUtils.responsiveMedium("flex-row"), "py-4");
 
               return Modal.builder()
-                  .setModalId(program.adminName() + "-publish-modal")
+                  .setModalId("publish-modal-" + program.id())
                   .setLocation(Modal.Location.ADMIN_FACING)
                   .setContent(
                       publishSingleProgramForm
@@ -277,7 +277,6 @@ public final class ProgramIndexView extends BaseHtmlView {
                           + " and all of its draft questions?")
                   .setTriggerButtonContent(
                       makeSvgTextButton("Publish", Icons.PUBLISH)
-                          .withId(program.adminName() + "-publish-modal-button")
                           .withClasses(ButtonStyles.CLEAR_WITH_ICON))
                   .setWidth(Modal.Width.THIRD)
                   .build();
@@ -450,7 +449,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         publishSingleProgramModals.stream()
             .forEach(
                 (modal) -> {
-                  if (modal.modalId().equals(draftProgram.get().adminName() + "-publish-modal")) {
+                  if (modal.modalId().equals("publish-modal-" + draftProgram.get().id())) {
                     draftRowActions.add(modal.getButton());
                   }
                 });

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -263,7 +263,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                           "flex", "flex-col", StyleUtils.responsiveMedium("flex-row"), "py-4");
 
               return Modal.builder()
-                  .setModalId("publish-modal-" + program.id())
+                  .setModalId("publish-modal-" + program.slug())
                   .setLocation(Modal.Location.ADMIN_FACING)
                   .setContent(
                       publishSingleProgramForm
@@ -449,7 +449,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         publishSingleProgramModals.stream()
             .forEach(
                 (modal) -> {
-                  if (modal.modalId().equals("publish-modal-" + draftProgram.get().id())) {
+                  if (modal.modalId().equals("publish-modal-" + draftProgram.get().slug())) {
                     draftRowActions.add(modal.getButton());
                   }
                 });

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -263,7 +263,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                           "flex", "flex-col", StyleUtils.responsiveMedium("flex-row"), "py-4");
 
               return Modal.builder()
-                  .setModalId("publish-modal-" + program.slug())
+                  .setModalId(buildPublishModalId(program.slug()))
                   .setLocation(Modal.Location.ADMIN_FACING)
                   .setContent(
                       publishSingleProgramForm
@@ -282,6 +282,10 @@ public final class ProgramIndexView extends BaseHtmlView {
                   .build();
             })
         .collect(ImmutableList.toImmutableList());
+  }
+
+  private String buildPublishModalId(String programSlug) {
+    return "publish-modal-" + programSlug;
   }
 
   private int getCountMissingUniversalQuestions(
@@ -449,7 +453,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         publishSingleProgramModals.stream()
             .forEach(
                 (modal) -> {
-                  if (modal.modalId().equals("publish-modal-" + draftProgram.get().slug())) {
+                  if (modal.modalId().equals(buildPublishModalId(draftProgram.get().slug()))) {
                     draftRowActions.add(modal.getButton());
                   }
                 });


### PR DESCRIPTION
### Description

When the Universal Questions feature flag is turned on, single program publish doesn't work with program admin names that include invalid characters. These characters are no longer allowed to be saved as `adminName` but this breaks with legacy data which impacts at least Seattle.

This fix changes the logic to reference `program.slug` instead of `program.adminName` when creating the reference name for the modal. `program.slug` is a [created from the admin name](https://github.com/civiform/civiform/blob/5e665380c10d7db32b1e8f1abdc264ada2455f68/server/app/services/program/ProgramDefinition.java#L495) with special characters stripped out.

## Release notes

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

1. Login as an admin and create a program
2. From the admin program index page, attempt to publish that one program
3. Program should publish successfully

Also try this with legacy data that includes invalid characters in `adminName` (Eg. "Gold Card (HSD)")

### Issue(s) this completes

Fixes #6194 ;
