### PR TITLE
Preserve option admin name casing in CSV export and update column header format

### DIFF
--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -97,7 +97,7 @@ test.describe('csv export for multioption question', () => {
     await adminPrograms.viewApplications(programName)
     const csvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(csvContent).toContain(
-      'Applicant ID,Application ID,Applicant Language,Submit Time,Submitter Type,TI Email,TI Organization,Status,name (first_name),name (middle_name),name (last_name),csvcolor (red_admin),csvcolor (green_admin),csvcolor (orange_admin),csvcolor (blue_admin),csvcolor (black_admin),csvcolor (white_admin)',
+      'Applicant ID,Application ID,Applicant Language,Submit Time,Submitter Type,TI Email,TI Organization,Status,name (first_name),name (middle_name),name (last_name),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcolor (selections - black_admin),csvcolor (selections - white_admin)',
     )
     // colors headers are - red,green,orange,blue,black,white
     expect(csvContent).toContain(
@@ -327,14 +327,14 @@ test.describe('normal application flow', () => {
     // so test for both situations.
     if (demographicsCsvContent.includes('Status')) {
       expect(demographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,name (first_name),name (middle_name),name (last_name),csvcolor (red_admin),csvcolor (green_admin),csvcolor (orange_admin),csvcolor (blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,name (first_name),name (middle_name),name (last_name),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
       )
       expect(demographicsCsvContent).toContain(
         'sarah,,smith,NOT_SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED,1000.00,05/10/2021,op2_admin,',
       )
     } else {
       expect(demographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,name (first_name),name (middle_name),name (last_name),csvcolor (red_admin),csvcolor (green_admin),csvcolor (orange_admin),csvcolor (blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,name (first_name),name (middle_name),name (last_name),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
       )
       expect(demographicsCsvContent).toContain(
         'sarah,,smith,1000.00,05/10/2021,op2_admin',
@@ -350,7 +350,7 @@ test.describe('normal application flow', () => {
 
     if (demographicsCsvContent.includes('Status')) {
       expect(newDemographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,csvcolor (red_admin),csvcolor (green_admin),csvcolor (orange_admin),csvcolor (blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),name (first_name),name (middle_name),name (last_name)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),name (first_name),name (middle_name),name (last_name)',
       )
     } else {
       expect(newDemographicsCsvContent).toContain(

--- a/server/app/services/applicant/question/FileUploadQuestion.java
+++ b/server/app/services/applicant/question/FileUploadQuestion.java
@@ -37,14 +37,11 @@ public final class FileUploadQuestion extends Question {
 
   @Override
   public ImmutableList<Path> getAllPaths() {
-    return ImmutableList.of();
+    return ImmutableList.of(getFileKeyPath());
   }
 
   @Override
   public boolean isAnswered() {
-    // TODO(#1944): Consider adding getFileKeyPath to getAllPaths.
-    // Adding it currently would cause the value to start being exported
-    // by the demographics exporter.
     return applicantQuestion.getApplicantData().hasPath(getFileKeyPath());
   }
 

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import java.io.ByteArrayOutputStream;
@@ -21,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import models.ApplicationModel;
 import models.QuestionTag;
@@ -36,7 +36,7 @@ import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
 import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.question.ApplicantQuestion;
-import services.applicant.question.Question;
+import services.applicant.question.MultiSelectQuestion;
 import services.program.Column;
 import services.program.ColumnType;
 import services.program.CsvExportConfig;
@@ -45,7 +45,6 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
 import services.question.QuestionService;
-import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 import services.question.types.ScalarType;
 
@@ -93,9 +92,11 @@ public final class CsvExporterService {
     ImmutableList<ProgramDefinition> allProgramVersions =
         programService.getAllVersionsFullProgramDefinition(programId).stream()
             .collect(ImmutableList.toImmutableList());
+
     ProgramDefinition currentProgram = programService.getFullProgramDefinition(programId);
     CsvExportConfig exportConfig =
-        generateDefaultCsvExportConfig(allProgramVersions, currentProgram.hasEligibilityEnabled());
+        generateAllProgramVersionsCsvExportConfig(
+            allProgramVersions, currentProgram.hasEligibilityEnabled());
 
     ImmutableList<ApplicationModel> applications =
         programService
@@ -108,7 +109,7 @@ public final class CsvExporterService {
     return exportCsv(exportConfig, applications, Optional.of(currentProgram));
   }
 
-  private CsvExportConfig generateDefaultCsvExportConfig(
+  private CsvExportConfig generateAllProgramVersionsCsvExportConfig(
       ImmutableList<ProgramDefinition> programDefinitions, boolean showEligibilityColumn)
       throws ProgramNotFoundException {
     Map<Path, AnswerData> answerMap = new HashMap<>();
@@ -146,7 +147,8 @@ public final class CsvExporterService {
         programService.getSubmittedProgramApplications(programId);
     ProgramDefinition programDefinition = programService.getFullProgramDefinition(programId);
     return exportCsv(
-        generateDefaultCsvConfig(programId, programDefinition.hasEligibilityEnabled()),
+        generateSingleProgramVersionCsvExportConfig(
+            programId, programDefinition.hasEligibilityEnabled()),
         applications,
         Optional.of(programDefinition));
   }
@@ -162,8 +164,7 @@ public final class CsvExporterService {
               exportConfig.columns(),
               config.getString("play.http.secret.key"),
               writer,
-              dateConverter,
-              exportConfig.checkboxQuestionNameToOptionsMap())) {
+              dateConverter)) {
         // Cache Program data which doesn't change, so we only look it up once rather than on every
         // exported row.
         // TODO(#1750): Lookup all relevant programs in one request to reduce cost of N lookups.
@@ -202,12 +203,13 @@ public final class CsvExporterService {
   }
 
   /**
-   * Produce the default CSV config for a given program. The default config includes the application
-   * id, the application submission time, and all possible scalar values from all of its
-   * applications. This means if one application had a question repeated for N repeated entities,
-   * then there would be N columns for each of that question's scalars.
+   * Produce the CSV config for a given program. The config includes the application id, the
+   * application submission time, and all possible scalar values from all of its applications. This
+   * means if one application had a question repeated for N repeated entities, then there would be N
+   * columns for each of that question's scalars.
    */
-  private CsvExportConfig generateDefaultCsvConfig(long programId, boolean showEligibilityColumn) {
+  private CsvExportConfig generateSingleProgramVersionCsvExportConfig(
+      long programId, boolean showEligibilityColumn) {
     ImmutableList<ApplicationModel> applications;
 
     try {
@@ -216,10 +218,11 @@ public final class CsvExporterService {
       throw new RuntimeException("Cannot find a program we are trying to generate CSVs for.", e);
     }
 
-    // Create a map from a key <block id, question index> to an answer with every application. It
-    // doesn't matter which answer ends up in the map, as long as every <block id, question index>
-    // is accounted for.
-    Map<String, AnswerData> answerMap = new HashMap<>();
+    // Create a map, keyed by <block id, question index>, holding an AnswerData for every <block id,
+    // question index> in all the applications
+    // for this program. The content of the answer doesn't matter, only that we have one
+    // representing every  <block id, question index>.
+    Map<String, AnswerData> representativeAnswerMap = new HashMap<>();
     for (ApplicationModel application : applications) {
       ReadOnlyApplicantProgramService roApplicantService =
           applicantService
@@ -228,28 +231,30 @@ public final class CsvExporterService {
               .join();
       roApplicantService
           .getSummaryDataOnlyActive()
-          .forEach(data -> answerMap.putIfAbsent(answerDataKey(data), data));
+          .forEach(
+              data -> representativeAnswerMap.putIfAbsent(representativeAnswersKey(data), data));
     }
 
-    // Get the list of all answers, sorted by block ID and question index, and generate the default
+    // Get the list of all representative answers, sorted by block ID and question index, and
+    // generate the
     // csv config.
-    ImmutableList<AnswerData> answers =
-        answerMap.values().stream()
+    ImmutableList<AnswerData> representativeAnswers =
+        representativeAnswerMap.values().stream()
             .sorted(
                 Comparator.comparing(AnswerData::blockId).thenComparing(AnswerData::questionIndex))
             .collect(ImmutableList.toImmutableList());
-    return buildColumnHeaders(answers, showEligibilityColumn);
+    return buildColumnHeaders(representativeAnswers, showEligibilityColumn);
   }
 
   /**
-   * Produce the default {@link CsvExportConfig} for a list of {@link AnswerData}s. The default
-   * config includes all the questions, the application id, and the application submission time.
+   * Produce the default {@link CsvExportConfig} for a list of {@link AnswerData}s. The config
+   * includes all the questions, the application id, and the application submission time.
    */
   private CsvExportConfig buildColumnHeaders(
-      ImmutableList<AnswerData> answerDataList, boolean showEligibilityColumn) {
+      ImmutableList<AnswerData> representativeAnswers, boolean showEligibilityColumn) {
     ImmutableList.Builder<Column> columnsBuilder = new ImmutableList.Builder<>();
 
-    // Default columns
+    // Metadata columns
     columnsBuilder.add(
         Column.builder().setHeader("Applicant ID").setColumnType(ColumnType.APPLICANT_ID).build());
     columnsBuilder.add(
@@ -286,59 +291,51 @@ public final class CsvExporterService {
     columnsBuilder.add(
         Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
 
-    Map<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap = new HashMap<>();
     // Add columns for each path to an answer.
-    for (AnswerData answerData : answerDataList) {
-      if (answerData.questionDefinition().isEnumerator()) {
-        continue; // Do not include Enumerator answers in CSVs.
-      }
-      // If the question type is checkbox, we need to find the unique options names
-      // to create the CSV headers,
-      // so we use exportServiceRepository to get the unique headers
-      if (answerData.questionDefinition().getQuestionType().equals(QuestionType.CHECKBOX)) {
-        QuestionDefinition questionDefinition = answerData.questionDefinition();
-        if (!checkboxQuestionNameToOptionsMap.containsKey(questionDefinition.getName())) {
-          checkboxQuestionNameToOptionsMap.put(
-              questionDefinition.getName(),
-              exportServiceRepository.getAllHistoricMultiOptionAdminNames(questionDefinition));
-        }
-        List<String> optionHeaders =
-            checkboxQuestionNameToOptionsMap.get(questionDefinition.getName());
-        optionHeaders.stream()
-            .forEachOrdered(
-                option -> {
-                  Path path = answerData.contextualizedPath().join(String.valueOf(option));
+    representativeAnswers.stream()
+        .filter(
+            answerData ->
+                !NON_EXPORTED_QUESTION_TYPES.contains(
+                    answerData.questionDefinition().getQuestionType()))
+        .flatMap(
+            answerData ->
+                answerData.questionDefinition().getQuestionType().equals(QuestionType.CHECKBOX)
+                    ? buildColumnsForEveryOption(answerData)
+                    : buildColumnsForEveryScalar(answerData))
+        .forEachOrdered(columnsBuilder::add);
 
-                  columnsBuilder.add(
-                      Column.builder()
-                          .setHeader(pathToHeader(path))
-                          .setJsonPath(path)
-                          .setColumnType(ColumnType.APPLICANT_ANSWER)
-                          .build());
-                });
-      } else {
-        for (Path path : answerData.scalarAnswersInDefaultLocale().keySet()) {
-          columnsBuilder.add(
-              Column.builder()
-                  .setHeader(pathToHeader(path))
-                  .setJsonPath(path)
-                  .setColumnType(ColumnType.APPLICANT_ANSWER)
-                  .build());
-        }
-      }
-    }
+    return CsvExportConfig.builder().setColumns(columnsBuilder.build()).build();
+  }
 
-    // We cache the checkboxQuestionNameToOptionsMap in csvExportConfig to help us fill the column
-    // values
-    ImmutableMap<String, ImmutableList<String>> immutableCheckboxQuestionNameToOptionsMap =
-        ImmutableMap.<String, ImmutableList<String>>builder()
-            .putAll(checkboxQuestionNameToOptionsMap)
-            .build();
-    return getCsvExportConfig(columnsBuilder, immutableCheckboxQuestionNameToOptionsMap);
+  private Stream<Column> buildColumnsForEveryOption(AnswerData answerData) {
+    // Columns are looked up by the scalar path, so we use the scalar path here
+    Path path = ((MultiSelectQuestion) answerData.createQuestion()).getSelectionPath();
+    return exportServiceRepository
+        .getAllHistoricMultiOptionAdminNames(answerData.questionDefinition())
+        .stream()
+        .map(
+            option ->
+                Column.builder()
+                    .setHeader(formatHeader(path, Optional.of(option)))
+                    .setJsonPath(path)
+                    .setOptionAdminName(option)
+                    .setColumnType(ColumnType.APPLICANT_ANSWER)
+                    .build());
+  }
+
+  private Stream<Column> buildColumnsForEveryScalar(AnswerData answerData) {
+    return answerData.scalarAnswersInDefaultLocale().keySet().stream()
+        .map(
+            path ->
+                Column.builder()
+                    .setHeader(formatHeader(path, Optional.empty()))
+                    .setJsonPath(path)
+                    .setColumnType(ColumnType.APPLICANT_ANSWER)
+                    .build());
   }
 
   /**
-   * Convert {@link Path} to a human readable header string.
+   * Convert {@link Path} to a human-readable header string.
    *
    * <p>The {@link ApplicantData#APPLICANT_PATH} is ignored, enumerator references are separated by
    * {@link #HEADER_SPACER_ENUM} and the scalar is separated by {@link #HEADER_SPACER_SCALAR}.
@@ -348,11 +345,26 @@ public final class CsvExporterService {
    *
    * <p>The currency_cents scalar is special cased to be named currency as the data will be dollars.
    *
-   * @param path is a path that ends in a {@link services.applicant.question.Scalar}.
+   * @param path is a path that ends in a {@link services.applicant.question.Scalar}
+   * @param optionAdminName the admin name of the multi-option question option, if it's a
+   *     multi-option question
    */
   @VisibleForTesting
-  static String pathToHeader(Path path) {
-    String scalarComponent = String.format("(%s)", path.keyName());
+  static String formatHeader(Path path, String optionAdminName) {
+    return formatHeader(path, Optional.of(optionAdminName));
+  }
+
+  @VisibleForTesting
+  static String formatHeader(Path path) {
+    return formatHeader(path, Optional.empty());
+  }
+
+  private static String formatHeader(Path path, Optional<String> optionAdminName) {
+    Path finalPath = path;
+    String scalarComponent =
+        optionAdminName
+            .map(o -> String.format("(%s - %s)", finalPath.keyName(), o))
+            .orElse(String.format("(%s)", finalPath.keyName()));
     // Remove "cents" from the currency string as the value will be dollars.
     if (path.keyName().equals(CURRENCY_CENTS_TYPE_STRING)) {
       scalarComponent = "(currency)";
@@ -385,12 +397,13 @@ public final class CsvExporterService {
    * A useful string that uniquely identifies an answer within an applicant program and is shared
    * across applicant programs.
    */
-  private static String answerDataKey(AnswerData answerData) {
+  private static String representativeAnswersKey(AnswerData answerData) {
     return String.format("%s-%d", answerData.blockId(), answerData.questionIndex());
   }
 
   /**
    * A string containing the CSV which maps applicants (opaquely) to the programs they applied to.
+   * TODO(#6746): Include repeated questions in the demographic export
    */
   public String getDemographicsCsv(TimeFilter filter) {
     return exportCsv(
@@ -401,6 +414,7 @@ public final class CsvExporterService {
 
   private CsvExportConfig getDemographicsExporterConfig() {
     ImmutableList.Builder<Column> columnsBuilder = new ImmutableList.Builder<>();
+
     // First add the ID, submit time, and submitter email columns.
     columnsBuilder.add(
         Column.builder().setHeader("Opaque ID").setColumnType(ColumnType.OPAQUE_ID).build());
@@ -427,83 +441,54 @@ public final class CsvExporterService {
         Column.builder().setHeader("Submit Time").setColumnType(ColumnType.SUBMIT_TIME).build());
     columnsBuilder.add(
         Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
-    Map<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap = new HashMap<>();
+
+    // We need this outer for-loop because the export type question tag isn't available on the
+    // question definition.
     for (QuestionTag tagType :
         ImmutableList.of(QuestionTag.DEMOGRAPHIC, QuestionTag.DEMOGRAPHIC_PII)) {
-      for (QuestionDefinition questionDefinition :
-          this.questionService.getQuestionsForTag(tagType)) {
-        if (NON_EXPORTED_QUESTION_TYPES.contains(questionDefinition.getQuestionType())) {
-          continue; // Do not include Enumerator answers in CSVs.
-        }
-        // Use a program question definition that doesn't have a program associated with it,
-        // which is okay because this should be program agnostic.
-        ProgramQuestionDefinition pqd =
-            ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
-        Question applicantQuestion =
-            new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()).getQuestion();
-        if (questionDefinition.getQuestionType().equals(QuestionType.CHECKBOX)) {
-          String questionName = questionDefinition.getName();
-          if (!checkboxQuestionNameToOptionsMap.containsKey(questionName)) {
-            checkboxQuestionNameToOptionsMap.put(
-                questionName,
-                exportServiceRepository.getAllHistoricMultiOptionAdminNames(questionDefinition));
-          }
-          List<String> optionHeaders = checkboxQuestionNameToOptionsMap.get(questionName);
-          optionHeaders.stream()
-              .forEachOrdered(
-                  option -> {
-                    Path path =
-                        applicantQuestion
-                            .getApplicantQuestion()
-                            .getContextualizedPath()
-                            .join(String.valueOf(option));
+      this.questionService.getQuestionsForTag(tagType).stream()
+          // Do not include Enumerator answers in CSVs.
+          .filter(qd -> !NON_EXPORTED_QUESTION_TYPES.contains(qd.getQuestionType()))
+          // Use a program question definition that doesn't have a program associated with it,
+          // which is okay because this should be program agnostic.
+          .map(qd -> ProgramQuestionDefinition.create(qd, Optional.empty()))
+          .map(pqd -> new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()))
+          .flatMap(
+              aq -> {
+                if (aq.getType().equals(QuestionType.CHECKBOX)) {
+                  // Columns are looked up by the scalar path, so we use the scalar path here
+                  Path path = aq.createMultiSelectQuestion().getSelectionPath();
+                  return exportServiceRepository
+                      .getAllHistoricMultiOptionAdminNames(aq.getQuestionDefinition())
+                      .stream()
+                      .map(
+                          option ->
+                              Column.builder()
+                                  .setHeader(formatHeader(path, option))
+                                  .setJsonPath(path)
+                                  .setOptionAdminName(option)
+                                  .setColumnType(
+                                      tagType == QuestionTag.DEMOGRAPHIC_PII
+                                          ? ColumnType.APPLICANT_OPAQUE
+                                          : ColumnType.APPLICANT_ANSWER)
+                                  .build());
+                }
 
-                    columnsBuilder.add(
-                        Column.builder()
-                            .setHeader(pathToHeader(path))
-                            .setJsonPath(path)
-                            .setColumnType(
-                                tagType == QuestionTag.DEMOGRAPHIC_PII
-                                    ? ColumnType.APPLICANT_OPAQUE
-                                    : ColumnType.APPLICANT_ANSWER)
-                            .build());
-                  });
-        } else {
-
-          for (Path path : applicantQuestion.getAllPaths()) {
-            columnsBuilder.add(
-                Column.builder()
-                    .setHeader(pathToHeader(path))
-                    .setJsonPath(path)
-                    .setColumnType(
-                        tagType == QuestionTag.DEMOGRAPHIC_PII
-                            ? ColumnType.APPLICANT_OPAQUE
-                            : ColumnType.APPLICANT_ANSWER)
-                    .build());
-          }
-        }
-      }
+                return aq.getQuestion().getAllPaths().stream()
+                    .map(
+                        path ->
+                            Column.builder()
+                                .setHeader(formatHeader(path))
+                                .setJsonPath(path)
+                                .setColumnType(
+                                    tagType == QuestionTag.DEMOGRAPHIC_PII
+                                        ? ColumnType.APPLICANT_OPAQUE
+                                        : ColumnType.APPLICANT_ANSWER)
+                                .build());
+              })
+          .forEachOrdered(columnsBuilder::add);
     }
-    ImmutableMap<String, ImmutableList<String>> immutableCheckboxQuestionNameToOptionsMap =
-        ImmutableMap.<String, ImmutableList<String>>builder()
-            .putAll(checkboxQuestionNameToOptionsMap)
-            .build();
-    return getCsvExportConfig(columnsBuilder, immutableCheckboxQuestionNameToOptionsMap);
-  }
 
-  private CsvExportConfig getCsvExportConfig(
-      ImmutableList.Builder<Column> columnsBuilder,
-      ImmutableMap<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap) {
-    return new CsvExportConfig() {
-      @Override
-      public ImmutableList<Column> columns() {
-        return columnsBuilder.build();
-      }
-
-      @Override
-      public ImmutableMap<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap() {
-        return checkboxQuestionNameToOptionsMap;
-      }
-    };
+    return CsvExportConfig.builder().setColumns(columnsBuilder.build()).build();
   }
 }

--- a/server/app/services/program/Column.java
+++ b/server/app/services/program/Column.java
@@ -16,6 +16,11 @@ public abstract class Column {
   @JsonProperty("jsonPath")
   public abstract Optional<Path> jsonPath();
 
+  // Represent the admin name for an option in a multi-select multi-option question (e.g. Checkbox
+  // Questions)
+  @JsonProperty("optionAdminName")
+  public abstract Optional<String> optionAdminName();
+
   @JsonProperty("columnType")
   public abstract ColumnType columnType();
 
@@ -30,6 +35,9 @@ public abstract class Column {
 
     @JsonProperty("jsonPath")
     public abstract Builder setJsonPath(Path jsonPath);
+
+    @JsonProperty("optionAdminName")
+    public abstract Builder setOptionAdminName(String optionAdminName);
 
     @JsonProperty("columnType")
     public abstract Builder setColumnType(ColumnType columnType);

--- a/server/app/services/program/CsvExportConfig.java
+++ b/server/app/services/program/CsvExportConfig.java
@@ -2,14 +2,11 @@ package services.program;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 /** Contains all information needed to export a CSV file for a program. */
 @AutoValue
 public abstract class CsvExportConfig {
   public abstract ImmutableList<Column> columns();
-
-  public abstract ImmutableMap<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap();
 
   public static CsvExportConfig.Builder builder() {
     return new AutoValue_CsvExportConfig.Builder();
@@ -19,16 +16,6 @@ public abstract class CsvExportConfig {
   public abstract static class Builder {
     public abstract CsvExportConfig.Builder setColumns(ImmutableList<Column> columns);
 
-    public abstract CsvExportConfig.Builder setCheckboxQuestionNameToOptionsMap(
-        ImmutableMap<String, ImmutableList<String>> checkboxQuestionNameToOptionsMap);
-
-    public abstract ImmutableList.Builder<Column> columnsBuilder();
-
     public abstract CsvExportConfig build();
-
-    public CsvExportConfig.Builder addColumn(Column column) {
-      columnsBuilder().add(column);
-      return this;
-    }
   }
 }

--- a/server/test/services/export/CsvExporterTest.java
+++ b/server/test/services/export/CsvExporterTest.java
@@ -21,7 +21,6 @@ import repository.TimeFilter;
 import repository.VersionRepository;
 import services.DateConverter;
 import services.LocalizedStrings;
-import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
 import services.applicant.question.ApplicantQuestion;
@@ -105,14 +104,16 @@ public class CsvExporterTest extends AbstractExporterTest {
             "TI Email",
             "TI Organization",
             "Status",
-            "kitchen tools (toaster)",
-            "kitchen tools (pepper_grinder)",
-            "kitchen tools (garlic_press)",
-            "kitchen tools (stand_mixer)");
-    assertThat(records.get(0).get("kitchen tools (toaster)")).contains("NOT_SELECTED");
-    assertThat(records.get(0).get("kitchen tools (pepper_grinder)")).contains("SELECTED");
-    assertThat(records.get(0).get("kitchen tools (garlic_press)")).contains("SELECTED");
-    assertThat(records.get(0).get("kitchen tools (stand_mixer)"))
+            "kitchen tools (selections - toaster)",
+            "kitchen tools (selections - pepper_grinder)",
+            "kitchen tools (selections - garlic_press)",
+            "kitchen tools (selections - stand_mixer)");
+    assertThat(records.get(0).get("kitchen tools (selections - toaster)")).contains("NOT_SELECTED");
+    assertThat(records.get(0).get("kitchen tools (selections - pepper_grinder)"))
+        .contains("SELECTED");
+    assertThat(records.get(0).get("kitchen tools (selections - garlic_press)"))
+        .contains("SELECTED");
+    assertThat(records.get(0).get("kitchen tools (selections - stand_mixer)"))
         .contains("NOT_AN_OPTION_AT_PROGRAM_VERSION");
   }
 
@@ -144,9 +145,9 @@ public class CsvExporterTest extends AbstractExporterTest {
             "applicant name (last_name)",
             "applicant phone (phone_number)",
             "applicant phone (country_code)",
-            "kitchen tools (toaster)",
-            "kitchen tools (pepper_grinder)",
-            "kitchen tools (garlic_press)",
+            "kitchen tools (selections - toaster)",
+            "kitchen tools (selections - pepper_grinder)",
+            "kitchen tools (selections - garlic_press)",
             "number of items applicant can juggle (number)",
             "applicant address (street)",
             "applicant address (line2)",
@@ -169,15 +170,15 @@ public class CsvExporterTest extends AbstractExporterTest {
         getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
             .createNameQuestion();
     String firstNameHeader =
-        CsvExporterService.pathToHeader(nameApplicantQuestion.getFirstNamePath());
+        CsvExporterService.formatHeader(nameApplicantQuestion.getFirstNamePath());
     String lastNameHeader =
-        CsvExporterService.pathToHeader(nameApplicantQuestion.getLastNamePath());
+        CsvExporterService.formatHeader(nameApplicantQuestion.getLastNamePath());
     QuestionModel phoneQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.PHONE);
     PhoneQuestion phoneQuestion1 =
         getApplicantQuestion(phoneQuestion.getQuestionDefinition()).createPhoneQuestion();
-    String phoneHeader = CsvExporterService.pathToHeader(phoneQuestion1.getPhoneNumberPath());
-    String countryCodeHeader = CsvExporterService.pathToHeader(phoneQuestion1.getCountryCodePath());
+    String phoneHeader = CsvExporterService.formatHeader(phoneQuestion1.getPhoneNumberPath());
+    String countryCodeHeader = CsvExporterService.formatHeader(phoneQuestion1.getCountryCodePath());
     assertThat(records.get(1).get(phoneHeader)).contains("6157571010");
     assertThat(records.get(1).get(countryCodeHeader)).contains("US");
 
@@ -187,6 +188,7 @@ public class CsvExporterTest extends AbstractExporterTest {
     assertThat(records.get(0).get("Status")).isEqualTo("");
     assertThat(records.get(1).get("Status")).isEqualTo(STATUS_VALUE);
     assertThat(records.get(0).get("Submitter Type")).isEqualTo("APPLICANT");
+
     // Check list for multiselect in default locale
     QuestionModel checkboxQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.CHECKBOX);
@@ -194,29 +196,26 @@ public class CsvExporterTest extends AbstractExporterTest {
         getApplicantQuestion(checkboxQuestion.getQuestionDefinition()).createMultiSelectQuestion();
 
     String multiSelectHeader_1 =
-        CsvExporterService.pathToHeader(
-            Path.create(multiSelectApplicantQuestion.getQuestionDefinition().getName())
-                .join("toaster"));
+        CsvExporterService.formatHeader(multiSelectApplicantQuestion.getSelectionPath(), "toaster");
     assertThat(records.get(1).get(multiSelectHeader_1))
         .isEqualTo(MultiOptionSelectionExportType.SELECTED.toString());
     String multiSelectHeader_2 =
-        CsvExporterService.pathToHeader(
-            Path.create(multiSelectApplicantQuestion.getQuestionDefinition().getName())
-                .join("pepper_grinder"));
+        CsvExporterService.formatHeader(
+            multiSelectApplicantQuestion.getSelectionPath(), "pepper_grinder");
     assertThat(records.get(1).get(multiSelectHeader_2))
         .isEqualTo(MultiOptionSelectionExportType.SELECTED.toString());
     String multiSelectHeader_3 =
-        CsvExporterService.pathToHeader(
-            Path.create(multiSelectApplicantQuestion.getQuestionDefinition().getName())
-                .join("garlic_press"));
+        CsvExporterService.formatHeader(
+            multiSelectApplicantQuestion.getSelectionPath(), "garlic_press");
     assertThat(records.get(1).get(multiSelectHeader_3))
         .isEqualTo(MultiOptionSelectionExportType.NOT_SELECTED.toString());
+
     QuestionModel fileuploadQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.FILEUPLOAD);
     FileUploadQuestion fileuploadApplicantQuestion =
         getApplicantQuestion(fileuploadQuestion.getQuestionDefinition()).createFileUploadQuestion();
     String fileKeyHeader =
-        CsvExporterService.pathToHeader(fileuploadApplicantQuestion.getFileKeyPath());
+        CsvExporterService.formatHeader(fileuploadApplicantQuestion.getFileKeyPath());
     assertThat(records.get(1).get(fileKeyHeader))
         .contains(String.format("/admin/programs/%d/files/my-file-key", fakeProgram.id));
   }
@@ -252,7 +251,7 @@ public class CsvExporterTest extends AbstractExporterTest {
         getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
             .createNameQuestion();
     String firstNameHeader =
-        CsvExporterService.pathToHeader(nameApplicantQuestion.getFirstNamePath());
+        CsvExporterService.formatHeader(nameApplicantQuestion.getFirstNamePath());
     // Applications should appear most recent first.
     assertThat(records.get(0).get(firstNameHeader)).isEqualTo("John");
     assertThat(records.get(1).get(firstNameHeader)).isEqualTo("John");


### PR DESCRIPTION
### Description

Refactor CsvExporter to preserve option admin name casing during export.

Previously, all option admin names were lowercased during the CSV export, causing collisions and the data to appear differently then in the JSON export. Now, option admin name cases are preserved.

See the [Fix for case-insensitive option admin name collision](https://docs.google.com/document/d/15jyNeTn7NItfBM3n2SqvWebbY3WD7E5dD_hIkiuhU-k/edit) doc for more

Details:
- Updates CSV columns for checkbox options to use the heading format `question name (selections - option_admin_name)`
- The `Column` in the CsvExportConfig now optionally includes the option admin name, to support checkbox questions. Before, we were adding the column name to the end of the path, causing it to be lowercased because `Path`s are all lowercase.
- `CsvExporter.exportRecord()` now builds a map of `<Path, AnswerData>` instead of `<Path, String>` when exporting records. It now fetches the answer text out of the `AnswerData` when exporting the record, instead of beforehand when building the map.
- The full `AnswerData` and the column name are enough to fill the value for checkbox question columns, so we do need to need to bring `checkboxQuestionNameToOptionsMap` into `exportRecord()`

In `CsvExporterService`
- Rename `answerMap` to `representativeAnswerMap`, as well as other similar data structures, to emphasize that this is not a map of _all_ answers, but rather a single answer for each question so that we can get a complete list of the columns we'll need
- Refactor the large for-loops into streams where possible
- We remove `checkboxQuestionNameToOptionsMap` because we don't need to cache the result of the query. Each question is only visited once, rather than once per application as we had previously assumed.

Also
- Adds a label to the `getAllHistoricOptionAdminNames()` query in ExportServiceRepository
- `FileUploadQuestion.getAllPaths()` now returns the file key path
- Removes the unnecessary wrapper around `CsvExportConfig`

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [n/a] Assigned two reviewers
- n/a ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [n/a] Downs created to undo changes in Ups

#### User visible changes

- [n/a] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [n/a] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [n/a] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [n/a] Manually evaluated tab order

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [n/a] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

Try creating a question with colliding admin names and export it.

### Issue(s) this completes

Fixes #6605, #6573

cc @swatkat1 