### PR TITLE
Reverting changes in CSV export filter to use LocalDateTime

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -226,7 +226,7 @@ public final class AdminApplicationController extends CiviFormController {
         .map(
             s -> {
               try {
-                return dateConverter.parseIso8601DateToStartOfUTCDateInstant(s);
+                return dateConverter.parseIso8601DateToStartOfLocalDateInstant(s);
               } catch (DateTimeParseException e) {
                 throw new BadRequestException("Malformed query param");
               }

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -66,16 +66,6 @@ public final class DateConverter {
     return parseIso8601DateToLocalDate(dateString).atStartOfDay(zoneId).toInstant();
   }
 
-  /**
-   * Parses a string containing a ISO-8601 date (i.e. "YYYY-MM-DD") and converts it to an {@link
-   * Instant} at the beginning of the day in UTC time zone.
-   *
-   * @throws DateTimeParseException if dateString is not well-formed.
-   */
-  public Instant parseIso8601DateToStartOfUTCDateInstant(String dateString) {
-    return parseIso8601DateToLocalDate(dateString).atStartOfDay(ZoneId.of("UTC")).toInstant();
-  }
-
   /** Formats an {@link Instant} to a human-readable date and time in the local time zone. */
   public String renderDateTime(Instant time) {
     ZonedDateTime dateTime = time.atZone(zoneId);

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -40,14 +40,6 @@ public class DateConverterTest {
   }
 
   @Test
-  public void parseIso8601DateToUTCDateInstant_isSuccessful() {
-    String inputDate = "2022-04-09";
-    Instant expected = Instant.parse("2022-04-09T00:00:00.00Z");
-    Instant result = dateConverter.parseIso8601DateToStartOfUTCDateInstant(inputDate);
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
   public void renderDate_isSuccessful() {
     String expectedResult = "2020-01-01";
     LocalDate date = LocalDate.of(2020, 1, 1);


### PR DESCRIPTION
### Description

Reverting changes in CSV export filter to use LocalDateTime. Commit Id - f6367df
In this PR I am reverting Fix-1.

Original Description  - 
Fix for Application count mismatch between CVS exports and Reporting.
Fix 1- Internally we store all submit time as UTC. On trying to the retrieve the records for dd-mm-yyyy, we should also covert it to UTC time zone so that we will get the same results.
Fix 2 - When converting java.sql.Timestamp into MM/yyyy format for reporting, there is no need to add time zone information as the time stamp is always set to the beginning of the month eg. 01-01-2024 00:00:000. So SimpleDateTimeFormatter is enough to extract the MM/yyyy format.

## Release notes

Reverting the Fix-1 from original PR - Commit Id - f6367df

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary


### Issue(s) this completes

Fixes #5824 
