### PR TITLE
Add EditOrDiscardAnswersModalCreatorTest

### DIFF
--- a/server/test/views/applicant/EditOrDiscardAnswersModalCreatorTest.java
+++ b/server/test/views/applicant/EditOrDiscardAnswersModalCreatorTest.java
@@ -1,0 +1,82 @@
+package views.applicant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.fakeRequest;
+import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS;
+import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_PREVIOUS;
+import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW;
+import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS;
+
+import auth.ProfileFactory;
+import controllers.WithMockedProfiles;
+import controllers.applicant.ApplicantRoutes;
+import java.util.Set;
+import org.junit.Test;
+import play.i18n.Lang;
+import play.i18n.MessagesApi;
+import services.applicant.ApplicantPersonalInfo;
+import services.applicant.Block;
+import services.cloud.ApplicantStorageClient;
+import views.ApplicationBaseView;
+import views.questiontypes.ApplicantQuestionRendererParams;
+
+public class EditOrDiscardAnswersModalCreatorTest extends WithMockedProfiles {
+  private final EditOrDiscardAnswersModalCreator modalCreator =
+      new EditOrDiscardAnswersModalCreator();
+
+  @Test
+  public void createModal_modeDisplayErrors_throws() {
+    ApplicationBaseView.Params params = makeParamsWithMode(DISPLAY_ERRORS);
+    assertThatThrownBy(() -> modalCreator.createModal(params))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void createModal_modeHideErrors_throws() {
+    ApplicationBaseView.Params params = makeParamsWithMode(HIDE_ERRORS);
+    assertThatThrownBy(() -> modalCreator.createModal(params))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void createModal_modeDisplayErrorsWithModalReview_ok() {
+    ApplicationBaseView.Params params = makeParamsWithMode(DISPLAY_ERRORS_WITH_MODAL_REVIEW);
+    modalCreator.createModal(params);
+    // No assert, just need no crash
+  }
+
+  @Test
+  public void createModal_modeDisplayErrorsWithModalPrevious_ok() {
+    ApplicationBaseView.Params params = makeParamsWithMode(DISPLAY_ERRORS_WITH_MODAL_PREVIOUS);
+    modalCreator.createModal(params);
+    // No assert, just need no crash
+  }
+
+  private ApplicationBaseView.Params makeParamsWithMode(
+      ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode) {
+    return ApplicationBaseView.Params.builder()
+        .setErrorDisplayMode(errorDisplayMode)
+        .setRequest(fakeRequest().build())
+        .setMessages(
+            fakeApplication()
+                .injector()
+                .instanceOf(MessagesApi.class)
+                .preferred(Set.of(Lang.defaultLang())))
+        .setApplicantId(1L)
+        .setProgramTitle("Title")
+        .setProgramId(1L)
+        .setBlock(mock(Block.class))
+        .setInReview(false)
+        .setBlockIndex(0)
+        .setTotalBlockCount(1)
+        .setApplicantPersonalInfo(mock(ApplicantPersonalInfo.class))
+        .setPreferredLanguageSupported(true)
+        .setApplicantStorageClient(mock(ApplicantStorageClient.class))
+        .setBaseUrl("baseUrl.com")
+        .setApplicantRoutes(new ApplicantRoutes())
+        .setProfile(instanceOf(ProfileFactory.class).wrap(createApplicant()))
+        .build();
+  }
+}


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
