### PR TITLE
Adding tests to cover using address as a visibility condition

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -1697,7 +1697,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.answerTextQuestion('answer 2')
       await applicantQuestions.clickNext()
 
-      await applicantQuestions.expectAddressHasBeenCorrected(
+      await applicantQuestions.expectQuestionAnsweredOnReviewPage(
         questionAddress,
         'Address In Area',
       )
@@ -1726,7 +1726,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.answerTextQuestion('answer 2')
       await applicantQuestions.clickNext()
 
-      await applicantQuestions.expectAddressHasBeenCorrected(
+      await applicantQuestions.expectQuestionAnsweredOnReviewPage(
         questionAddress,
         'Nonlegit Address',
       )

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -1589,6 +1589,10 @@ describe('Applicant navigation flow', () => {
       const {page, adminQuestions, adminPrograms, adminPredicates} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await enableFeatureFlag(
+        page,
+        'esri_address_service_area_validation_enabled',
+      )
 
       // Create Questions
       await adminQuestions.addAddressQuestion({
@@ -1673,7 +1677,6 @@ describe('Applicant navigation flow', () => {
 
     it('when address is eligible show hidden screen', async () => {
       const {page, applicantQuestions} = ctx
-      await enableFeatureFlag(page, 'esri_address_correction_enabled')
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.
@@ -1688,6 +1691,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.clickNext()
       await applicantQuestions.expectVerifyAddressPage(true)
       await applicantQuestions.clickNext()
+      // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an valid address.
       await applicantQuestions.answerTextQuestion('answer 1')
       await applicantQuestions.clickNext()
       await applicantQuestions.answerTextQuestion('answer 2')
@@ -1704,7 +1708,6 @@ describe('Applicant navigation flow', () => {
 
     it('when address is not eligible do not show hidden screen', async () => {
       const {page, applicantQuestions} = ctx
-      await enableFeatureFlag(page, 'esri_address_correction_enabled')
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.
@@ -1719,6 +1722,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.clickNext()
       await applicantQuestions.expectVerifyAddressPage(false)
       await applicantQuestions.clickNext()
+      // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an invalid address.
       await applicantQuestions.answerTextQuestion('answer 2')
       await applicantQuestions.clickNext()
 

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -1576,5 +1576,161 @@ describe('Applicant navigation flow', () => {
     })
   })
 
+  describe('using address as visibility condition', () => {
+    const programName = 'Test program for address as visibility condition'
+    const questionAddress = 'address-test-q'
+    const questionText1 = 'text-test-q-one'
+    const questionText2 = 'text-test-q-two'
+    const screen1 = 'Screen 1'
+    const screen2 = 'Screen 2'
+    const screen3 = 'Screen 3'
+
+    beforeAll(async () => {
+      const {page, adminQuestions, adminPrograms, adminPredicates} = ctx
+      await loginAsAdmin(page)
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+
+      // Create Questions
+      await adminQuestions.addAddressQuestion({
+        questionName: questionAddress,
+        questionText: questionAddress,
+      })
+
+      await adminQuestions.addTextQuestion({
+        questionName: questionText1,
+        questionText: questionText1,
+      })
+
+      await adminQuestions.addTextQuestion({
+        questionName: questionText2,
+        questionText: questionText2,
+      })
+
+      // Create Program
+      await adminPrograms.addProgram(programName)
+
+      // Attach questions to program
+      await adminPrograms.editProgramBlock(programName, screen1, [
+        questionAddress,
+      ])
+
+      await adminPrograms.addProgramBlock(programName, screen2, [questionText1])
+
+      await adminPrograms.addProgramBlock(programName, screen3, [questionText2])
+
+      await adminPrograms.goToBlockInProgram(programName, screen1)
+
+      await adminPrograms.clickAddressCorrectionToggleByName(questionAddress)
+
+      const addressCorrectionInput =
+        adminPrograms.getAddressCorrectionToggleByName(questionAddress)
+
+      // TODO: Change this to true when done with other PR 6598 before merging this PR
+      expect(await addressCorrectionInput.inputValue()).toBe('false')
+
+      // Set thing to soft eligibilty
+      await adminPrograms.toggleEligibilityGating()
+
+      // Add address eligibility predicate
+      await adminPrograms.goToEditBlockEligibilityPredicatePage(
+        programName,
+        screen1,
+      )
+
+      await adminPredicates.addPredicates([
+        {
+          questionName: questionAddress,
+          scalar: 'service_area',
+          operator: 'in service area',
+          values: ['Seattle'],
+        },
+      ])
+
+      // Add the address visibility predicate
+      await adminPrograms.goToBlockInProgram(programName, screen2)
+
+      await adminPrograms.goToEditBlockVisibilityPredicatePage(
+        programName,
+        screen2,
+      )
+
+      await adminPredicates.addPredicates([
+        {
+          questionName: questionAddress,
+          action: 'shown if',
+          scalar: 'service_area',
+          operator: 'in service area',
+          values: ['Seattle'],
+        },
+      ])
+
+      // Publish Program
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishProgram(programName)
+
+      await logout(page)
+    })
+
+    it('when address is eligible show hidden screen', async () => {
+      const {page, applicantQuestions} = ctx
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await applicantQuestions.applyProgram(programName)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerAddressQuestion(
+        'Legit Address',
+        '',
+        'Seattle',
+        'WA',
+        '98109',
+        0,
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.expectVerifyAddressPage(true)
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerTextQuestion('answer 1')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerTextQuestion('answer 2')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.expectAddressHasBeenCorrected(
+        questionAddress,
+        'Address In Area',
+      )
+
+      await applicantQuestions.clickSubmit()
+      await logout(page)
+    })
+
+    it('when address is not eligible do not show hidden screen', async () => {
+      const {page, applicantQuestions} = ctx
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await applicantQuestions.applyProgram(programName)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerAddressQuestion(
+        'Nonlegit Address',
+        '',
+        'Seattle',
+        'WA',
+        '98109',
+        0,
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.expectVerifyAddressPage(false)
+      await applicantQuestions.clickNext()
+      await applicantQuestions.answerTextQuestion('answer 2')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.expectAddressHasBeenCorrected(
+        questionAddress,
+        'Nonlegit Address',
+      )
+
+      await applicantQuestions.clickSubmit()
+      await logout(page)
+    })
+  })
+
   // TODO: Add tests for "next" navigation
 })

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -1629,8 +1629,7 @@ describe('Applicant navigation flow', () => {
       const addressCorrectionInput =
         adminPrograms.getAddressCorrectionToggleByName(questionAddress)
 
-      // TODO: Change this to true when done with other PR 6598 before merging this PR
-      expect(await addressCorrectionInput.inputValue()).toBe('false')
+      expect(await addressCorrectionInput.inputValue()).toBe('true')
 
       // Set thing to soft eligibilty
       await adminPrograms.toggleEligibilityGating()

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1179,4 +1179,12 @@ export class AdminPrograms {
   async clickCommonIntakeFormToggle() {
     await this.page.click('input[name=isCommonIntakeForm]')
   }
+
+  async toggleEligibilityGating() {
+    await this.page.getByTestId('goto-program-settings-link').click()
+    await this.page.waitForLoadState()
+    await this.page.click('#eligibility-toggle')
+    await this.page.getByText('Back').click()
+    await this.page.waitForLoadState()
+  }
 }

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -651,7 +651,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
     emptyPredicateContentBuilder
         .add(text(" You can change this in the "))
         .add(
-            a().withText("program settings.")
+            a().withData("testid", "goto-program-settings-link")
+                .withText("program settings.")
                 .withHref(routes.AdminProgramController.editProgramSettings(program.id()).url())
                 .withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT));
     return div().with(emptyPredicateContentBuilder.build());


### PR DESCRIPTION
### Description

Adding these two tests to cover using Address eligibility as a Visibility Condition that is NOT gated. This works and I don't want to find it gets broken at some point. I'm not certain, but I don't think this is working because it was designed this way. Getting it working is quite convoluted. I suspect it's a happy accident of overlapping features. 

I'll write up some documentation in a separate PR. I'm attaching videos of the output for reference when I write docs.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary


### Issue(s) this completes
Fixes #6505

[ admin setup of the program.webm](https://github.com/civiform/civiform/assets/195162/0730ddea-2d05-4b91-806e-0e599e724ac9)
[when address is eligible show hidden screen.webm](https://github.com/civiform/civiform/assets/195162/5fdf19b9-8ae6-4735-8e77-520e8b09c353)
[when address is not eligible do not show hidden screen.webm](https://github.com/civiform/civiform/assets/195162/e5f7a41a-ef92-407b-aeb0-cef80e3d1d84)


