### PR TITLE
Make header flow better on narrow screens

### DIFF
--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -228,7 +228,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                             "grow",
                             "shrink-0",
                             "place-content-center",
-                            "w-full",
+                            "max-w-full",
                             StyleUtils.responsiveMedium("grow-0", "shrink"))))
         .condWith(
             !onTiDashboardPage(request),

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -228,6 +228,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                             "grow",
                             "shrink-0",
                             "place-content-center",
+                            "w-full",
                             StyleUtils.responsiveMedium("grow-0", "shrink"))))
         .condWith(
             !onTiDashboardPage(request),


### PR DESCRIPTION
### Description

Prevent header from overflowing the width of the screen on mobile.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

#### User visible changes

- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size


### Issue(s) this completes

Fixes #6388
