### PR TITLE
Removing Seattle Staging Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![ci](https://github.com/civiform/civiform/actions/workflows/push_tests.yaml/badge.svg)](https://github.com/civiform/civiform/actions/workflows/push_tests.yaml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6008/badge)](https://bestpractices.coreinfrastructure.org/projects/6008)
-[![Seattle Staging Deploy](https://github.com/seattle-civiform/civiform-deploy-tf/actions/workflows/deploy.yml/badge.svg)](https://github.com/seattle-civiform/civiform-deploy-tf/actions/workflows/deploy.yml)
 [![AWS Staging Deploy](https://github.com/civiform/civiform-staging-deploy/actions/workflows/aws_deploy.yaml/badge.svg?branch=main)](https://github.com/civiform/civiform-staging-deploy/actions/workflows/aws_deploy.yaml)
 ![codecov.io](https://codecov.io/github/civiform/civiform/coverage.svg?branch=main)
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://google.github.io/styleguide/)


### PR DESCRIPTION
### Description

Seattle's Staging has been failing due to false positive on a toggle on the admin page for quite some time. It looks bad to keep having the red show on the project so I'm removing it, at least until it can be working. Sometimes it maybe have been green, but only when I skip running probers.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
