### PR TITLE
Removing the IDCS_DISCOVERY_URI that is set to Seattle

### DIFF
--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -40,7 +40,6 @@ idcs.client_id = ${?APPLICANT_OIDC_CLIENT_ID}
 idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?APPLICANT_OIDC_CLIENT_SECRET}
 idcs.secret = ${?IDCS_SECRET}
-idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
 idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration


### PR DESCRIPTION
### Description

The `IDCS_DISCOVERY_URI` has long been set to default to Seattle's Oracle instance. Dev/Test instances are set in docker compose files. Deployed versions should be setting it themselves if they need it.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)



Fixes #4706
