### PR TITLE
Remove unneeded ternary operator

### DIFF
--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -253,7 +253,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.CHECKBOX_LABEL,
-                true ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+                BaseStyles.BORDER_SEATTLE_BLUE)
             .with(
                 input()
                     .withId(id)


### PR DESCRIPTION
### Description

Removing unneeded ternary operator


- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
