### PR TITLE
Fixing some tests to run individually

### DIFF
--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -10,6 +10,7 @@ import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.question.QuestionAnswerer;
@@ -17,7 +18,7 @@ import services.question.types.FileUploadQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 
 @RunWith(JUnitParamsRunner.class)
-public class FileUploadQuestionTest {
+public class FileUploadQuestionTest extends ResetPostgres {
   private static final FileUploadQuestionDefinition fileUploadQuestionDefinition =
       new FileUploadQuestionDefinition(
           QuestionDefinitionConfig.builder()

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.Before;
 import org.junit.Test;
+import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.MessageKey;
 import services.Path;
@@ -23,7 +24,7 @@ import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestion
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
 
-public class MultiSelectQuestionTest {
+public class MultiSelectQuestionTest extends ResetPostgres {
 
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -11,6 +11,7 @@ import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.program.ProgramQuestionDefinition;
@@ -19,7 +20,7 @@ import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 
 @RunWith(JUnitParamsRunner.class)
-public class NameQuestionTest {
+public class NameQuestionTest extends ResetPostgres {
   private static final NameQuestionDefinition nameQuestionDefinition =
       new NameQuestionDefinition(
           QuestionDefinitionConfig.builder()

--- a/server/test/services/applicant/question/PhoneQuestionTest.java
+++ b/server/test/services/applicant/question/PhoneQuestionTest.java
@@ -13,6 +13,7 @@ import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.MessageKey;
 import services.Path;
@@ -24,7 +25,7 @@ import services.question.types.PhoneQuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 
 @RunWith(JUnitParamsRunner.class)
-public class PhoneQuestionTest {
+public class PhoneQuestionTest extends ResetPostgres {
   private static final PhoneQuestionDefinition phoneQuestionDefinition =
       new PhoneQuestionDefinition(
           QuestionDefinitionConfig.builder()

--- a/server/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/server/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -9,6 +9,7 @@ import java.util.OptionalLong;
 import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
+import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.question.LocalizedQuestionOption;
@@ -18,7 +19,7 @@ import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.QuestionDefinitionConfig;
 
-public class SingleSelectQuestionTest {
+public class SingleSelectQuestionTest extends ResetPostgres {
 
   private static final QuestionDefinitionConfig CONFIG =
       QuestionDefinitionConfig.builder()


### PR DESCRIPTION
### Description

Adding `extends ResetPostgres` to these tests so they can successfully run on their own.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).


