### PR TITLE
[Program Card Images] Add warning to PublicFileNameFormatter about modifying file keys

### DIFF
--- a/server/app/services/cloud/PublicFileNameFormatter.java
+++ b/server/app/services/cloud/PublicFileNameFormatter.java
@@ -14,6 +14,10 @@ public final class PublicFileNameFormatter {
    *
    * <p>If this key is changed, also check with {@link ApplicantFileNameFormatter} to verify that
    * the names don't conflict.
+   *
+   * <p>If this key is changed, you may also need to update the cloud storage bucket permissions to
+   * ensure the files are still publicly visible. For AWS, see the
+   * cloud/aws/templates/aws_oidc/filestorage.tf file in the cloud-deploy-infra repository.
    */
   public static String formatPublicProgramImageFileKey(long programId) {
     return String.format("%s%d/${filename}", PROGRAM_IMAGE_FILE_KEY_PREFIX, programId);

--- a/server/app/services/cloud/PublicFileNameFormatter.java
+++ b/server/app/services/cloud/PublicFileNameFormatter.java
@@ -16,8 +16,9 @@ public final class PublicFileNameFormatter {
    * the names don't conflict.
    *
    * <p>If this key is changed, you may also need to update the cloud storage bucket permissions to
-   * ensure the files are still publicly visible. For AWS, see
-   * cloud/aws/templates/aws_oidc/filestorage.tf in the cloud-deploy-infra repository.
+   * ensure the files are still publicly visible. For AWS, see <a
+   * href="https://github.com/civiform/cloud-deploy-infra/blob/ffcc84855b7215149b494b1e2591eed510ca30ca/cloud/aws/templates/aws_oidc/filestorage.tf#L131">filestorage.tf
+   * in the cloud-deploy-infra repository</a>.
    */
   public static String formatPublicProgramImageFileKey(long programId) {
     return String.format("%s%d/${filename}", PROGRAM_IMAGE_FILE_KEY_PREFIX, programId);

--- a/server/app/services/cloud/PublicFileNameFormatter.java
+++ b/server/app/services/cloud/PublicFileNameFormatter.java
@@ -16,8 +16,8 @@ public final class PublicFileNameFormatter {
    * the names don't conflict.
    *
    * <p>If this key is changed, you may also need to update the cloud storage bucket permissions to
-   * ensure the files are still publicly visible. For AWS, see the
-   * cloud/aws/templates/aws_oidc/filestorage.tf file in the cloud-deploy-infra repository.
+   * ensure the files are still publicly visible. For AWS, see
+   * cloud/aws/templates/aws_oidc/filestorage.tf in the cloud-deploy-infra repository.
    */
   public static String formatPublicProgramImageFileKey(long programId) {
     return String.format("%s%d/${filename}", PROGRAM_IMAGE_FILE_KEY_PREFIX, programId);


### PR DESCRIPTION
### Description

This PR adds some documentation to the `PublicFileNameFormatter` class warning that if the file key format is changed, then the cloud storage bucket permissions may also need to be changed.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Epic #5676 
