### PR TITLE
DOM text reinterpreted as HTML {Patch}

### DIFF
--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -257,7 +257,8 @@ function addIndexToLabelAndButton(field: Element, index: number) {
     document.querySelector('div[data-label-text]'),
   ).getAttribute('data-label-text')
   const labelElement = assertNotNull(field.querySelector('label'))
-  labelElement.innerHTML = labelBaseText ? labelBaseText + indexString : ''
+  labelElement.innerText = labelBaseText ? labelBaseText + indexString : '';
+
 
   const buttonBaseText = assertNotNull(
     document.querySelector('div[data-button-text]'),

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -257,8 +257,7 @@ function addIndexToLabelAndButton(field: Element, index: number) {
     document.querySelector('div[data-label-text]'),
   ).getAttribute('data-label-text')
   const labelElement = assertNotNull(field.querySelector('label'))
-  labelElement.innerText = labelBaseText ? labelBaseText + indexString : '';
-
+  labelElement.innerText = labelBaseText ? labelBaseText + indexString : ''
 
   const buttonBaseText = assertNotNull(
     document.querySelector('div[data-button-text]'),


### PR DESCRIPTION
patch for this issue: https://issuetracker.google.com/issues/324680545
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.
