### PR TITLE
Update file upload file label even if there is an existing label

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -24,7 +24,6 @@ export function init() {
       const uploadText = assertNotNull(uploadedDiv.getAttribute(UPLOAD_ATTR))
 
       blockForm.addEventListener('change', (event) => {
-        if (uploadedDiv.innerHTML) return
         const files = (event.target! as HTMLInputElement).files
         const file = assertNotNull(files)[0]
         uploadedDiv.innerHTML = uploadText.replace('{0}', file.name)


### PR DESCRIPTION
### Description

The File uploaded: X text wasn't updating when the file was changed because we were only updating it when there was no existing file. This removes that condition

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Instructions for manual testing

Go to a file upload question, upload a file, then upload a different file. Verify that the filename updates correctly

### Issue(s) this completes

Fixes #6221 
