### PR TITLE
Update configuration file to accept APPLICANT_OIDC_DISCOVERY_URI for IDCS_DISCOVERY_URI

### DIFF
--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -41,6 +41,7 @@ idcs.client_id = ${?IDCS_CLIENT_ID}
 idcs.secret = ${?APPLICANT_OIDC_CLIENT_SECRET}
 idcs.secret = ${?IDCS_SECRET}
 idcs.discovery_uri = "https://idcs-f582fefb879b4db5a88a370e8f2f6013.identity.oraclecloud.com/.well-known/openid-configuration"
+idcs.discovery_uri = ${?APPLICANT_OIDC_DISCOVERY_URI}
 idcs.discovery_uri = ${?IDCS_DISCOVERY_URI}
 
 ## LoginRadius integration


### PR DESCRIPTION
### Description

This is a standard we use for the different applicant authentication providers to either use the specific variable for that provider or to accept the APPLICANT_OIDC_DISCOVERY_URI.  i.e. you can see this done for [login.gov](https://github.com/civiform/civiform/blob/0087d5d017951ca45ff588c9d84ae1f080bbc037/server/conf/helper/auth.conf#L92)

## Release notes

Allow IDCS users to specify the discovery URI as the APPLICANT_OIDC_DISCOVERY_URI

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #6445

and this should also resolve the issue with Seattle's prod deployment #4687