### PR TITLE
[Refactor] Update additional files to use new getProgramDefinition function

### DIFF
--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
+import repository.ProgramRepository;
 import repository.VersionRepository;
 import services.apikey.ApiKeyService;
 import services.settings.SettingsManifest;
@@ -29,6 +30,7 @@ public final class ProfileFactory {
   private final DatabaseExecutionContext dbContext;
   private final HttpExecutionContext httpContext;
   private final Provider<VersionRepository> versionRepositoryProvider;
+  private final Provider<ProgramRepository> programRepositoryProvider;
   private final Provider<ApiKeyService> apiKeyService;
   private final Provider<AccountRepository> accountRepositoryProvider;
   private final SettingsManifest settingsManifest;
@@ -38,12 +40,14 @@ public final class ProfileFactory {
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
       Provider<VersionRepository> versionRepositoryProvider,
+      Provider<ProgramRepository> programRepositoryProvider,
       Provider<ApiKeyService> apiKeyService,
       Provider<AccountRepository> accountRepositoryProvider,
       SettingsManifest settingsManifest) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
     this.versionRepositoryProvider = Preconditions.checkNotNull(versionRepositoryProvider);
+    this.programRepositoryProvider = Preconditions.checkNotNull(programRepositoryProvider);
     this.apiKeyService = Preconditions.checkNotNull(apiKeyService);
     this.accountRepositoryProvider = Preconditions.checkNotNull(accountRepositoryProvider);
     this.settingsManifest = Preconditions.checkNotNull(settingsManifest);
@@ -141,7 +145,9 @@ public final class ProfileFactory {
                   .get()
                   .getProgramsForVersion(versionRepositoryProvider.get().getActiveVersion())
                   .forEach(
-                      program -> account.addAdministeredProgram(program.getProgramDefinition()));
+                      program ->
+                          account.addAdministeredProgram(
+                              programRepositoryProvider.get().getProgramDefinition(program)));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
               account.setAuthorityId(generateFakeAdminAuthorityId());
               account.save();
@@ -166,7 +172,9 @@ public final class ProfileFactory {
                   .get()
                   .getProgramsForVersion(versionRepositoryProvider.get().getActiveVersion())
                   .forEach(
-                      program -> account.addAdministeredProgram(program.getProgramDefinition()));
+                      program ->
+                          account.addAdministeredProgram(
+                              programRepositoryProvider.get().getProgramDefinition(program)));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
               account.save();
             })

--- a/server/app/controllers/admin/ProgramAdminManagementController.java
+++ b/server/app/controllers/admin/ProgramAdminManagementController.java
@@ -110,7 +110,10 @@ public final class ProgramAdminManagementController {
 
         return ok(
             manageAdminsView.render(
-                request, program.get().getProgramDefinition(), programAdmins, message));
+                request,
+                programRepository.getProgramDefinition(program.get()),
+                programAdmins,
+                message));
       }
     } catch (ProgramNotFoundException e) {
       return notFound(e.getLocalizedMessage());

--- a/server/app/models/ApplicationModel.java
+++ b/server/app/models/ApplicationModel.java
@@ -94,11 +94,6 @@ public class ApplicationModel extends BaseModel {
     return this.program;
   }
 
-  /** Returns the admin name of the program this application is associated with. */
-  public String getProgramName() {
-    return getProgram().getProgramDefinition().adminName();
-  }
-
   public ApplicantData getApplicantData() {
     if (this.preferredLocale == null || this.preferredLocale.isEmpty()) {
       // Default to English.

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -45,6 +45,7 @@ import play.libs.concurrent.HttpExecutionContext;
 import repository.AccountRepository;
 import repository.ApplicationEventRepository;
 import repository.ApplicationRepository;
+import repository.ProgramRepository;
 import repository.StoredFileRepository;
 import repository.TimeFilter;
 import repository.VersionRepository;
@@ -97,6 +98,7 @@ public final class ApplicantService {
   private final StoredFileRepository storedFileRepository;
   private final JsonPathPredicateGeneratorFactory jsonPathPredicateGeneratorFactory;
   private final VersionRepository versionRepository;
+  private final ProgramRepository programRepository;
   private final ProgramService programService;
   private final SimpleEmail amazonSESClient;
   private final Clock clock;
@@ -116,6 +118,7 @@ public final class ApplicantService {
       ApplicationRepository applicationRepository,
       AccountRepository accountRepository,
       VersionRepository versionRepository,
+      ProgramRepository programRepository,
       StoredFileRepository storedFileRepository,
       JsonPathPredicateGeneratorFactory jsonPathPredicateGeneratorFactory,
       ProgramService programService,
@@ -131,6 +134,7 @@ public final class ApplicantService {
     this.applicationRepository = checkNotNull(applicationRepository);
     this.accountRepository = checkNotNull(accountRepository);
     this.versionRepository = checkNotNull(versionRepository);
+    this.programRepository = checkNotNull(programRepository);
     this.storedFileRepository = checkNotNull(storedFileRepository);
     this.jsonPathPredicateGeneratorFactory = checkNotNull(jsonPathPredicateGeneratorFactory);
     this.programService = checkNotNull(programService);
@@ -463,7 +467,8 @@ public final class ApplicantService {
 
               ApplicationModel application = applicationMaybe.get();
               ProgramModel applicationProgram = application.getProgram();
-              ProgramDefinition programDefinition = applicationProgram.getProgramDefinition();
+              ProgramDefinition programDefinition =
+                  programRepository.getProgramDefinition(applicationProgram);
               String programName = programDefinition.adminName();
               Optional<StatusDefinitions.Status> maybeDefaultStatus =
                   applicationProgram.getDefaultStatus();
@@ -838,7 +843,7 @@ public final class ApplicantService {
             .toCompletableFuture();
     ImmutableList<ProgramDefinition> activeProgramDefinitions =
         versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream()
-            .map(ProgramModel::getProgramDefinition)
+            .map(p -> programRepository.getProgramDefinition(p))
             .filter(
                 pdef ->
                     pdef.displayMode().equals(DisplayMode.PUBLIC)
@@ -857,7 +862,9 @@ public final class ApplicantService {
               }
               List<ProgramDefinition> programDefinitionsList =
                   applications.stream()
-                      .map(application -> application.getProgram().getProgramDefinition())
+                      .map(
+                          application ->
+                              programRepository.getProgramDefinition(application.getProgram()))
                       .collect(Collectors.toList());
               programDefinitionsList.addAll(activeProgramDefinitions);
               return programService.syncQuestionsToProgramDefinitions(
@@ -953,7 +960,7 @@ public final class ApplicantService {
             .collect(
                 Collectors.groupingBy(
                     a -> {
-                      return a.getProgram().getProgramDefinition().adminName();
+                      return programRepository.getProgramDefinition(a.getProgram()).adminName();
                     },
                     Collectors.groupingBy(
                         ApplicationModel::getLifecycleStage,
@@ -1007,7 +1014,7 @@ public final class ApplicantService {
             // version at the time of submission are used. However, when clicking "reapply", we use
             // the latest program version below.
             ProgramDefinition applicationProgramVersion =
-                maybeSubmittedApp.get().getProgram().getProgramDefinition();
+                programRepository.getProgramDefinition(maybeSubmittedApp.get().getProgram());
             Optional<String> maybeLatestStatus = maybeSubmittedApp.get().getLatestStatus();
             Optional<StatusDefinitions.Status> maybeCurrentStatus =
                 maybeLatestStatus.isPresent()
@@ -1089,7 +1096,7 @@ public final class ApplicantService {
             .collect(
                 Collectors.groupingBy(
                     a -> {
-                      return a.getProgram().getProgramDefinition().adminName();
+                      return programRepository.getProgramDefinition(a.getProgram()).adminName();
                     },
                     Collectors.groupingBy(ApplicationModel::getLifecycleStage)))
             .values();
@@ -1101,14 +1108,19 @@ public final class ApplicantService {
             String.join(
                 ", ",
                 draftApplications.stream()
-                    .map(a -> String.format("%d", a.getProgram().getProgramDefinition().id()))
+                    .map(
+                        a ->
+                            String.format(
+                                "%d", programRepository.getProgramDefinition(a.getProgram()).id()))
                     .collect(ImmutableList.toImmutableList()));
         logger.debug(
             String.format(
                 "DEBUG LOG ID: 98afa07855eb8e69338b5af13236a6b7. Program"
                     + " Admin Name: %1$s, Duplicate Program Definition"
                     + " ids: %2$s.",
-                draftApplications.get(0).getProgram().getProgramDefinition().adminName(),
+                programRepository
+                    .getProgramDefinition(draftApplications.get(0).getProgram())
+                    .adminName(),
                 joinedProgramIds));
       }
     }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -243,12 +243,13 @@ public final class ProgramService {
       // This method makes multiple calls to get questions for the active and
       // draft versions, so we should only call it if we're syncing program
       // associations for a draft program (which means we're in the admin flow).
-      return syncProgramDefinitionQuestions(program.getProgramDefinition())
+      return syncProgramDefinitionQuestions(programRepository.getProgramDefinition(program))
           .thenApply(ProgramDefinition::orderBlockDefinitions);
     }
 
     ProgramDefinition programDefinition =
-        syncProgramDefinitionQuestions(program.getProgramDefinition(), maxVersionForProgram);
+        syncProgramDefinitionQuestions(
+            programRepository.getProgramDefinition(program), maxVersionForProgram);
 
     if (settingsManifest.getQuestionCacheEnabled()) {
       // It is safe to set the program definition cache, since we have already checked that it is
@@ -334,7 +335,8 @@ public final class ProgramService {
             programType,
             programAcls);
 
-    return ErrorAnd.of(programRepository.insertProgramSync(program).getProgramDefinition());
+    return ErrorAnd.of(
+        programRepository.getProgramDefinition(programRepository.insertProgramSync(program)));
   }
 
   /**
@@ -464,7 +466,8 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.updateProgramSync(program).getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(program)))
             .toCompletableFuture()
             .join());
   }
@@ -514,9 +517,8 @@ public final class ProgramService {
       return;
     }
     ProgramDefinition draftCommonIntakeProgramDefinition =
-        programRepository
-            .createOrUpdateDraft(maybeCommonIntakeForm.get().toProgram())
-            .getProgramDefinition();
+        programRepository.getProgramDefinition(
+            programRepository.createOrUpdateDraft(maybeCommonIntakeForm.get().toProgram()));
     ProgramModel commonIntakeProgram =
         draftCommonIntakeProgramDefinition.toBuilder()
             .setProgramType(ProgramType.DEFAULT)
@@ -550,9 +552,8 @@ public final class ProgramService {
     // Note: It's unclear that we actually want to update an existing draft this way, as it would
     // effectively reset the  draft which is not part of any user flow. Given the interdependency of
     // draft updates this is likely to cause issues as in #2179.
-    return programRepository
-        .createOrUpdateDraft(this.getProgramDefinition(id).toProgram())
-        .getProgramDefinition();
+    return programRepository.getProgramDefinition(
+        programRepository.createOrUpdateDraft(this.getProgramDefinition(id).toProgram()));
   }
 
   private ImmutableSet<CiviFormError> validateProgramData(
@@ -674,9 +675,8 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository
-                    .updateProgramSync(newProgram.build().toProgram())
-                    .getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(newProgram.build().toProgram())))
             .toCompletableFuture()
             .join());
   }
@@ -767,7 +767,8 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.updateProgramSync(program.toProgram()).getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
   }
@@ -830,7 +831,8 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.updateProgramSync(program.toProgram()).getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
   }
@@ -861,7 +863,8 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.updateProgramSync(program.toProgram()).getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
   }
@@ -884,9 +887,8 @@ public final class ProgramService {
       throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     programDefinition = programDefinition.toBuilder().setEligibilityIsGating(gating).build();
-    return programRepository
-        .updateProgramSync(programDefinition.toProgram())
-        .getProgramDefinition();
+    return programRepository.getProgramDefinition(
+        programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
   /**
@@ -913,9 +915,8 @@ public final class ProgramService {
         getUpdatedSummaryImageDescription(programDefinition, locale, summaryImageDescription);
     programDefinition =
         programDefinition.toBuilder().setLocalizedSummaryImageDescription(newStrings).build();
-    return programRepository
-        .updateProgramSync(programDefinition.toProgram())
-        .getProgramDefinition();
+    return programRepository.getProgramDefinition(
+        programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
   private void updateSummaryImageDescriptionLocalization(
@@ -959,9 +960,8 @@ public final class ProgramService {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     programDefinition =
         programDefinition.toBuilder().setSummaryImageFileKey(Optional.of(fileKey)).build();
-    return programRepository
-        .updateProgramSync(programDefinition.toProgram())
-        .getProgramDefinition();
+    return programRepository.getProgramDefinition(
+        programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
   /**
@@ -973,9 +973,8 @@ public final class ProgramService {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     programDefinition =
         programDefinition.toBuilder().setSummaryImageFileKey(Optional.empty()).build();
-    return programRepository
-        .updateProgramSync(programDefinition.toProgram())
-        .getProgramDefinition();
+    return programRepository.getProgramDefinition(
+        programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
   /**
@@ -1038,7 +1037,8 @@ public final class ProgramService {
         programDefinition.insertBlockDefinitionInTheRightPlace(blockDefinition).toProgram();
     ProgramDefinition updatedProgram =
         syncProgramDefinitionQuestions(
-                programRepository.updateProgramSync(program).getProgramDefinition())
+                programRepository.getProgramDefinition(
+                    programRepository.updateProgramSync(program)))
             .toCompletableFuture()
             .join();
     BlockDefinition updatedBlockDefinition =
@@ -1079,7 +1079,7 @@ public final class ProgramService {
           "Something happened to the program's block while trying to move it", e);
     }
     return syncProgramDefinitionQuestions(
-            programRepository.updateProgramSync(program).getProgramDefinition())
+            programRepository.getProgramDefinition(programRepository.updateProgramSync(program)))
         .toCompletableFuture()
         .join();
   }
@@ -1785,7 +1785,8 @@ public final class ProgramService {
     }
 
     return syncProgramDefinitionQuestions(
-            programRepository.updateProgramSync(program.toProgram()).getProgramDefinition())
+            programRepository.getProgramDefinition(
+                programRepository.updateProgramSync(program.toProgram())))
         .toCompletableFuture()
         .join();
   }

--- a/server/test/services/applications/ProgramAdminApplicationServiceTest.java
+++ b/server/test/services/applications/ProgramAdminApplicationServiceTest.java
@@ -31,6 +31,7 @@ import play.i18n.MessagesApi;
 import repository.AccountRepository;
 import repository.ApplicationEventRepository;
 import repository.ApplicationRepository;
+import repository.ProgramRepository;
 import repository.ResetPostgres;
 import services.DeploymentType;
 import services.LocalizedStrings;
@@ -184,6 +185,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
             instanceOf(ApplicantService.class),
             instanceOf(ApplicationEventRepository.class),
             instanceOf(AccountRepository.class),
+            instanceOf(ProgramRepository.class),
             instanceOf(Config.class),
             simpleEmail,
             instanceOf(DeploymentType.class),
@@ -244,6 +246,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
             instanceOf(ApplicantService.class),
             instanceOf(ApplicationEventRepository.class),
             instanceOf(AccountRepository.class),
+            instanceOf(ProgramRepository.class),
             instanceOf(Config.class),
             simpleEmail,
             instanceOf(DeploymentType.class),
@@ -296,6 +299,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
             instanceOf(ApplicantService.class),
             instanceOf(ApplicationEventRepository.class),
             instanceOf(AccountRepository.class),
+            instanceOf(ProgramRepository.class),
             instanceOf(Config.class),
             simpleEmail,
             instanceOf(DeploymentType.class),
@@ -356,6 +360,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
             instanceOf(ApplicantService.class),
             instanceOf(ApplicationEventRepository.class),
             instanceOf(AccountRepository.class),
+            instanceOf(ProgramRepository.class),
             instanceOf(Config.class),
             simpleEmail,
             instanceOf(DeploymentType.class),
@@ -493,6 +498,7 @@ public class ProgramAdminApplicationServiceTest extends ResetPostgres {
             instanceOf(ApplicantService.class),
             instanceOf(ApplicationEventRepository.class),
             instanceOf(AccountRepository.class),
+            instanceOf(ProgramRepository.class),
             instanceOf(Config.class),
             simpleEmail,
             instanceOf(DeploymentType.class),


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/6611 created a new getProgramDefinition function, which uses the program def cache if available. 

This refactors additional files to use the new method. We also remove a helper function on the ApplicationModel.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6466