### PR TITLE
[Refactor] Update repository files to use new getProgramDefinition function

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -80,7 +80,7 @@ public final class ApplicationRepository {
               .createQuery(ApplicationModel.class)
               .where()
               .eq("applicant.id", applicant.id)
-              .eq("program.name", program.getProgramDefinition().adminName())
+              .eq("program.name", programRepository.getProgramDefinition(program).adminName())
               .setLabel("ApplicationModel.findList")
               .setProfileLocation(queryProfileLocationBuilder.create("submitApplicationInternal"))
               .findList();
@@ -118,7 +118,7 @@ public final class ApplicationRepository {
                 + " will be set to OBSOLETE. Application IDs: {}",
             applicant.id,
             program.id,
-            program.getProgramDefinition().adminName(),
+            programRepository.getProgramDefinition(program).adminName(),
             String.join(
                 ",",
                 previousActive.stream()
@@ -134,7 +134,7 @@ public final class ApplicationRepository {
                   + " not saved",
               applicant.id,
               program.id,
-              program.getProgramDefinition().adminName());
+              programRepository.getProgramDefinition(program).adminName());
           throw new DuplicateApplicationException();
         }
         // https://github.com/civiform/civiform/issues/3227
@@ -240,7 +240,7 @@ public final class ApplicationRepository {
               .createQuery(ApplicationModel.class)
               .where()
               .eq("applicant.id", applicant.id)
-              .eq("program.name", program.getProgramDefinition().adminName())
+              .eq("program.name", programRepository.getProgramDefinition(program).adminName())
               .eq("lifecycle_stage", LifecycleStage.DRAFT)
               .setLabel("ApplicationModel.findById")
               .setProfileLocation(


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/6611 created a new getProgramDefinition function, which uses the program def cache if available. 

This refactors the remaining repository files to use the new method.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6466