### PR TITLE
Renaming base style fields with Seattle in them

### DIFF
--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -152,10 +152,10 @@ public final class AdminLayout extends BaseHtmlLayout {
 
     String activeNavStyle =
         StyleUtils.joinStyles(
-            BaseStyles.TEXT_SEATTLE_BLUE,
+            BaseStyles.TEXT_CIVIFORM_BLUE,
             "font-medium",
             "border-b-2",
-            BaseStyles.BORDER_SEATTLE_BLUE);
+            BaseStyles.BORDER_CIVIFORM_BLUE);
 
     DomContent reportingHeaderLink =
         headerLink(

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -274,7 +274,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                 "rounded-lg",
                 "bg-white",
                 "text-lg",
-                StyleUtils.focus(BaseStyles.BORDER_SEATTLE_BLUE));
+                StyleUtils.focus(BaseStyles.BORDER_CIVIFORM_BLUE));
 
     // Add the options available to the admin.
     // When no status is currently applied to the application, add a placeholder option that is

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -253,7 +253,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.CHECKBOX_LABEL,
-                BaseStyles.BORDER_SEATTLE_BLUE)
+                BaseStyles.BORDER_CIVIFORM_BLUE)
             .with(
                 input()
                     .withId(id)

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -448,7 +448,7 @@ public final class QuestionsListView extends BaseHtmlView {
                   "cursor-pointer",
                   "font-medium",
                   "underline",
-                  BaseStyles.TEXT_SEATTLE_BLUE,
+                  BaseStyles.TEXT_CIVIFORM_BLUE,
                   StyleUtils.hover("text-black"))
               .withText("See list"));
     }

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -454,7 +454,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
     DivTag progressInner =
         div()
             .withClasses(
-                BaseStyles.BG_SEATTLE_BLUE,
+                BaseStyles.BG_CIVIFORM_BLUE,
                 "transition-all",
                 "duration-300",
                 "h-full",
@@ -470,7 +470,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
             .withId("progress-indicator")
             .withClasses(
                 "border",
-                BaseStyles.BORDER_SEATTLE_BLUE,
+                BaseStyles.BORDER_CIVIFORM_BLUE,
                 "rounded-full",
                 "font-semibold",
                 "bg-white",

--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -76,7 +76,7 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
     H1Tag titleDiv =
         h1().withText(programTitle)
             .withClasses(
-                BaseStyles.TEXT_SEATTLE_BLUE, "text-2xl", "font-semibold", "text-gray-700", "mt-4");
+                BaseStyles.TEXT_CIVIFORM_BLUE, "text-2xl", "font-semibold", "text-gray-700", "mt-4");
 
     // "Markdown" the program description.
     ImmutableList<DomContent> items =

--- a/server/app/views/applicant/ApplicantProgramInfoView.java
+++ b/server/app/views/applicant/ApplicantProgramInfoView.java
@@ -76,7 +76,11 @@ public class ApplicantProgramInfoView extends BaseHtmlView {
     H1Tag titleDiv =
         h1().withText(programTitle)
             .withClasses(
-                BaseStyles.TEXT_CIVIFORM_BLUE, "text-2xl", "font-semibold", "text-gray-700", "mt-4");
+                BaseStyles.TEXT_CIVIFORM_BLUE,
+                "text-2xl",
+                "font-semibold",
+                "text-gray-700",
+                "mt-4");
 
     // "Markdown" the program description.
     ImmutableList<DomContent> items =

--- a/server/app/views/applicant/ProgramCardViewRenderer.java
+++ b/server/app/views/applicant/ProgramCardViewRenderer.java
@@ -211,7 +211,7 @@ public final class ProgramCardViewRenderer {
                 // The visual bar at the top of each program card.
                 div()
                     .withClasses(
-                        "block", "shrink-0", BaseStyles.BG_SEATTLE_BLUE, "rounded-t-xl", "h-3"));
+                        "block", "shrink-0", BaseStyles.BG_CIVIFORM_BLUE, "rounded-t-xl", "h-3"));
     programImage.ifPresent(cardListItem::with);
 
     return cardListItem.with(programData).with(actionDiv);
@@ -244,12 +244,12 @@ public final class ProgramCardViewRenderer {
         .with(
             Icons.svg(Icons.INFO)
                 // 4.5 is 18px as defined in tailwind.config.js
-                .withClasses("inline-block", "h-4.5", "w-4.5", BaseStyles.TEXT_SEATTLE_BLUE),
+                .withClasses("inline-block", "h-4.5", "w-4.5", BaseStyles.TEXT_CIVIFORM_BLUE),
             span(String.format(
                     "%s: %s",
                     messages.at(MessageKey.TITLE_STATUS.getKeyName()),
                     status.localizedStatusText().getOrDefault(preferredLocale)))
-                .withClasses("p-2", "text-xs", "font-medium", BaseStyles.TEXT_SEATTLE_BLUE));
+                .withClasses("p-2", "text-xs", "font-medium", BaseStyles.TEXT_CIVIFORM_BLUE));
   }
 
   private PTag eligibilityTag(

--- a/server/app/views/components/ButtonStyles.java
+++ b/server/app/views/components/ButtonStyles.java
@@ -22,7 +22,7 @@ public final class ButtonStyles {
   private static final String BUTTON_BASE_SOLID_BLUE_SEMIBOLD =
       StyleUtils.joinStyles(
           BUTTON_BASE,
-          BaseStyles.BG_SEATTLE_BLUE,
+          BaseStyles.BG_CIVIFORM_BLUE,
           "border-transparent",
           "text-white",
           "rounded-full",
@@ -37,8 +37,8 @@ public final class ButtonStyles {
           "px-8",
           BUTTON_BASE,
           "bg-transparent",
-          BaseStyles.TEXT_SEATTLE_BLUE,
-          BaseStyles.BORDER_SEATTLE_BLUE,
+          BaseStyles.TEXT_CIVIFORM_BLUE,
+          BaseStyles.BORDER_CIVIFORM_BLUE,
           StyleUtils.hover("bg-blue-100"));
 
   // ---------------- CLIENT-FACING STYLES BELOW ----------------
@@ -86,7 +86,7 @@ public final class ButtonStyles {
           "border-none",
           "rounded-full",
           "bg-transparent",
-          BaseStyles.TEXT_SEATTLE_BLUE,
+          BaseStyles.TEXT_CIVIFORM_BLUE,
           StyleUtils.hover("bg-gray-200"));
 
   // Just like CLEAR_WITH_ICON, but in dropdowns we want to remove the rounded corners.

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -30,7 +30,7 @@ public final class LinkElement {
           "ring-offset-2",
           "border",
           "border-transparent",
-          BaseStyles.BG_SEATTLE_BLUE,
+          BaseStyles.BG_CIVIFORM_BLUE,
           "text-white",
           StyleUtils.hover("bg-blue-700"),
           StyleUtils.focus("outline-none", "ring-2"));

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -90,7 +90,7 @@ public class CheckboxQuestionRenderer extends ApplicantCompositeQuestionRenderer
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.CHECKBOX_LABEL,
-                isSelected ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+                isSelected ? BaseStyles.BORDER_CIVIFORM_BLUE : "")
             .with(
                 input()
                     .withId(id)

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -105,7 +105,7 @@ public class RadioButtonQuestionRenderer extends ApplicantCompositeQuestionRende
             ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
             ReferenceClasses.RADIO_OPTION,
             BaseStyles.RADIO_LABEL,
-            checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
+            checked ? BaseStyles.BORDER_CIVIFORM_BLUE : "")
         .with(labelTag);
   }
 }

--- a/server/app/views/style/ApplicantStyles.java
+++ b/server/app/views/style/ApplicantStyles.java
@@ -39,7 +39,7 @@ public final class ApplicantStyles {
   public static final String PROGRAM_APPLICATION_TITLE =
       StyleUtils.joinStyles("text-3xl", "text-black", "font-bold", "mt-8", "mb-4");
   public static final String PROGRAM_TITLE =
-      StyleUtils.joinStyles(BaseStyles.TEXT_SEATTLE_BLUE, "text-lg", "font-bold");
+      StyleUtils.joinStyles(BaseStyles.TEXT_CIVIFORM_BLUE, "text-lg", "font-bold");
 
   public static final String PROGRAM_CARDS_SUBTITLE =
       StyleUtils.joinStyles("my-4", "text-lg", "px-4");

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -14,9 +14,9 @@ public final class BaseStyles {
 
   public static final String BG_CIVIFORM_WHITE = "bg-civiform-white";
 
-  public static final String BG_SEATTLE_BLUE = "bg-seattle-blue";
-  public static final String TEXT_SEATTLE_BLUE = "text-seattle-blue";
-  public static final String BORDER_SEATTLE_BLUE = "border-seattle-blue";
+  public static final String BG_CIVIFORM_BLUE = "bg-seattle-blue";
+  public static final String TEXT_CIVIFORM_BLUE = "text-seattle-blue";
+  public static final String BORDER_CIVIFORM_BLUE = "border-seattle-blue";
 
   public static final String TEXT_CIVIFORM_GREEN = "text-civiform-green";
   public static final String BG_CIVIFORM_GREEN_LIGHT = "bg-civiform-green-light";
@@ -57,7 +57,7 @@ public final class BaseStyles {
           BaseStyles.FORM_FIELD_BORDER_COLOR,
           "rounded-lg",
           "w-full",
-          StyleUtils.focus(BORDER_SEATTLE_BLUE));
+          StyleUtils.focus(BORDER_CIVIFORM_BLUE));
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, "placeholder-gray-500");


### PR DESCRIPTION
### Description

Renamed java fields named for Seattle. New names match other color class names.

- `BG_SEATTLE_BLUE` :point_right: `BG_CIVIFORM_BLUE`
- `TEXT_SEATTLE_BLUE` :point_right: `TEXT_CIVIFORM_BLUE`
- `BORDER_SEATTLE_BLUE` :point_right: `BORDER_CIVIFORM_BLUE`

 CSS class names to be done later.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
