### PR TITLE
Switch release trigger to published

### DIFF
--- a/.github/workflows/sbom_generator.yaml
+++ b/.github/workflows/sbom_generator.yaml
@@ -4,7 +4,7 @@ name: Generate SBOM
 
 on:
   release:
-    types: ['created']
+    types: ['published']
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Turns out the created trigger doesn't fire for drafts >_<

Switching to published which will trigger when the release is create immediately or in draft state


For [reference](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)