### PR TITLE
add break-words class to break long words/urls on mobile

### DIFF
--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -55,7 +55,7 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
     DivTag blockDiv =
         div()
             .with(div(renderBlockWithSubmitForm(params)).withClasses("my-8"))
-            .withClasses("my-8", "m-auto");
+            .withClasses("my-8", "m-auto", "break-words");
 
     String errorMessage = "";
     if (params.block().hasErrors()


### PR DESCRIPTION
### Description

Add break-words css class to form body to prevent extra long words/urls from overflowing on small screens. It will attempt to break at the word level, but if one word is too long to fit on its own line (like a long URL) it will be broken up.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

#### User visible changes

- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size


### Issue(s) this completes

Fixes #2877 
