### PR TITLE
Updating image sync script

### DIFF
--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -16,6 +16,8 @@ readonly CURL_ARGS=(-L
   -H "Authorization: Bearer ${GITHUB_TOKEN}"
   -H "X-GitHub-Api-Version: 2022-11-28")
 
+readonly SNAPSHOT_FOLDER="./browser-test/image_snapshots"
+
 #######################################
 # Exit if jq query fails or is null
 # Arguments:
@@ -88,6 +90,71 @@ function verify_dependencies() {
   fi
 }
 
+#######################################
+# Processes a single artifact url
+# Globals:
+#   CURL_ARGS - constant variable of shared curl arguments
+#   SNAPSHOT_FOLDER - path to where snapshot folder is located
+# Arguments:
+#   ARTIFACT_LIST_URL - full url for curl to call
+#######################################
+function process_artifact_list_urls() {
+  local ARTIFACT_LIST_URL="${1}"
+
+  exit_on_jq_failure "$?" "${ARTIFACT_LIST_URL}" "Branch '${BRANCH_NAME}' doesn't appear to have any snapshots to download"
+
+  # Determine the url for the artifact we want to download
+  local ARTIFACT_LIST_JSON="$(get_json_or_exit_on_failure "${ARTIFACT_LIST_URL}")"
+  echo "Looking for artifacts... ${ARTIFACT_LIST_URL}"
+
+  # Determine the url for the archive download endpoint
+  local ARTIFACT_DOWNLOAD_URL_ARRAY="$(echo "${ARTIFACT_LIST_JSON}" | jq -r -c '
+  .artifacts 
+  | map(
+    select((.name | startswith("updated snapshots output directory")) and .expired == false) 
+    | .archive_download_url
+  ) | join (" ")')"
+
+
+  for ARTIFACT_DOWNLOAD_URL in ${ARTIFACT_DOWNLOAD_URL_ARRAY[@]}; do # We want to have work splitting here so don't put quotes
+    echo "Downloading... ${ARTIFACT_DOWNLOAD_URL}"
+
+    exit_on_jq_failure "$?" "${ARTIFACT_DOWNLOAD_URL}" "Unable to find artifact url"
+
+    # Download the archive
+    local ARTIFACT_FILE="$(mktemp)"
+
+    curl "${CURL_ARGS[@]}" "${ARTIFACT_DOWNLOAD_URL}" --output "${ARTIFACT_FILE}"
+
+    # Unzip archive file
+    unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
+
+    # If there's an error unzipping the most common issue is permissions on the token
+    # We'll attempt to print downloaded file as that often has the error message.
+    if (($? != 0)); then
+      # This is looking to see if the zip file is 30k or smaller. This should be large enough
+      # for the error response, and also not spam the terminal if it somehow happens to be a
+      # large corrupt zip file.
+      readonly FOUND_FILE="$(find "${ARTIFACT_FILE}" -type f -size -30720c)"
+
+      if (($? != 0)); then
+        echo "The artifact file path appears to not be set or another error caused 'find' to fail ${ARTIFACT_FILE}"
+        exit 1
+      fi
+
+      if [[ -z "${FOUND_FILE}" ]]; then
+        echo "Did not find a matching artifact file under 30k. Check this file manually ${ARTIFACT_FILE}"
+      fi
+      echo "Something is wrong with the artifact zip file."
+      echo "Here are the contents of the downloaded file."
+      echo
+      cat "${ARTIFACT_FILE}"
+      exit 1
+    fi
+  done
+}
+
+
 verify_dependencies
 
 # Set branch name to user provided value or default to the current active branch
@@ -99,58 +166,16 @@ readonly JOB_RUN_LIST_URL="https://api.github.com/repos/civiform/civiform/action
 readonly JOB_RUN_LIST_JSON="$(get_json_or_exit_on_failure "${JOB_RUN_LIST_URL}")"
 
 # Determine the url for the artifacts endpoint
-readonly ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
+# Take the first one, it'll be the latest run
+ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
 .workflow_runs 
 | map(
   select(.name == "Server - On PR to Main")
   | .artifacts_url
 )[0]')"
 
-exit_on_jq_failure "$?" "${ARTIFACT_LIST_URL}" "Branch '${BRANCH_NAME}' doesn't appear to have any snapshots to download"
+process_artifact_list_urls "${ARTIFACT_LIST_URL}"
 
-# Determine the url for the artifact we want to download
-readonly ARTIFACT_LIST_JSON="$(get_json_or_exit_on_failure "${ARTIFACT_LIST_URL}")"
-
-readonly ARTIFACT_DOWNLOAD_URL="$(echo "${ARTIFACT_LIST_JSON}" | jq -r -c '
-.artifacts 
-| map(
-  select(.name == "updated snapshots output directory" and .expired == false) 
-  | .archive_download_url
-)[0]')"
-
-exit_on_jq_failure "$?" "${ARTIFACT_DOWNLOAD_URL}" "Unable to find artifact url"
-
-# Download the archive
-readonly ARTIFACT_FILE="$(mktemp)"
-readonly SNAPSHOT_FOLDER="./browser-test/image_snapshots"
-
-curl "${CURL_ARGS[@]}" "${ARTIFACT_DOWNLOAD_URL}" --output "${ARTIFACT_FILE}"
-
-# Unzip archive file
-unzip -qq "${ARTIFACT_FILE}" -d "${SNAPSHOT_FOLDER}"
-
-# If there's an error unzipping the most common issue is permissions on the token
-# We'll attempt to print downloaded file as that often has the error message.
-if (($? != 0)); then
-  # This is looking to see if the zip file is 30k or smaller. This should be large enough
-  # for the error response, and also not spam the terminal if it somehow happens to be a
-  # large corrupt zip file.
-  readonly FOUND_FILE="$(find "${ARTIFACT_FILE}" -type f -size -30720c)"
-
-  if (($? != 0)); then
-    echo "The artifact file path appears to not be set or another error caused 'find' to fail ${ARTIFACT_FILE}"
-    exit 1
-  fi
-
-  if [[ -z "${FOUND_FILE}" ]]; then
-    echo "Did not find a matching artifact file under 30k. Check this file manually ${ARTIFACT_FILE}"
-  fi
-  echo "Something is wrong with the artifact zip file."
-  echo "Here are the contents of the downloaded file."
-  echo
-  cat "${ARTIFACT_FILE}"
-  exit 1
-fi
 
 # Rename updated files removing the playwright "-received" suffix
 find "${SNAPSHOT_FOLDER}" \

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -143,7 +143,9 @@ function process_artifact_list_urls() {
 
       if [[ -z "${FOUND_FILE}" ]]; then
         echo "Did not find a matching artifact file under 30k. Check this file manually ${ARTIFACT_FILE}"
+        exit 1
       fi
+
       echo "Something is wrong with the artifact zip file."
       echo "Here are the contents of the downloaded file."
       echo

--- a/bin/sync-failed-browser-test-images
+++ b/bin/sync-failed-browser-test-images
@@ -115,7 +115,6 @@ function process_artifact_list_urls() {
     | .archive_download_url
   ) | join (" ")')"
 
-
   for ARTIFACT_DOWNLOAD_URL in ${ARTIFACT_DOWNLOAD_URL_ARRAY[@]}; do # We want to have work splitting here so don't put quotes
     echo "Downloading... ${ARTIFACT_DOWNLOAD_URL}"
 
@@ -154,7 +153,6 @@ function process_artifact_list_urls() {
   done
 }
 
-
 verify_dependencies
 
 # Set branch name to user provided value or default to the current active branch
@@ -175,7 +173,6 @@ ARTIFACT_LIST_URL="$(echo "${JOB_RUN_LIST_JSON}" | jq -r -c '
 )[0]')"
 
 process_artifact_list_urls "${ARTIFACT_LIST_URL}"
-
 
 # Rename updated files removing the playwright "-received" suffix
 find "${SNAPSHOT_FOLDER}" \


### PR DESCRIPTION
### Description

The github action upload-artifact changed at v4 to require all uploads to have separate file names. This fixes the script to get them all
