### PR TITLE
Don't run address visiblity test on staging

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -1576,164 +1576,170 @@ describe('Applicant navigation flow', () => {
     })
   })
 
-  describe('using address as visibility condition', () => {
-    const programName = 'Test program for address as visibility condition'
-    const questionAddress = 'address-test-q'
-    const questionText1 = 'text-test-q-one'
-    const questionText2 = 'text-test-q-two'
-    const screen1 = 'Screen 1'
-    const screen2 = 'Screen 2'
-    const screen3 = 'Screen 3'
+  if (isLocalDevEnvironment()) {
+    describe('using address as visibility condition', () => {
+      const programName = 'Test program for address as visibility condition'
+      const questionAddress = 'address-test-q'
+      const questionText1 = 'text-test-q-one'
+      const questionText2 = 'text-test-q-two'
+      const screen1 = 'Screen 1'
+      const screen2 = 'Screen 2'
+      const screen3 = 'Screen 3'
 
-    beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms, adminPredicates} = ctx
-      await loginAsAdmin(page)
-      await enableFeatureFlag(page, 'esri_address_correction_enabled')
-      await enableFeatureFlag(
-        page,
-        'esri_address_service_area_validation_enabled',
-      )
+      beforeAll(async () => {
+        const {page, adminQuestions, adminPrograms, adminPredicates} = ctx
+        await loginAsAdmin(page)
+        await enableFeatureFlag(page, 'esri_address_correction_enabled')
+        await enableFeatureFlag(
+          page,
+          'esri_address_service_area_validation_enabled',
+        )
 
-      // Create Questions
-      await adminQuestions.addAddressQuestion({
-        questionName: questionAddress,
-        questionText: questionAddress,
-      })
-
-      await adminQuestions.addTextQuestion({
-        questionName: questionText1,
-        questionText: questionText1,
-      })
-
-      await adminQuestions.addTextQuestion({
-        questionName: questionText2,
-        questionText: questionText2,
-      })
-
-      // Create Program
-      await adminPrograms.addProgram(programName)
-
-      // Attach questions to program
-      await adminPrograms.editProgramBlock(programName, screen1, [
-        questionAddress,
-      ])
-
-      await adminPrograms.addProgramBlock(programName, screen2, [questionText1])
-
-      await adminPrograms.addProgramBlock(programName, screen3, [questionText2])
-
-      await adminPrograms.goToBlockInProgram(programName, screen1)
-
-      await adminPrograms.clickAddressCorrectionToggleByName(questionAddress)
-
-      const addressCorrectionInput =
-        adminPrograms.getAddressCorrectionToggleByName(questionAddress)
-
-      expect(await addressCorrectionInput.inputValue()).toBe('true')
-
-      // Set thing to soft eligibilty
-      await adminPrograms.toggleEligibilityGating()
-
-      // Add address eligibility predicate
-      await adminPrograms.goToEditBlockEligibilityPredicatePage(
-        programName,
-        screen1,
-      )
-
-      await adminPredicates.addPredicates([
-        {
+        // Create Questions
+        await adminQuestions.addAddressQuestion({
           questionName: questionAddress,
-          scalar: 'service_area',
-          operator: 'in service area',
-          values: ['Seattle'],
-        },
-      ])
+          questionText: questionAddress,
+        })
 
-      // Add the address visibility predicate
-      await adminPrograms.goToBlockInProgram(programName, screen2)
+        await adminQuestions.addTextQuestion({
+          questionName: questionText1,
+          questionText: questionText1,
+        })
 
-      await adminPrograms.goToEditBlockVisibilityPredicatePage(
-        programName,
-        screen2,
-      )
+        await adminQuestions.addTextQuestion({
+          questionName: questionText2,
+          questionText: questionText2,
+        })
 
-      await adminPredicates.addPredicates([
-        {
-          questionName: questionAddress,
-          action: 'shown if',
-          scalar: 'service_area',
-          operator: 'in service area',
-          values: ['Seattle'],
-        },
-      ])
+        // Create Program
+        await adminPrograms.addProgram(programName)
 
-      // Publish Program
-      await adminPrograms.gotoAdminProgramsPage()
-      await adminPrograms.publishProgram(programName)
+        // Attach questions to program
+        await adminPrograms.editProgramBlock(programName, screen1, [
+          questionAddress,
+        ])
 
-      await logout(page)
+        await adminPrograms.addProgramBlock(programName, screen2, [
+          questionText1,
+        ])
+
+        await adminPrograms.addProgramBlock(programName, screen3, [
+          questionText2,
+        ])
+
+        await adminPrograms.goToBlockInProgram(programName, screen1)
+
+        await adminPrograms.clickAddressCorrectionToggleByName(questionAddress)
+
+        const addressCorrectionInput =
+          adminPrograms.getAddressCorrectionToggleByName(questionAddress)
+
+        expect(await addressCorrectionInput.inputValue()).toBe('true')
+
+        // Set thing to soft eligibilty
+        await adminPrograms.toggleEligibilityGating()
+
+        // Add address eligibility predicate
+        await adminPrograms.goToEditBlockEligibilityPredicatePage(
+          programName,
+          screen1,
+        )
+
+        await adminPredicates.addPredicates([
+          {
+            questionName: questionAddress,
+            scalar: 'service_area',
+            operator: 'in service area',
+            values: ['Seattle'],
+          },
+        ])
+
+        // Add the address visibility predicate
+        await adminPrograms.goToBlockInProgram(programName, screen2)
+
+        await adminPrograms.goToEditBlockVisibilityPredicatePage(
+          programName,
+          screen2,
+        )
+
+        await adminPredicates.addPredicates([
+          {
+            questionName: questionAddress,
+            action: 'shown if',
+            scalar: 'service_area',
+            operator: 'in service area',
+            values: ['Seattle'],
+          },
+        ])
+
+        // Publish Program
+        await adminPrograms.gotoAdminProgramsPage()
+        await adminPrograms.publishProgram(programName)
+
+        await logout(page)
+      })
+
+      it('when address is eligible show hidden screen', async () => {
+        const {page, applicantQuestions} = ctx
+        await applicantQuestions.applyProgram(programName)
+
+        // Fill out application and submit.
+        await applicantQuestions.answerAddressQuestion(
+          'Legit Address',
+          '',
+          'Seattle',
+          'WA',
+          '98109',
+          0,
+        )
+        await applicantQuestions.clickNext()
+        await applicantQuestions.expectVerifyAddressPage(true)
+        await applicantQuestions.clickNext()
+        // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an valid address.
+        await applicantQuestions.answerTextQuestion('answer 1')
+        await applicantQuestions.clickNext()
+        await applicantQuestions.answerTextQuestion('answer 2')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.expectQuestionAnsweredOnReviewPage(
+          questionAddress,
+          'Address In Area',
+        )
+
+        await applicantQuestions.clickSubmit()
+        await logout(page)
+      })
+
+      it('when address is not eligible do not show hidden screen', async () => {
+        const {page, applicantQuestions} = ctx
+        await applicantQuestions.applyProgram(programName)
+
+        // Fill out application and submit.
+        await applicantQuestions.answerAddressQuestion(
+          'Nonlegit Address',
+          '',
+          'Seattle',
+          'WA',
+          '98109',
+          0,
+        )
+        await applicantQuestions.clickNext()
+        await applicantQuestions.expectVerifyAddressPage(false)
+        await applicantQuestions.clickNext()
+        // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an invalid address.
+        await applicantQuestions.answerTextQuestion('answer 2')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.expectQuestionAnsweredOnReviewPage(
+          questionAddress,
+          'Nonlegit Address',
+        )
+
+        await applicantQuestions.clickSubmit()
+        await logout(page)
+      })
     })
-
-    it('when address is eligible show hidden screen', async () => {
-      const {page, applicantQuestions} = ctx
-      await applicantQuestions.applyProgram(programName)
-
-      // Fill out application and submit.
-      await applicantQuestions.answerAddressQuestion(
-        'Legit Address',
-        '',
-        'Seattle',
-        'WA',
-        '98109',
-        0,
-      )
-      await applicantQuestions.clickNext()
-      await applicantQuestions.expectVerifyAddressPage(true)
-      await applicantQuestions.clickNext()
-      // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an valid address.
-      await applicantQuestions.answerTextQuestion('answer 1')
-      await applicantQuestions.clickNext()
-      await applicantQuestions.answerTextQuestion('answer 2')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.expectQuestionAnsweredOnReviewPage(
-        questionAddress,
-        'Address In Area',
-      )
-
-      await applicantQuestions.clickSubmit()
-      await logout(page)
-    })
-
-    it('when address is not eligible do not show hidden screen', async () => {
-      const {page, applicantQuestions} = ctx
-      await applicantQuestions.applyProgram(programName)
-
-      // Fill out application and submit.
-      await applicantQuestions.answerAddressQuestion(
-        'Nonlegit Address',
-        '',
-        'Seattle',
-        'WA',
-        '98109',
-        0,
-      )
-      await applicantQuestions.clickNext()
-      await applicantQuestions.expectVerifyAddressPage(false)
-      await applicantQuestions.clickNext()
-      // Screen 1 will only be visible when the address is validated as being eligible. This test case uses an invalid address.
-      await applicantQuestions.answerTextQuestion('answer 2')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.expectQuestionAnsweredOnReviewPage(
-        questionAddress,
-        'Nonlegit Address',
-      )
-
-      await applicantQuestions.clickSubmit()
-      await logout(page)
-    })
-  })
+  }
 
   // TODO: Add tests for "next" navigation
 })


### PR DESCRIPTION
These tests fail if not using the mock web services since data is different from live endpoints. Don't run them on staging environments.

All this does is wrap the tests in an `if (isLocalDevEnvironment())`. The diff looks busy, but the test itself remains unchanged.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
