### PR TITLE
Make apple icon be at webroot

### DIFF
--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -222,8 +222,8 @@ public final class HtmlBundle {
         .condWith(
             faviconURL.isPresent(),
             link().withRel("icon").withHref(faviconURL.orElse("")),
-            link().withRel("apple-touch-icon").withHref("apple-touch-icon.png"),
-            link().withRel("apple-touch-icon-precomposed.png").withHref("apple-touch-icon.png"))
+            link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
+            link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
         .with(metadata)
         .with(stylesheets)
         .with(headScripts);


### PR DESCRIPTION
### Description

I missed making this only point at the webroot when I added it originally so it was failing to load on any deep routes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
