### PR TITLE
Move logic for Previous button route to ApplicantRoutes

### DIFF
--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -189,7 +189,7 @@ public final class ApplicantRoutes {
   }
 
   /**
-   * Returns the route corresponding to the applicant previous block action, or the route *
+   * Returns the route corresponding to the applicant previous block action, or the route
    * corresponding to the review page if there's no valid previous block.
    *
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -189,16 +189,31 @@ public final class ApplicantRoutes {
   }
 
   /**
-   * Returns the route corresponding to the applicant previous block action.
+   * Returns the route corresponding to the applicant previous block action, or the route *
+   * corresponding to the review page if there's no valid previous block.
    *
    * @param profile - Profile corresponding to the logged-in user (applicant or TI).
    * @param applicantId - ID of applicant for whom the action should be performed.
    * @param programId - ID of program to review
-   * @param previousBlockIndex - index of the previous block
+   * @param currentBlockIndex - index of the current block
    * @param inReview - true if executing the review action (as opposed to edit)
    * @return Route for the applicant previous block action
    */
-  public Call blockPrevious(
+  public Call blockPreviousOrReview(
+      CiviFormProfile profile,
+      long applicantId,
+      long programId,
+      int currentBlockIndex,
+      boolean inReview) {
+    int previousBlockIndex = currentBlockIndex - 1;
+    if (previousBlockIndex >= 0) {
+      return blockPrevious(profile, applicantId, programId, previousBlockIndex, inReview);
+    } else {
+      return review(profile, applicantId, programId);
+    }
+  }
+
+  private Call blockPrevious(
       CiviFormProfile profile,
       long applicantId,
       long programId,

--- a/server/app/views/ApplicationBaseView.java
+++ b/server/app/views/ApplicationBaseView.java
@@ -78,25 +78,16 @@ public class ApplicationBaseView extends BaseHtmlView {
   }
 
   protected ATag renderPreviousButton(ApplicationBaseView.Params params) {
-    int previousBlockIndex = params.blockIndex() - 1;
-    String redirectUrl;
-
-    if (previousBlockIndex >= 0) {
-      ApplicantRoutes applicantRoutes = params.applicantRoutes();
-      redirectUrl =
-          applicantRoutes
-              .blockPrevious(
-                  params.profile(),
-                  params.applicantId(),
-                  params.programId(),
-                  previousBlockIndex,
-                  params.inReview())
-              .url();
-    } else {
-      ApplicantRoutes applicantRoutes = params.applicantRoutes();
-      redirectUrl =
-          applicantRoutes.review(params.profile(), params.applicantId(), params.programId()).url();
-    }
+    String redirectUrl =
+        params
+            .applicantRoutes()
+            .blockPreviousOrReview(
+                params.profile(),
+                params.applicantId(),
+                params.programId(),
+                /* currentBlockIndex= */ params.blockIndex(),
+                params.inReview())
+            .url();
     return a().withHref(redirectUrl)
         .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
         .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -26,7 +26,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
   private static long TI_ACCOUNT_ID = 789L;
   private static long PROGRAM_ID = 321L;
   private static String BLOCK_ID = "test_block";
-  private static int PREVIOUS_BLOCK_INDEX = 7;
+  private static final int CURRENT_BLOCK_INDEX = 7;
 
   // Class to hold counter values.
   static class Counts {
@@ -546,7 +546,8 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   @Parameters({"true", "false"})
-  public void testPreviousRoute_forApplicantWithIdInProfile_newSchemaEnabled(String inReview) {
+  public void testPreviousOrReviewRoute_forApplicantWithIdInProfile_newSchemaEnabled(
+      String inReview) {
     Counts before = getApplicantIdInProfileCounts();
 
     CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
@@ -557,14 +558,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
     String expectedPreviousUrl =
         String.format(
-            "/programs/%d/blocks/%d/previous/%s", PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
+            "/programs/%d/blocks/%d/previous/%s", PROGRAM_ID, CURRENT_BLOCK_INDEX - 1, inReview);
     assertThat(
             new ApplicantRoutes()
-                .blockPrevious(
+                .blockPreviousOrReview(
                     applicantProfile,
                     APPLICANT_ID,
                     PROGRAM_ID,
-                    PREVIOUS_BLOCK_INDEX,
+                    CURRENT_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -576,7 +577,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   @Parameters({"true", "false"})
-  public void testPreviousRoute_forApplicantWithoutIdInProfile(String inReview) {
+  public void testPreviousOrReviewRoute_forApplicantWithoutIdInProfile(String inReview) {
     Counts before = getApplicantIdInProfileCounts();
 
     CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
@@ -587,14 +588,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedPreviousUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%d/previous/%s",
-            APPLICANT_ID, PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
+            APPLICANT_ID, PROGRAM_ID, CURRENT_BLOCK_INDEX - 1, inReview);
     assertThat(
             new ApplicantRoutes()
-                .blockPrevious(
+                .blockPreviousOrReview(
                     applicantProfile,
                     APPLICANT_ID,
                     PROGRAM_ID,
-                    PREVIOUS_BLOCK_INDEX,
+                    CURRENT_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -606,7 +607,7 @@ public class ApplicantRoutesTest extends ResetPostgres {
 
   @Test
   @Parameters({"true", "false"})
-  public void testPreviousRoute_forTrustedIntermediary(String inReview) {
+  public void testPreviousOrReviewRoute_forTrustedIntermediary(String inReview) {
     Counts before = getApplicantIdInProfileCounts();
 
     CiviFormProfileData profileData = new CiviFormProfileData(TI_ACCOUNT_ID);
@@ -616,14 +617,14 @@ public class ApplicantRoutesTest extends ResetPostgres {
     String expectedPreviousUrl =
         String.format(
             "/applicants/%d/programs/%d/blocks/%d/previous/%s",
-            APPLICANT_ID, PROGRAM_ID, PREVIOUS_BLOCK_INDEX, inReview);
+            APPLICANT_ID, PROGRAM_ID, CURRENT_BLOCK_INDEX - 1, inReview);
     assertThat(
             new ApplicantRoutes()
-                .blockPrevious(
+                .blockPreviousOrReview(
                     tiProfile,
                     APPLICANT_ID,
                     PROGRAM_ID,
-                    PREVIOUS_BLOCK_INDEX,
+                    CURRENT_BLOCK_INDEX,
                     Boolean.valueOf(inReview))
                 .url())
         .isEqualTo(expectedPreviousUrl);
@@ -631,6 +632,72 @@ public class ApplicantRoutesTest extends ResetPostgres {
     Counts after = getApplicantIdInProfileCounts();
     assertThat(after.present).isEqualTo(before.present);
     assertThat(after.absent).isEqualTo(before.absent + 1);
+  }
+
+  @Test
+  public void testPreviousOrReviewRoute_currentBlockIndexOne_returnsPreviousBlock() {
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedPreviousUrl =
+        String.format("/programs/%d/blocks/%d/previous/%s", PROGRAM_ID, 0, false);
+    assertThat(
+            new ApplicantRoutes()
+                .blockPreviousOrReview(
+                    applicantProfile,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    /* currentBlockIndex= */ 1,
+                    /* inReview= */ false)
+                .url())
+        .isEqualTo(expectedPreviousUrl);
+  }
+
+  @Test
+  public void testPreviousOrReviewRoute_currentBlockIndexZero_returnsReviewUrl() {
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl = String.format("/programs/%d/review", PROGRAM_ID);
+
+    assertThat(
+            new ApplicantRoutes()
+                .blockPreviousOrReview(
+                    applicantProfile,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    /* currentBlockIndex= */ 0,
+                    /* inReview= */ false)
+                .url())
+        .isEqualTo(expectedReviewUrl);
+  }
+
+  @Test
+  public void testPreviousOrReviewRoute_currentBlockIndexNegativeOne_returnsReviewUrl() {
+    CiviFormProfileData profileData = new CiviFormProfileData(APPLICANT_ACCOUNT_ID);
+    profileData.addRole(Role.ROLE_APPLICANT.toString());
+    profileData.addAttribute(
+        ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, String.valueOf(APPLICANT_ID));
+    CiviFormProfile applicantProfile = profileFactory.wrapProfileData(profileData);
+
+    String expectedReviewUrl = String.format("/programs/%d/review", PROGRAM_ID);
+
+    assertThat(
+            new ApplicantRoutes()
+                .blockPreviousOrReview(
+                    applicantProfile,
+                    APPLICANT_ID,
+                    PROGRAM_ID,
+                    /* currentBlockIndex= */ -1,
+                    /* inReview= */ false)
+                .url())
+        .isEqualTo(expectedReviewUrl);
   }
 
   @Test


### PR DESCRIPTION
### Description

The "Previous" button in the application flow will redirect users to the previous block, or to the review page if they're at the first block. We'll need to reuse this logic in a future PR that changes the functionality of the "Previous" button, so this PR pulls out the logic into the `ApplicantRoutes` file so it can be reused.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Instructions for manual testing

- Click "Previous" while on the first block of an application. Verify it takes you to the review page.
- Click "Previous" while on a further block of an application. Verify it takes you to the previous block.

### Issue(s) this completes

Related to #6450 
