### PR TITLE
[Program Card Images] Prevent admin from removing alt-text description if there's an image set

### DIFF
--- a/browser-test/src/admin_program_image.test.ts
+++ b/browser-test/src/admin_program_image.test.ts
@@ -216,6 +216,63 @@ describe('Admin can manage program image', () => {
       )
     })
 
+    it('does not remove description if image present (description set to empty)', async () => {
+      const {page, adminProgramImage} = ctx
+      await adminProgramImage.setImageDescriptionAndSubmit(
+        'Original description',
+      )
+      await adminProgramImage.setImageFileAndSubmit(
+        'src/assets/program-summary-image-wide.png',
+      )
+
+      await adminProgramImage.setImageDescriptionAndSubmit('')
+
+      await adminProgramImage.expectDescriptionIs('Original description')
+      await validateToastMessage(
+        page,
+        adminProgramImage.descriptionNotClearedToastMessage(),
+      )
+    })
+
+    it('does not remove description if image present (description set to blank)', async () => {
+      const {page, adminProgramImage} = ctx
+      await adminProgramImage.setImageDescriptionAndSubmit(
+        'Original description',
+      )
+      await adminProgramImage.setImageFileAndSubmit(
+        'src/assets/program-summary-image-wide.png',
+      )
+
+      await adminProgramImage.setImageDescriptionAndSubmit('      ')
+
+      await adminProgramImage.expectDescriptionIs('Original description')
+      await validateToastMessage(
+        page,
+        adminProgramImage.descriptionNotClearedToastMessage(),
+      )
+    })
+
+    it('can remove description after deleting image', async () => {
+      const {adminProgramImage} = ctx
+
+      // Set a description and image
+      await adminProgramImage.setImageDescriptionAndSubmit(
+        'Original description',
+      )
+      await adminProgramImage.setImageFileAndSubmit(
+        'src/assets/program-summary-image-wide.png',
+      )
+
+      // If the image is deleted
+      await adminProgramImage.clickDeleteImageButton()
+      await adminProgramImage.confirmDeleteImageButton()
+
+      // Then the description can also be deleted afterwards
+      await adminProgramImage.setImageDescriptionAndSubmit('')
+
+      await adminProgramImage.expectDescriptionIs('')
+    })
+
     it('disables submit button after save', async () => {
       const {adminProgramImage} = ctx
 

--- a/browser-test/src/support/admin_program_image.ts
+++ b/browser-test/src/support/admin_program_image.ts
@@ -170,6 +170,10 @@ export class AdminProgramImage {
     return `Image description removed`
   }
 
+  descriptionNotClearedToastMessage() {
+    return `Description can't be removed because an image is present. Delete the image before deleting the description.`
+  }
+
   imageUpdatedToastMessage() {
     return `Image set`
   }

--- a/server/app/controllers/admin/AdminProgramImageController.java
+++ b/server/app/controllers/admin/AdminProgramImageController.java
@@ -66,22 +66,26 @@ public final class AdminProgramImageController extends CiviFormController {
                 request, ProgramImageDescriptionForm.FIELD_NAMES.toArray(new String[0]));
     String newDescription = form.get().getSummaryImageDescription();
 
+    String toastType;
+    String toastMessage;
     try {
       programService.setSummaryImageDescription(
           programId, LocalizedStrings.DEFAULT_LOCALE, newDescription);
+      toastType = "success";
+      if (newDescription.isBlank()) {
+        toastMessage = "Image description removed";
+      } else {
+        toastMessage = "Image description set to " + newDescription;
+      }
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
-    }
-
-    String toastMessage;
-    if (newDescription.isBlank()) {
-      toastMessage = "Image description removed";
-    } else {
-      toastMessage = "Image description set to " + newDescription;
+    } catch (ImageDescriptionNotRemovableException e) {
+      toastType = "error";
+      toastMessage = e.getMessage();
     }
 
     final String indexUrl = routes.AdminProgramImageController.index(programId, editStatus).url();
-    return redirect(indexUrl).flashing("success", toastMessage);
+    return redirect(indexUrl).flashing(toastType, toastMessage);
   }
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)

--- a/server/app/controllers/admin/ImageDescriptionNotRemovableException.java
+++ b/server/app/controllers/admin/ImageDescriptionNotRemovableException.java
@@ -1,0 +1,13 @@
+package controllers.admin;
+
+/**
+ * Exception thrown when an admin attempts to remove the summary image description but isn't allowed
+ * to.
+ *
+ * <p>The message provided will be shown to the admin as an error.
+ */
+public class ImageDescriptionNotRemovableException extends RuntimeException {
+  public ImageDescriptionNotRemovableException(String message) {
+    super(message);
+  }
+}

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import controllers.BadRequestException;
+import controllers.admin.ImageDescriptionNotRemovableException;
 import forms.BlockForm;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -877,11 +878,21 @@ public final class ProgramService {
    *
    * <p>If the {@code locale} is the default locale and the {@code summaryImageDescription} is empty
    * or blank, then the description for *all* locales will be erased.
+   *
+   * @throws ImageDescriptionNotRemovableException if the admin tries to remove a description while
+   *     they still have an image.
    */
   public ProgramDefinition setSummaryImageDescription(
       long programId, Locale locale, String summaryImageDescription)
       throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
+
+    if (summaryImageDescription.isBlank() && programDefinition.summaryImageFileKey().isPresent()) {
+      throw new ImageDescriptionNotRemovableException(
+          "Description can't be removed because an image is present. Delete the image before"
+              + " deleting the description.");
+    }
+
     Optional<LocalizedStrings> newStrings =
         getUpdatedSummaryImageDescription(programDefinition, locale, summaryImageDescription);
     programDefinition =

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -143,6 +143,8 @@ public final class ProgramImageView extends BaseHtmlView {
     Http.Flash flash = request.flash();
     if (flash.get("success").isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
+    } else if (flash.get("error").isPresent()) {
+      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(flash.get("error").get()));
     }
 
     return layout.renderCentered(htmlBundle);

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -402,7 +402,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   }
 
   @Test
-    public void updateDescription_redirectIncludesSameEditStatus() {
+  public void updateDescription_redirectIncludesSameEditStatus() {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Result result =

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -206,7 +206,8 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void updateDescription_empty_removesDescription() throws ProgramNotFoundException {
+  public void updateDescription_empty_noImageFile_removesDescription()
+      throws ProgramNotFoundException {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("test name")
             .setLocalizedSummaryImageDescription(
@@ -229,7 +230,62 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void updateDescription_blank_removesDescription() throws ProgramNotFoundException {
+  public void updateDescription_empty_hasImageFile_descriptionNotRemoved()
+      throws ProgramNotFoundException {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("test name")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(Locale.US, "original description"))
+            .build();
+    setValidFileKeyOnProgram(program);
+
+    Result result =
+        controller.updateDescription(
+            addCSRFToken(
+                    fakeRequest()
+                        .method("POST")
+                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+                .build(),
+            program.id,
+            ProgramEditStatus.CREATION.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
+    assertThat(updatedProgram.localizedSummaryImageDescription().get().getDefault())
+        .isEqualTo("original description");
+  }
+
+  @Test
+  public void updateDescription_blank_hasImageFile_descriptionNotRemoved()
+      throws ProgramNotFoundException {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("test name")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(Locale.US, "original description"))
+            .build();
+    setValidFileKeyOnProgram(program);
+
+    Result result =
+        controller.updateDescription(
+            addCSRFToken(
+                    fakeRequest()
+                        .method("POST")
+                        .bodyForm(ImmutableMap.of("summaryImageDescription", "    ")))
+                .build(),
+            program.id,
+            ProgramEditStatus.CREATION.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
+    assertThat(updatedProgram.localizedSummaryImageDescription().get().getDefault())
+        .isEqualTo("original description");
+  }
+
+  @Test
+  public void updateDescription_blank_noImageFile_removesDescription()
+      throws ProgramNotFoundException {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("test name")
             .setLocalizedSummaryImageDescription(
@@ -300,7 +356,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void updateDescription_empty_toastsSuccess() {
+  public void updateDescription_empty_noImageFile_toastsSuccess() {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("test name")
             .setLocalizedSummaryImageDescription(
@@ -322,7 +378,31 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void updateDescription_redirectIncludesSameEditStatus() {
+  public void updateDescription_empty_hasImageFile_toastsError() throws ProgramNotFoundException {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("test name")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(Locale.US, "original description"))
+            .build();
+    setValidFileKeyOnProgram(program);
+
+    Result result =
+        controller.updateDescription(
+            addCSRFToken(
+                    fakeRequest()
+                        .method("POST")
+                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+                .build(),
+            program.id,
+            ProgramEditStatus.CREATION.name());
+
+    assertThat(result.flash().data()).containsOnlyKeys("error");
+    assertThat(result.flash().data().get("error"))
+        .contains("Description can't be removed because an image is present");
+  }
+
+  @Test
+    public void updateDescription_redirectIncludesSameEditStatus() {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Result result =

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import controllers.BadRequestException;
+import controllers.admin.ImageDescriptionNotRemovableException;
 import forms.BlockForm;
 import io.ebean.DB;
 import java.util.ArrayList;
@@ -2823,7 +2824,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setSummaryImageDescription_defaultLocaleAndBlank_removesAllTranslations()
-      throws ProgramNotFoundException, TranslationNotFoundException {
+      throws ProgramNotFoundException {
     ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
     ps.setSummaryImageDescription(program.id(), Locale.US, "US description");
     ps.setSummaryImageDescription(program.id(), Locale.CANADA, "Canada description");
@@ -2832,6 +2833,18 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramDefinition result = ps.setSummaryImageDescription(program.id(), DEFAULT_LOCALE, "");
 
     assertThat(result.localizedSummaryImageDescription().isPresent()).isFalse();
+  }
+
+  @Test
+  public void setSummaryImageDescription_blank_hasImageFile_throwsNotRemovableException()
+      throws ProgramNotFoundException {
+    ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
+    ps.setSummaryImageDescription(program.id(), Locale.US, "US description");
+    ps.setSummaryImageFileKey(program.id(), "fileKey.png");
+
+    assertThatThrownBy(() -> ps.setSummaryImageDescription(program.id(), Locale.US, ""))
+        .isInstanceOf(ImageDescriptionNotRemovableException.class)
+        .hasMessageContaining("Description can't be removed because an image is present");
   }
 
   @Test


### PR DESCRIPTION
### Description

For program card images, we want to require admins to provide an alt-text description before providing an image. This PR also prevents admins from deleting the alt-text description if there's currently an image set.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Enable PROGRAM_CARD_IMAGES flag.
2. Edit a program then click "Edit program image".
3. Set a description.
4. Upload an image.
5. Try removing the description by deleting the text in the description box and clicking "Save image description".
6. Verify an error toast appears and the previously-set description is still there.

### Issue(s) this completes

Part of epic #5676 
