### PR TITLE
Ensure phone questions have the correct aria-describedby

### DIFF
--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -16,7 +16,7 @@ import views.components.FieldWithLabel;
 import views.components.SelectWithLabel;
 import views.style.ReferenceClasses;
 
-public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
+public class PhoneQuestionRenderer extends ApplicantCompositeQuestionRenderer {
   PhoneQuestionRenderer(ApplicantQuestion question) {
     super(question);
   }
@@ -27,10 +27,9 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
   }
 
   @Override
-  protected DivTag renderInputTag(
+  protected DivTag renderInputTags(
       ApplicantQuestionRendererParams params,
       ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors,
-      ImmutableList<String> ariaDescribedByIds,
       boolean isOptional) {
     PhoneQuestion phoneQuestion = applicantQuestion.createPhoneQuestion();
 
@@ -54,7 +53,6 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
                     messages,
                     validationErrors.getOrDefault(
                         phoneQuestion.getCountryCodePath(), ImmutableSet.of()))
-                .setAriaDescribedByIds(ariaDescribedByIds)
                 .addReferenceClass(ReferenceClasses.PHONE_COUNTRY_CODE)
                 .setId(ReferenceClasses.PHONE_COUNTRY_CODE);
 
@@ -77,7 +75,6 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
                 messages,
                 validationErrors.getOrDefault(
                     phoneQuestion.getPhoneNumberPath(), ImmutableSet.of()))
-            .setAriaDescribedByIds(ariaDescribedByIds)
             .setScreenReaderText(applicantQuestion.getQuestionTextForScreenReader())
             .addReferenceClass(ReferenceClasses.PHONE_NUMBER)
             .setId(ReferenceClasses.PHONE_NUMBER);

--- a/server/app/views/questiontypes/PhoneQuestionRenderer.java
+++ b/server/app/views/questiontypes/PhoneQuestionRenderer.java
@@ -54,6 +54,7 @@ public class PhoneQuestionRenderer extends ApplicantSingleQuestionRenderer {
                     messages,
                     validationErrors.getOrDefault(
                         phoneQuestion.getCountryCodePath(), ImmutableSet.of()))
+                .setAriaDescribedByIds(ariaDescribedByIds)
                 .addReferenceClass(ReferenceClasses.PHONE_COUNTRY_CODE)
                 .setId(ReferenceClasses.PHONE_COUNTRY_CODE);
 

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -89,6 +89,7 @@ public class ApplicantQuestionRendererFactoryTest {
       case CHECKBOX:
       case ENUMERATOR:
       case NAME:
+      case PHONE:
       case RADIO_BUTTON:
         assertThat(renderedContent).contains("fieldset");
         break;
@@ -100,7 +101,6 @@ public class ApplicantQuestionRendererFactoryTest {
       case ID:
       case NUMBER:
       case STATIC:
-      case PHONE:
       case TEXT:
         assertThat(renderedContent).doesNotContain("fieldset");
         break;


### PR DESCRIPTION
### Description

Updates PhoneQuestionRenderer to use ApplicantCompositeQuestionRenderer instead of ApplicantSingleQuestionRenderer. This is because phone questions consist of 2 questions (country and phone number). By making it a composite question, the  ApplicantCompositeQuestionRenderer correctly adds the aria-describedby on the outer container (instead of being on just 1 of the two question elements). This makes it so the question is read when the user first enters the question, no matter which field they navigate to (similar to an address question).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #5526 
