### PR TITLE
Fixed TI client search bug so that cleared search parameters return the full client list

### DIFF
--- a/browser-test/src/support/ti_dashboard.ts
+++ b/browser-test/src/support/ti_dashboard.ts
@@ -114,6 +114,12 @@ export class TIDashboard {
     await this.page.click('button:text("Search")')
   }
 
+  async searchByNameAndDateOfBirth(name: string, dobDate: string) {
+    await this.page.fill('label:has-text("Search by Name")', name)
+    await this.page.fill('label:has-text("Search Date Of Birth")', dobDate)
+    await this.page.click('button:text("Search")')
+  }
+
   async clickOnApplicantDashboard() {
     await this.page
       .locator('.cf-admin-question-table-row a:text("Applicant Dashboard")')

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -399,6 +399,35 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardNotContainClient(client2)
   })
 
+  it('empty search parameters returns all clients', async () => {
+    const {page, tiDashboard} = ctx
+    await loginAsTrustedIntermediary(page)
+
+    await tiDashboard.gotoTIDashboardPage(page)
+    await waitForPageJsLoad(page)
+    const client1: ClientInformation = {
+      emailAddress: 'fake@sample.com',
+      firstName: 'first1',
+      middleName: 'middle',
+      lastName: 'last1',
+      dobDate: '2021-07-10',
+    }
+    await tiDashboard.createClient(client1)
+    const client2: ClientInformation = {
+      emailAddress: 'fake2@sample.com',
+      firstName: 'first2',
+      middleName: 'middle',
+      lastName: 'last2',
+      dobDate: '2021-11-10',
+    }
+    await tiDashboard.createClient(client2)
+
+    await tiDashboard.searchByNameAndDateOfBirth('', '')
+    await waitForPageJsLoad(page)
+    await tiDashboard.expectDashboardContainClient(client1)
+    await tiDashboard.expectDashboardContainClient(client2)
+  })
+
   it('managing trusted intermediary ', async () => {
     const {page, adminTiGroups} = ctx
     await loginAsAdmin(page)

--- a/server/app/services/ti/TrustedIntermediaryService.java
+++ b/server/app/services/ti/TrustedIntermediaryService.java
@@ -256,7 +256,12 @@ public final class TrustedIntermediaryService {
   public TrustedIntermediarySearchResult getManagedAccounts(
       SearchParameters searchParameters, TrustedIntermediaryGroupModel tiGroup) {
     ImmutableList<AccountModel> allAccounts = tiGroup.getManagedAccounts();
-    if (searchParameters.nameQuery().isEmpty() && searchParameters.dateQuery().isEmpty()) {
+    if ((searchParameters.nameQuery().isEmpty() && searchParameters.dateQuery().isEmpty()) ||
+      (searchParameters.nameQuery().isPresent() &&
+        searchParameters.nameQuery().get().isEmpty() &&
+        searchParameters.dateQuery().isPresent() &&
+        searchParameters.dateQuery().get().isEmpty())
+    ) {
       return TrustedIntermediarySearchResult.success(allAccounts);
     }
     final ImmutableList<AccountModel> searchedResult;

--- a/server/app/services/ti/TrustedIntermediaryService.java
+++ b/server/app/services/ti/TrustedIntermediaryService.java
@@ -256,12 +256,13 @@ public final class TrustedIntermediaryService {
   public TrustedIntermediarySearchResult getManagedAccounts(
       SearchParameters searchParameters, TrustedIntermediaryGroupModel tiGroup) {
     ImmutableList<AccountModel> allAccounts = tiGroup.getManagedAccounts();
-    if ((searchParameters.nameQuery().isEmpty() && searchParameters.dateQuery().isEmpty()) ||
-      (searchParameters.nameQuery().isPresent() &&
-        searchParameters.nameQuery().get().isEmpty() &&
-        searchParameters.dateQuery().isPresent() &&
-        searchParameters.dateQuery().get().isEmpty())
-    ) {
+    /* Filtering to transform empty strings into empty optionals.
+    Empty parameters should return all accounts. */
+    Optional<String> filteredNameQuery =
+        searchParameters.nameQuery().filter(s -> !s.isEmpty() && !s.isBlank());
+    Optional<String> filteredDateQuery =
+        searchParameters.dateQuery().filter(s -> !s.isEmpty() && !s.isBlank());
+    if (filteredNameQuery.isEmpty() && filteredDateQuery.isEmpty()) {
       return TrustedIntermediarySearchResult.success(allAccounts);
     }
     final ImmutableList<AccountModel> searchedResult;

--- a/server/test/services/ti/TrustedIntermediaryServiceTest.java
+++ b/server/test/services/ti/TrustedIntermediaryServiceTest.java
@@ -44,6 +44,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     formFactory = instanceOf(FormFactory.class);
     profileFactory = instanceOf(ProfileFactory.class);
     ApplicantModel managedApplicant = createApplicant();
+    // Note that this results in a blank managed account being added to tiGroup and tiGroup2
     createTIWithMockedProfile(managedApplicant);
     ApplicantModel managedApplicant2 = createApplicant();
     createTIWithMockedProfile(managedApplicant2);
@@ -334,36 +335,31 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     assertThat(tiResult.getAccounts().get().get(0).getEmailAddress()).isEqualTo("email20");
   }
 
-//  @Test
-//  public void getManagedAccounts_SearchWithEmptyStringNameAndDob_returnsFullList() {
-//    setupTiClientAccountWithApplicant("First", "2022-07-08", "email10", tiGroup);
-//    setupTiClientAccountWithApplicant("Emily", "2022-07-08", "email20", tiGroup);
-//    setupTiClientAccountWithApplicant("Third", "2022-07-10", "email30", tiGroup);
-//    SearchParameters searchParameters =
-//      SearchParameters.builder()
-//        .setNameQuery(Optional.of(""))
-//        .setDateQuery(Optional.of(""))
-//        .build();
-//    TrustedIntermediarySearchResult tiResult =
-//      service.getManagedAccounts(searchParameters, tiGroup);
-////    assertThat(tiResult.getAccounts().get().size()).isEqualTo(3);
-//  }
+  @Test
+  public void getManagedAccounts_SearchWithEmptyStringNameAndDob_returnsFullList() {
+    setupTiClientAccountWithApplicant("Bobo", "2022-07-08", "bobo@clown.test", tiGroup);
+    SearchParameters searchParameters =
+        SearchParameters.builder()
+            .setNameQuery(Optional.of(""))
+            .setDateQuery(Optional.of(""))
+            .build();
+    TrustedIntermediarySearchResult tiResult =
+        service.getManagedAccounts(searchParameters, tiGroup);
+    // The size is 3 because two other accounts are added to the tiGroup in setup()
+    assertThat(tiResult.getAccounts().get().size()).isEqualTo(3);
+  }
 
   @Test
   public void getManagedAccounts_SearchWithEmptyOptionalNameAndDob_returnsFullList() {
-//    setupTiClientAccountWithApplicant("First", "2022-07-08", "email10", tiGroup);
-//    setupTiClientAccountWithApplicant("Emily", "2022-07-08", "email20", tiGroup);
-//    setupTiClientAccountWithApplicant("Third", "2022-07-10", "email30", tiGroup);
+    setupTiClientAccountWithApplicant("Bobo", "2022-07-08", "bobo@clown.test", tiGroup);
     SearchParameters searchParameters =
-      SearchParameters.builder()
-        .setNameQuery(Optional.empty())
-        .setDateQuery(Optional.empty())
-        .build();
+        SearchParameters.builder()
+            .setNameQuery(Optional.empty())
+            .setDateQuery(Optional.empty())
+            .build();
     TrustedIntermediarySearchResult tiResult =
-      service.getManagedAccounts(searchParameters, tiGroup2);
-    assertThat(tiResult.getAccounts().get().size()).isEqualTo(0);
-//    assertThat(tiResult.getAccounts().get().get(0).getApplicantName()).isEqualTo("iiii");
-//    assertThat(tiResult.getAccounts().get().get(1).getApplicantName()).isEqualTo("jjjj");
+        service.getManagedAccounts(searchParameters, tiGroup);
+    assertThat(tiResult.getAccounts().get().size()).isEqualTo(3);
   }
 
   @Test

--- a/server/test/services/ti/TrustedIntermediaryServiceTest.java
+++ b/server/test/services/ti/TrustedIntermediaryServiceTest.java
@@ -334,6 +334,38 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     assertThat(tiResult.getAccounts().get().get(0).getEmailAddress()).isEqualTo("email20");
   }
 
+//  @Test
+//  public void getManagedAccounts_SearchWithEmptyStringNameAndDob_returnsFullList() {
+//    setupTiClientAccountWithApplicant("First", "2022-07-08", "email10", tiGroup);
+//    setupTiClientAccountWithApplicant("Emily", "2022-07-08", "email20", tiGroup);
+//    setupTiClientAccountWithApplicant("Third", "2022-07-10", "email30", tiGroup);
+//    SearchParameters searchParameters =
+//      SearchParameters.builder()
+//        .setNameQuery(Optional.of(""))
+//        .setDateQuery(Optional.of(""))
+//        .build();
+//    TrustedIntermediarySearchResult tiResult =
+//      service.getManagedAccounts(searchParameters, tiGroup);
+////    assertThat(tiResult.getAccounts().get().size()).isEqualTo(3);
+//  }
+
+  @Test
+  public void getManagedAccounts_SearchWithEmptyOptionalNameAndDob_returnsFullList() {
+//    setupTiClientAccountWithApplicant("First", "2022-07-08", "email10", tiGroup);
+//    setupTiClientAccountWithApplicant("Emily", "2022-07-08", "email20", tiGroup);
+//    setupTiClientAccountWithApplicant("Third", "2022-07-10", "email30", tiGroup);
+    SearchParameters searchParameters =
+      SearchParameters.builder()
+        .setNameQuery(Optional.empty())
+        .setDateQuery(Optional.empty())
+        .build();
+    TrustedIntermediarySearchResult tiResult =
+      service.getManagedAccounts(searchParameters, tiGroup2);
+    assertThat(tiResult.getAccounts().get().size()).isEqualTo(0);
+//    assertThat(tiResult.getAccounts().get().get(0).getApplicantName()).isEqualTo("iiii");
+//    assertThat(tiResult.getAccounts().get().get(1).getApplicantName()).isEqualTo("jjjj");
+  }
+
   @Test
   public void getManagedAccounts_ExpectUnformattedDobException() {
     setupTiClientAccountWithApplicant("First", "2022-07-08", "email11", tiGroup);


### PR DESCRIPTION
### Description

When searching for clients on the TI dashboard, if the user cleared their search parameters, an empty list was returned.  This meant that if a TI searched for a client and then wanted to see the full list afterwards, they were not able to do that.  This PR fixes that bug so that when a client clears their search parameters, they are able to see the full list of clients.

### Instructions for manual testing

1. Log in as a trusted intermediary and go to the TI dashboard.
2. Search for a client either by name or date of birth.
3. Delete the content from the search fields and click "Search".
4. Note that the full client list is shown.

