### PR TITLE
Adding casing comparison to Option Admin names. 

### DIFF
--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -291,20 +291,20 @@ public abstract class QuestionDefinition {
 
       var existingAdminNames =
           previousDefinition
-              .map(qd -> (MultiOptionQuestionDefinition) qd)
               .map(
-                  result -> {
+                  qd -> {
                     ImmutableList<String> optionList =
-                        multiOptionQuestionDefinition.getOptionAdminNames();
+                        ((MultiOptionQuestionDefinition) qd).getOptionAdminNames();
                     return optionList.stream()
                         .map(e -> e.toLowerCase(Locale.ROOT))
                         .collect(Collectors.toUnmodifiableList());
                   })
               .orElse(ImmutableList.of());
+
       if (multiOptionQuestionDefinition.getOptionAdminNames().stream()
           // This is O(n^2) but the list is small and it's simpler than creating a Set
           .filter(n -> !existingAdminNames.contains(n.toLowerCase(Locale.ROOT)))
-          .anyMatch(s -> !s.matches("[0-9a-z_-]+"))) {
+          .anyMatch(s -> !s.matches("[0-9a-zA-Z_-]+"))) {
         errors.add(
             CiviFormError.of(
                 "Multi-option admin names can only contain letters, numbers, underscores, and"
@@ -319,7 +319,7 @@ public abstract class QuestionDefinition {
       long numUniqueOptionDefaultValues =
           multiOptionQuestionDefinition.getOptions().stream()
               .map(QuestionOption::optionText)
-              .map(LocalizedStrings::getDefault)
+              .map(e -> e.getDefault().toLowerCase(Locale.ROOT))
               .distinct()
               .count();
       if (numUniqueOptionDefaultValues != numOptions) {
@@ -329,6 +329,7 @@ public abstract class QuestionDefinition {
       long numUniqueOptionAdminNames =
           multiOptionQuestionDefinition.getOptions().stream()
               .map(QuestionOption::adminName)
+              .map(e -> e.toLowerCase(Locale.ROOT))
               .distinct()
               .count();
       if (numUniqueOptionAdminNames != numOptions) {

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -304,7 +304,7 @@ public abstract class QuestionDefinition {
       if (multiOptionQuestionDefinition.getOptionAdminNames().stream()
           // This is O(n^2) but the list is small and it's simpler than creating a Set
           .filter(n -> !existingAdminNames.contains(n.toLowerCase(Locale.ROOT)))
-          .anyMatch(s -> !s.matches("[0-9a-zA-Z_-]+"))) {
+          .anyMatch(s -> !s.matches("[0-9a-z_-]+"))) {
         errors.add(
             CiviFormError.of(
                 "Multi-option admin names can only contain letters, numbers, underscores, and"

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -444,6 +444,22 @@ public class QuestionDefinitionTest {
   }
 
   @Test
+  public void validate_multiOptionQuestion_withDuplicateOptionsWithDifferentCase_returnsError() {
+    QuestionDefinitionConfig config = configBuilder.build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L, "Parks_and_Recreation", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(
+                2L, "Parks_and_recreation", LocalizedStrings.withDefaultValue("a")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+  }
+
+  @Test
   public void validate_multiOptionQuestion_withDuplicateOptionAdminNames_returnsError() {
     QuestionDefinitionConfig config = configBuilder.build();
     ImmutableList<QuestionOption> questionOptions =
@@ -525,6 +541,37 @@ public class QuestionDefinitionTest {
 
   @Test
   public void
+      validate_multiOptionQuestion_withValidOptionInPreviousDraftSameOptionWithDifferentCaseInNewOption_ReturnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "OptionA", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "OptionB", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "optionA", LocalizedStrings.withDefaultValue("optiona")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
+        .containsOnly(CiviFormError.of("Multi-option question admin names must be unique"));
+  }
+
+  @Test
+  public void
       validate_multiOptionQuestion_withInvalidOptionAdminNameInPreviousAndUpdatedDefinition_returnsError() {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
@@ -549,7 +596,6 @@ public class QuestionDefinitionTest {
     QuestionDefinition updatedQuestion =
         new MultiOptionQuestionDefinition(
             config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
-
     assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
         .containsOnly(
             CiviFormError.of(

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -449,14 +449,14 @@ public class QuestionDefinitionTest {
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(
             QuestionOption.create(
-                1L, "Parks_and_Recreation", LocalizedStrings.withDefaultValue("a")),
+                1L, "Parks_and_Recreation", LocalizedStrings.withDefaultValue("a1")),
             QuestionOption.create(
-                2L, "Parks_and_recreation", LocalizedStrings.withDefaultValue("a")));
+                2L, "Parks_and_recreation", LocalizedStrings.withDefaultValue("a2")));
     QuestionDefinition question =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.CHECKBOX);
     assertThat(question.validate())
-        .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+        .contains(CiviFormError.of("Multi-option question admin names must be unique"));
   }
 
   @Test
@@ -541,7 +541,7 @@ public class QuestionDefinitionTest {
 
   @Test
   public void
-      validate_multiOptionQuestion_withValidOptionInPreviousDraftSameOptionWithDifferentCaseInNewOption_ReturnsError() {
+      validate_multiOptionQuestion_withValidOptionAdminNameInPreviousAndDuplicateNameInUpdate_returnsError() {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("test")
@@ -551,8 +551,8 @@ public class QuestionDefinitionTest {
             .build();
     ImmutableList<QuestionOption> previousQuestionOptions =
         ImmutableList.of(
-            QuestionOption.create(1L, "OptionA", LocalizedStrings.withDefaultValue("a")),
-            QuestionOption.create(2L, "OptionB", LocalizedStrings.withDefaultValue("b")));
+            QuestionOption.create(1L, "a_valid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
     QuestionDefinition previousQuestion =
         new MultiOptionQuestionDefinition(
             config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
@@ -560,7 +560,7 @@ public class QuestionDefinitionTest {
     ImmutableList<QuestionOption> updatedQuestionOptions =
         ImmutableList.<QuestionOption>builder()
             .addAll(previousQuestionOptions)
-            .add(QuestionOption.create(2L, "optionA", LocalizedStrings.withDefaultValue("optiona")))
+            .add(QuestionOption.create(2L, "A_valid", LocalizedStrings.withDefaultValue("c")))
             .build();
     QuestionDefinition updatedQuestion =
         new MultiOptionQuestionDefinition(
@@ -596,6 +596,7 @@ public class QuestionDefinitionTest {
     QuestionDefinition updatedQuestion =
         new MultiOptionQuestionDefinition(
             config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
     assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
         .containsOnly(
             CiviFormError.of(


### PR DESCRIPTION
### Description

Bug fix - On creating new Admin Names for question options, we do not check for case sensitivity with existing admin names.

## Release notes

Bug fix - On creating new Admin Names for question options, we do not check for case sensitivity with existing admin names.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
(https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Fixes #6605 
