### PR TITLE
Renaming getSummaryData() function to getSummaryDataOnlyActive()

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -311,7 +311,7 @@ public final class AdminApplicationController extends CiviFormController {
             .toCompletableFuture()
             .join();
     ImmutableList<Block> blocks = roApplicantService.getAllActiveBlocks();
-    ImmutableList<AnswerData> answers = roApplicantService.getSummaryData();
+    ImmutableList<AnswerData> answers = roApplicantService.getSummaryDataOnlyActive();
     Optional<String> noteMaybe = programAdminApplicationService.getNote(application);
 
     return ok(

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -274,7 +274,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
   private ApplicantProgramSummaryView.Params.Builder generateParamsBuilder(
       ReadOnlyApplicantProgramService roApplicantProgramService) {
-    ImmutableList<AnswerData> summaryData = roApplicantProgramService.getSummaryData();
+    ImmutableList<AnswerData> summaryData = roApplicantProgramService.getSummaryDataOnlyActive();
     int totalBlockCount = roApplicantProgramService.getAllActiveBlocks().size();
     int completedBlockCount = roApplicantProgramService.getActiveAndCompletedInProgramBlockCount();
     String programTitle = roApplicantProgramService.getProgramTitle();

--- a/server/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -92,8 +92,12 @@ public interface ReadOnlyApplicantProgramService {
    */
   Optional<Block> getFirstIncompleteBlockExcludingStatic();
 
-  /** Returns summary data for each question in this application. */
-  ImmutableList<AnswerData> getSummaryData();
+  /**
+   * Returns summary data for each question in the active blocks in this application. Active block
+   * is the block an applicant must complete for this program. This will not include blocks that are
+   * hidden from the applicant.
+   */
+  ImmutableList<AnswerData> getSummaryDataOnlyActive();
 
   /** Get the string identifiers for all stored files for this application. */
   ImmutableList<String> getStoredFileKeys();

--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -258,7 +258,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
-  public ImmutableList<AnswerData> getSummaryData() {
+  public ImmutableList<AnswerData> getSummaryDataOnlyActive() {
     // TODO: We need to be able to use this on the admin side with admin-specific l10n.
     ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
     ImmutableList<Block> blocks = getAllActiveBlocks();

--- a/server/app/services/export/CsvExporter.java
+++ b/server/app/services/export/CsvExporter.java
@@ -70,7 +70,7 @@ public final class CsvExporter implements AutoCloseable {
       Optional<Boolean> optionalEligibilityStatus)
       throws IOException {
     ImmutableMap.Builder<Path, String> answerMapBuilder = new ImmutableMap.Builder<>();
-    for (AnswerData answerData : roApplicantService.getSummaryData()) {
+    for (AnswerData answerData : roApplicantService.getSummaryDataOnlyActive()) {
       if (answerData.questionDefinition().getQuestionType().equals(QuestionType.CHECKBOX)) {
         String questionName = answerData.questionDefinition().getName();
         // If the question isn't present in the scalar map, it means, its demographic export and

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -227,7 +227,7 @@ public final class CsvExporterService {
               .toCompletableFuture()
               .join();
       roApplicantService
-          .getSummaryData()
+          .getSummaryDataOnlyActive()
           .forEach(data -> answerMap.putIfAbsent(answerDataKey(data), data));
     }
 

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -118,7 +118,7 @@ public final class CsvExporterService {
           programService.getSubmittedProgramApplications(programDefinition.id())) {
         applicantService
             .getReadOnlyApplicantProgramService(application, programDefinition)
-            .getSummaryData()
+            .getSummaryDataOnlyActive()
             .forEach(data -> answerMap.putIfAbsent(data.contextualizedPath(), data));
       }
     }

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -117,7 +117,7 @@ public final class JsonExporter {
     ReadOnlyApplicantProgramService roApplicantProgramService =
         applicantService.getReadOnlyApplicantProgramService(application, programDefinition);
 
-    ImmutableList<AnswerData> answerDataList = roApplicantProgramService.getSummaryData();
+    ImmutableList<AnswerData> answerDataList = roApplicantProgramService.getSummaryDataOnlyActive();
     ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
 
     for (AnswerData answerData : answerDataList) {

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -62,7 +62,7 @@ public final class PdfExporter {
             .getReadOnlyApplicantProgramService(application)
             .toCompletableFuture()
             .join();
-    ImmutableList<AnswerData> answers = roApplicantService.getSummaryData();
+    ImmutableList<AnswerData> answers = roApplicantService.getSummaryDataOnlyActive();
 
     // We expect a name to be present at this point. However, if it's not, we use a placeholder
     // rather than throwing an error here.

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -982,7 +982,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getSummaryData_returnsCompletedData() {
+  public void getSummaryDataOnlyActive_returnsCompletedData() {
     // Create a program with lots of questions
     QuestionDefinition singleSelectQuestionDefinition =
         testQuestionBank.applicantSeason().getQuestionDefinition();
@@ -1056,7 +1056,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
-    ImmutableList<AnswerData> result = subject.getSummaryData();
+    ImmutableList<AnswerData> result = subject.getSummaryDataOnlyActive();
 
     assertThat(result).hasSize(9);
     assertThat(result.get(0).answerText()).isEqualTo("Alice Middle Last");
@@ -1144,7 +1144,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
-  public void getSummaryData_returnsLinkForUploadedFile() {
+  public void getSummaryDataOnlyActive_returnsLinkForUploadedFile() {
     // Create a program with a fileupload question and a non-fileupload question
     QuestionDefinition fileUploadQuestionDefinition =
         testQuestionBank.applicantFile().getQuestionDefinition();
@@ -1165,7 +1165,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
-    ImmutableList<AnswerData> result = subject.getSummaryData();
+    ImmutableList<AnswerData> result = subject.getSummaryDataOnlyActive();
 
     assertThat(result).hasSize(2);
     // Non-fileupload question does not have a file key
@@ -1176,7 +1176,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
 
   @Test
   @Parameters({"5, true", "1, false"})
-  public void getSummaryData_isEligible(long answer, boolean expectedResult) {
+  public void getSummaryDataOnlyActive_isEligible(long answer, boolean expectedResult) {
     // Create a program with an eligibility condition == 5 and answer it with different values.
     QuestionDefinition numberQuestionDefinition =
         testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
@@ -1210,19 +1210,19 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
-    ImmutableList<AnswerData> result = subject.getSummaryData();
+    ImmutableList<AnswerData> result = subject.getSummaryDataOnlyActive();
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).isEligible()).isEqualTo(expectedResult);
   }
 
   @Test
-  public void getSummaryData_returnsWithEmptyData() {
+  public void getSummaryDataOnlyActive_returnsWithEmptyData() {
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(
             jsonPathPredicateGeneratorFactory, applicantData, programDefinition, FAKE_BASE_URL);
 
-    ImmutableList<AnswerData> result = subject.getSummaryData();
+    ImmutableList<AnswerData> result = subject.getSummaryDataOnlyActive();
 
     assertThat(result).hasSize(3);
     assertThat(result.get(0).answerText()).isEqualTo("");


### PR DESCRIPTION
### Description

Renaming `getSummaryData()` to `getSummaryDataOnlyActive()` since this function only returns summary data from active blocks in an application. There will be another function `getSummaryDataOnlyHidden()` in the next PR for hidden questions in pdf.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Part of Fixes ##6288
