### PR TITLE
Add message for x of y progress status for translation

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -64,6 +64,7 @@ public enum MessageKey {
   CURRENCY_VALIDATION_MISFORMATTED("validation.currencyMisformatted"),
   CONTENT_ADMIN_LOGIN_PROMPT("content.adminLoginPrompt"),
   CONTENT_ADMIN_FOOTER_PROMPT("content.adminFooterPrompt"),
+  CONTENT_BLOCK_PROGRESS("content.blockProgress"),
   CONTENT_SAVE_TIME("content.saveTime"),
   CONTENT_CHANGE_ELIGIBILITY_ANSWERS("content.changeAnswersForEligibility"),
   CONTENT_CIVIFORM_DESCRIPTION("content.description"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -62,6 +62,7 @@ button.nextScreen=Save and next
 button.previousScreen=Previous
 button.review=Review
 button.skipFileUpload=Skip
+content.blockProgress={0} of {1}
 toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
 link.allDone=I''m all done
 link.applyToAnotherProgram=Apply to another program


### PR DESCRIPTION
### Description

Add message for "x of y" progress indicator so it can be translated. See https://github.com/civiform/civiform/issues/3068

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
