### PR TITLE
Fixing NullPointerException When Address Is Invalid

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -221,7 +221,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       Request request, long applicantId, long programId, String blockId, boolean inReview) {
 
     DynamicForm form = formFactory.form().bindFromRequest(request);
-    Optional<String> selectedAddress = Optional.ofNullable(form.get(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME));
+    Optional<String> selectedAddress =
+        Optional.ofNullable(form.get(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME));
     Optional<String> maybeAddressJson = request.session().get(ADDRESS_JSON_SESSION_KEY);
 
     ImmutableList<AddressSuggestion> suggestions =

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -221,7 +221,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       Request request, long applicantId, long programId, String blockId, boolean inReview) {
 
     DynamicForm form = formFactory.form().bindFromRequest(request);
-    String selectedAddress = form.get(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME);
+    Optional<String> selectedAddress = Optional.ofNullable(form.get(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME));
     Optional<String> maybeAddressJson = request.session().get(ADDRESS_JSON_SESSION_KEY);
 
     ImmutableList<AddressSuggestion> suggestions =
@@ -252,7 +252,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       long programId,
       String blockId,
       boolean inReview,
-      String selectedAddress,
+      Optional<String> selectedAddress,
       ImmutableList<AddressSuggestion> suggestions) {
     CompletableFuture<ApplicantPersonalInfo> applicantStage =
         applicantService.getPersonalInfo(applicantId).toCompletableFuture();
@@ -804,7 +804,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
           programId,
           blockId,
           inReview,
-          suggestionMatch[0].getSingleLineAddress(),
+          Optional.of(suggestionMatch[0].getSingleLineAddress()),
           suggestions);
     } else {
       String json = addressSuggestionJsonSerializer.serialize(suggestions);

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1459,7 +1459,7 @@ public final class ApplicantService {
       long applicantId,
       long programId,
       String blockId,
-      String selectedAddress,
+      Optional<String> selectedAddress,
       ImmutableList<AddressSuggestion> addressSuggestions) {
     return getReadOnlyApplicantProgramService(applicantId, programId)
         .thenComposeAsync(
@@ -1479,7 +1479,7 @@ public final class ApplicantService {
                   addressSuggestions.stream()
                       .filter(
                           addressSuggestion ->
-                              addressSuggestion.getSingleLineAddress().equals(selectedAddress))
+                              addressSuggestion.getSingleLineAddress().equals(selectedAddress.orElse("")))
                       .findFirst();
 
               ImmutableMap<String, String> questionPathToValueMap =
@@ -1502,7 +1502,7 @@ public final class ApplicantService {
       String blockId,
       AddressQuestion addressQuestion,
       Optional<AddressSuggestion> suggestionMaybe,
-      String selectedAddress) {
+      Optional<String> selectedAddress) {
 
     ImmutableMap.Builder<String, String> questionPathToValueMap = ImmutableMap.builder();
 
@@ -1525,7 +1525,7 @@ public final class ApplicantService {
       questionPathToValueMap.put(
           addressQuestion.getCorrectedPath().toString(),
           CorrectedAddressState.CORRECTED.getSerializationFormat());
-    } else if (selectedAddress.equals(AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE)) {
+    } else if (selectedAddress.isPresent() && selectedAddress.get().equals(AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE)) {
       questionPathToValueMap.put(
           addressQuestion.getCorrectedPath().toString(),
           CorrectedAddressState.AS_ENTERED_BY_USER.getSerializationFormat());

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1479,7 +1479,9 @@ public final class ApplicantService {
                   addressSuggestions.stream()
                       .filter(
                           addressSuggestion ->
-                              addressSuggestion.getSingleLineAddress().equals(selectedAddress.orElse("")))
+                              addressSuggestion
+                                  .getSingleLineAddress()
+                                  .equals(selectedAddress.orElse("")))
                       .findFirst();
 
               ImmutableMap<String, String> questionPathToValueMap =
@@ -1525,7 +1527,8 @@ public final class ApplicantService {
       questionPathToValueMap.put(
           addressQuestion.getCorrectedPath().toString(),
           CorrectedAddressState.CORRECTED.getSerializationFormat());
-    } else if (selectedAddress.isPresent() && selectedAddress.get().equals(AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE)) {
+    } else if (selectedAddress.isPresent()
+        && selectedAddress.get().equals(AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE)) {
       questionPathToValueMap.put(
           addressQuestion.getCorrectedPath().toString(),
           CorrectedAddressState.AS_ENTERED_BY_USER.getSerializationFormat());

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3067,7 +3067,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 program.id,
                 String.valueOf(blockDefinition.id()),
-                addressSuggestion1.getSingleLineAddress(),
+                Optional.of(addressSuggestion1.getSingleLineAddress()),
                 addressSuggestionList)
             .toCompletableFuture()
             .get();
@@ -3175,7 +3175,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 program.id,
                 String.valueOf(blockDefinition.id()),
-                AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE,
+                Optional.of(AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE),
                 addressSuggestionList)
             .toCompletableFuture()
             .get();
@@ -3267,7 +3267,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                 applicant.id,
                 program.id,
                 String.valueOf(blockDefinition.id()),
-                "asdf",
+                Optional.of("asdf"),
                 addressSuggestionList)
             .toCompletableFuture()
             .get();

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3260,7 +3260,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ImmutableList<AddressSuggestion> addressSuggestionList =
         ImmutableList.of(addressSuggestion1, addressSuggestion2);
 
-    // Act
+    // Act - Tests with invalid value
     ImmutableMap<String, String> correctedAddress =
         subject
             .getCorrectedAddress(
@@ -3275,6 +3275,23 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Assert
     assertThat(correctedAddress.get(addressQuestion.getCorrectedPath().toString()))
         .isEqualTo(CorrectedAddressState.FAILED.getSerializationFormat());
+
+
+    // Act - Tests with null
+    ImmutableMap<String, String> correctedAddressWithNull =
+      subject
+        .getCorrectedAddress(
+          applicant.id,
+          program.id,
+          String.valueOf(blockDefinition.id()),
+          Optional.ofNullable(null),
+          addressSuggestionList)
+        .toCompletableFuture()
+        .get();
+
+    // Assert
+    assertThat(correctedAddressWithNull.get(addressQuestion.getCorrectedPath().toString()))
+      .isEqualTo(CorrectedAddressState.FAILED.getSerializationFormat());
   }
 
   @Test

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3276,22 +3276,21 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(correctedAddress.get(addressQuestion.getCorrectedPath().toString()))
         .isEqualTo(CorrectedAddressState.FAILED.getSerializationFormat());
 
-
     // Act - Tests with null
     ImmutableMap<String, String> correctedAddressWithNull =
-      subject
-        .getCorrectedAddress(
-          applicant.id,
-          program.id,
-          String.valueOf(blockDefinition.id()),
-          Optional.ofNullable(null),
-          addressSuggestionList)
-        .toCompletableFuture()
-        .get();
+        subject
+            .getCorrectedAddress(
+                applicant.id,
+                program.id,
+                String.valueOf(blockDefinition.id()),
+                Optional.ofNullable(null),
+                addressSuggestionList)
+            .toCompletableFuture()
+            .get();
 
     // Assert
     assertThat(correctedAddressWithNull.get(addressQuestion.getCorrectedPath().toString()))
-      .isEqualTo(CorrectedAddressState.FAILED.getSerializationFormat());
+        .isEqualTo(CorrectedAddressState.FAILED.getSerializationFormat());
   }
 
   @Test


### PR DESCRIPTION
### Description

Fixing NullPointerException when address is invalid. This occurred when the address was configured for validation, and the user tried to move forward to the not eligible page.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Updated tests

Fixes #5831