### PR TITLE
Turn on cache for program data by default

### DIFF
--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -32,7 +32,7 @@ api_generated_docs_enabled = false
 api_generated_docs_enabled = ${?API_GENERATED_DOCS_ENABLED}
 
 # Caching features
-version_cache_enabled = true
+version_cache_enabled = false
 version_cache_enabled = ${?VERSION_CACHE_ENABLED}
 program_cache_enabled = true
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -32,9 +32,9 @@ api_generated_docs_enabled = false
 api_generated_docs_enabled = ${?API_GENERATED_DOCS_ENABLED}
 
 # Caching features
-version_cache_enabled = false
+version_cache_enabled = true
 version_cache_enabled = ${?VERSION_CACHE_ENABLED}
-program_cache_enabled = false
+program_cache_enabled = true
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}
 question_cache_enabled = false
 question_cache_enabled = ${?QUESTION_CACHE_ENABLED}

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ProgramRepository;
@@ -35,10 +36,12 @@ import services.question.types.QuestionType;
 public class ProgramModelTest extends ResetPostgres {
 
   private ProgramRepository repo;
+  private Long uniqueProgramId;
 
   @Before
   public void setupProgramRepository() {
     repo = instanceOf(ProgramRepository.class);
+    uniqueProgramId = new Random().nextLong();
   }
 
   @Test
@@ -51,7 +54,7 @@ public class ProgramModelTest extends ResetPostgres {
             .setDescription("applicant's name")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
             .build();
-    long programDefinitionId = 1L;
+    long programDefinitionId = uniqueProgramId;
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(1L)
@@ -139,7 +142,7 @@ public class ProgramModelTest extends ResetPostgres {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .build();
 
-    long programDefinitionId = 1L;
+    long programDefinitionId = uniqueProgramId;
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(1L)
@@ -212,7 +215,7 @@ public class ProgramModelTest extends ResetPostgres {
 
     ProgramDefinition definition =
         ProgramDefinition.builder()
-            .setId(1L)
+            .setId(uniqueProgramId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "ProgramTest"))
@@ -241,7 +244,7 @@ public class ProgramModelTest extends ResetPostgres {
 
   @Test
   public void unorderedBlockDefinitions_getOrderedBlockDefinitionsOnSave() {
-    long programDefinitionId = 45832L;
+    long programDefinitionId = uniqueProgramId;
     ImmutableList<BlockDefinition> unorderedBlocks =
         ImmutableList.<BlockDefinition>builder()
             .add(
@@ -369,7 +372,7 @@ public class ProgramModelTest extends ResetPostgres {
 
     ProgramDefinition definition =
         ProgramDefinition.builder()
-            .setId(1L)
+            .setId(new Random().nextLong())
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "ProgramTest"))
@@ -391,7 +394,7 @@ public class ProgramModelTest extends ResetPostgres {
 
     ProgramDefinition definition2 =
         ProgramDefinition.builder()
-            .setId(2L)
+            .setId(uniqueProgramId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "ProgramTest"))

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -2600,7 +2601,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     var programWithEligibleAndIneligibleAnswers =
         ProgramBuilder.newDraftProgram(
                 ProgramDefinition.builder()
-                    .setId(123)
+                    .setId(new Random().nextLong())
                     .setAdminName("name")
                     .setAdminDescription("desc")
                     .setExternalLink("https://usa.gov")
@@ -2675,7 +2676,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel commonIntakeForm =
         ProgramBuilder.newDraftProgram(
                 ProgramDefinition.builder()
-                    .setId(123)
+                    .setId(new Random().nextLong())
                     .setAdminName("common_intake_form")
                     .setAdminDescription("common_intake_form")
                     .setExternalLink("https://usa.gov")
@@ -2962,7 +2963,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     programDefinition =
         ProgramBuilder.newDraftProgram(
                 ProgramDefinition.builder()
-                    .setId(123)
+                    .setId(new Random().nextLong())
                     .setAdminName("name")
                     .setAdminDescription("desc")
                     .setExternalLink("https://usa.gov")


### PR DESCRIPTION
### Description

Turn on the program caching feature by default, since we've tested it in Seattle and on staging.

This change involved updating some tests to ensure programs have unique IDs.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Fixes #5745
