### PR TITLE
Fix for Application count mismatch between CVS exports and Reporting

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -217,7 +217,7 @@ public final class AdminApplicationController extends CiviFormController {
 
   /**
    * Parses a date from a raw query string (e.g. 2022-01-02) and returns an instant representing the
-   * start of that date in the time zone configured for the server deployment.
+   * start of that date in the UTC time zone.
    */
   private Optional<Instant> parseDateFromQuery(
       DateConverter dateConverter, Optional<String> maybeQueryParam) {

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -226,7 +226,7 @@ public final class AdminApplicationController extends CiviFormController {
         .map(
             s -> {
               try {
-                return dateConverter.parseIso8601DateToStartOfDateInstant(s);
+                return dateConverter.parseIso8601DateToStartOfUTCDateInstant(s);
               } catch (DateTimeParseException e) {
                 throw new BadRequestException("Malformed query param");
               }

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -221,7 +221,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
 
   private Instant parseParamDateToInstant(String paramName, String paramDate) {
     try {
-      return dateConverter.parseIso8601DateToStartOfDateInstant(paramDate);
+      return dateConverter.parseIso8601DateToStartOfLocalDateInstant(paramDate);
     } catch (DateTimeParseException e) {
       throw new BadApiRequestException("Malformed query param: " + paramName);
     }

--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -87,7 +87,7 @@ public final class DurableJobModule extends AbstractModule {
         DurableJobName.REPORTING_DASHBOARD_MONTHLY_REFRESH,
         persistedDurableJob ->
             new ReportingDashboardMonthlyRefreshJob(reportingRepository, persistedDurableJob),
-        new RecurringJobExecutionTimeResolvers.Sunday2Am());
+        new RecurringJobExecutionTimeResolvers.FirstOfMonth2Am());
 
     durableJobRegistry.register(
         DurableJobName.UNUSED_ACCOUNT_CLEANUP,

--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -87,7 +87,7 @@ public final class DurableJobModule extends AbstractModule {
         DurableJobName.REPORTING_DASHBOARD_MONTHLY_REFRESH,
         persistedDurableJob ->
             new ReportingDashboardMonthlyRefreshJob(reportingRepository, persistedDurableJob),
-        new RecurringJobExecutionTimeResolvers.FirstOfMonth2Am());
+        new RecurringJobExecutionTimeResolvers.Sunday2Am());
 
     durableJobRegistry.register(
         DurableJobName.UNUSED_ACCOUNT_CLEANUP,

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.Inject;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -11,8 +12,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Calendar;
-import java.util.TimeZone;
 
 /** Utility class for converting dates between different formats. */
 public final class DateConverter {
@@ -100,10 +99,7 @@ public final class DateConverter {
 
   /** Formats a {@link java.sql.Timestamp} to MM/YY. */
   public String renderAsTwoDigitMonthAndYear(Timestamp timestamp) {
-    var calendar = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
-    calendar.setTimeInMillis(timestamp.getTime());
-
-    return (calendar.get(Calendar.MONTH) + 1) + "/" + calendar.get(Calendar.YEAR);
+    return new SimpleDateFormat("MM/yyyy").format(timestamp);
   }
 
   /** Gets the {@link Long} timestamp from an age, by subtracting the age from today's date. */

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -64,7 +64,7 @@ public final class DateConverter {
    * @throws DateTimeParseException if dateString is not well-formed.
    */
   public Instant parseIso8601DateToStartOfDateInstant(String dateString) {
-    return parseIso8601DateToLocalDate(dateString).atStartOfDay(zoneId).toInstant();
+    return parseIso8601DateToLocalDate(dateString).atStartOfDay(ZoneId.of("UTC")).toInstant();
   }
 
   /** Formats an {@link Instant} to a human-readable date and time in the local time zone. */

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -58,11 +58,21 @@ public final class DateConverter {
 
   /**
    * Parses a string containing a ISO-8601 date (i.e. "YYYY-MM-DD") and converts it to an {@link
+   * Instant} at the beginning of the day in Local time zone.
+   *
+   * @throws DateTimeParseException if dateString is not well-formed.
+   */
+  public Instant parseIso8601DateToStartOfLocalDateInstant(String dateString) {
+    return parseIso8601DateToLocalDate(dateString).atStartOfDay(zoneId).toInstant();
+  }
+
+  /**
+   * Parses a string containing a ISO-8601 date (i.e. "YYYY-MM-DD") and converts it to an {@link
    * Instant} at the beginning of the day in UTC time zone.
    *
    * @throws DateTimeParseException if dateString is not well-formed.
    */
-  public Instant parseIso8601DateToStartOfDateInstant(String dateString) {
+  public Instant parseIso8601DateToStartOfUTCDateInstant(String dateString) {
     return parseIso8601DateToLocalDate(dateString).atStartOfDay(ZoneId.of("UTC")).toInstant();
   }
 

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -59,7 +59,7 @@ public final class DateConverter {
 
   /**
    * Parses a string containing a ISO-8601 date (i.e. "YYYY-MM-DD") and converts it to an {@link
-   * Instant} at the beginning of the day in local time zone.
+   * Instant} at the beginning of the day in UTC time zone.
    *
    * @throws DateTimeParseException if dateString is not well-formed.
    */
@@ -87,6 +87,7 @@ public final class DateConverter {
     ZonedDateTime dateTime = time.atZone(zoneId);
     return dateTime.format(DATE_TIME_FORMATTER_WITH_SLASH);
   }
+
   /** Formats an {@link LocalDate} to a String. */
   public String formatIso8601Date(LocalDate date) {
     return date.format(DATE_TIME_FORMATTER_WITH_DASH);

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -107,7 +107,7 @@ public final class DateConverter {
     return Instant.ofEpochMilli(timestamp).atZone(this.zoneId).toLocalDate();
   }
 
-  /** Formats a {@link java.sql.Timestamp} to MM/YY. */
+  /** Formats a {@link java.sql.Timestamp} to MM/YYYY. */
   public String renderAsTwoDigitMonthAndYear(Timestamp timestamp) {
     return new SimpleDateFormat("MM/yyyy").format(timestamp);
   }

--- a/server/app/services/apikey/ApiKeyService.java
+++ b/server/app/services/apikey/ApiKeyService.java
@@ -229,7 +229,8 @@ public final class ApiKeyService {
     }
 
     try {
-      Instant expiration = dateConverter.parseIso8601DateToStartOfDateInstant(expirationString);
+      Instant expiration =
+          dateConverter.parseIso8601DateToStartOfLocalDateInstant(expirationString);
       apiKey.setExpiration(expiration);
     } catch (DateTimeParseException e) {
       return form.withError(

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -203,9 +203,9 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     ProgramModel programOne = createDraftProgram("first");
     ProgramModel programTwo = createDraftProgram("second");
 
-    Instant yesterday = dateConverter.parseIso8601DateToStartOfDateInstant("2022-01-02");
-    Instant today = dateConverter.parseIso8601DateToStartOfDateInstant("2022-01-03");
-    Instant tomorrow = dateConverter.parseIso8601DateToStartOfDateInstant("2022-01-04");
+    Instant yesterday = dateConverter.parseIso8601DateToStartOfLocalDateInstant("2022-01-02");
+    Instant today = dateConverter.parseIso8601DateToStartOfLocalDateInstant("2022-01-03");
+    Instant tomorrow = dateConverter.parseIso8601DateToStartOfLocalDateInstant("2022-01-04");
 
     // Create applications at each instant in each program.
     ApplicationModel programOneYesterday = createSubmittedAppAtInstant(programOne, yesterday);

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -3,6 +3,7 @@ package services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.text.ParseException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -18,7 +19,7 @@ public class DateConverterTest {
   @Test
   public void workingWith_Iso8601_dates() {
     String original = "2021-01-01Z";
-    Instant parsed = dateConverter.parseIso8601DateToStartOfDateInstant(original);
+    Instant parsed = dateConverter.parseIso8601DateToStartOfLocalDateInstant(original);
     String formatted = dateConverter.formatIso8601Date(parsed);
 
     assertThat(formatted).isEqualTo(original);
@@ -39,10 +40,27 @@ public class DateConverterTest {
   }
 
   @Test
+  public void parseIso8601DateToUTCDateInstant_isSuccessful() {
+    String inputDate = "2022-04-09";
+    Instant expected = Instant.parse("2022-04-09T00:00:00.00Z");
+    Instant result = dateConverter.parseIso8601DateToStartOfUTCDateInstant(inputDate);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
   public void renderDate_isSuccessful() {
     String expectedResult = "2020-01-01";
     LocalDate date = LocalDate.of(2020, 1, 1);
     String result = dateConverter.formatIso8601Date(date);
+    assertThat(expectedResult).isEqualTo(result);
+  }
+
+  @Test
+  public void renderAsTwoDigitMonthAndYear_isSuccessful() throws ParseException {
+    String expectedResult = "01/2022";
+    String result =
+        dateConverter.renderAsTwoDigitMonthAndYear(
+            java.sql.Timestamp.valueOf("2022-01-01 10:10:10.0"));
     assertThat(expectedResult).isEqualTo(result);
   }
 

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -17,7 +17,7 @@ public class DateConverterTest {
   private DateConverter dateConverter = new DateConverter(clock);
 
   @Test
-  public void workingWith_Iso8601_dates() {
+  public void parseIso8601DateToLocalDateInstant_isSuccessful() {
     String original = "2021-01-01Z";
     Instant parsed = dateConverter.parseIso8601DateToStartOfLocalDateInstant(original);
     String formatted = dateConverter.formatIso8601Date(parsed);

--- a/server/test/services/apikey/ApiKeyServiceTest.java
+++ b/server/test/services/apikey/ApiKeyServiceTest.java
@@ -309,7 +309,7 @@ public class ApiKeyServiceTest extends ResetPostgres {
     assertThat(apiKey.getSubnet()).isEqualTo("0.0.0.1/32,1.1.1.0/32");
     assertThat(apiKey.getSubnetSet()).isEqualTo(ImmutableSet.of("0.0.0.1/32", "1.1.1.0/32"));
     assertThat(apiKey.getExpiration())
-        .isEqualTo(dateConverter.parseIso8601DateToStartOfDateInstant("2020-01-30"));
+        .isEqualTo(dateConverter.parseIso8601DateToStartOfLocalDateInstant("2020-01-30"));
     assertThat(apiKey.getGrants().hasProgramPermission("test-program", Permission.READ)).isTrue();
   }
 
@@ -339,7 +339,7 @@ public class ApiKeyServiceTest extends ResetPostgres {
     assertThat(apiKey.getSubnet()).isEqualTo("0.0.0.1/32,1.1.1.0/32");
     assertThat(apiKey.getSubnetSet()).isEqualTo(ImmutableSet.of("0.0.0.1/32", "1.1.1.0/32"));
     assertThat(apiKey.getExpiration())
-        .isEqualTo(dateConverter.parseIso8601DateToStartOfDateInstant("2020-01-30"));
+        .isEqualTo(dateConverter.parseIso8601DateToStartOfLocalDateInstant("2020-01-30"));
     assertThat(apiKey.getGrants().hasProgramPermission("test-program", Permission.READ)).isTrue();
   }
 

--- a/server/test/services/reporting/ReportingServiceTest.java
+++ b/server/test/services/reporting/ReportingServiceTest.java
@@ -61,9 +61,9 @@ public class ReportingServiceTest extends ResetPostgres {
 
     List<CSVRecord> records = parser.getRecords();
     assertThat(records.get(0).toList())
-        .containsExactly("12/2020", "4", "00:05:25", "00:06:40", "00:07:55", "00:09:07");
+        .containsExactly("01/2021", "4", "00:05:25", "00:06:40", "00:07:55", "00:09:07");
     assertThat(records.get(1).toList())
-        .containsExactly("11/2020", "4", "00:05:25", "00:06:40", "00:07:55", "00:09:07");
+        .containsExactly("12/2020", "4", "00:05:25", "00:06:40", "00:07:55", "00:09:07");
     assertThat(records.size()).isEqualTo(2);
 
     parser =
@@ -101,9 +101,9 @@ public class ReportingServiceTest extends ResetPostgres {
 
     records = parser.getRecords();
     assertThat(records.get(0).toList())
-        .containsExactly("12/2020", "2", "00:00:25", "00:00:50", "00:01:15", "00:01:39");
+        .containsExactly("01/2021", "2", "00:00:25", "00:00:50", "00:01:15", "00:01:39");
     assertThat(records.get(1).toList())
-        .containsExactly("11/2020", "2", "00:10:25", "00:12:30", "00:14:35", "00:16:35");
+        .containsExactly("12/2020", "2", "00:10:25", "00:12:30", "00:14:35", "00:16:35");
     assertThat(records.size()).isEqualTo(2);
   }
 


### PR DESCRIPTION
### Description

Fix for Application count mismatch between CVS exports and Reporting.
Fix 1- Internally we store all submit time as UTC. On trying to the retrieve the records for dd-mm-yyyy, we should also covert it to UTC time zone so that we will get the same results.
Fix 2 - When converting java.sql.Timestamp into MM/yyyy format for reporting, there is no need to add time zone information as the time stamp is always set to the beginning of the month eg. 01-01-2024 00:00:000. So SimpleDateTimeFormatter is enough to extract the MM/yyyy format.  

## Release notes

Fix for Application count mismatch between CVS exports and Reporting.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5824 
