### PR TITLE
Include hidden questions in JSON API

### DIFF
--- a/server/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -102,11 +102,10 @@ public interface ReadOnlyApplicantProgramService {
   Optional<Block> getFirstIncompleteBlockExcludingStatic();
 
   /**
-   * Returns summary data for each question in the hidden blocks in this application. Hidden block
-   * is the block not visible to the applicant based on the visibility setting by the admin. This
-   * will not include blocks that are active.
+   * Returns summary data for each question in this application. Includes blocks that are hidden
+   * from the applicant due to visibility conditions.
    */
-  ImmutableList<AnswerData> getSummaryDataOnlyHidden();
+  ImmutableList<AnswerData> getSummaryDataAllQuestions();
 
   /**
    * Returns summary data for each question in the active blocks in this application. Active block
@@ -114,6 +113,13 @@ public interface ReadOnlyApplicantProgramService {
    * hidden from the applicant.
    */
   ImmutableList<AnswerData> getSummaryDataOnlyActive();
+
+  /**
+   * Returns summary data for each question in the hidden blocks in this application. Hidden block
+   * is the block not visible to the applicant based on the visibility setting by the admin. This
+   * will not include blocks that are active.
+   */
+  ImmutableList<AnswerData> getSummaryDataOnlyHidden();
 
   /** Get the string identifiers for all stored files for this application. */
   ImmutableList<String> getStoredFileKeys();

--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -281,11 +281,19 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
+  public ImmutableList<AnswerData> getSummaryDataAllQuestions() {
+    ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
+    ImmutableList<Block> blocks = getBlocks((block) -> true);
+    addDataToBuilder(blocks, builder, /* showAnswerText */ true);
+    return builder.build();
+  }
+
+  @Override
   public ImmutableList<AnswerData> getSummaryDataOnlyActive() {
     // TODO: We need to be able to use this on the admin side with admin-specific l10n.
     ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
     ImmutableList<Block> activeBlocks = getAllActiveBlocks();
-    addDataToBuilder(activeBlocks, builder, /* hiddenBlocks= */ false);
+    addDataToBuilder(activeBlocks, builder, /* showAnswerText= */ true);
     return builder.build();
   }
 
@@ -294,7 +302,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     // TODO: We need to be able to use this on the admin side with admin-specific l10n.
     ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
     ImmutableList<Block> hiddenBlocks = getAllHiddenBlocks();
-    addDataToBuilder(hiddenBlocks, builder, /* hiddenBlocks= */ true);
+    addDataToBuilder(hiddenBlocks, builder, /* showAnswerText= */ false);
     return builder.build();
   }
 
@@ -302,11 +310,16 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
    * Helper method for {@link ReadOnlyApplicantProgramServiceImpl#getSummaryDataOnlyActive()} and
    * {@link ReadOnlyApplicantProgramServiceImpl#getSummaryDataOnlyHidden()}. Adds {@link AnswerData}
    * data to {@link ImmutableList.Builder<AnswerData>}.
+   *
+   * @param blocks the blocks to add to the builder
+   * @param builder the builder to add the blocks to
+   * @param showAnswerText whether to include the answer text in the result. If {@code false},
+   *     answers are replaced with "N/A".
    */
   private void addDataToBuilder(
       ImmutableList<Block> blocks,
       ImmutableList.Builder<AnswerData> builder,
-      boolean hiddenBlocks) {
+      boolean showAnswerText) {
     for (Block block : blocks) {
       ImmutableList<ApplicantQuestion> questions = block.getQuestions();
       for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
@@ -320,7 +333,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
         String questionText = applicantQuestion.getQuestionText();
         String questionTextForScreenReader = applicantQuestion.getQuestionTextForScreenReader();
         String answerText =
-            hiddenBlocks ? NOT_APPLICABLE : applicantQuestion.getQuestion().getAnswerString();
+            showAnswerText ? applicantQuestion.getQuestion().getAnswerString() : NOT_APPLICABLE;
         Optional<Long> timestamp = applicantQuestion.getLastUpdatedTimeMetadata();
         Optional<Long> updatedProgram = applicantQuestion.getUpdatedInProgramMetadata();
         Optional<String> originalFileName = Optional.empty();

--- a/server/app/services/export/JsonExporter.java
+++ b/server/app/services/export/JsonExporter.java
@@ -117,7 +117,8 @@ public final class JsonExporter {
     ReadOnlyApplicantProgramService roApplicantProgramService =
         applicantService.getReadOnlyApplicantProgramService(application, programDefinition);
 
-    ImmutableList<AnswerData> answerDataList = roApplicantProgramService.getSummaryDataOnlyActive();
+    ImmutableList<AnswerData> answerDataList =
+        roApplicantProgramService.getSummaryDataAllQuestions();
     ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
 
     for (AnswerData answerData : answerDataList) {

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -586,6 +586,35 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
+    /**
+     * Adds a question with a visibility predicate. If the text question ({@code applicant favorite
+     * color}) is answered with "red" then the date question ({@code applicant birth date}) isn't
+     * shown to the applicant.
+     *
+     * @return the fake {@link ProgramBuilder}
+     */
+    FakeProgramBuilder withDateQuestionWithVisibilityPredicateOnTextQuestion() {
+      QuestionModel dateQuestion = testQuestionBank.applicantDate();
+      QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
+
+      PredicateDefinition colorPredicate =
+          PredicateDefinition.create(
+              PredicateExpressionNode.create(
+                  LeafOperationExpressionNode.create(
+                      colorQuestion.id, Scalar.TEXT, Operator.EQUAL_TO, PredicateValue.of("red"))),
+              PredicateAction.HIDE_BLOCK);
+
+      fakeProgramBuilder
+          .withBlock()
+          .withRequiredQuestion(colorQuestion)
+          .withBlock()
+          .withRequiredQuestions(dateQuestion)
+          .withVisibilityPredicate(colorPredicate)
+          .build();
+
+      return this;
+    }
+
     FakeProgramBuilder withHouseholdMembersEnumeratorQuestion() {
       addEnumeratorQuestion = true;
       return this;
@@ -729,6 +758,18 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
       QuestionAnswerer.answerEmailQuestion(applicant.getApplicantData(), answerPath, answer);
+      applicant.save();
+      return this;
+    }
+
+    public FakeApplicationFiller answerTextQuestion(String answer) {
+      Path answerPath =
+          testQuestionBank
+              .applicantFavoriteColor()
+              .getQuestionDefinition()
+              .getContextualizedPath(
+                  /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
+      QuestionAnswerer.answerTextQuestion(applicant.getApplicantData(), answerPath, answer);
       applicant.save();
       return this;
     }

--- a/server/test/services/export/JsonExporterTest.java
+++ b/server/test/services/export/JsonExporterTest.java
@@ -675,7 +675,6 @@ public class JsonExporterTest extends AbstractExporterTest {
             SubmittedApplicationFilter.EMPTY);
     ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
 
-    //    resultAsserter.assertJsonAtApplicationPath(".applicant_household_members", "[ ]");
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
         "{\n" // comment to prevent fmt wrapping
@@ -966,6 +965,38 @@ public class JsonExporterTest extends AbstractExporterTest {
             + "    }\n"
             + "  } ],\n"
             + "  \"question_type\" : \"ENUMERATOR\"\n"
+            + "}");
+  }
+
+  @Test
+  public void export_questionWithVisibilityPredicate_isInResponseWhenHiddenFromApplicant() {
+    createFakeQuestions();
+    ProgramModel fakeProgram =
+        new FakeProgramBuilder().withDateQuestionWithVisibilityPredicateOnTextQuestion().build();
+    new FakeApplicationFiller(fakeProgram).answerTextQuestion("red").submit();
+
+    JsonExporter exporter = instanceOf(JsonExporter.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    // assert answered question
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_favorite_color",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"question_type\" : \"TEXT\",\n"
+            + "  \"text\" : \"red\"\n"
+            + "}");
+    // assert hidden question is still in export
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_birth_date",
+        "{\n" // comment to prevent fmt wrapping
+            + "  \"date\" : null,\n"
+            + "  \"question_type\" : \"DATE\"\n"
             + "}");
   }
 


### PR DESCRIPTION
### Description

Includes questions hidden from applicants in the API response.

## Release notes

Previously, only questions shown to applicants were included in the API response. This means that if a question was skipped due to a visibility predicate, it wasn't included in the API.

That's proven to be an unexpected behavior, so with this change all questions will be included in the API response, regardless of visibility.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

To manually test:
- Create a program with a question that contains a visibility predicate
- Answer the questions such that the question with the predicate is hidden from the applicant
- Query the API and confirm that the hidden question is still in the API response

### We've confirmed with all civic entities that this won't break anything:
- [x] Seattle
- [x] Bloomington
- [x] Arkansas
- [ ] 
### Issue(s) this completes

Fixes #6285
