### PR TITLE
When screen is very narrow, use 1 column instead of 2 to prevent text overflow

### DIFF
--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -39,7 +39,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
 
   private static final String ENUMERATOR_FIELD_CLASSES =
       StyleUtils.joinStyles(
-          ReferenceClasses.ENUMERATOR_FIELD, "grid", "grid-cols-2", "gap-4", "mb-4");
+          ReferenceClasses.ENUMERATOR_FIELD, "grid", "grid-cols-1",  "sm:grid-cols-2", "gap-4", "mb-4");
 
   public EnumeratorQuestionRenderer(ApplicantQuestion question) {
     super(question);

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -39,7 +39,12 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
 
   private static final String ENUMERATOR_FIELD_CLASSES =
       StyleUtils.joinStyles(
-          ReferenceClasses.ENUMERATOR_FIELD, "grid", "grid-cols-1",  "sm:grid-cols-2", "gap-4", "mb-4");
+          ReferenceClasses.ENUMERATOR_FIELD,
+          "grid",
+          "grid-cols-1",
+          "sm:grid-cols-2",
+          "gap-4",
+          "mb-4");
 
   public EnumeratorQuestionRenderer(ApplicantQuestion question) {
     super(question);


### PR DESCRIPTION
### Description

For enumeration questions in narrow screens (<640px), use 1 column for the grid instead of 2. This prevents the text from the remove button from overflowing the input for long question titles (either in English or translated).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #5822 
