### PR TITLE
Use X of Y message in applicant layout

### DIFF
--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -77,7 +77,11 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
             .addMainStyles(ApplicantStyles.MAIN_PROGRAM_APPLICATION)
             .addMainContent(
                 layout.renderProgramApplicationTitleAndProgressIndicator(
-                    params.programTitle(), params.blockIndex(), params.totalBlockCount(), false, messages),
+                    params.programTitle(),
+                    params.blockIndex(),
+                    params.totalBlockCount(),
+                    false,
+                    messages),
                 content);
 
     return layout.renderWithNav(

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -73,11 +73,11 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
             .getBundle(params.request())
             .setTitle(
                 layout.renderPageTitleWithBlockProgress(
-                    params.programTitle(), params.blockIndex(), params.totalBlockCount()))
+                    params.programTitle(), params.blockIndex(), params.totalBlockCount(), messages))
             .addMainStyles(ApplicantStyles.MAIN_PROGRAM_APPLICATION)
             .addMainContent(
                 layout.renderProgramApplicationTitleAndProgressIndicator(
-                    params.programTitle(), params.blockIndex(), params.totalBlockCount(), false),
+                    params.programTitle(), params.blockIndex(), params.totalBlockCount(), false, messages),
                 content);
 
     return layout.renderWithNav(

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -444,7 +444,11 @@ public class ApplicantLayout extends BaseHtmlLayout {
    * <p>For the summary view, there is no "current" block, and full progress can be shown.
    */
   protected DivTag renderProgramApplicationTitleAndProgressIndicator(
-      String programTitle, int blockIndex, int totalBlockCount, boolean forSummary, Messages messages) {
+      String programTitle,
+      int blockIndex,
+      int totalBlockCount,
+      boolean forSummary,
+      Messages messages) {
     int percentComplete = getPercentComplete(blockIndex, totalBlockCount, forSummary);
 
     DivTag progressInner =
@@ -497,9 +501,9 @@ public class ApplicantLayout extends BaseHtmlLayout {
   /**
    * Returns whole number out of 100 representing the completion percent of this program.
    *
-   * <p>See {@link #renderProgramApplicationTitleAndProgressIndicator(String, int, int, boolean, Messages)}
-   * about why there's a difference between the percent complete for summary views, and for
-   * non-summary views.
+   * <p>See {@link #renderProgramApplicationTitleAndProgressIndicator(String, int, int, boolean,
+   * Messages)} about why there's a difference between the percent complete for summary views, and
+   * for non-summary views.
    */
   private int getPercentComplete(int blockIndex, int totalBlockCount, boolean forSummary) {
     if (totalBlockCount == 0) {

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -425,11 +425,13 @@ public class ApplicantLayout extends BaseHtmlLayout {
   }
 
   protected String renderPageTitleWithBlockProgress(
-      String pageTitle, int blockIndex, int totalBlockCount) {
+      String pageTitle, int blockIndex, int totalBlockCount, Messages messages) {
     // While applicant is filling out the application, include the block they are on as part of
     // their progress.
     blockIndex++;
-    return String.format("%s — %d of %d", pageTitle, blockIndex, totalBlockCount);
+    String blockNumberText =
+        messages.at(MessageKey.CONTENT_BLOCK_PROGRESS.getKeyName(), blockIndex, totalBlockCount);
+    return String.format("%s — %s", pageTitle, blockNumberText);
   }
 
   /**
@@ -442,7 +444,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
    * <p>For the summary view, there is no "current" block, and full progress can be shown.
    */
   protected DivTag renderProgramApplicationTitleAndProgressIndicator(
-      String programTitle, int blockIndex, int totalBlockCount, boolean forSummary) {
+      String programTitle, int blockIndex, int totalBlockCount, boolean forSummary, Messages messages) {
     int percentComplete = getPercentComplete(blockIndex, totalBlockCount, forSummary);
 
     DivTag progressInner =
@@ -479,13 +481,13 @@ public class ApplicantLayout extends BaseHtmlLayout {
     }
 
     String blockNumberText =
-        forSummary ? "" : String.format("%d of %d", blockIndex, totalBlockCount);
+        messages.at(MessageKey.CONTENT_BLOCK_PROGRESS.getKeyName(), blockIndex, totalBlockCount);
 
     H1Tag programTitleContainer =
         h1().withClasses("flex")
             .with(span(programTitle).withClasses(ApplicantStyles.PROGRAM_TITLE))
             .condWith(
-                !blockNumberText.isEmpty(),
+                !forSummary,
                 span().withClasses("flex-grow"),
                 span(blockNumberText).withClasses("text-gray-500", "text-base", "text-right"));
 
@@ -495,7 +497,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
   /**
    * Returns whole number out of 100 representing the completion percent of this program.
    *
-   * <p>See {@link #renderProgramApplicationTitleAndProgressIndicator(String, int, int, boolean)}
+   * <p>See {@link #renderProgramApplicationTitleAndProgressIndicator(String, int, int, boolean, Messages)}
    * about why there's a difference between the percent complete for summary views, and for
    * non-summary views.
    */

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -70,7 +70,7 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
             .getBundle(params.request())
             .setTitle(
                 layout.renderPageTitleWithBlockProgress(
-                        params.programTitle(), params.blockIndex(), params.totalBlockCount())
+                        params.programTitle(), params.blockIndex(), params.totalBlockCount(), params.messages())
                     + errorMessage);
 
     Optional<DivTag> maybeBackToAdminViewButton =
@@ -81,7 +81,7 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
     bundle
         .addMainContent(
             layout.renderProgramApplicationTitleAndProgressIndicator(
-                params.programTitle(), params.blockIndex(), params.totalBlockCount(), false),
+                params.programTitle(), params.blockIndex(), params.totalBlockCount(), false, params.messages()),
             blockDiv)
         .addMainStyles(ApplicantStyles.MAIN_PROGRAM_APPLICATION);
 

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -70,7 +70,10 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
             .getBundle(params.request())
             .setTitle(
                 layout.renderPageTitleWithBlockProgress(
-                        params.programTitle(), params.blockIndex(), params.totalBlockCount(), params.messages())
+                        params.programTitle(),
+                        params.blockIndex(),
+                        params.totalBlockCount(),
+                        params.messages())
                     + errorMessage);
 
     Optional<DivTag> maybeBackToAdminViewButton =
@@ -81,7 +84,11 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
     bundle
         .addMainContent(
             layout.renderProgramApplicationTitleAndProgressIndicator(
-                params.programTitle(), params.blockIndex(), params.totalBlockCount(), false, params.messages()),
+                params.programTitle(),
+                params.blockIndex(),
+                params.totalBlockCount(),
+                false,
+                params.messages()),
             blockDiv)
         .addMainStyles(ApplicantStyles.MAIN_PROGRAM_APPLICATION);
 

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -150,7 +150,11 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     }
     bundle.addMainContent(
         layout.renderProgramApplicationTitleAndProgressIndicator(
-            params.programTitle(), params.completedBlockCount(), params.totalBlockCount(), true, messages),
+            params.programTitle(),
+            params.completedBlockCount(),
+            params.totalBlockCount(),
+            true,
+            messages),
         h2(pageTitle).withClasses(ApplicantStyles.PROGRAM_APPLICATION_TITLE),
         ApplicationBaseView.requiredFieldsExplanationContent(messages),
         content);

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -150,7 +150,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     }
     bundle.addMainContent(
         layout.renderProgramApplicationTitleAndProgressIndicator(
-            params.programTitle(), params.completedBlockCount(), params.totalBlockCount(), true),
+            params.programTitle(), params.completedBlockCount(), params.totalBlockCount(), true, messages),
         h2(pageTitle).withClasses(ApplicantStyles.PROGRAM_APPLICATION_TITLE),
         ApplicationBaseView.requiredFieldsExplanationContent(messages),
         content);


### PR DESCRIPTION
### Description

Use the message created in https://github.com/civiform/civiform/pull/6431 . The translations aren't done yet, but it was already untranslated, so this won't change anything in the meantime

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)

### Issue(s) this completes

Fixes #3068
