### PR TITLE
[Program Card Images] Only allow PNGs and JPEGs for program card images

### DIFF
--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -54,8 +54,9 @@ import views.fileupload.FileUploadViewStrategy;
 
 /** A view for admins to update the image associated with a particular program. */
 public final class ProgramImageView extends BaseHtmlView {
-  // TODO(#5676): Should we prohibit gifs?
-  private static final String MIME_TYPES_IMAGES = "image/*";
+  // Only allow JPEG and PNG images. We want to specifically prohibit SVGs (which don't render well
+  // in the <img> element) and GIFs (which would be too distracting on the homepage).
+  private static final String MIME_TYPES_IMAGES = "image/jpeg,image/png";
   private static final String IMAGE_DESCRIPTION_FORM_ID = "image-description-form";
   private static final String IMAGE_FILE_UPLOAD_FORM_ID = "image-file-upload-form";
   private static final String PAGE_TITLE = "Image upload";


### PR DESCRIPTION
### Description

This is a small PR that restricts the mimetype for program images to be only PNGs or JPEGs. We don't want admins uploading SVGs because they don't render correctly in the `<img>` element (maybe we could make them render correctly but that doesn't seem worth the time), and we also don't want admins uploading GIFs because that would make the homepage too distracting.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox)

### Instructions for manual testing

1. Enable the PROGRAM_CARD_IMAGES flag.
2. As an admin, navigate to the edit program images page.
3. When uploading a file, verify that only the PNGs and JPEGs are the files allowed by the filepicker.

### Issue(s) this completes

Epic #5676
