### PR TITLE
Adding GitHub Action to Generate SBOM

### DIFF
--- a/.github/workflows/sbom_generator.yaml
+++ b/.github/workflows/sbom_generator.yaml
@@ -1,0 +1,33 @@
+# Generates the SBOM from our docker image and uploads the
+# articact to the release
+name: Generate SBOM
+
+on:
+  release:
+    types: ['created']
+
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The tag name of the release'
+        required: true
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    env:
+      # Get the tag value from the workflow dispatch or the release event info
+      TAG_NAME: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+
+    steps:
+      - name: Generate and Upload SBOM to Release ${{ env.TAG_NAME }}
+        uses: anchore/sbom-action@v0
+        with:
+          image: docker.io/civiform/civiform:${{ env.TAG_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Triggers when a release is created (or manually) to generate a Software Bill of Materials (SBOM). It looks at the `civiform/civiform:VERSION` docker image. We can include additional files for each docker image if needed, but starting with the prod image for now.

I opted for a separate GH action in case we ever needed to re-run on a previous release.

The `anchore/sbom-action`, while not Maintained by GitHub, is listed in their [documentation](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api#generating-and-submitting-a-software-bill-of-materials-sbom). The GitHub maintained option hasn't been updated in over a year, and the Microsoft one is more complicated to run.

I tested this in a separate repo and it works, I don't anticipate issues other than maybe perms.

### Release Notes

Include a Software Bill of Materials (SBOM) with a release.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #6371 
