### PR TITLE
Set the pgadmin version

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,7 +59,7 @@ services:
 
   pgadmin:
     profiles: ['pgadmin']
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:8.2
     restart: always
     depends_on:
       - db


### PR DESCRIPTION
Set the pgadmin version to 8.2 (current release) for the dev docker compose file. It was stuck on an old version of 7.x. Renovatebot will keep it updated going forward.
