### PR TITLE
Add Missing Compose Files to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "extends": ["config:base"],
   "labels": ["dependencies"],
+  "docker-compose": {
+    "fileMatch": ["^(browser-test|test-support)/[w-]*-compose.*.yml$"]
+  },
   "packageRules": [
     {
       "groupName": "autovalue",


### PR DESCRIPTION
### Description

Default file matching for renovate does not catch all of our compose files. 

I think I have the format for this correct, but there may be a little churn to get it right.


### Checklist


- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

