### PR TITLE
Swapping to use innertext

### DIFF
--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -248,7 +248,7 @@ function repaintAllLabelsAndButtons() {
 /**
  * When enumerator entities are added or removed from the page we need to repaint
  * the label and button text to update the index
- * @param {Element} field The element comtaining the button and label to be relabled
+ * @param {Element} field The element containing the button and label to be relabeled
  * @param {number} index The index to add to the button and label
  */
 function addIndexToLabelAndButton(field: Element, index: number) {
@@ -263,5 +263,5 @@ function addIndexToLabelAndButton(field: Element, index: number) {
     document.querySelector('div[data-button-text]'),
   ).getAttribute('data-button-text')
   const buttonElement = assertNotNull(field.querySelector('button'))
-  buttonElement.innerHTML = buttonBaseText ? buttonBaseText + indexString : ''
+  buttonElement.innerText = buttonBaseText ? buttonBaseText + indexString : ''
 }


### PR DESCRIPTION
### Description

Set the button text via innerText instead of innerHTML.

Fixing incorrectly spelled words in comments.

This is related to #6677.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
