### PR TITLE
[Refactor] Rename getProgramDefinition to getShallowProgramDefinition for clarity

### DIFF
--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -147,7 +147,9 @@ public final class ProfileFactory {
                   .forEach(
                       program ->
                           account.addAdministeredProgram(
-                              programRepositoryProvider.get().getProgramDefinition(program)));
+                              programRepositoryProvider
+                                  .get()
+                                  .getShallowProgramDefinition(program)));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
               account.setAuthorityId(generateFakeAdminAuthorityId());
               account.save();
@@ -174,7 +176,9 @@ public final class ProfileFactory {
                   .forEach(
                       program ->
                           account.addAdministeredProgram(
-                              programRepositoryProvider.get().getProgramDefinition(program)));
+                              programRepositoryProvider
+                                  .get()
+                                  .getShallowProgramDefinition(program)));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
               account.save();
             })

--- a/server/app/controllers/admin/ProgramAdminManagementController.java
+++ b/server/app/controllers/admin/ProgramAdminManagementController.java
@@ -111,7 +111,7 @@ public final class ProgramAdminManagementController {
         return ok(
             manageAdminsView.render(
                 request,
-                programRepository.getProgramDefinition(program.get()),
+                programRepository.getShallowProgramDefinition(program.get()),
                 programAdmins,
                 message));
       }

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -133,7 +133,7 @@ public class ProgramModel extends BaseModel {
    * Gets the program definition from the database.
    *
    * <p>This should never be called directly, but instead called from {@link
-   * repository.ProgramRepository#getProgramDefinition}.
+   * repository.ProgramRepository#getShallowProgramDefinition}.
    */
   public ProgramDefinition getProgramDefinition() {
     return checkNotNull(this.programDefinition);

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -80,7 +80,9 @@ public final class ApplicationRepository {
               .createQuery(ApplicationModel.class)
               .where()
               .eq("applicant.id", applicant.id)
-              .eq("program.name", programRepository.getProgramDefinition(program).adminName())
+              .eq(
+                  "program.name",
+                  programRepository.getShallowProgramDefinition(program).adminName())
               .setLabel("ApplicationModel.findList")
               .setProfileLocation(queryProfileLocationBuilder.create("submitApplicationInternal"))
               .findList();
@@ -118,7 +120,7 @@ public final class ApplicationRepository {
                 + " will be set to OBSOLETE. Application IDs: {}",
             applicant.id,
             program.id,
-            programRepository.getProgramDefinition(program).adminName(),
+            programRepository.getShallowProgramDefinition(program).adminName(),
             String.join(
                 ",",
                 previousActive.stream()
@@ -134,7 +136,7 @@ public final class ApplicationRepository {
                   + " not saved",
               applicant.id,
               program.id,
-              programRepository.getProgramDefinition(program).adminName());
+              programRepository.getShallowProgramDefinition(program).adminName());
           throw new DuplicateApplicationException();
         }
         // https://github.com/civiform/civiform/issues/3227
@@ -240,7 +242,9 @@ public final class ApplicationRepository {
               .createQuery(ApplicationModel.class)
               .where()
               .eq("applicant.id", applicant.id)
-              .eq("program.name", programRepository.getProgramDefinition(program).adminName())
+              .eq(
+                  "program.name",
+                  programRepository.getShallowProgramDefinition(program).adminName())
               .eq("lifecycle_stage", LifecycleStage.DRAFT)
               .setLabel("ApplicationModel.findById")
               .setProfileLocation(

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -127,17 +127,11 @@ public final class ProgramRepository {
   }
 
   /**
-   * Gets the program definition from the cache if it exists, otherwise calls the method on the
-   * program model.
-   *
-   * <p>The program definition in the cache will have all the associated question data.
+   * Gets the program definition without the associated question data.
    *
    * <p>This method should replace any calls to ProgramModel.getProgramDefinition()
    */
-  public ProgramDefinition getProgramDefinition(ProgramModel program) {
-    if (getFullProgramDefinitionFromCache(program).isPresent()) {
-      return getFullProgramDefinitionFromCache(program).get();
-    }
+  public ProgramDefinition getShallowProgramDefinition(ProgramModel program) {
     return program.getProgramDefinition();
   }
 
@@ -182,7 +176,7 @@ public final class ProgramRepository {
         versionRepository
             .get()
             .getProgramByNameForVersion(
-                getProgramDefinition(existingProgram).adminName(), draftVersion);
+                getShallowProgramDefinition(existingProgram).adminName(), draftVersion);
     if (existingDraftOpt.isPresent()) {
       ProgramModel existingDraft = existingDraftOpt.get();
       if (!existingDraft.id.equals(existingProgram.id)) {
@@ -194,7 +188,7 @@ public final class ProgramRepository {
             existingProgram.id);
       }
       ProgramModel updatedDraft =
-          getProgramDefinition(existingProgram).toBuilder()
+          getShallowProgramDefinition(existingProgram).toBuilder()
               .setId(existingDraft.id)
               .build()
               .toProgram();
@@ -208,7 +202,8 @@ public final class ProgramRepository {
       // Program -> builder -> back to program in order to clear any metadata stored in the program
       // (for example, version information).
       ProgramModel newDraft =
-          new ProgramModel(getProgramDefinition(existingProgram).toBuilder().build(), draftVersion);
+          new ProgramModel(
+              getShallowProgramDefinition(existingProgram).toBuilder().build(), draftVersion);
       newDraft = insertProgramSync(newDraft);
       draftVersion.refresh();
       Preconditions.checkState(
@@ -218,10 +213,10 @@ public final class ProgramRepository {
           draftVersion.getLifecycleStage().equals(LifecycleStage.DRAFT),
           "Draft version must remain a draft throughout this transaction.");
       // Ensure we didn't add a duplicate with other code running at the same time.
-      String programName = getProgramDefinition(existingProgram).adminName();
+      String programName = getShallowProgramDefinition(existingProgram).adminName();
       Preconditions.checkState(
           versionRepository.get().getProgramsForVersion(draftVersion).stream()
-                  .map(this::getProgramDefinition)
+                  .map(this::getShallowProgramDefinition)
                   .map(ProgramDefinition::adminName)
                   .filter(programName::equals)
                   .count()
@@ -302,7 +297,7 @@ public final class ProgramRepository {
     if (program.isEmpty()) {
       throw new ProgramNotFoundException(programId);
     }
-    return getProgramAdministrators(getProgramDefinition(program.get()).adminName());
+    return getProgramAdministrators(getShallowProgramDefinition(program.get()).adminName());
   }
 
   public ImmutableList<ProgramModel> getAllProgramVersions(long programId) {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -472,7 +472,7 @@ public final class ApplicantService {
               ApplicationModel application = applicationMaybe.get();
               ProgramModel applicationProgram = application.getProgram();
               ProgramDefinition programDefinition =
-                  programRepository.getProgramDefinition(applicationProgram);
+                  programRepository.getShallowProgramDefinition(applicationProgram);
               String programName = programDefinition.adminName();
               Optional<StatusDefinitions.Status> maybeDefaultStatus =
                   applicationProgram.getDefaultStatus();
@@ -847,7 +847,7 @@ public final class ApplicantService {
             .toCompletableFuture();
     ImmutableList<ProgramDefinition> activeProgramDefinitions =
         versionRepository.getProgramsForVersion(versionRepository.getActiveVersion()).stream()
-            .map(p -> programRepository.getProgramDefinition(p))
+            .map(p -> programRepository.getShallowProgramDefinition(p))
             .filter(
                 pdef ->
                     pdef.displayMode().equals(DisplayMode.PUBLIC)
@@ -868,7 +868,8 @@ public final class ApplicantService {
                   applications.stream()
                       .map(
                           application ->
-                              programRepository.getProgramDefinition(application.getProgram()))
+                              programRepository.getShallowProgramDefinition(
+                                  application.getProgram()))
                       .collect(Collectors.toList());
               programDefinitionsList.addAll(activeProgramDefinitions);
               return programService.syncQuestionsToProgramDefinitions(
@@ -964,7 +965,9 @@ public final class ApplicantService {
             .collect(
                 Collectors.groupingBy(
                     a -> {
-                      return programRepository.getProgramDefinition(a.getProgram()).adminName();
+                      return programRepository
+                          .getShallowProgramDefinition(a.getProgram())
+                          .adminName();
                     },
                     Collectors.groupingBy(
                         ApplicationModel::getLifecycleStage,
@@ -1018,7 +1021,7 @@ public final class ApplicantService {
             // version at the time of submission are used. However, when clicking "reapply", we use
             // the latest program version below.
             ProgramDefinition applicationProgramVersion =
-                programRepository.getProgramDefinition(maybeSubmittedApp.get().getProgram());
+                programRepository.getShallowProgramDefinition(maybeSubmittedApp.get().getProgram());
             Optional<String> maybeLatestStatus = maybeSubmittedApp.get().getLatestStatus();
             Optional<StatusDefinitions.Status> maybeCurrentStatus =
                 maybeLatestStatus.isPresent()
@@ -1100,7 +1103,9 @@ public final class ApplicantService {
             .collect(
                 Collectors.groupingBy(
                     a -> {
-                      return programRepository.getProgramDefinition(a.getProgram()).adminName();
+                      return programRepository
+                          .getShallowProgramDefinition(a.getProgram())
+                          .adminName();
                     },
                     Collectors.groupingBy(ApplicationModel::getLifecycleStage)))
             .values();
@@ -1115,7 +1120,8 @@ public final class ApplicantService {
                     .map(
                         a ->
                             String.format(
-                                "%d", programRepository.getProgramDefinition(a.getProgram()).id()))
+                                "%d",
+                                programRepository.getShallowProgramDefinition(a.getProgram()).id()))
                     .collect(ImmutableList.toImmutableList()));
         logger.debug(
             String.format(
@@ -1123,7 +1129,7 @@ public final class ApplicantService {
                     + " Admin Name: %1$s, Duplicate Program Definition"
                     + " ids: %2$s.",
                 programRepository
-                    .getProgramDefinition(draftApplications.get(0).getProgram())
+                    .getShallowProgramDefinition(draftApplications.get(0).getProgram())
                     .adminName(),
                 joinedProgramIds));
       }

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -122,7 +122,7 @@ public final class ProgramAdminApplicationService {
       Optional<String> adminSubmitterEmail = application.getSubmitterEmail();
       if (adminSubmitterEmail.isPresent()) {
         sendAdminSubmitterEmail(
-            programRepository.getProgramDefinition(program),
+            programRepository.getShallowProgramDefinition(program),
             applicant,
             statusDef,
             adminSubmitterEmail);
@@ -136,7 +136,10 @@ public final class ProgramAdminApplicationService {
               : Optional.empty();
       if (applicantEmail.isPresent()) {
         sendApplicantEmail(
-            programRepository.getProgramDefinition(program), applicant, statusDef, applicantEmail);
+            programRepository.getShallowProgramDefinition(program),
+            applicant,
+            statusDef,
+            applicantEmail);
       } else {
         // An email was requested to be sent but the applicant doesn't have one.
         throw new AccountHasNoEmailException(applicant.getAccount().id);
@@ -253,11 +256,11 @@ public final class ProgramAdminApplicationService {
       throws ProgramNotFoundException {
     if (application.isEmpty()
         || programRepository
-            .getProgramDefinition(application.get().getProgram())
+            .getShallowProgramDefinition(application.get().getProgram())
             .adminName()
             .isEmpty()
         || !programRepository
-            .getProgramDefinition(application.get().getProgram())
+            .getShallowProgramDefinition(application.get().getProgram())
             .adminName()
             .equals(program.adminName())) {
       throw new ProgramNotFoundException("Application or program is empty or mismatched");

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -264,13 +264,13 @@ public final class ProgramService {
       // This method makes multiple calls to get questions for the active and
       // draft versions, so we should only call it if we're syncing program
       // associations for a draft program (which means we're in the admin flow).
-      return syncProgramDefinitionQuestions(programRepository.getProgramDefinition(program))
+      return syncProgramDefinitionQuestions(programRepository.getShallowProgramDefinition(program))
           .thenApply(ProgramDefinition::orderBlockDefinitions);
     }
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(
-            programRepository.getProgramDefinition(program), maxVersionForProgram);
+            programRepository.getShallowProgramDefinition(program), maxVersionForProgram);
 
     // It is safe to set the program definition cache, since we have already checked that it is
     // not a draft program.
@@ -355,7 +355,8 @@ public final class ProgramService {
             programAcls);
 
     return ErrorAnd.of(
-        programRepository.getProgramDefinition(programRepository.insertProgramSync(program)));
+        programRepository.getShallowProgramDefinition(
+            programRepository.insertProgramSync(program)));
   }
 
   /**
@@ -485,7 +486,7 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(program)))
             .toCompletableFuture()
             .join());
@@ -536,7 +537,7 @@ public final class ProgramService {
       return;
     }
     ProgramDefinition draftCommonIntakeProgramDefinition =
-        programRepository.getProgramDefinition(
+        programRepository.getShallowProgramDefinition(
             programRepository.createOrUpdateDraft(maybeCommonIntakeForm.get().toProgram()));
     ProgramModel commonIntakeProgram =
         draftCommonIntakeProgramDefinition.toBuilder()
@@ -571,7 +572,7 @@ public final class ProgramService {
     // Note: It's unclear that we actually want to update an existing draft this way, as it would
     // effectively reset the  draft which is not part of any user flow. Given the interdependency of
     // draft updates this is likely to cause issues as in #2179.
-    return programRepository.getProgramDefinition(
+    return programRepository.getShallowProgramDefinition(
         programRepository.createOrUpdateDraft(this.getFullProgramDefinition(id).toProgram()));
   }
 
@@ -694,7 +695,7 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(newProgram.build().toProgram())))
             .toCompletableFuture()
             .join());
@@ -786,7 +787,7 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
@@ -850,7 +851,7 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
@@ -882,7 +883,7 @@ public final class ProgramService {
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(program.toProgram())))
             .toCompletableFuture()
             .join());
@@ -906,7 +907,7 @@ public final class ProgramService {
       throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
     programDefinition = programDefinition.toBuilder().setEligibilityIsGating(gating).build();
-    return programRepository.getProgramDefinition(
+    return programRepository.getShallowProgramDefinition(
         programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
@@ -934,7 +935,7 @@ public final class ProgramService {
         getUpdatedSummaryImageDescription(programDefinition, locale, summaryImageDescription);
     programDefinition =
         programDefinition.toBuilder().setLocalizedSummaryImageDescription(newStrings).build();
-    return programRepository.getProgramDefinition(
+    return programRepository.getShallowProgramDefinition(
         programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
@@ -979,7 +980,7 @@ public final class ProgramService {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
     programDefinition =
         programDefinition.toBuilder().setSummaryImageFileKey(Optional.of(fileKey)).build();
-    return programRepository.getProgramDefinition(
+    return programRepository.getShallowProgramDefinition(
         programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
@@ -992,7 +993,7 @@ public final class ProgramService {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
     programDefinition =
         programDefinition.toBuilder().setSummaryImageFileKey(Optional.empty()).build();
-    return programRepository.getProgramDefinition(
+    return programRepository.getShallowProgramDefinition(
         programRepository.updateProgramSync(programDefinition.toProgram()));
   }
 
@@ -1056,7 +1057,7 @@ public final class ProgramService {
         programDefinition.insertBlockDefinitionInTheRightPlace(blockDefinition).toProgram();
     ProgramDefinition updatedProgram =
         syncProgramDefinitionQuestions(
-                programRepository.getProgramDefinition(
+                programRepository.getShallowProgramDefinition(
                     programRepository.updateProgramSync(program)))
             .toCompletableFuture()
             .join();
@@ -1098,7 +1099,8 @@ public final class ProgramService {
           "Something happened to the program's block while trying to move it", e);
     }
     return syncProgramDefinitionQuestions(
-            programRepository.getProgramDefinition(programRepository.updateProgramSync(program)))
+            programRepository.getShallowProgramDefinition(
+                programRepository.updateProgramSync(program)))
         .toCompletableFuture()
         .join();
   }
@@ -1804,7 +1806,7 @@ public final class ProgramService {
     }
 
     return syncProgramDefinitionQuestions(
-            programRepository.getProgramDefinition(
+            programRepository.getShallowProgramDefinition(
                 programRepository.updateProgramSync(program.toProgram())))
         .toCompletableFuture()
         .join();

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -353,7 +353,7 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
             .map(
                 application ->
                     programRepository
-                        .getProgramDefinition(application.getProgram())
+                        .getShallowProgramDefinition(application.getProgram())
                         .localizedName()
                         .getDefault())
             .collect(Collectors.joining(", "));


### PR DESCRIPTION
### Description

Update `ProgramRepository.getProgramDefinition` to get the program definition without the question data and rename this for clarity - see [TDD](https://docs.google.com/document/d/1out9Sg5y7gVQISzB5212P1SJB8saT9XDYFoEVcAkvZk/edit)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6711
