### PR TITLE
Second attempt to get missing compose files in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,14 @@
   "extends": ["config:base"],
   "labels": ["dependencies"],
   "docker-compose": {
-    "fileMatch": ["^(browser-test|test-support)/[w-]*-compose.*.yml$"]
+    "fileMatch": [
+      "browser-test/browser-test-compose.yml",
+      "browser-test/browser-test-compose.dev.yml",
+      "browser-test/browser-test-compose.dev_local.yml",
+      "test-support/prod-simulator-compose.yml",
+      "test-support/unit-test-docker-compose.yml",
+      "test-support/unit-test-docker-compose.dev.yml"
+    ]
   },
   "packageRules": [
     {


### PR DESCRIPTION
### Description

Second try

Default file matching for renovate does not catch all of our compose files. 

I think I have the format for this correct, but there may be a little churn to get it right.


### Checklist


- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

