### PR TITLE
[Refactor] rename getProgramDefinition to getFullProgramDefinition when the definition includes all question data

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -124,7 +124,7 @@ public final class AdminApplicationController extends CiviFormController {
     final ProgramDefinition program;
 
     try {
-      program = programService.getProgramDefinition(programId);
+      program = programService.getFullProgramDefinition(programId);
       checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();
@@ -181,7 +181,7 @@ public final class AdminApplicationController extends CiviFormController {
                 .setApplicationStatus(applicationStatus)
                 .build();
       }
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       checkProgramAdminAuthorization(request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
       String csv = exporterService.getProgramAllVersionsCsv(programId, filters);
@@ -202,7 +202,7 @@ public final class AdminApplicationController extends CiviFormController {
   public Result downloadSingleVersion(Http.Request request, long programId)
       throws ProgramNotFoundException {
     try {
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       checkProgramAdminAuthorization(request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
       String csv = exporterService.getProgramCsv(programId);
@@ -257,7 +257,7 @@ public final class AdminApplicationController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result download(Http.Request request, long programId, long applicationId)
       throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     try {
       checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
@@ -282,7 +282,7 @@ public final class AdminApplicationController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result show(Http.Request request, long programId, long applicationId)
       throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     String programName = program.adminName();
 
     try {
@@ -339,7 +339,7 @@ public final class AdminApplicationController extends CiviFormController {
           StatusEmailNotFoundException,
           StatusNotFoundException,
           AccountHasNoEmailException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     String programName = program.adminName();
 
     try {
@@ -417,7 +417,7 @@ public final class AdminApplicationController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result updateNote(Http.Request request, long programId, long applicationId)
       throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     String programName = program.adminName();
 
     try {
@@ -491,7 +491,7 @@ public final class AdminApplicationController extends CiviFormController {
 
     final ProgramDefinition program;
     try {
-      program = programService.getProgramDefinition(programId);
+      program = programService.getFullProgramDefinition(programId);
       checkProgramAdminAuthorization(request, program.adminName()).join();
     } catch (CompletionException | NoSuchElementException e) {
       return unauthorized();

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -76,7 +76,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       return ok(
@@ -104,7 +104,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       return ok(
@@ -122,6 +122,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     }
   }
+
   /** POST endpoint for updating show-hide configurations. */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result updateVisibility(Request request, long programId, long blockDefinitionId) {
@@ -133,7 +134,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     try {
       PredicateDefinition predicateDefinition =
           predicateGenerator.generatePredicateDefinition(
-              programService.getProgramDefinition(programId),
+              programService.getFullProgramDefinition(programId),
               formFactory.form().bindFromRequest(request),
               roQuestionService);
 
@@ -167,7 +168,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     DynamicForm form = formFactory.form().bindFromRequest(request);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       return ok(
@@ -187,7 +188,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       ImmutableList<Long> visibilityQuestionIds =
@@ -223,7 +224,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     DynamicForm form = formFactory.form().bindFromRequest(request);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       return ok(
@@ -243,7 +244,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       ImmutableList<Long> eligibilityQuestionIds =
@@ -310,7 +311,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
           EligibilityDefinition.builder()
               .setPredicate(
                   predicateGenerator.generatePredicateDefinition(
-                      programService.getProgramDefinition(programId),
+                      programService.getFullProgramDefinition(programId),
                       formFactory.form().bindFromRequest(request),
                       roQuestionService))
               .build();

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -163,7 +163,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockDefinitionId);
 
       // In these cases, we warn admins that changing address correction is not allowed in the

--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -83,7 +83,7 @@ public final class AdminProgramBlocksController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result readOnlyIndex(long programId) {
-    return index(programId, /* readOnly=*/ true);
+    return index(programId, /* readOnly= */ true);
   }
 
   /**
@@ -95,7 +95,7 @@ public final class AdminProgramBlocksController extends CiviFormController {
    */
   private Result index(long programId, boolean readOnly) {
     try {
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       long blockId = program.getLastBlockDefinition().id();
 
       String redirectUrl =
@@ -155,7 +155,7 @@ public final class AdminProgramBlocksController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       BlockDefinition block = program.getBlockDefinition(blockId);
 
       Optional<ToastMessage> maybeToastMessage =
@@ -175,7 +175,7 @@ public final class AdminProgramBlocksController extends CiviFormController {
     requestChecker.throwIfProgramNotActive(programId);
 
     try {
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       BlockDefinition block = program.getBlockDefinition(blockId);
       return renderReadOnlyViewWithMessage(request, program, block);
     } catch (ProgramNotFoundException | ProgramBlockDefinitionNotFoundException e) {

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -163,7 +163,7 @@ public final class AdminProgramController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Request request, long id, String editStatus) throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(id);
+    ProgramDefinition program = programService.getFullProgramDefinition(id);
     requestChecker.throwIfProgramNotDraft(id);
     return ok(editView.render(request, program, ProgramEditStatus.getStatusFromString(editStatus)));
   }
@@ -181,7 +181,7 @@ public final class AdminProgramController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result publishProgram(Request request, long programId) throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     requestChecker.throwIfProgramNotDraft(programId);
 
     try {
@@ -202,7 +202,7 @@ public final class AdminProgramController extends CiviFormController {
       // TODO(#2246): Implement FE staleness detection system to handle this more robustly.
       Optional<ProgramModel> existingDraft =
           versionRepository.getProgramByNameForVersion(
-              programService.getProgramDefinition(programId).adminName(),
+              programService.getFullProgramDefinition(programId).adminName(),
               versionRepository.getDraftVersionOrCreate());
       final Long idToEdit;
       if (existingDraft.isPresent()) {
@@ -228,7 +228,7 @@ public final class AdminProgramController extends CiviFormController {
   public Result update(Request request, long programId, String editStatus)
       throws ProgramNotFoundException {
     requestChecker.throwIfProgramNotDraft(programId);
-    ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+    ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm programData = programForm.bindFromRequest(request).get();
 
@@ -289,7 +289,7 @@ public final class AdminProgramController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result editProgramSettings(Request request, Long programId)
       throws ProgramNotFoundException {
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     requestChecker.throwIfProgramNotDraft(programId);
     return ok(programSettingsEditView.render(request, program));
   }

--- a/server/app/controllers/admin/AdminProgramImageController.java
+++ b/server/app/controllers/admin/AdminProgramImageController.java
@@ -57,7 +57,7 @@ public final class AdminProgramImageController extends CiviFormController {
     requestChecker.throwIfProgramNotDraft(programId);
     return ok(
         programImageView.render(
-            request, programService.getProgramDefinition(programId), editStatus));
+            request, programService.getFullProgramDefinition(programId), editStatus));
   }
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)

--- a/server/app/controllers/admin/AdminProgramStatusesController.java
+++ b/server/app/controllers/admin/AdminProgramStatusesController.java
@@ -59,7 +59,7 @@ public final class AdminProgramStatusesController extends CiviFormController {
     return ok(
         statusesView.render(
             request,
-            service.getProgramDefinition(programId),
+            service.getFullProgramDefinition(programId),
             /* maybeStatusForm= */ Optional.empty()));
   }
 
@@ -77,7 +77,7 @@ public final class AdminProgramStatusesController extends CiviFormController {
   public Result createOrUpdate(Http.Request request, long programId)
       throws ProgramNotFoundException {
     requestChecker.throwIfProgramNotDraft(programId);
-    ProgramDefinition program = service.getProgramDefinition(programId);
+    ProgramDefinition program = service.getFullProgramDefinition(programId);
     int previousStatusCount = program.statusDefinitions().getStatuses().size();
     Optional<StatusDefinitions.Status> previousDefaultStatus =
         program.toProgram().getDefaultStatus();
@@ -201,7 +201,7 @@ public final class AdminProgramStatusesController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result delete(Http.Request request, long programId) throws ProgramNotFoundException {
     requestChecker.throwIfProgramNotDraft(programId);
-    ProgramDefinition program = service.getProgramDefinition(programId);
+    ProgramDefinition program = service.getFullProgramDefinition(programId);
 
     DynamicForm requestData = formFactory.form().bindFromRequest(request);
     String rawDeleteStatusText = requestData.get(ProgramStatusesView.DELETE_STATUS_TEXT_NAME);

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -732,7 +732,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     }
 
     try {
-      ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+      ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
       if (shouldRenderIneligibleBlockView(roApplicantProgramService, programDefinition, blockId)) {
         return supplyAsync(
             () ->

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -256,7 +256,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   private boolean shouldShowNotEligibleBanner(
       ReadOnlyApplicantProgramService roApplicantProgramService, long programId)
       throws ProgramNotFoundException {
-    if (!programService.getProgramDefinition(programId).eligibilityIsGating()) {
+    if (!programService.getFullProgramDefinition(programId).eligibilityIsGating()) {
       return false;
     }
     return roApplicantProgramService.isApplicationNotEligible();
@@ -331,7 +331,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
                   try {
                     ProgramDefinition programDefinition =
-                        programService.getProgramDefinition(programId);
+                        programService.getFullProgramDefinition(programId);
 
                     return ok(
                         ineligibleBlockView.render(

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -93,7 +93,7 @@ public final class UpsellController extends CiviFormController {
 
     CompletableFuture<Boolean> isCommonIntake =
         programService
-            .getProgramDefinitionAsync(programId)
+            .getFullProgramDefinitionAsync(programId)
             .thenApplyAsync(ProgramDefinition::isCommonIntakeForm)
             .toCompletableFuture();
 

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -174,7 +174,7 @@ public final class ApplicantService {
     CompletableFuture<Optional<ApplicantModel>> applicantCompletableFuture =
         accountRepository.lookupApplicant(applicantId).toCompletableFuture();
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getFullProgramDefinitionAsync(programId).toCompletableFuture();
 
     return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
         .thenApplyAsync(
@@ -199,7 +199,7 @@ public final class ApplicantService {
           new ReadOnlyApplicantProgramServiceImpl(
               jsonPathPredicateGeneratorFactory,
               application.getApplicantData(),
-              programService.getProgramDefinition(application.getProgram().id),
+              programService.getFullProgramDefinition(application.getProgram().id),
               baseUrl));
     } catch (ProgramNotFoundException e) {
       throw new RuntimeException("Cannot find a program that has applications for it.", e);
@@ -284,7 +284,7 @@ public final class ApplicantService {
         accountRepository.lookupApplicant(applicantId).toCompletableFuture();
 
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getFullProgramDefinitionAsync(programId).toCompletableFuture();
 
     return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
         .thenComposeAsync(
@@ -544,7 +544,7 @@ public final class ApplicantService {
     }
 
     try {
-      if (!programService.getProgramDefinition(programId).eligibilityIsGating()) {
+      if (!programService.getFullProgramDefinition(programId).eligibilityIsGating()) {
         return CompletableFuture.completedFuture(null);
       }
     } catch (ProgramNotFoundException e) {
@@ -564,7 +564,7 @@ public final class ApplicantService {
    */
   private CompletionStage<Void> updateStoredFileAclsForSubmit(long applicantId, long programId) {
     CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+        programService.getFullProgramDefinitionAsync(programId).toCompletableFuture();
 
     CompletableFuture<List<StoredFileModel>> storedFilesFuture =
         getReadOnlyApplicantProgramService(applicantId, programId)

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -93,7 +93,7 @@ public final class CsvExporterService {
     ImmutableList<ProgramDefinition> allProgramVersions =
         programService.getAllProgramDefinitionVersions(programId).stream()
             .collect(ImmutableList.toImmutableList());
-    ProgramDefinition currentProgram = programService.getProgramDefinition(programId);
+    ProgramDefinition currentProgram = programService.getFullProgramDefinition(programId);
     CsvExportConfig exportConfig =
         generateDefaultCsvExportConfig(allProgramVersions, currentProgram.hasEligibilityEnabled());
 
@@ -144,7 +144,7 @@ public final class CsvExporterService {
   public String getProgramCsv(long programId) throws ProgramNotFoundException {
     ImmutableList<ApplicationModel> applications =
         programService.getSubmittedProgramApplications(programId);
-    ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
+    ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
     return exportCsv(
         generateDefaultCsvConfig(programId, programDefinition.hasEligibilityEnabled()),
         applications,
@@ -175,7 +175,7 @@ public final class CsvExporterService {
           Long programId = application.getProgram().id;
           if (!programDefinitions.containsKey(programId)) {
             try {
-              programDefinitions.put(programId, programService.getProgramDefinition(programId));
+              programDefinitions.put(programId, programService.getFullProgramDefinition(programId));
             } catch (ProgramNotFoundException e) {
               throw new RuntimeException("Cannot find a program that has applications for it.", e);
             }

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -56,7 +56,7 @@ public final class ActiveAndDraftPrograms {
             .map(
                 program ->
                     service.isPresent()
-                        ? getProgramDefinition(service.get(), program.id)
+                        ? getFullProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
@@ -66,7 +66,7 @@ public final class ActiveAndDraftPrograms {
             .map(
                 program ->
                     service.isPresent()
-                        ? getProgramDefinition(service.get(), program.id)
+                        ? getFullProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
@@ -131,7 +131,7 @@ public final class ActiveAndDraftPrograms {
     return draftPrograms.size() > 0;
   }
 
-  private ProgramDefinition getProgramDefinition(ProgramService service, long id) {
+  private ProgramDefinition getFullProgramDefinition(ProgramService service, long id) {
     try {
       return service.getFullProgramDefinition(id);
     } catch (ProgramNotFoundException e) {

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -133,7 +133,7 @@ public final class ActiveAndDraftPrograms {
 
   private ProgramDefinition getProgramDefinition(ProgramService service, long id) {
     try {
-      return service.getProgramDefinition(id);
+      return service.getFullProgramDefinition(id);
     } catch (ProgramNotFoundException e) {
       // This is not possible because we query with existing program ids.
       throw new RuntimeException(e);

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -56,7 +56,7 @@ public final class RoleService {
       return Optional.empty();
     }
 
-    ProgramDefinition program = programService.getProgramDefinition(programId);
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
     // admin.
     ImmutableSet<String> globalAdminEmails =
@@ -113,7 +113,7 @@ public final class RoleService {
   public void removeProgramAdmins(long programId, ImmutableSet<String> accountEmails)
       throws ProgramNotFoundException {
     if (!accountEmails.isEmpty()) {
-      ProgramDefinition program = programService.getProgramDefinition(programId);
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       accountEmails.forEach(email -> accountRepository.removeAdministeredProgram(email, program));
     }
   }

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -151,7 +151,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
     assertThat(updatedProgram.localizedSummaryImageDescription().get().get(Locale.US))
         .isEqualTo("fake description");
@@ -177,7 +177,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
     assertThat(updatedProgram.localizedSummaryImageDescription().get().get(Locale.US))
         .isEqualTo("second description");
@@ -209,7 +209,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
     assertThat(updatedProgram.localizedSummaryImageDescription().get().get(Locale.US))
         .isEqualTo("new US description");
@@ -239,7 +239,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isEmpty()).isTrue();
   }
 
@@ -264,7 +264,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
     assertThat(updatedProgram.localizedSummaryImageDescription().get().getDefault())
         .isEqualTo("original description");
@@ -291,7 +291,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isPresent()).isTrue();
     assertThat(updatedProgram.localizedSummaryImageDescription().get().getDefault())
         .isEqualTo("original description");
@@ -317,7 +317,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isEmpty()).isTrue();
   }
 
@@ -347,7 +347,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.localizedSummaryImageDescription().isEmpty()).isTrue();
   }
 
@@ -553,7 +553,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         program.id,
         ProgramEditStatus.CREATION.name());
 
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
         .isEqualTo("program-summary-image/program-15/myImage.png");
@@ -587,7 +587,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         program.id,
         ProgramEditStatus.CREATION.name());
 
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
         .isEqualTo("program-summary-image/program-15/oldImage.png");
@@ -608,7 +608,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         ProgramEditStatus.CREATION.name());
 
     // THEN the database reflects the changes
-    updatedProgram = programService.getProgramDefinition(program.id);
+    updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isNotEmpty();
     assertThat(updatedProgram.summaryImageFileKey().get())
         .isEqualTo("program-summary-image/program-15/newImage.png");
@@ -671,7 +671,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     controller.deleteFileKey(
         addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
 
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey().isEmpty()).isTrue();
   }
 
@@ -683,7 +683,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     controller.deleteFileKey(
         addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
 
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isEmpty();
   }
 
@@ -735,7 +735,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             program.id,
             ProgramEditStatus.CREATION.name());
 
-    ProgramDefinition programWithKey = programService.getProgramDefinition(program.id);
+    ProgramDefinition programWithKey = programService.getFullProgramDefinition(program.id);
     assertThat(programWithKey.summaryImageFileKey()).isNotEmpty();
     assertThat(programWithKey.summaryImageFileKey().get()).isEqualTo(VALID_FILE_KEY);
     return result;

--- a/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
@@ -136,7 +136,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
     // Load the updated program and ensure the status is present.
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.statusDefinitions().getStatuses())
         .isEqualTo(
             ImmutableList.of(
@@ -175,7 +175,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
     // Load the updated program and ensure the status is present.
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.statusDefinitions().getStatuses())
         .isEqualTo(
             ImmutableList.of(
@@ -208,7 +208,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
         .containsExactlyEntriesOf(
             ImmutableMap.of("success", "bar has been updated to the default status"));
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
-    ProgramDefinition newlyUpdatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition newlyUpdatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(newlyUpdatedProgram.statusDefinitions().getStatuses())
         .isEqualTo(
             ImmutableList.of(
@@ -261,7 +261,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
             .build();
 
     // Load the updated program and ensure the status is present.
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(expectedStatus, REJECTED_STATUS, WITH_STATUS_TRANSLATIONS));
   }
 
@@ -308,7 +309,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
             .build();
 
     // Load the updated program and ensure the status is present.
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(APPROVED_STATUS, REJECTED_STATUS, expectedStatus));
   }
 
@@ -348,7 +350,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
             .build();
 
     // Load the updated program and ensure the status is present.
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(APPROVED_STATUS, REJECTED_STATUS, expectedStatus));
   }
 
@@ -384,7 +387,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
             .build();
 
     // Load the updated program and ensure the status is present.
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(expectedStatus, REJECTED_STATUS, WITH_STATUS_TRANSLATIONS));
 
     Result result2 =
@@ -419,7 +423,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
             .build();
 
     // Load the updated program and ensure the status is present.
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(foo, bar, WITH_STATUS_TRANSLATIONS));
   }
 
@@ -442,7 +447,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(Helpers.contentAsString(result)).contains("This field is required");
     assertThat(contentAsString(result)).containsOnlyOnce(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ORIGINAL_STATUSES);
   }
 
@@ -466,7 +472,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
         .contains("A status with name Rejected already exists");
     assertThat(contentAsString(result)).containsOnlyOnce(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ORIGINAL_STATUSES);
   }
 
@@ -490,7 +497,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
         .contains("The status being edited no longer exists");
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ORIGINAL_STATUSES);
   }
 
@@ -514,7 +522,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
         .contains("A status with name Rejected already exists");
     assertThat(contentAsString(result)).containsOnlyOnce(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
-    assertThat(programService.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(
+            programService.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ORIGINAL_STATUSES);
   }
 
@@ -557,7 +566,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
     // Load the updated program and ensure the status is present.
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(APPROVED_STATUS, WITH_STATUS_TRANSLATIONS));
   }
@@ -578,7 +587,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).doesNotContain(ReferenceClasses.MODAL_DISPLAY_ON_LOAD);
 
     // Load the updated program and ensure statuses weren't updated.
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.statusDefinitions().getStatuses()).isEqualTo(ORIGINAL_STATUSES);
   }
 
@@ -594,7 +603,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
 
     // Load the updated program and ensure statuses weren't updated.
-    ProgramDefinition updatedProgram = programService.getProgramDefinition(program.id);
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.statusDefinitions().getStatuses()).isEqualTo(ORIGINAL_STATUSES);
   }
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3320,7 +3320,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     programService.setProgramQuestionDefinitionAddressCorrectionEnabled(
         program.id, blockDefinition.id(), questionDefinition.getId(), true);
 
-    programDefinition = programService.getProgramDefinition(program.id);
+    programDefinition = programService.getFullProgramDefinition(program.id);
     blockDefinition = programDefinition.getBlockDefinition(blockDefinition.id());
 
     Block block =
@@ -3392,7 +3392,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     programService.setProgramQuestionDefinitionAddressCorrectionEnabled(
         program.id, blockDefinition.id(), questionDefinition.getId(), true);
 
-    programDefinition = programService.getProgramDefinition(program.id);
+    programDefinition = programService.getFullProgramDefinition(program.id);
     blockDefinition = programDefinition.getBlockDefinition(blockDefinition.id());
 
     Block block =

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -642,7 +642,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.hasResult()).isTrue();
     ProgramDefinition updatedProgram = result.getResult();
 
-    ProgramDefinition found = ps.getProgramDefinition(updatedProgram.id());
+    ProgramDefinition found = ps.getFullProgramDefinition(updatedProgram.id());
 
     assertThat(ps.getActiveAndDraftPrograms().getDraftPrograms()).hasSize(1);
     assertThat(ps.getActiveAndDraftProgramsWithoutQuestionLoad().getDraftPrograms()).hasSize(1);
@@ -771,7 +771,7 @@ public class ProgramServiceTest extends ResetPostgres {
   @Test
   public void getProgramDefinition() throws Exception {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
-    ProgramDefinition found = ps.getProgramDefinition(programDefinition.id());
+    ProgramDefinition found = ps.getFullProgramDefinition(programDefinition.id());
 
     assertThat(found.adminName()).isEqualTo(programDefinition.adminName());
   }
@@ -1003,7 +1003,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void getProgramDefinition_throwsWhenProgramNotFound() {
-    assertThatThrownBy(() -> ps.getProgramDefinition(1L))
+    assertThatThrownBy(() -> ps.getFullProgramDefinition(1L))
         .isInstanceOf(ProgramNotFoundException.class)
         .hasMessageContaining("Program not found for ID");
   }
@@ -1014,7 +1014,7 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id());
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id());
 
     QuestionDefinition foundQuestion =
         found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
@@ -1025,7 +1025,8 @@ public class ProgramServiceTest extends ResetPostgres {
   public void getProgramDefinitionAsync_getsDraftProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().buildDefinition();
 
-    CompletionStage<ProgramDefinition> found = ps.getProgramDefinitionAsync(programDefinition.id());
+    CompletionStage<ProgramDefinition> found =
+        ps.getFullProgramDefinitionAsync(programDefinition.id());
 
     assertThat(found.toCompletableFuture().join().adminName())
         .isEqualTo(programDefinition.adminName());
@@ -1036,7 +1037,8 @@ public class ProgramServiceTest extends ResetPostgres {
   public void getProgramDefinitionAsync_getsActiveProgram() {
     ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
-    CompletionStage<ProgramDefinition> found = ps.getProgramDefinitionAsync(programDefinition.id());
+    CompletionStage<ProgramDefinition> found =
+        ps.getFullProgramDefinitionAsync(programDefinition.id());
     assertThat(found.toCompletableFuture().join().id()).isEqualTo(programDefinition.id());
   }
 
@@ -1045,7 +1047,7 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramDefinition programDefinition = ProgramBuilder.newActiveProgram().buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
-        ps.getProgramDefinitionAsync(programDefinition.id() + 1);
+        ps.getFullProgramDefinitionAsync(programDefinition.id() + 1);
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)
@@ -1063,7 +1065,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .buildDefinition();
 
     ProgramDefinition found =
-        ps.getProgramDefinitionAsync(program.id()).toCompletableFuture().join();
+        ps.getFullProgramDefinitionAsync(program.id()).toCompletableFuture().join();
 
     QuestionDefinition foundQuestion =
         found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
@@ -1080,7 +1082,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .buildDefinition();
 
     ProgramDefinition found =
-        ps.getProgramDefinitionAsync(program.id()).toCompletableFuture().join();
+        ps.getFullProgramDefinitionAsync(program.id()).toCompletableFuture().join();
     ProgramDefinition cachedProgram =
         (ProgramDefinition) programDefCache.get(String.valueOf(program.id())).get();
 
@@ -1105,7 +1107,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .buildDefinition();
 
     ProgramDefinition found =
-        ps.getProgramDefinitionAsync(program.id()).toCompletableFuture().join();
+        ps.getFullProgramDefinitionAsync(program.id()).toCompletableFuture().join();
     Optional<ProgramDefinition> maybeCachedProgram =
         programDefCache.get(String.valueOf(program.id()));
 
@@ -1178,7 +1180,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.getResult().maybeAddedBlock()).isNotEmpty();
     BlockDefinition addedBlock = result.getResult().maybeAddedBlock().get();
 
-    ProgramDefinition found = ps.getProgramDefinition(programDefinition.id());
+    ProgramDefinition found = ps.getFullProgramDefinition(programDefinition.id());
 
     assertThat(found.blockDefinitions()).hasSize(2);
     assertThat(found.blockDefinitions())
@@ -1210,7 +1212,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.getResult().maybeAddedBlock()).isNotEmpty();
     BlockDefinition addedBlock = result.getResult().maybeAddedBlock().get();
 
-    ProgramDefinition found = ps.getProgramDefinition(programId);
+    ProgramDefinition found = ps.getFullProgramDefinition(programId);
 
     assertThat(found.blockDefinitions()).hasSize(2);
     assertThat(found.blockDefinitions())
@@ -1239,7 +1241,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.getResult().maybeAddedBlock()).isNotEmpty();
     BlockDefinition addedBlock = result.getResult().maybeAddedBlock().get();
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id);
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id);
 
     assertThat(found.blockDefinitions()).hasSize(4);
     assertThat(found.getBlockDefinitionByIndex(0).get().isEnumerator()).isTrue();
@@ -1288,7 +1290,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.getResult().maybeAddedBlock()).isNotEmpty();
     BlockDefinition addedBlock = result.getResult().maybeAddedBlock().get();
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id);
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id);
 
     assertThat(found.blockDefinitions()).hasSize(4);
     assertThat(found.getBlockDefinitionByIndex(0).get().isEnumerator()).isFalse();
@@ -1365,7 +1367,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.isError()).isFalse();
     assertThat(result.hasResult()).isTrue();
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id());
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id());
 
     assertThat(found.blockDefinitions()).hasSize(1);
     assertThat(found.getBlockDefinition(1L).name()).isEqualTo("new screen name");
@@ -1382,7 +1384,7 @@ public class ProgramServiceTest extends ResetPostgres {
         programId,
         1L,
         ImmutableList.of(ProgramQuestionDefinition.create(question, Optional.of(programId))));
-    ProgramDefinition found = ps.getProgramDefinition(programId);
+    ProgramDefinition found = ps.getFullProgramDefinition(programId);
 
     assertThat(found.blockDefinitions()).hasSize(1);
 
@@ -1591,7 +1593,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
     ps.setBlockVisibilityPredicate(program.id, 2L, Optional.of(predicate));
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id);
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id);
 
     // Verify serialization and deserialization.
     assertThat(found.blockDefinitions().get(1).visibilityPredicate()).hasValue(predicate);
@@ -1707,7 +1709,7 @@ public class ProgramServiceTest extends ResetPostgres {
         2L,
         Optional.of(EligibilityDefinition.builder().setPredicate(predicate).build()));
 
-    ProgramDefinition found = ps.getProgramDefinition(program.id);
+    ProgramDefinition found = ps.getFullProgramDefinition(program.id);
 
     // Verify serialization and deserialization.
     assertThat(found.blockDefinitions().get(1).eligibilityDefinition()).isPresent();
@@ -1765,14 +1767,14 @@ public class ProgramServiceTest extends ResetPostgres {
             PredicateAction.HIDE_BLOCK);
     ps.setBlockVisibilityPredicate(program.id, 2L, Optional.of(predicate));
 
-    ProgramDefinition foundWithPredicate = ps.getProgramDefinition(program.id);
+    ProgramDefinition foundWithPredicate = ps.getFullProgramDefinition(program.id);
     assertThat(foundWithPredicate.blockDefinitions().get(1).visibilityPredicate())
         .hasValue(predicate);
 
     // Then remove that predicate and assert its absence.
     ps.removeBlockPredicate(program.id, 2L);
 
-    ProgramDefinition foundWithoutPredicate = ps.getProgramDefinition(program.id);
+    ProgramDefinition foundWithoutPredicate = ps.getFullProgramDefinition(program.id);
     assertThat(foundWithoutPredicate.blockDefinitions().get(1).visibilityPredicate()).isEmpty();
   }
 
@@ -2528,7 +2530,8 @@ public class ProgramServiceTest extends ResetPostgres {
             mapper.writeValueAsString(unorderedBlockDefinitions), programId);
     DB.sqlUpdate(updateString).execute();
 
-    ProgramDefinition found = ps.getProgramDefinitionAsync(programId).toCompletableFuture().get();
+    ProgramDefinition found =
+        ps.getFullProgramDefinitionAsync(programId).toCompletableFuture().get();
 
     assertThat(found.hasOrderedBlockDefinitions()).isTrue();
   }
@@ -2727,7 +2730,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(REJECTED_STATUS));
-    assertThat(ps.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(ps.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(REJECTED_STATUS));
   }
 
@@ -2754,7 +2757,7 @@ public class ProgramServiceTest extends ResetPostgres {
             CiviFormError.of(
                 "The status being deleted no longer exists and may have been deleted in a"
                     + " separate window."));
-    assertThat(ps.getProgramDefinition(program.id).statusDefinitions().getStatuses())
+    assertThat(ps.getFullProgramDefinition(program.id).statusDefinitions().getStatuses())
         .isEqualTo(ImmutableList.of(APPROVED_STATUS));
   }
 


### PR DESCRIPTION
### Description

This just renames the getProgramDefinition and getProgramDefinitionAsync functions in [ProgramService](https://github.com/civiform/civiform/blob/e677def7bdcbd0da027cf93602613054f8943d79/server/app/services/program/ProgramService.java#L160-L191) and ActiveAndDraftPrograms to getFullProgramDefinition and getFullProgramDefinitionAsync to make it clearer that these functions get the full program definition with question data.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

