### PR TITLE
Auto label .github changes as ignore-for-release

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,3 +10,7 @@ database:
 i18n:
   - changed-files:
       - any-glob-to-any-file: 'server/conf/i18n/*'
+
+ignore-for-release:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**/*'


### PR DESCRIPTION
Automatically label PRs with changed files in the .github directory with the ignore-for-release.