### PR TITLE
Making Address Correction Toggle Value Show the Current State.

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -292,12 +292,11 @@ describe('program creation', () => {
 
     const addressCorrectionInput = adminPrograms.getAddressCorrectionToggle()
 
-    // the input value shows what it will be set to when clicked
-    expect(await addressCorrectionInput.inputValue()).toBe('true')
+    expect(await addressCorrectionInput.inputValue()).toBe('false')
 
     await adminPrograms.clickAddressCorrectionToggle()
 
-    expect(await addressCorrectionInput.inputValue()).toBe('false')
+    expect(await addressCorrectionInput.inputValue()).toBe('true')
 
     await validateScreenshot(
       page,
@@ -346,18 +345,16 @@ describe('program creation', () => {
     const addressCorrectionHelpText2 =
       adminPrograms.getAddressCorrectionHelpTextByName('ace-address-two')
 
-    // the input value shows what it will be set to when clicked, so the
-    // opposite of its current value
-    expect(await addressCorrectionInput1.inputValue()).toBe('true')
-    expect(await addressCorrectionInput2.inputValue()).toBe('true')
+    expect(await addressCorrectionInput1.inputValue()).toBe('false')
+    expect(await addressCorrectionInput2.inputValue()).toBe('false')
 
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).not.toContain(helpText)
 
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-one')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('false')
-    expect(await addressCorrectionInput2.inputValue()).toBe('true')
+    expect(await addressCorrectionInput1.inputValue()).toBe('true')
+    expect(await addressCorrectionInput2.inputValue()).toBe('false')
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).toContain(helpText)
 
@@ -369,8 +366,8 @@ describe('program creation', () => {
     // Trying to toggle the other one should not do anything
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-two')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('false')
-    expect(await addressCorrectionInput2.inputValue()).toBe('true')
+    expect(await addressCorrectionInput1.inputValue()).toBe('true')
+    expect(await addressCorrectionInput2.inputValue()).toBe('false')
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).toContain(helpText)
 
@@ -383,8 +380,8 @@ describe('program creation', () => {
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-one')
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-two')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('true')
-    expect(await addressCorrectionInput2.inputValue()).toBe('false')
+    expect(await addressCorrectionInput1.inputValue()).toBe('false')
+    expect(await addressCorrectionInput2.inputValue()).toBe('true')
     expect(await addressCorrectionHelpText1.innerText()).toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).not.toContain(helpText)
 
@@ -417,12 +414,11 @@ describe('program creation', () => {
 
     const addressCorrectionInput = adminPrograms.getAddressCorrectionToggle()
 
-    // the input value shows what it will be set to when clicked
-    expect(await addressCorrectionInput.inputValue()).toBe('true')
+    expect(await addressCorrectionInput.inputValue()).toBe('false')
 
     await adminPrograms.clickAddressCorrectionToggle()
     // should be the same as before with button submit disabled
-    expect(await addressCorrectionInput.inputValue()).toBe('true')
+    expect(await addressCorrectionInput.inputValue()).toBe('false')
   })
 
   it('change questions order within block', async () => {

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -192,8 +192,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
           programId,
           blockDefinitionId,
           questionDefinitionId,
-          // Flop the bit to the next (desired state) from the current setting to toggle this
-          // setting
+          // Flop the bit to the next (desired state) from the current setting.
           !programQuestionDefinition.get().addressCorrectionEnabled());
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers.Labels;
 import com.google.common.collect.ImmutableList;
-import forms.ProgramQuestionDefinitionAddressCorrectionEnabledForm;
 import forms.ProgramQuestionDefinitionOptionalityForm;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -17,12 +16,14 @@ import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.VersionRepository;
+import services.program.BlockDefinition;
 import services.program.CantAddQuestionToBlockException;
 import services.program.IllegalPredicateOrderingException;
 import services.program.InvalidQuestionPositionException;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramQuestionDefinition;
 import services.program.ProgramQuestionDefinitionInvalidException;
 import services.program.ProgramQuestionDefinitionNotFoundException;
 import services.program.ProgramService;
@@ -157,12 +158,13 @@ public class AdminProgramBlockQuestionsController extends Controller {
 
   /** POST endpoint for editing whether or not a question has address correction enabled. */
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
-  public Result setAddressCorrectionEnabled(
+  public Result toggleAddressCorrectionEnabledState(
       Request request, long programId, long blockDefinitionId, long questionDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
       ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       // In these cases, we warn admins that changing address correction is not allowed in the
       // tooltip, so we can silently ignore the request.
@@ -176,18 +178,23 @@ public class AdminProgramBlockQuestionsController extends Controller {
                 programId, blockDefinitionId));
       }
 
-      ProgramQuestionDefinitionAddressCorrectionEnabledForm
-          programQuestionDefinitionAddressCorrectionEnabledForm =
-              formFactory
-                  .form(ProgramQuestionDefinitionAddressCorrectionEnabledForm.class)
-                  .bindFromRequest(request)
-                  .get();
+      Optional<ProgramQuestionDefinition> programQuestionDefinition =
+          blockDefinition.programQuestionDefinitions().stream()
+              .filter(pqd -> pqd.id() == questionDefinitionId)
+              .findFirst();
+
+      if (programQuestionDefinition.isEmpty()) {
+        throw new ProgramQuestionDefinitionNotFoundException(
+            programId, blockDefinitionId, questionDefinitionId);
+      }
 
       programService.setProgramQuestionDefinitionAddressCorrectionEnabled(
           programId,
           blockDefinitionId,
           questionDefinitionId,
-          programQuestionDefinitionAddressCorrectionEnabledForm.getAddressCorrectionEnabled());
+          // Flop the bit to the next (desired state) from the current setting to toggle this
+          // setting
+          !programQuestionDefinition.get().addressCorrectionEnabled());
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
     } catch (ProgramBlockDefinitionNotFoundException e) {

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -651,8 +651,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     emptyPredicateContentBuilder
         .add(text(" You can change this in the "))
         .add(
-            a().withData("testid", "goto-program-settings-link")
-                .withText("program settings.")
+            a().withText("program settings.")
                 .withHref(routes.AdminProgramController.editProgramSettings(program.id()).url())
                 .withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT));
     return div().with(emptyPredicateContentBuilder.build());

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -651,7 +651,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
     emptyPredicateContentBuilder
         .add(text(" You can change this in the "))
         .add(
-            a().withText("program settings.")
+            a().withData("testid", "goto-program-settings-link")
+                .withText("program settings.")
                 .withHref(routes.AdminProgramController.editProgramSettings(program.id()).url())
                 .withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT));
     return div().with(emptyPredicateContentBuilder.build());
@@ -971,7 +972,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
     }
 
     String toggleAddressCorrectionAction =
-        controllers.admin.routes.AdminProgramBlockQuestionsController.setAddressCorrectionEnabled(
+        controllers.admin.routes.AdminProgramBlockQuestionsController
+            .toggleAddressCorrectionEnabledState(
                 programDefinition.id(), blockDefinition.id(), questionDefinition.getId())
             .url();
     ButtonTag addressCorrectionButton =
@@ -1018,7 +1020,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 input()
                     .isHidden()
                     .withName("addressCorrectionEnabled")
-                    .withValue(addressCorrectionEnabled ? "false" : "true"))
+                    .withValue(String.valueOf(addressCorrectionEnabled)))
             .with(addressCorrectionButton));
   }
 

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -73,7 +73,7 @@ POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions          
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions/:questionDefinitionId/delete                       controllers.admin.AdminProgramBlockQuestionsController.destroy(programId: Long, blockDefinitionId: Long, questionDefinitionId: Long)
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions/:questionDefinitionId/setOptional                  controllers.admin.AdminProgramBlockQuestionsController.setOptional(request: Request, programId: Long, blockDefinitionId: Long, questionDefinitionId: Long)
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions/:questionDefinitionId/move                         controllers.admin.AdminProgramBlockQuestionsController.move(request: Request, programId: Long, blockDefinitionId: Long, questionDefinitionId: Long)
-POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions/:questionDefinitionId/setAddressCorrectionEnabled  controllers.admin.AdminProgramBlockQuestionsController.setAddressCorrectionEnabled(request: Request, programId: Long, blockDefinitionId: Long, questionDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions/:questionDefinitionId/toggleAddressCorrectionEnabledState  controllers.admin.AdminProgramBlockQuestionsController.toggleAddressCorrectionEnabledState(request: Request, programId: Long, blockDefinitionId: Long, questionDefinitionId: Long)
 
 # A controller for a page for an admin to view, edit, and create questions
 GET     /admin/questions             controllers.admin.AdminQuestionController.index(request: Request)


### PR DESCRIPTION
### Description

Toggling address correction on and off kept the next toggle state in a hidden field on the page. It lead to quite some confusion when trying to add a new test. This now toggles the value based on what's stored in the database. Technically we don't need to even store the hidden fields on the page, but it's the only good way in browser tests to check. How when you inspect the field it shows the current state.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

