### PR TITLE
Disable flaky program images test in staging

### DIFF
--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -3,6 +3,7 @@ import {
   createTestContext,
   disableFeatureFlag,
   enableFeatureFlag,
+  isLocalDevEnvironment,
   loginAsAdmin,
   validateScreenshot,
 } from './support'
@@ -317,32 +318,36 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-with-new-draft-image')
   })
 
-  it('program list with different active and draft image', async () => {
-    const {page, adminPrograms, adminProgramImage} = ctx
-    await loginAsAdmin(page)
-    await enableFeatureFlag(page, 'program_card_images')
+  // This test is flaky in staging prober tests, so only run it locally and on
+  // GitHub actions. See issue #6624 for more details.
+  if (isLocalDevEnvironment()) {
+    it('program list with different active and draft image', async () => {
+      const {page, adminPrograms, adminProgramImage} = ctx
+      await loginAsAdmin(page)
+      await enableFeatureFlag(page, 'program_card_images')
 
-    const programName = 'Different Images Program'
-    await adminPrograms.addProgram(programName)
-    await adminPrograms.goToProgramImagePage(programName)
-    await adminProgramImage.setImageFileAndSubmit(
-      'src/assets/program-summary-image-wide.png',
-    )
-    await adminPrograms.publishAllDrafts()
+      const programName = 'Different Images Program'
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.goToProgramImagePage(programName)
+      await adminProgramImage.setImageFileAndSubmit(
+        'src/assets/program-summary-image-wide.png',
+      )
+      await adminPrograms.publishAllDrafts()
 
-    // Set a new image on the new draft program
-    await adminPrograms.createNewVersion(programName)
-    await adminPrograms.goToProgramImagePage(programName)
-    await adminProgramImage.setImageFileAndSubmit(
-      'src/assets/program-summary-image-tall.png',
-    )
-    await adminPrograms.gotoAdminProgramsPage()
+      // Set a new image on the new draft program
+      await adminPrograms.createNewVersion(programName)
+      await adminPrograms.goToProgramImagePage(programName)
+      await adminProgramImage.setImageFileAndSubmit(
+        'src/assets/program-summary-image-tall.png',
+      )
+      await adminPrograms.gotoAdminProgramsPage()
 
-    await validateScreenshot(
-      page,
-      'program-list-with-different-active-and-draft-images',
-    )
-  })
+      await validateScreenshot(
+        page,
+        'program-list-with-different-active-and-draft-images',
+      )
+    })
+  }
 
   it('program list with same active and draft image', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx


### PR DESCRIPTION
### Description

Disable the `program list with different active and draft image` test on staging because it's only flaky on staging.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Run `admin_program_list` test locally and verify the `program list with different active and draft image` test still runs.

### Issue(s) this completes

Related to #6624 
