### PR TITLE
Fix evolution for primary applicant info

### DIFF
--- a/server/conf/evolutions/default/62.sql
+++ b/server/conf/evolutions/default/62.sql
@@ -16,11 +16,19 @@ CREATE INDEX IF NOT EXISTS index_first_name ON applicants USING gin (first_name 
 CREATE INDEX IF NOT EXISTS index_middle_name ON applicants USING gin (middle_name gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS index_last_name ON applicants USING gin (last_name gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS index_email_address ON applicants (email_address);
-CREATE INDEX IF NOT EXISTS index_country_code ON applicants USING gin(country_code);
+CREATE INDEX IF NOT EXISTS index_country_code ON applicants USING gin (country_code);
 CREATE INDEX IF NOT EXISTS index_phone_number ON applicants USING gin (phone_number gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS index_date_of_birth ON applicants (date_of_birth);
 
 # --- !Downs
+DROP INDEX IF EXISTS index_first_name;
+DROP INDEX IF EXISTS index_middle_name;
+DROP INDEX IF EXISTS index_last_name;
+DROP INDEX IF EXISTS index_email_address;
+DROP INDEX IF EXISTS index_country_code;
+DROP INDEX IF EXISTS index_phone_number;
+DROP INDEX IF EXISTS index_date_of_birth;
+
 ALTER TABLE applicants DROP column IF EXISTS first_name;
 ALTER TABLE applicants DROP column IF EXISTS middle_name;
 ALTER TABLE applicants DROP column IF EXISTS last_name;
@@ -29,10 +37,5 @@ ALTER TABLE applicants DROP column IF EXISTS country_code;
 ALTER TABLE applicants DROP column IF EXISTS phone_number;
 ALTER TABLE applicants DROP column IF EXISTS date_of_birth;
 
-DROP INDEX IF EXISTS index_first_name;
-DROP INDEX IF EXISTS index_middle_name;
-DROP INDEX IF EXISTS index_last_name;
-DROP INDEX IF EXISTS index_email_address;
-DROP INDEX IF EXISTS index_country_code;
-DROP INDEX IF EXISTS index_phone_number;
-DROP INDEX IF EXISTS index_date_of_birth;
+DROP EXTENSION IF EXISTS pg_trgm;
+DROP EXTENSION IF EXISTS btree_gin;


### PR DESCRIPTION
This evolution neglected to have the IF NOT EXISTS guard for creating the extensions and columns. This can be problematic for the extension if the database user does not have permission to create extensions. In this case, the extension will need to be added manually, but then this evolution would fail because it didn't have the IF NOT EXISTS on it.

If your deployment has already applied this evolution successfully, this commit will not change anything.