### PR TITLE
TI Dashboard No Longer Uses Hard-coded Country Code

### DIFF
--- a/server/app/services/ti/TrustedIntermediaryService.java
+++ b/server/app/services/ti/TrustedIntermediaryService.java
@@ -20,7 +20,6 @@ import play.i18n.Messages;
 import repository.AccountRepository;
 import repository.SearchParameters;
 import services.DateConverter;
-import services.MessageKey;
 import services.PhoneValidationUtils;
 import services.applicant.exception.ApplicantNotFoundException;
 
@@ -46,7 +45,6 @@ public final class TrustedIntermediaryService {
   public static final String FORM_FIELD_NAME_PHONE = "phoneNumber";
   public static final String FORM_FIELD_NAME_MIDDLE_NAME = "middleName";
   public static final String FORM_FIELD_NAME_TI_NOTES = "tiNote";
-  public static final String COUNTRY_CODE_FOR_US_REGION = "US";
 
   @Inject
   public TrustedIntermediaryService(
@@ -143,15 +141,19 @@ public final class TrustedIntermediaryService {
   private Form<EditTiClientInfoForm> validatePhoneNumber(
       Form<EditTiClientInfoForm> form, Messages preferredLanguage) {
     String phoneNumber = form.value().get().getPhoneNumber();
+
     if (Strings.isNullOrEmpty(phoneNumber)) {
       return form;
     }
-    Optional<MessageKey> error =
-        PhoneValidationUtils.validatePhoneNumber(
-            Optional.of(phoneNumber), Optional.of(COUNTRY_CODE_FOR_US_REGION));
-    if (error.isPresent()) {
-      return form.withError(FORM_FIELD_NAME_PHONE, preferredLanguage.at(error.get().getKeyName()));
+
+    var phoneValidationResult = PhoneValidationUtils.determineCountryCode(Optional.of(phoneNumber));
+
+    if (!phoneValidationResult.isValid()) {
+      return form.withError(
+          FORM_FIELD_NAME_PHONE,
+          preferredLanguage.at(phoneValidationResult.getMessageKey().get().getKeyName()));
     }
+
     return form;
   }
 

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -47,6 +47,8 @@ import play.twirl.api.Content;
 import repository.ProgramRepository;
 import repository.SearchParameters;
 import services.DateConverter;
+import services.PhoneValidationResult;
+import services.PhoneValidationUtils;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantPersonalInfo;
 import services.ti.TrustedIntermediaryService;
@@ -327,8 +329,11 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
 
   private String formatPhone(String phone) {
     try {
+      PhoneValidationResult phoneValidationResults =
+          PhoneValidationUtils.determineCountryCode(Optional.ofNullable(phone));
+
       Phonenumber.PhoneNumber phoneNumber =
-          PHONE_NUMBER_UTIL.parse(phone, TrustedIntermediaryService.COUNTRY_CODE_FOR_US_REGION);
+          PHONE_NUMBER_UTIL.parse(phone, phoneValidationResults.getCountryCode().orElse(""));
       return PHONE_NUMBER_UTIL.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.NATIONAL);
     } catch (NumberParseException e) {
       return "-";


### PR DESCRIPTION
### Description

Removing the hard-coded US country code in the TI Dashboard and calling the new method which will determine the County Code and it's validity based on the supported Country Code options (US and CA at this time).

This is the next step in removing the country code dropdown from the Phone Question input control.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

