### PR TITLE
Removing Legacy Question Columns

### DIFF
--- a/server/app/models/QuestionModel.java
+++ b/server/app/models/QuestionModel.java
@@ -1,13 +1,9 @@
 package models;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Streams;
 import io.ebean.annotation.DbArray;
 import io.ebean.annotation.DbJsonB;
 import io.ebean.annotation.WhenCreated;
@@ -15,7 +11,6 @@ import io.ebean.annotation.WhenModified;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/server/conf/evolutions/default/63.sql
+++ b/server/conf/evolutions/default/63.sql
@@ -1,0 +1,13 @@
+# --- Remove legacy question columns
+
+# --- !Ups
+alter table questions drop column if exists legacy_question_text;
+alter table questions drop column if exists legacy_question_help_text;
+alter table questions drop column if exists legacy_question_options;
+
+# --- !Downs
+alter table questions add column if not exists legacy_question_text jsonb;
+alter table questions add column if not exists legacy_question_help_text jsonb;
+alter table questions add column if not exists legacy_question_options jsonb;
+
+

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
-import io.ebean.DB;
 import io.ebean.DataIntegrityException;
 import java.util.Locale;
 import java.util.Map;

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -249,28 +249,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void loadLegacy() {
-    DB.sqlUpdate(
-            "insert into questions (name, description, legacy_question_text,"
-                + " legacy_question_help_text, question_type) values ('old schema"
-                + " entry', 'description', '{\"en_us\": \"text\"}', '{\"en_us\": \"help\"}',"
-                + " 'REPEATER');")
-        .execute();
-
-    QuestionModel found =
-        repo.listQuestions().toCompletableFuture().join().stream()
-            .filter(
-                question -> question.getQuestionDefinition().getName().equals("old schema entry"))
-            .findFirst()
-            .get();
-
-    assertThat(found.getQuestionDefinition().getQuestionText())
-        .isEqualTo(LocalizedStrings.of(Locale.US, "text"));
-    assertThat(found.getQuestionDefinition().getQuestionHelpText())
-        .isEqualTo(LocalizedStrings.of(Locale.US, "help"));
-  }
-
-  @Test
   public void createOrUpdateDraft_managesUniversalTagCorrectly()
       throws UnsupportedQuestionTypeException {
     // Question will be published in an ACTIVE version


### PR DESCRIPTION
### Description

The `questions` table contains the following columns: `legacy_question_text`, `legacy_question_help_text`, `legacy_question_options`.

These columns were removed prior to **June 2021**. Seattle's earliest production application is June 16th and all our questions records have these three columns set to null.

No other deployments would have occurred until well after this change. It's safe and time to clean this up.

## Release notes

Removing three obsolete columns from the questions table: legacy_question_text, legacy_question_help_text, and legacy_question_options.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).