### PR TITLE
Have better formatting for the LocalStack URL

### DIFF
--- a/server/app/services/cloud/aws/AwsApplicantStorage.java
+++ b/server/app/services/cloud/aws/AwsApplicantStorage.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.when;
 import static services.cloud.aws.AwsStorageUtils.AWS_PRESIGNED_URL_DURATION;
 
 import com.typesafe.config.Config;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -181,13 +179,11 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
     LocalStackClient(Config config, AwsStorageUtils awsStorageUtils) {
       this.config = checkNotNull(config);
       this.awsStorageUtils = checkNotNull(awsStorageUtils);
-      String localEndpoint = awsStorageUtils.localStackEndpoint(config);
-      try {
-        URI localUri = new URI(localEndpoint);
-        presigner = S3Presigner.builder().endpointOverride(localUri).region(region).build();
-      } catch (URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
+      this.presigner =
+          S3Presigner.builder()
+              .endpointOverride(awsStorageUtils.localStackEndpoint(config))
+              .region(region)
+              .build();
     }
 
     @Override

--- a/server/app/services/cloud/aws/AwsStorageUtils.java
+++ b/server/app/services/cloud/aws/AwsStorageUtils.java
@@ -89,9 +89,17 @@ public final class AwsStorageUtils {
     }
   }
 
-  /** Returns the endpoint to use to connect with LocalStack. */
+  /** Returns the endpoint to use to connect with LocalStack to manage file storage. */
   public URI localStackEndpoint(Config config) {
     String localEndpoint = checkNotNull(config).getString(AWS_LOCAL_ENDPOINT_CONF_PATH);
-    return URI.create(localEndpoint);
+    // LocalStack actions that deal with file storage (upload, download, deletion) need to have
+    // "s3." prepended to the URL for them to work correctly. However, we also use LocalStack
+    // for non-file actions like emailing applicants when they've submitted an application (see
+    // SimpleEmail). Those actions do *not* need the "s3." in the URL.
+    // So, AWS_LOCAL_ENDPOINT_CONF_PATH represents the main LocalStack URL without the "s3."
+    // and we manually add the "s3." here since it's only needed for file-related LocalStack
+    // actions.
+    URI mainUri = URI.create(localEndpoint);
+    return URI.create(String.format("%s://s3.%s", mainUri.getScheme(), mainUri.getAuthority()));
   }
 }

--- a/server/app/services/cloud/aws/AwsStorageUtils.java
+++ b/server/app/services/cloud/aws/AwsStorageUtils.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.typesafe.config.Config;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
@@ -76,7 +75,7 @@ public final class AwsStorageUtils {
               .resolveEndpoint(
                   (builder) ->
                       builder
-                          .endpoint(localStackEndpoint(config))
+                          .endpoint(localStackEndpoint(config).toString())
                           .bucket(bucketName)
                           .region(region))
               .get()
@@ -91,14 +90,8 @@ public final class AwsStorageUtils {
   }
 
   /** Returns the endpoint to use to connect with LocalStack. */
-  public String localStackEndpoint(Config config) {
+  public URI localStackEndpoint(Config config) {
     String localEndpoint = checkNotNull(config).getString(AWS_LOCAL_ENDPOINT_CONF_PATH);
-    try {
-      URI localUri = new URI(localEndpoint);
-      return String.format("%s://s3.%s", localUri.getScheme(), localUri.getAuthority());
-    } catch (URISyntaxException e) {
-      logger.warn("Unable to create a Localstack endpoint URL. Returning empty string");
-      return "";
-    }
+    return URI.create(localEndpoint);
   }
 }

--- a/server/conf/helper/cloud.conf
+++ b/server/conf/helper/cloud.conf
@@ -7,7 +7,7 @@ aws.s3.bucket=civiform-local-s3
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
 aws.s3.public_bucket=civiform-local-s3-public
 aws.s3.public_bucket=${?AWS_S3_PUBLIC_BUCKET_NAME}
-aws.local.endpoint="http://localhost.localstack.cloud:4566"
+aws.local.endpoint="http://s3.localhost.localstack.cloud:4566"
 # Max size of file in Mb allowed to be uploaded to S3.
 aws.s3.filelimitmb=100
 aws.s3.filelimitmb=${?AWS_S3_FILE_LIMIT_MB}

--- a/server/conf/helper/cloud.conf
+++ b/server/conf/helper/cloud.conf
@@ -7,7 +7,7 @@ aws.s3.bucket=civiform-local-s3
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
 aws.s3.public_bucket=civiform-local-s3-public
 aws.s3.public_bucket=${?AWS_S3_PUBLIC_BUCKET_NAME}
-aws.local.endpoint="http://s3.localhost.localstack.cloud:4566"
+aws.local.endpoint="http://localhost.localstack.cloud:4566"
 # Max size of file in Mb allowed to be uploaded to S3.
 aws.s3.filelimitmb=100
 aws.s3.filelimitmb=${?AWS_S3_FILE_LIMIT_MB}


### PR DESCRIPTION
### Description

This change is a minor improvement to how we create the URL to connect to LocalStack (a fake version of AWS used during local development):

1. Include the ".s3" part of the URI directly in the configuration file instead of adding it later in the Java code.
2. Have the `localStackEndpoint` method return a `URI` instead of a `String` so that `AwsApplicantStorage doesn't need to convert the `String` back to a `URI`. (And a future PR for program images also requires a `URI` object instead of a `String`.)

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. On a local server, verify uploading a file as an applicant still works.
2. On a local server, verify uploading a program image as an admin still works.

### Issue(s) this completes

Related to epic #5676 
