### PR TITLE
Add `verbose: true` to browser tests

### DIFF
--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
   },
   globalSetup: './src/delete_database.ts',
   setupFilesAfterEnv: ['./src/support/setup-jest.ts'],
+  verbose: true,
 }


### PR DESCRIPTION
### Description

Adds `verbose: true` to our browser test config so that browser test runs will print each test case they ran instead of just the test file name:

![image](https://github.com/civiform/civiform/assets/147177873/6d2219f9-7506-4dea-a0c7-5114caf68683)

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
