### PR TITLE
Updating security document with info on SBOM

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,3 +11,9 @@ All production deployments are encouraged to deploy weekly and keep in regular c
 To report a vulnerability, please email civiform-escalations@googlegroups.com
 
 Please include the docker image tag for the version in which you have found the vulnerability, or a link to code on GitHub if that is more appropriate.
+
+## Software Bill of Materials
+
+The US Cybersecurity & Infrastructure Security Agency (CISA) recommends the inclusion of a Software Bill of Materials (SBOM). We create the SBOM file with each release. It can be found on the [releases page](https://github.com/civiform/civiform/releases).
+
+For more information on the SBOM visit the [US National Telecommunications and Information Administration website](https://www.ntia.gov/page/software-bill-materials)


### PR DESCRIPTION
### Description

Our Releases now generate a Software Bill of Materials (SBOM) as recommended by the US Cybersecurity & Infrastructure Security Agency. The SBOM can be found on the Releases page for each release.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform

Related: #6371
