### PR TITLE
Only add debug modal on dev or staging

### DIFF
--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -107,7 +107,9 @@ public class ApplicantLayout extends BaseHtmlLayout {
 
     bundle.addFooterStyles("mt-24");
 
-    bundle.addModals(DEBUG_CONTENT_MODAL);
+    if (isDevOrStaging && !disableDemoModeLogins) {
+      bundle.addModals(DEBUG_CONTENT_MODAL);
+    }
 
     Content rendered = super.render(bundle);
     if (!rendered.body().contains("<h1")) {


### PR DESCRIPTION
The debug modal was always getting added to the page, even on prod when it is impossible to trigger it. This removes the modal from the page when it isn't triggerable.