### PR TITLE
Don't run auto request review on forks

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -10,6 +10,9 @@ jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
+    # Only run this for the main civiform owner. PRs from forks don't have the permissions
+    # needed to run this. See #6681 for notes on a possible better option.
+    if: github.repository_owner == 'civiform'
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.13.0


### PR DESCRIPTION
### Description

Don't run auto request review on forks. This fails due to permissions problems. See #6681 for info on a likely better solution.


- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
