### PR TITLE
Use GIN trigram index for email_address instead of btree

### DIFF
--- a/server/conf/evolutions/default/65.sql
+++ b/server/conf/evolutions/default/65.sql
@@ -1,0 +1,9 @@
+# --- Replace index on email_address column with trigram index
+
+# --- !Ups
+DROP INDEX IF EXISTS index_email_address;
+CREATE INDEX IF NOT EXISTS index_email_address ON applicants USING gin (email_address gin_trgm_ops);
+
+# --- !Downs
+DROP INDEX IF EXISTS index_email_address;
+CREATE INDEX IF NOT EXISTS index_email_address ON applicants (email_address);


### PR DESCRIPTION
This was actually intended to be a GIN trigram index, rather than the default btree index, to enable fuzzy searching this field.