### PR TITLE
[Refactor] Rename the program definition cache

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -52,7 +52,7 @@ public class DevDatabaseSeedController extends Controller {
       @NamedCache("version-questions") AsyncCacheApi questionsByVersionCache,
       @NamedCache("version-programs") AsyncCacheApi programsByVersionCache,
       @NamedCache("program") AsyncCacheApi programCache,
-      @NamedCache("program-definition") AsyncCacheApi programDefCache,
+      @NamedCache("full-program-definition") AsyncCacheApi programDefCache,
       @NamedCache("program-versions") AsyncCacheApi versionsByProgramCache) {
     this.devDatabaseSeedTask = checkNotNull(devDatabaseSeedTask);
     this.view = checkNotNull(view);

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -63,7 +63,7 @@ public final class ProgramRepository {
       Provider<VersionRepository> versionRepository,
       SettingsManifest settingsManifest,
       @NamedCache("program") SyncCacheApi programCache,
-      @NamedCache("program-definition") SyncCacheApi programDefCache,
+      @NamedCache("full-program-definition") SyncCacheApi programDefCache,
       @NamedCache("program-versions") SyncCacheApi versionsByProgramCache) {
     this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions", "program-definition"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions", "full-program-definition"]
 }
 
 ## Security rules for play-pac4j SecurityFilter

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -66,7 +66,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
     BindingKey<SyncCacheApi> programDefKey =
         new BindingKey<>(SyncCacheApi.class)
-            .qualifiedWith(new NamedCacheImpl("program-definition"));
+            .qualifiedWith(new NamedCacheImpl("full-program-definition"));
     programDefCache = instanceOf(programDefKey.asScala());
 
     repo =

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -72,7 +72,7 @@ public class ProgramServiceTest extends ResetPostgres {
   public void setProgramServiceImpl() {
     BindingKey<SyncCacheApi> programDefKey =
         new BindingKey<>(SyncCacheApi.class)
-            .qualifiedWith(new NamedCacheImpl("program-definition"));
+            .qualifiedWith(new NamedCacheImpl("full-program-definition"));
     programDefCache = instanceOf(programDefKey.asScala());
     ps = instanceOf(ProgramService.class);
   }


### PR DESCRIPTION
### Description

Rename the program definition cache to be clear that it is the full version of the program definition.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6711
