### PR TITLE
Add evolution for Primary Applicant Information

### DIFF
--- a/server/conf/evolutions/default/62.sql
+++ b/server/conf/evolutions/default/62.sql
@@ -1,0 +1,38 @@
+# --- Add primary applicant information columns
+
+# --- !Ups
+CREATE EXTENSION pg_trgm;
+CREATE EXTENSION btree_gin;
+
+ALTER TABLE applicants add column first_name varchar;
+ALTER TABLE applicants add column middle_name varchar;
+ALTER TABLE applicants add column last_name varchar;
+ALTER TABLE applicants add column email_address varchar;
+ALTER TABLE applicants add column country_code varchar;
+ALTER TABLE applicants add column phone_number varchar;
+ALTER TABLE applicants add column date_of_birth date;
+
+CREATE INDEX IF NOT EXISTS index_first_name ON applicants USING gin (first_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS index_middle_name ON applicants USING gin (middle_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS index_last_name ON applicants USING gin (last_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS index_email_address ON applicants (email_address);
+CREATE INDEX IF NOT EXISTS index_country_code ON applicants USING gin(country_code);
+CREATE INDEX IF NOT EXISTS index_phone_number ON applicants USING gin (phone_number gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS index_date_of_birth ON applicants (date_of_birth);
+
+# --- !Downs
+ALTER TABLE applicants drop column first_name;
+ALTER TABLE applicants drop column middle_name;
+ALTER TABLE applicants drop column last_name;
+ALTER TABLE applicants drop column email_address;
+ALTER TABLE applicants drop column country_code;
+ALTER TABLE applicants drop column phone_number;
+ALTER TABLE applicants drop column date_of_birth;
+
+DROP INDEX IF EXISTS index_first_name;
+DROP INDEX IF EXISTS index_middle_name;
+DROP INDEX IF EXISTS index_last_name;
+DROP INDEX IF EXISTS index_email_address;
+DROP INDEX IF EXISTS index_country_code;
+DROP INDEX IF EXISTS index_phone_number;
+DROP INDEX IF EXISTS index_date_of_birth;


### PR DESCRIPTION
This adds new columns to the applicants table for primary applicant information. Answers to questions marked with a PAI tag will be saved to these columns.

This also adds indexing, including adding the pg_trgm and btree_gin extensions to allow for creating trigrams for fuzzy matching.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6394
