### PR TITLE
Adding link for apple-touch-icon

### DIFF
--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -219,7 +219,11 @@ public final class HtmlBundle {
         .with(title(pageTitle))
         // The "orElse" value is never used, but it must be included because the
         // "withHref" evaluates even if the "condWith" is false.
-        .condWith(faviconURL.isPresent(), link().withRel("icon").withHref(faviconURL.orElse("")))
+        .condWith(
+            faviconURL.isPresent(),
+            link().withRel("icon").withHref(faviconURL.orElse("")),
+            link().withRel("apple-touch-icon").withHref("apple-touch-icon.png"),
+            link().withRel("apple-touch-icon-precomposed.png").withHref("apple-touch-icon.png"))
         .with(metadata)
         .with(stylesheets)
         .with(headScripts);

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -6,8 +6,10 @@
 GET /*path/ controllers.UntrailingController.untrail(path: String)
 
 # Redirect automatic requests from the browser to the specified favicon.
-GET     /favicon.ico    controllers.HomeController.favicon()
-GET     /favicon.png    controllers.HomeController.favicon()
+GET     /favicon.ico                         controllers.HomeController.favicon()
+GET     /favicon.png                         controllers.HomeController.favicon()
+GET     /apple-touch-icon.png                controllers.HomeController.favicon()
+GET     /apple-touch-icon-precomposed.png    controllers.HomeController.favicon()
 
 # The landing page
 GET     /                           controllers.HomeController.index(request: Request)


### PR DESCRIPTION
### Description

I've noticed an increase of 404's in my logs for requests to the `apple-touch-icon`. For reference the the `apple-touch-icon` gets called when the user attempts to bookmark the site, but there may be other times.

This is not an exhaustive addition for supporting various sized icons, but it'll be a quick win for serving something to the user. This will use the same image as the favicon.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

