### PR TITLE
Adding warning log message if this page is called

### DIFF
--- a/server/app/views/support/UnconfirmedIdcsEmailBugView.java
+++ b/server/app/views/support/UnconfirmedIdcsEmailBugView.java
@@ -6,6 +6,8 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
 
 import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import views.BaseHtmlView;
@@ -14,6 +16,7 @@ import views.applicant.ApplicantLayout;
 import views.style.BaseStyles;
 
 public class UnconfirmedIdcsEmailBugView extends BaseHtmlView {
+  private static final Logger logger = LoggerFactory.getLogger(UnconfirmedIdcsEmailBugView.class);
 
   private final ApplicantLayout applicantLayout;
 
@@ -23,6 +26,8 @@ public class UnconfirmedIdcsEmailBugView extends BaseHtmlView {
   }
 
   public Content render(Http.Request request) {
+    logger.warn("Call make to UnconfirmedIdcsEmailBugView, a Seattle specific error page.");
+
     HtmlBundle bundle = applicantLayout.getBundle(request);
 
     bundle.setTitle("Please contact support");


### PR DESCRIPTION
### Description

This page was created to handle legacy accounts created in Jan 2022 to handle Seattle accounts that didn't have an authority_id. This was back when we thought email was going to be unique. This was added about a month after Seattle went live with CiviForm. Uses that have logged back in since Jan 2022 would have gotten the authority_id added. Anyone that doesn't have one at this point hasn't been in the system for two years. We'll log for a little bit to see if anyone ends up here. Ultimately though we are fine remove this at this point.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
