### PR TITLE
[Refactor] rename getProgramDefinition to getFullProgramDefinition when the definition includes all question data

### DIFF
--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -56,7 +56,7 @@ public final class ActiveAndDraftPrograms {
             .map(
                 program ->
                     service.isPresent()
-                        ? getProgramDefinition(service.get(), program.id)
+                        ? getFullProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
@@ -66,7 +66,7 @@ public final class ActiveAndDraftPrograms {
             .map(
                 program ->
                     service.isPresent()
-                        ? getProgramDefinition(service.get(), program.id)
+                        ? getFullProgramDefinition(service.get(), program.id)
                         : program.getProgramDefinition())
             .collect(
                 ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
@@ -131,7 +131,7 @@ public final class ActiveAndDraftPrograms {
     return draftPrograms.size() > 0;
   }
 
-  private ProgramDefinition getProgramDefinition(ProgramService service, long id) {
+  private ProgramDefinition getFullProgramDefinition(ProgramService service, long id) {
     try {
       return service.getFullProgramDefinition(id);
     } catch (ProgramNotFoundException e) {


### PR DESCRIPTION
### Description

This just renames the getProgramDefinition in ActiveAndDraftQuestions to getFullProgramDefinition to make it clearer that this function gets the full program defintion with question data.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

