### PR TITLE
Making the browser test container stay resident

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
 # DOC: Run the browser tests using Docker. Requires browser test env already running.
+# DOC: Optional environment variables:
+# DOC:   RECORD_VIDEO - If set (typically to 1) records video of the test run.
+# DOC:   TEST_CIVIC_ENTITY_SHORT_NAME - Overrides the default value of the short name.
+# DOC: Globals:
+# DOC:   DOCKER_NETWORK_NAME - from lib/docker.sh 
 
 source bin/lib.sh
 docker::set_project_name_browser_tests

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -12,13 +12,13 @@ docker::set_project_name_browser_tests
 bin/pull-image
 
 readonly CONTAINER_NAME="civiform-browser-test-runner"
-readonly CONTAINER_IMAGE_ID="$(docker inspect "${CONTAINER_NAME}" | jq '.[0].Image')"
+readonly CONTAINER_IMAGE_ID="$(docker inspect "${CONTAINER_NAME}" 2>/dev/null | jq '.[0].Image')"
 readonly LAST_IMAGE_ID="$(docker image inspect civiform-browser-test:latest | jq '.[0].Id')"
 
 # Check if the current browser test image is different. If it is remove the container
 # so that it can be recreated with the newer image.
 if [[ "${CONTAINER_IMAGE_ID}" != "${LAST_IMAGE_ID}" ]]; then
-  docker rm --volumes --force "${CONTAINER_NAME}"
+  docker rm --volumes --force "${CONTAINER_NAME}" 2>/dev/null
 fi
 
 # Check if the container is running. If it is not run the container and detach so it

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -28,7 +28,7 @@ fi
 # We map full browser-test local directory to the container so that it uses local changes.
 # Additionally we map node_modules to a separate anonymous volume so that it doesn't
 # conflict with node_modules created locally.
-if [[ -z "$(docker ps -f "name=${CONTAINER_NAME}" --format "{{.Names}}")" ]]; then
+if [[ -z "$(docker ps --filter "name=${CONTAINER_NAME}" --format "{{.Names}}")" ]]; then
   docker run \
     --detach \
     --interactive \

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -6,17 +6,42 @@ source bin/lib.sh
 docker::set_project_name_browser_tests
 bin/pull-image
 
-# Run browser tests from within the civiform-browser-test container. We map
-# full browser-test local directory to the container so that it uses local changes.
-# Additionally we map node_modules to a separate volume so that it doesn't
+readonly CONTAINER_NAME="civiform-browser-test-runner"
+readonly CONTAINER_IMAGE_ID="$(docker inspect "${CONTAINER_NAME}" | jq '.[0].Image')"
+readonly LAST_IMAGE_ID="$(docker image inspect civiform-browser-test:latest | jq '.[0].Id')"
+
+# Check if the current browser test image is different. If it is remove the container
+# so that it can be recreated with the newer image.
+if [[ "${CONTAINER_IMAGE_ID}" != "${LAST_IMAGE_ID}" ]]; then
+  docker rm --volumes --force "${CONTAINER_NAME}"
+fi
+
+# Check if the container is running. If it is not run the container and detach so it
+# stays running in docker.
+#
+# We map full browser-test local directory to the container so that it uses local changes.
+# Additionally we map node_modules to a separate anonymous volume so that it doesn't
 # conflict with node_modules created locally.
-# --init enables https://github.com/krallin/tini
-docker run --rm -it \
-  -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
-  -e RECORD_VIDEO="${RECORD_VIDEO}" \
-  -e TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
-  --network "${DOCKER_NETWORK_NAME}" \
-  --init \
-  civiform-browser-test:latest \
+if [[ -z "$(docker ps -f "name=${CONTAINER_NAME}" --format "{{.Names}}")" ]]; then
+  docker run \
+    --detach \
+    --interactive \
+    --tty \
+    --volume "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
+    --name "${CONTAINER_NAME}" \
+    --env RECORD_VIDEO="${RECORD_VIDEO}" \
+    --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
+    --network "${DOCKER_NETWORK_NAME}" \
+    --entrypoint bash \
+    civiform-browser-test:latest
+fi
+
+# Run browser tests from within the civiform-browser-test container.
+docker exec \
+  --interactive \
+  --tty \
+  --env RECORD_VIDEO="${RECORD_VIDEO}" \
+  --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
+  "${CONTAINER_NAME}" \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \
   "$@"

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -5,7 +5,7 @@
 # DOC:   RECORD_VIDEO - If set (typically to 1) records video of the test run.
 # DOC:   TEST_CIVIC_ENTITY_SHORT_NAME - Overrides the default value of the short name.
 # DOC: Globals:
-# DOC:   DOCKER_NETWORK_NAME - from lib/docker.sh 
+# DOC:   DOCKER_NETWORK_NAME - from lib/docker.sh
 
 source bin/lib.sh
 docker::set_project_name_browser_tests

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -14,6 +14,7 @@ bin/pull-image
 readonly CONTAINER_NAME="civiform-browser-test-runner"
 readonly CONTAINER_IMAGE_ID="$(docker inspect "${CONTAINER_NAME}" 2>/dev/null | jq '.[0].Image')"
 readonly LAST_IMAGE_ID="$(docker image inspect civiform-browser-test:latest | jq '.[0].Id')"
+readonly TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}"
 
 # Check if the current browser test image is different. If it is remove the container
 # so that it can be recreated with the newer image.
@@ -35,7 +36,7 @@ if [[ -z "$(docker ps -f "name=${CONTAINER_NAME}" --format "{{.Names}}")" ]]; th
     --volume "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
     --name "${CONTAINER_NAME}" \
     --env RECORD_VIDEO="${RECORD_VIDEO}" \
-    --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
+    --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME}" \
     --network "${DOCKER_NETWORK_NAME}" \
     --entrypoint bash \
     civiform-browser-test:latest
@@ -46,7 +47,7 @@ docker exec \
   --interactive \
   --tty \
   --env RECORD_VIDEO="${RECORD_VIDEO}" \
-  --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME:-TestCity}" \
+  --env TEST_CIVIC_ENTITY_SHORT_NAME="${TEST_CIVIC_ENTITY_SHORT_NAME}" \
   "${CONTAINER_NAME}" \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \
   "$@"


### PR DESCRIPTION
### Description

The `bin/run-browser-tests` script currently  runs the browser tests and immediately and removes the container. This also removes the anonymous volume which stores the node_modules. This means it's downloading everything each time.

Changing this to:
* Smartly remove the container if the image has changed
* Run and detach the container and pop into a bash
* Then runs the tests in the resident container

This speeds up running tests when the container is already up and prevents re-downloading each time 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

