### PR TITLE
add aria-live attribute to file upload label

### DIFF
--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -85,7 +85,8 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
                     // can render the translated text if it gets added
                     .attr(
                         "data-upload-text",
-                        params.messages().at(MessageKey.INPUT_FILE_ALREADY_UPLOADED.getKeyName())));
+                        params.messages().at(MessageKey.INPUT_FILE_ALREADY_UPLOADED.getKeyName()))
+                    .attr("aria-live", "polite"));
     result.with(
         fileUploadViewStrategy.additionalFileUploadFormInputs(params.signedFileUploadRequest()));
     result.with(createFileInputFormElement(fileInputId, ariaDescribedByIds, hasErrors));


### PR DESCRIPTION
### Description

Add aria-live attribute to file upload label so it is announced when the file is uploaded

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1) enable a screenreader (I tested with Chromevox)
2) Upload a file to a file upload question
3) When it is done uploading and the UI updates, the screenreader should read the updated text "File uploaded: file_name"

### Issue(s) this completes

Fixes #3590 