### PR TITLE
[Program Card Images] Check bucket is correct before storing file key

### DIFF
--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -485,8 +485,6 @@ describe('applicant program index page with images', () => {
     await validateAccessibility(page)
   })
 
-  // TODO(#5676): Test with a very small image.
-
   async function submitApplicationAndApplyStatus(
     page: Page,
     programName: string,

--- a/server/app/controllers/admin/AdminProgramImageController.java
+++ b/server/app/controllers/admin/AdminProgramImageController.java
@@ -106,8 +106,8 @@ public final class AdminProgramImageController extends CiviFormController {
         request
             .queryString("key")
             .orElseThrow(() -> new IllegalArgumentException("Request must contain file key name"));
-    // TODO(#5676): If Azure support is needed, see ApplicantProgramBlocksController#updateFile for
-    // some additional Azure-specific logic that's needed.
+    // Note: If Azure support is needed, see ApplicantProgramBlocksController#updateFile for
+    // some additional Azure-specific logic that should also be added here.
 
     if (!PublicFileNameFormatter.isFileKeyForPublicProgramImage(key)) {
       throw new IllegalArgumentException("Key incorrectly formatted for public program image file");

--- a/server/app/services/cloud/PublicStorageClient.java
+++ b/server/app/services/cloud/PublicStorageClient.java
@@ -9,6 +9,9 @@ import com.google.common.collect.ImmutableSet;
  * instead.
  */
 public abstract class PublicStorageClient {
+  /** Returns the name of the cloud storage bucket that's storing the files. */
+  public abstract String getBucketName();
+
   /**
    * Creates and returns a request to upload a **publicly accessible** file to cloud storage.
    *

--- a/server/app/services/cloud/aws/AwsPublicStorage.java
+++ b/server/app/services/cloud/aws/AwsPublicStorage.java
@@ -2,6 +2,7 @@ package services.cloud.aws;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
@@ -23,7 +24,7 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 /** An AWS Simple Storage Service (S3) implementation of public storage. */
 @Singleton
 public final class AwsPublicStorage extends PublicStorageClient {
-  private static final String AWS_PUBLIC_S3_BUCKET_CONF_PATH = "aws.s3.public_bucket";
+  @VisibleForTesting static final String AWS_PUBLIC_S3_BUCKET_CONF_PATH = "aws.s3.public_bucket";
   private static final String AWS_PUBLIC_S3_FILE_LIMIT_CONF_PATH = "aws.s3.public_file_limit_mb";
 
   private static final Logger logger = LoggerFactory.getLogger(AwsPublicStorage.class);
@@ -57,6 +58,11 @@ public final class AwsPublicStorage extends PublicStorageClient {
     } else {
       client = new NullClient();
     }
+  }
+
+  @Override
+  public String getBucketName() {
+    return bucket;
   }
 
   @Override

--- a/server/app/services/cloud/azure/AzurePublicStorage.java
+++ b/server/app/services/cloud/azure/AzurePublicStorage.java
@@ -7,6 +7,11 @@ import services.cloud.StorageUploadRequest;
 /** An Azure Blob Storage implementation of public storage. */
 public class AzurePublicStorage extends PublicStorageClient {
   @Override
+  public String getBucketName() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
   public StorageUploadRequest getSignedUploadRequest(
       String fileKey, String successRedirectActionLink) {
     throw new UnsupportedOperationException("not implemented");

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -138,8 +138,7 @@ public final class ProgramImageView extends BaseHtmlView {
             .addMainContent(div().with(backButton, mainContent))
             .addModals(deleteImageModal);
 
-    // TODO(#5676): This toast code is re-implemented across multiple controllers. Can we write a
-    // helper method for it?
+    // TODO(#6593): Write a helper method for this toast display logic.
     Http.Flash flash = request.flash();
     if (flash.get("success").isPresent()) {
       htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
@@ -273,15 +272,12 @@ public final class ProgramImageView extends BaseHtmlView {
             .isDisabled());
     buttonsDiv.with(deleteButton);
 
-    // TODO(#5676): Replace with final UX once we have it.
     return div()
         .withClass("mt-10")
         .with(fullForm)
         .with(buttonsDiv)
         .with(p("Note: Image description is required before uploading an image.").withClass("mt-1"))
         .with(fileUploadViewStrategy.footerTags());
-
-    // TODO(#5676): Warn admins of recommended image size and dimensions.
   }
 
   private StorageUploadRequest createStorageUploadRequest(

--- a/server/test/services/cloud/aws/AwsPublicStorageTest.java
+++ b/server/test/services/cloud/aws/AwsPublicStorageTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static services.cloud.aws.AwsPublicStorage.AWS_PUBLIC_S3_BUCKET_CONF_PATH;
 import static support.cloud.FakeAwsS3Client.DELETION_ERROR_FILE_KEY;
 import static support.cloud.FakeAwsS3Client.LIST_ERROR_FILE_KEY;
 
@@ -26,6 +27,14 @@ public class AwsPublicStorageTest extends ResetPostgres {
 
   private final FakeAwsS3Client fakeAwsS3Client = new FakeAwsS3Client();
   private final Credentials credentials = instanceOf(Credentials.class);
+
+  @Test
+  public void getBucketName_returnsBucketFromConfig() {
+    AwsPublicStorage awsPublicStorage = instanceOf(AwsPublicStorage.class);
+
+    assertThat(awsPublicStorage.getBucketName())
+        .isEqualTo(instanceOf(Config.class).getString(AWS_PUBLIC_S3_BUCKET_CONF_PATH));
+  }
 
   @Test
   public void getSignedUploadRequest_prodEnv_actionLinkIsProdAws() {

--- a/server/test/services/cloud/azure/AzurePublicStorageTest.java
+++ b/server/test/services/cloud/azure/AzurePublicStorageTest.java
@@ -17,6 +17,12 @@ public class AzurePublicStorageTest extends ResetPostgres {
   }
 
   @Test
+  public void getBucketName_throwsUnsupported() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(() -> azurePublicStorage.getBucketName());
+  }
+
+  @Test
   public void getSignedUploadRequest_throwsUnsupported() {
     assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(() -> azurePublicStorage.getSignedUploadRequest("fileKey", "successRedirect"));

--- a/server/test/support/cloud/FakePublicStorageClient.java
+++ b/server/test/support/cloud/FakePublicStorageClient.java
@@ -7,9 +7,16 @@ import services.cloud.StorageUploadRequest;
 /** A fake implementation of {@link PublicStorageClient} to be used in tests. */
 public final class FakePublicStorageClient extends PublicStorageClient {
 
+  public static final String FAKE_BUCKET_NAME = "fakeBucket";
+
   private ImmutableSet<String> lastInUseFileKeys;
 
   public FakePublicStorageClient() {}
+
+  @Override
+  public String getBucketName() {
+    return FAKE_BUCKET_NAME;
+  }
 
   @Override
   public StorageUploadRequest getSignedUploadRequest(


### PR DESCRIPTION
### Description

When an admin uploads a program image, the image is first sent to AWS. Once AWS has successfully stored the image, it calls `AdminProgramImageController#updateFileKey` with the bucket the file was stored in and the key identifying the file. This PR updates that `#updateFileKey` method to verify that the bucket name in the request matches the public bucket name that we have in our config. The bucket names should always match, but this is an extra safeguard around keeping applicant data safe. Because applicant files are stored in a different bucket with a different name, this check should ensure that applicant-uploaded files are never stored as the program image key somehow.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Verify you can still upload a program image successfully.

### Issue(s) this completes

Part of epic #5676 
