### PR TITLE
[Program Card Images] Remove the old image from cloud storage when a new image is uploaded

### DIFF
--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -422,42 +422,74 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     controller.updateFileKey(
-        addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of(
-                            "bucket",
-                            "fakeBucket",
-                            "key",
-                            "program-summary-image/program-15/oldImage.png"))))
-            .build(),
-        program.id);
+            addCSRFToken(
+                    fakeRequest(
+                            "POST",
+                            createUriWithQueryString(
+                                    ImmutableMap.of(
+                                            "bucket",
+                                            "fakeBucket",
+                                            "key",
+                    "program-summary-image/program-15/oldImage.png")))).build(),
+            program.id);
 
     ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
-        .isEqualTo("program-summary-image/program-15/oldImage.png");
+            .isEqualTo("program-summary-image/program-15/oldImage.png");
 
     // WHEN the key is updated
     controller.updateFileKey(
-        addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of(
-                            "bucket",
-                            "fakeBucket",
-                            "key",
-                            "program-summary-image/program-15/newImage.png"))))
-            .build(),
-        program.id);
+            addCSRFToken(
+                    fakeRequest(
+                            "POST",
+                            createUriWithQueryString(
+                                    ImmutableMap.of(
+                                            "bucket",
+                                            "fakeBucket",
+                                            "key",
+                                            "program-summary-image/program-15/newImage.png")))).build(),
+            program.id);
 
     // THEN the database reflects the changes
     updatedProgram = programService.getProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
-        .isEqualTo("program-summary-image/program-15/newImage.png");
+            .isEqualTo("program-summary-image/program-15/newImage.png");
+  }
+
+  @Test
+  public void updateFileKey_hadPreviousFile_oldFileRemoved() throws ProgramNotFoundException {
+    ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
+
+    controller.updateFileKey(
+            addCSRFToken(
+                    fakeRequest(
+                            "POST",
+                            createUriWithQueryString(
+                                    ImmutableMap.of(
+                                            "bucket",
+                                            "fakeBucket",
+                                            "key",
+                                            "program-summary-image/program-15/image-1.png"))))
+                    .build(),
+            program.id);
+
+    controller.updateFileKey(
+            addCSRFToken(
+                    fakeRequest(
+                            "POST",
+                            createUriWithQueryString(
+                                    ImmutableMap.of(
+                                            "bucket",
+                                            "fakeBucket",
+                                            "key",
+                                            "program-summary-image/program-15/image-2.png"))))
+                    .build(),
+            program.id);
+
+    assertThat(fakePublicStorageClient.getLastDeletedFileKey())
+            .isEqualTo("program-summary-image/program-15/image-1.png");
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -422,40 +422,42 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequest(
-                            "POST",
-                            createUriWithQueryString(
-                                    ImmutableMap.of(
-                                            "bucket",
-                                            "fakeBucket",
-                                            "key",
-                    "program-summary-image/program-15/oldImage.png")))).build(),
-            program.id);
+        addCSRFToken(
+                fakeRequest(
+                    "POST",
+                    createUriWithQueryString(
+                        ImmutableMap.of(
+                            "bucket",
+                            "fakeBucket",
+                            "key",
+                            "program-summary-image/program-15/oldImage.png"))))
+            .build(),
+        program.id);
 
     ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
-            .isEqualTo("program-summary-image/program-15/oldImage.png");
+        .isEqualTo("program-summary-image/program-15/oldImage.png");
 
     // WHEN the key is updated
     controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequest(
-                            "POST",
-                            createUriWithQueryString(
-                                    ImmutableMap.of(
-                                            "bucket",
-                                            "fakeBucket",
-                                            "key",
-                                            "program-summary-image/program-15/newImage.png")))).build(),
-            program.id);
+        addCSRFToken(
+                fakeRequest(
+                    "POST",
+                    createUriWithQueryString(
+                        ImmutableMap.of(
+                            "bucket",
+                            "fakeBucket",
+                            "key",
+                            "program-summary-image/program-15/newImage.png"))))
+            .build(),
+        program.id);
 
     // THEN the database reflects the changes
     updatedProgram = programService.getProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
-            .isEqualTo("program-summary-image/program-15/newImage.png");
+        .isEqualTo("program-summary-image/program-15/newImage.png");
   }
 
   @Test
@@ -463,33 +465,33 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequest(
-                            "POST",
-                            createUriWithQueryString(
-                                    ImmutableMap.of(
-                                            "bucket",
-                                            "fakeBucket",
-                                            "key",
-                                            "program-summary-image/program-15/image-1.png"))))
-                    .build(),
-            program.id);
+        addCSRFToken(
+                fakeRequest(
+                    "POST",
+                    createUriWithQueryString(
+                        ImmutableMap.of(
+                            "bucket",
+                            "fakeBucket",
+                            "key",
+                            "program-summary-image/program-15/image-1.png"))))
+            .build(),
+        program.id);
 
     controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequest(
-                            "POST",
-                            createUriWithQueryString(
-                                    ImmutableMap.of(
-                                            "bucket",
-                                            "fakeBucket",
-                                            "key",
-                                            "program-summary-image/program-15/image-2.png"))))
-                    .build(),
-            program.id);
+        addCSRFToken(
+                fakeRequest(
+                    "POST",
+                    createUriWithQueryString(
+                        ImmutableMap.of(
+                            "bucket",
+                            "fakeBucket",
+                            "key",
+                            "program-summary-image/program-15/image-2.png"))))
+            .build(),
+        program.id);
 
     assertThat(fakePublicStorageClient.getLastDeletedFileKey())
-            .isEqualTo("program-summary-image/program-15/image-1.png");
+        .isEqualTo("program-summary-image/program-15/image-1.png");
   }
 
   @Test

--- a/server/test/support/cloud/FakePublicStorageClient.java
+++ b/server/test/support/cloud/FakePublicStorageClient.java
@@ -6,6 +6,7 @@ import services.cloud.StorageUploadRequest;
 /** A fake implementation of {@link PublicStorageClient} to be used in tests. */
 public final class FakePublicStorageClient extends PublicStorageClient {
   private boolean shouldDeleteSuccessfully = true;
+  private String lastDeletedFileKey;
 
   public FakePublicStorageClient() {}
 
@@ -22,11 +23,16 @@ public final class FakePublicStorageClient extends PublicStorageClient {
 
   @Override
   protected boolean deletePublicFileInternal(String fileKey) {
+    lastDeletedFileKey = fileKey;
     return shouldDeleteSuccessfully;
   }
 
   /** Sets whether this storage client should delete files successfully or fail to delete them. */
   public void setShouldDeleteSuccessfully(boolean shouldDeleteSuccessfully) {
     this.shouldDeleteSuccessfully = shouldDeleteSuccessfully;
+  }
+
+  public String getLastDeletedFileKey() {
+    return lastDeletedFileKey;
   }
 }


### PR DESCRIPTION
### Description

When a program has an existing image and an admin uploads a new image to replace it, this PR makes sure to delete the old image from cloud storage so that CEs don't have a lot of unused images stored in their bucket.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Enable the PROGRAM_CARD_IMAGES flag.
2. Edit a program then click "Edit program image" on the program's edit page.
3. Upload and save an image.
4. Go to https://civiform-local-s3-public.s3.localhost.localstack.cloud:4566/ and verify that your image is listed as a resource:

```
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Name>civiform-local-s3-public</Name>
  <MaxKeys>1000</MaxKeys>
  <IsTruncated>false</IsTruncated>

   // Single item with the `program-summary-image-old.png` name.
  <Contents>     
    <Key>program-summary-image/program-3/program-summary-image-old.png</Key>
    <LastModified>2024-01-10T17:34:36.000Z</LastModified>
    <ETag>"4d2facdd58b313b63ba4a54a4a23187f"</ETag>
    <Size>1001</Size>
    <StorageClass>STANDARD</StorageClass>
    <Owner>
      <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
      <DisplayName>webfile</DisplayName>
    </Owner>
  </Contents>
  <Marker/>
</ListBucketResult>
```

5. Upload a different image.
6. Go to https://civiform-local-s3-public.s3.localhost.localstack.cloud:4566/ and verify that your old image no longer appears and the new one does:

```
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Name>civiform-local-s3-public</Name>
  <MaxKeys>1000</MaxKeys>
  <IsTruncated>false</IsTruncated>
 
   // Single item with the `program-summary-image-new.png` name. `program-summary-image-old.png` is no longer listed.
  <Contents>
    <Key>program-summary-image/program-3/program-summary-image-new.png</Key>
    <LastModified>2024-01-10T17:34:36.000Z</LastModified>
    <ETag>"4d2facdd58b313b63ba4a54a4a23187f"</ETag>
    <Size>1001</Size>
    <StorageClass>STANDARD</StorageClass>
    <Owner>
      <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
      <DisplayName>webfile</DisplayName>
    </Owner>
  </Contents>
  <Marker/>
</ListBucketResult>
```

(Previously, both the old and new images would be listed.)

### Issue(s) this completes

Epic #5676 

Fixes #6004 
