### PR TITLE
re-enable program image tests

### DIFF
--- a/browser-test/src/admin_program_image.test.ts
+++ b/browser-test/src/admin_program_image.test.ts
@@ -112,10 +112,7 @@ describe('Admin can manage program image', () => {
     })
   })
 
-  // TODO(#5676): The program image files are stored in a new bucket in cloud storage,
-  // so our deploy scripts need to create that new bucket. Ignore this test until
-  // the deploy scripts are correctly updated (this test will fail otherwise).
-  xdescribe('image file upload', () => {
+  describe('image file upload', () => {
     const programName = 'Test program'
 
     beforeEach(async () => {

--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -253,8 +253,7 @@ describe('applicant program index page', () => {
   })
 })
 
-// TODO(#5676): Re-enable once the deployment scripts are correctly updated.
-xdescribe('applicant program index page with images', () => {
+describe('applicant program index page with images', () => {
   const ctx = createTestContext()
 
   it('shows program with wide image', async () => {


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
