### PR TITLE
Add information about patch rewards program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,10 @@ To report a vulnerability, please email civiform-escalations@googlegroups.com
 
 Please include the docker image tag for the version in which you have found the vulnerability, or a link to code on GitHub if that is more appropriate.
 
+## Fixing a Vulnerability
+
+If you fix a vulnerability, you can qualify for the [Patch Rewards Program](https://bughunters.google.com/about/rules/4928084514701312/patch-rewards-program-rules) and receive a reward for your vulnerability fix.
+
 ## Software Bill of Materials
 
 The US Cybersecurity & Infrastructure Security Agency (CISA) recommends the inclusion of a Software Bill of Materials (SBOM). We create the SBOM file with each release. It can be found on the [releases page](https://github.com/civiform/civiform/releases).


### PR DESCRIPTION
### Description

Add details about patch rewards program to security page

## Release notes

Add link to [Patch Rewards Program](https://bughunters.google.com/about/rules/4928084514701312/patch-rewards-program-rules), which compensates for vulnerability fixes to CiviForm.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).


### Issue(s) this completes

Fixes #6475
