### PR TITLE
Update Modal.java Javadoc to say it's deprecated

### DIFF
--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -20,7 +20,9 @@ import views.style.StyleUtils;
 /**
  * Utility class for rendering a modal box.
  *
- * @deprecated Use {@link views.ViewUtils#makeUSWDSModal} instead.
+ * @deprecated Use {@link views.ViewUtils#makeUSWDSModal} instead. We're migrating existing modals
+ *     to use the USWDS modal component, so new modals should use the USWDS modal from the
+ *     beginning. See https://github.com/civiform/civiform/issues/6264.
  */
 @AutoValue
 @Deprecated

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -20,12 +20,11 @@ import views.style.StyleUtils;
 /**
  * Utility class for rendering a modal box.
  *
- * @deprecated Use {@link views.ViewUtils#makeUSWDSModal} instead. We're migrating existing modals
- *     to use the USWDS modal component, so new modals should use the USWDS modal from the
- *     beginning. See https://github.com/civiform/civiform/issues/6264.
+ * <p>Note that this is deprecated in favor of the USWDS modal component. Prefer using {@link
+ * views.ViewUtils#makeUSWDSModal} instead of this class. See
+ * https://github.com/civiform/civiform/issues/6264.
  */
 @AutoValue
-@Deprecated
 public abstract class Modal {
 
   public abstract String modalId();

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -17,8 +17,13 @@ import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
-/** Utility class for rendering a modal box. */
+/**
+ * Utility class for rendering a modal box.
+ *
+ * @deprecated Use {@link views.ViewUtils#makeUSWDSModal} instead.
+ */
 @AutoValue
+@Deprecated
 public abstract class Modal {
 
   public abstract String modalId();

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -18,6 +18,8 @@ import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
 /**
+ * DEPRECATED
+ * 
  * Utility class for rendering a modal box.
  *
  * <p>Note that this is deprecated in favor of the USWDS modal component. Prefer using {@link

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -19,8 +19,8 @@ import views.style.StyleUtils;
 
 /**
  * DEPRECATED
- * 
- * Utility class for rendering a modal box.
+ *
+ * <p>Utility class for rendering a modal box.
  *
  * <p>Note that this is deprecated in favor of the USWDS modal component. Prefer using {@link
  * views.ViewUtils#makeUSWDSModal} instead of this class. See


### PR DESCRIPTION
### Description

This PR updates the Javadoc of `Modal.java` to say it's deprecated and encourages people to use `ViewUtils#makeUSWDSModal` instead.


## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/6264
