### PR TITLE
Prevent form id from starting with a digit

### DIFF
--- a/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditViewV2.java
@@ -168,7 +168,7 @@ public final class ProgramPredicatesEditViewV2 extends ProgramBaseView {
 
     String title =
         String.format("%s condition for %s", predicateTypeNameTitleCase, blockDefinition.name());
-    String removePredicateFormId = UUID.randomUUID().toString();
+    String removePredicateFormId = String.format("form-%s", UUID.randomUUID());
     FormTag removePredicateForm =
         form(csrfTag)
             .withId(removePredicateFormId)


### PR DESCRIPTION
### Description

On page load a random UUID is used for as the Id on the form to replace eligibility predicates. Sometimes the UUID would start with a digit. This is valid for an HTML Id, but not for CSS or Javascript's `document.querySelector`. This would cause an random error when trying use that form when the Id started with a digit.

This PR adds a fixed prefix to the Id before the UUID so this no long occurs.

## Release notes

Prevent admin program eligibility predicate form from getting an Id value that starts with a digit (0-9).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes
Related to #5372