### PR TITLE
Remove terraform from formatter dockerfile

### DIFF
--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -11,7 +11,7 @@ FROM ${TARGETARCH}
 ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/v1.18.1/google-java-format-1.18.1-all-deps.jar"
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar && \
     apk update && \
-    apk add --no-cache --update bash wget npm shfmt git py3-pip terraform && \
+    apk add --no-cache --update bash wget npm shfmt git py3-pip && \
     pip install yapf && \
     apk cache clean
 


### PR DESCRIPTION
No longer needed and now causing problems since alpine no longer provides terraform (https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.19.0)
