### PR TITLE
Add appropriate inputmode attribute for questions

### DIFF
--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -484,10 +484,7 @@ public class FieldWithLabel {
     ImmutableMap<String, Optional<String>> attributesMap = this.attributesMapBuilder.build();
     attributesMap
         .entrySet()
-        .forEach(
-            entry ->
-                fieldTag.attr(
-                    entry.getKey(), entry.getValue().orElse(null)));
+        .forEach(entry -> fieldTag.attr(entry.getKey(), entry.getValue().orElse(null)));
   }
 
   private DivTag buildFieldErrorsTag(String id) {

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -487,7 +487,7 @@ public class FieldWithLabel {
         .forEach(
             entry ->
                 fieldTag.attr(
-                    entry.getKey(), entry.getValue().isPresent() ? entry.getValue().get() : null));
+                    entry.getKey(), entry.getValue().orElse(null)));
   }
 
   private DivTag buildFieldErrorsTag(String id) {

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -7,6 +7,7 @@ import static j2html.TagCreator.span;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
@@ -85,7 +86,8 @@ public class FieldWithLabel {
   protected ImmutableList.Builder<String> referenceClassesBuilder = ImmutableList.builder();
   protected ImmutableList.Builder<String> styleClassesBuilder = ImmutableList.builder();
   private ImmutableList.Builder<String> ariaDescribedByBuilder = ImmutableList.builder();
-  private final ImmutableSet.Builder<String> attributesSetBuilder = ImmutableSet.builder();
+  private final ImmutableMap.Builder<String, Optional<String>> attributesMapBuilder =
+      ImmutableMap.builder();
 
   private static final String MAX_INPUT_TEXT_LENGTH = "10000";
 
@@ -213,7 +215,13 @@ public class FieldWithLabel {
 
   /** Sets a valueless attribute. */
   public FieldWithLabel setAttribute(String attribute) {
-    this.attributesSetBuilder.add(attribute);
+    this.attributesMapBuilder.put(attribute, Optional.empty());
+    return this;
+  }
+
+  /** Sets an attribute/value pairing. */
+  public FieldWithLabel setAttribute(String attribute, String value) {
+    this.attributesMapBuilder.put(attribute, Optional.of(value));
     return this;
   }
 
@@ -395,7 +403,7 @@ public class FieldWithLabel {
   private InputTag nonNumberGenTagApplyAttrs() {
     InputTag inputFieldTag = TagCreator.input();
     inputFieldTag.withType(getFieldType());
-    applyAttributesFromSet(inputFieldTag);
+    applyAttributesFromMap(inputFieldTag);
     if (!this.fieldType.equals("number")) {
       inputFieldTag.withValue(this.fieldValue);
     } else {
@@ -413,7 +421,7 @@ public class FieldWithLabel {
   private DivTag getNonNumberInputTag() {
     InputTag inputFieldTag = TagCreator.input();
     inputFieldTag.withType(getFieldType());
-    applyAttributesFromSet(inputFieldTag);
+    applyAttributesFromMap(inputFieldTag);
     if (!this.fieldType.equals("number")) {
       inputFieldTag.withValue(this.fieldValue);
     } else {
@@ -426,7 +434,7 @@ public class FieldWithLabel {
   public DivTag getTextareaTag() {
     if (isTagTypeTextarea()) {
       TextareaTag textareaFieldTag = TagCreator.textarea();
-      applyAttributesFromSet(textareaFieldTag);
+      applyAttributesFromMap(textareaFieldTag);
       textareaFieldTag.withText(this.fieldValue);
       if (this.rows.isPresent()) {
         textareaFieldTag.withRows(String.valueOf(this.rows.getAsLong()));
@@ -455,7 +463,7 @@ public class FieldWithLabel {
   public DivTag getNumberTag() {
     InputTag inputFieldTag = TagCreator.input();
     inputFieldTag.withType(getFieldType());
-    applyAttributesFromSet(inputFieldTag);
+    applyAttributesFromMap(inputFieldTag);
     if (this.fieldType.equals("number")) {
       numberTagApplyAttrs(inputFieldTag);
     } else {
@@ -472,8 +480,14 @@ public class FieldWithLabel {
     return getNonNumberInputTag();
   }
 
-  protected void applyAttributesFromSet(Tag fieldTag) {
-    this.attributesSetBuilder.build().forEach(attr -> fieldTag.attr(attr, null));
+  protected void applyAttributesFromMap(Tag fieldTag) {
+    ImmutableMap<String, Optional<String>> attributesMap = this.attributesMapBuilder.build();
+    attributesMap
+        .entrySet()
+        .forEach(
+            entry ->
+                fieldTag.attr(
+                    entry.getKey(), entry.getValue().isPresent() ? entry.getValue().get() : null));
   }
 
   private DivTag buildFieldErrorsTag(String id) {

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -125,6 +125,7 @@ public class AddressQuestionRenderer extends ApplicantCompositeQuestionRenderer 
         FieldWithLabel.input()
             .setFieldName(addressQuestion.getZipPath().toString())
             .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_ZIPCODE.getKeyName()))
+            .setAttribute("inputmode", "numeric")
             .setAutocomplete(Optional.of("postal-code"))
             .setValue(addressQuestion.getZipValue().orElse(""))
             .setFieldErrors(

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -35,6 +35,7 @@ public class CurrencyQuestionRenderer extends ApplicantSingleQuestionRenderer {
     FieldWithLabel currencyField =
         FieldWithLabel.currency()
             .setFieldName(currencyQuestion.getCurrencyPath().toString())
+            .setAttribute("inputmode", "decimal")
             .addReferenceClass(ReferenceClasses.CURRENCY_VALUE)
             .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .setAriaRequired(!isOptional)

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -37,6 +37,7 @@ public class EmailQuestionRenderer extends ApplicantSingleQuestionRenderer {
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setAutocomplete(Optional.of("email"))
             .setValue(emailQuestion.getEmailValue().orElse(""))
+            .setAttribute("inputmode", "email")
             .setAriaRequired(!isOptional)
             .setFieldErrors(
                 params.messages(),

--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -69,6 +69,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
         FieldWithLabel.input()
             .setPlaceholderText("(xxx) xxx-xxxx")
             .setFieldName(phoneQuestion.getPhoneNumberPath().toString())
+            .setAttribute("inputmode", "tel")
             .setValue(phoneQuestion.getPhoneNumberValue().orElse(""))
             .setLabelText(messages.at(MessageKey.PHONE_LABEL_PHONE_NUMBER.getKeyName()))
             .setAriaRequired(!isOptional)

--- a/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CurrencyQuestionRendererTest.java
@@ -81,7 +81,7 @@ public class CurrencyQuestionRendererTest extends ResetPostgres {
 
     assertThat(
             cleanHtml.matches(
-                ".*input type=\"text\" currency value=\"\""
+                ".*input type=\"text\" currency inputmode=\"decimal\" value=\"\""
                     + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }


### PR DESCRIPTION
### Description

Adds inputmode attribute for inputs so that an appropriate keyboard is used on mobile.
- numeric keyboard for zip
- decimal keyboard for currency
- email keyboard for email
- numeric keyboard for phone

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #5867
