### PR TITLE
Fix Back button on translations page to redirect correctly

### DIFF
--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -153,24 +153,13 @@ public class AdminProgramTranslationsController extends CiviFormController {
       return redirect(routes.AdminProgramTranslationsController.edit(programName, locale, referer))
           .flashing("error", e.userFacingMessage());
     }
-    if (result.isError()) {
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(result.getErrors()));
-      return ok(
-          translationView.render(
-              request,
-              localeToUpdate,
-              program,
-              translationForm,
-              Optional.of(errorMessage),
-              referer.getReferer()));
-    }
+
+    Optional<ToastMessage> errorMessage =
+        result.isError()
+            ? Optional.of(ToastMessage.errorNonLocalized(joinErrors(result.getErrors())))
+            : Optional.empty();
     return ok(
         translationView.render(
-            request,
-            localeToUpdate,
-            program,
-            translationForm,
-            /* message= */ Optional.empty(),
-            referer.getReferer()));
+            request, localeToUpdate, program, translationForm, errorMessage, referer.getReferer()));
   }
 }

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -110,8 +110,6 @@ public final class AdminLayout extends BaseHtmlLayout {
   /**
    * Creates a button that will redirect to the translations management page. Returns an empty
    * optional if there are no locales to translate to.
-   *
-   * @param referer the
    */
   public Optional<ButtonTag> createManageTranslationsButton(
       String programAdminName,

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -110,6 +110,8 @@ public final class AdminLayout extends BaseHtmlLayout {
   /**
    * Creates a button that will redirect to the translations management page. Returns an empty
    * optional if there are no locales to translate to.
+   *
+   * @param referer the
    */
   public Optional<ButtonTag> createManageTranslationsButton(
       String programAdminName,

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -26,6 +26,8 @@ import views.BaseHtmlLayout;
 import views.HtmlBundle;
 import views.JsBundle;
 import views.ViewUtils;
+import views.admin.programs.ProgramTranslationReferer;
+import views.admin.programs.ProgramTranslationRefererWrapper;
 import views.components.Icons;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
@@ -110,12 +112,17 @@ public final class AdminLayout extends BaseHtmlLayout {
    * optional if there are no locales to translate to.
    */
   public Optional<ButtonTag> createManageTranslationsButton(
-      String programAdminName, Optional<String> buttonId, String buttonStyles) {
+      String programAdminName,
+      Optional<String> buttonId,
+      String buttonStyles,
+      ProgramTranslationReferer referer) {
     if (translationLocales.translatableLocales().isEmpty()) {
       return Optional.empty();
     }
     String linkDestination =
-        routes.AdminProgramTranslationsController.redirectToFirstLocale(programAdminName).url();
+        routes.AdminProgramTranslationsController.redirectToFirstLocale(
+                programAdminName, new ProgramTranslationRefererWrapper(referer))
+            .url();
     ButtonTag button =
         makeSvgTextButton("Manage translations", Icons.LANGUAGE).withClass(buttonStyles);
     buttonId.ifPresent(button::withId);

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -16,6 +16,7 @@ import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.LegendTag;
 import java.util.Locale;
+import org.apache.commons.lang3.tuple.Pair;
 import play.mvc.Http;
 import services.LocalizedStrings;
 import services.TranslationLocales;
@@ -30,37 +31,38 @@ import views.style.AdminStyles;
  */
 public abstract class TranslationFormView extends BaseHtmlView {
 
-  private final TranslationLocales translationLocales;
+  protected final TranslationLocales translationLocales;
 
   public TranslationFormView(TranslationLocales translationLocales) {
     this.translationLocales = checkNotNull(translationLocales);
   }
 
-  /** Render a list of languages, with the currently selected language underlined. */
-  protected final DivTag renderLanguageLinks(String entityName, Locale currentlySelected) {
+  /**
+   * Renders a list of languages, with the currently selected language underlined.
+   *
+   * @param localeLinkDestinations a list of locales paired with the destination that the locale
+   *     should link to.
+   */
+  protected final DivTag renderLanguageLinks(
+      Locale currentlySelected, ImmutableList<Pair<Locale, String>> localeLinkDestinations) {
     return div()
         .withClasses("m-2")
         .with(
             each(
-                translationLocales.translatableLocales(),
-                locale -> {
-                  String linkDestination = languageLinkDestination(entityName, locale);
+                localeLinkDestinations,
+                localeAndDestination -> {
+                  Locale locale = localeAndDestination.getKey();
+                  String linkDestination = localeAndDestination.getValue();
                   return renderLanguageLink(
                       linkDestination, locale, locale.equals(currentlySelected));
                 }));
   }
 
   /**
-   * Given the name of the entity to translate and a locale for translation, returns a link
-   * destination URL for the edit form to translate the entity in the given locale.
-   */
-  protected abstract String languageLinkDestination(String entityName, Locale locale);
-
-  /**
    * Renders a single locale as the English version of the language (ex: es-US would read
    * "Spanish"). The text links to a form to translate the entity into that language.
    */
-  private ATag renderLanguageLink(
+  protected final ATag renderLanguageLink(
       String linkDestination, Locale locale, boolean isCurrentlySelected) {
     LinkElement link =
         new LinkElement()

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -85,11 +85,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
       Locale locale,
       String formAction,
       ImmutableList<DomContent> formFieldContent,
-      boolean isProgramEdit) {
-    String redirectUrl =
-        isProgramEdit
-            ? controllers.admin.routes.AdminProgramController.index().url()
-            : controllers.admin.routes.AdminQuestionController.index().url();
+      String backUrl) {
     FormTag form =
         form()
             .withMethod("POST")
@@ -101,7 +97,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
                     .withClasses("flex", "flex-row", "gap-x-2")
                     .with(
                         a("Back")
-                            .withHref(redirectUrl)
+                            .withHref(backUrl)
                             .withId("back-to-list-button")
                             .withClasses(ButtonStyles.OUTLINED_TRANSPARENT),
                         submitButton(

--- a/server/app/views/admin/TranslationFormView.java
+++ b/server/app/views/admin/TranslationFormView.java
@@ -62,7 +62,7 @@ public abstract class TranslationFormView extends BaseHtmlView {
    * Renders a single locale as the English version of the language (ex: es-US would read
    * "Spanish"). The text links to a form to translate the entity into that language.
    */
-  protected final ATag renderLanguageLink(
+  private ATag renderLanguageLink(
       String linkDestination, Locale locale, boolean isCurrentlySelected) {
     LinkElement link =
         new LinkElement()
@@ -81,6 +81,8 @@ public abstract class TranslationFormView extends BaseHtmlView {
   /**
    * Renders a form that allows an admin to enter localized text for an entity's applicant-visible
    * fields.
+   *
+   * @param backUrl where the "Back" button on the page should take the admin.
    */
   protected final FormTag renderTranslationForm(
       Http.Request request,

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -5,6 +5,9 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.p;
+import static views.admin.programs.ProgramEditStatus.EDIT;
+import static views.admin.programs.ProgramTranslationReferer.PROGRAM_CREATION_IMAGE_UPLOAD;
+import static views.admin.programs.ProgramTranslationReferer.PROGRAM_IMAGE_UPLOAD;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
@@ -201,7 +204,10 @@ public final class ProgramImageView extends BaseHtmlView {
             // admin_program_image.ts will enable the submit button when the description changes.
             .isDisabled());
     Optional<ButtonTag> manageTranslationsButton =
-        createManageTranslationsButton(programDefinition, existingDescription);
+        createManageTranslationsButton(
+            programDefinition,
+            existingDescription,
+            ProgramEditStatus.getStatusFromString(editStatus));
     manageTranslationsButton.ifPresent(buttonsDiv::with);
 
     return div()
@@ -226,12 +232,17 @@ public final class ProgramImageView extends BaseHtmlView {
   }
 
   private Optional<ButtonTag> createManageTranslationsButton(
-      ProgramDefinition programDefinition, String existingDescription) {
+      ProgramDefinition programDefinition,
+      String existingDescription,
+      ProgramEditStatus editStatus) {
+    ProgramTranslationReferer referer =
+        editStatus == EDIT ? PROGRAM_IMAGE_UPLOAD : PROGRAM_CREATION_IMAGE_UPLOAD;
     Optional<ButtonTag> button =
         layout.createManageTranslationsButton(
             programDefinition.adminName(),
             /* buttonId= */ Optional.empty(),
-            StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "flex", "ml-2"));
+            StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "flex", "ml-2"),
+            referer);
     // Disable the translations button if there's no description in the first place.
     return button.map(buttonTag -> buttonTag.withCondDisabled(existingDescription.isBlank()));
   }

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -6,8 +6,6 @@ import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.p;
 import static views.admin.programs.ProgramEditStatus.EDIT;
-import static views.admin.programs.ProgramTranslationReferer.PROGRAM_CREATION_IMAGE_UPLOAD;
-import static views.admin.programs.ProgramTranslationReferer.PROGRAM_IMAGE_UPLOAD;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
@@ -236,7 +234,9 @@ public final class ProgramImageView extends BaseHtmlView {
       String existingDescription,
       ProgramEditStatus editStatus) {
     ProgramTranslationReferer referer =
-        editStatus == EDIT ? PROGRAM_IMAGE_UPLOAD : PROGRAM_CREATION_IMAGE_UPLOAD;
+        editStatus == ProgramEditStatus.EDIT
+            ? ProgramTranslationReferer.PROGRAM_IMAGE_UPLOAD_EDIT
+            : ProgramTranslationReferer.PROGRAM_IMAGE_UPLOAD_CREATION;
     Optional<ButtonTag> button =
         layout.createManageTranslationsButton(
             programDefinition.adminName(),

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.p;
-import static views.admin.programs.ProgramEditStatus.EDIT;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -575,7 +575,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         program.adminName(),
         /* buttonId= */ Optional.of("program-translations-link-" + program.id()),
         ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN,
-        ProgramTranslationReferer.PROGRAM_EDIT);
+        ProgramTranslationReferer.PROGRAM_DASHBOARD);
   }
 
   private ButtonTag renderEditStatusesLink(ProgramDefinition program) {

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -574,7 +574,8 @@ public final class ProgramIndexView extends BaseHtmlView {
     return layout.createManageTranslationsButton(
         program.adminName(),
         /* buttonId= */ Optional.of("program-translations-link-" + program.id()),
-        ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
+        ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN,
+        ProgramTranslationReferer.PROGRAM_EDIT);
   }
 
   private ButtonTag renderEditStatusesLink(ProgramDefinition program) {

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -140,7 +140,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
         program.adminName(),
         /* buttonId= */ Optional.empty(),
         ButtonStyles.OUTLINED_WHITE_WITH_ICON,
-        ProgramTranslationReferer.PROGRAM_EDIT);
+        ProgramTranslationReferer.PROGRAM_STATUSES);
   }
 
   /**

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -139,7 +139,8 @@ public final class ProgramStatusesView extends BaseHtmlView {
     return layout.createManageTranslationsButton(
         program.adminName(),
         /* buttonId= */ Optional.empty(),
-        ButtonStyles.OUTLINED_WHITE_WITH_ICON);
+        ButtonStyles.OUTLINED_WHITE_WITH_ICON,
+        ProgramTranslationReferer.PROGRAM_EDIT);
   }
 
   /**

--- a/server/app/views/admin/programs/ProgramTranslationReferer.java
+++ b/server/app/views/admin/programs/ProgramTranslationReferer.java
@@ -5,10 +5,7 @@ package views.admin.programs;
  * button on the translations page goes back to the right place.
  */
 public enum ProgramTranslationReferer {
-  /**
-   * The admin came from the program dashboard page (by clicking "Manage translations" on a specific
-   * program).
-   */
+  /** The admin came from the program dashboard page. */
   PROGRAM_DASHBOARD,
   /** The admin came from the program statuses page. */
   PROGRAM_STATUSES,
@@ -22,6 +19,6 @@ public enum ProgramTranslationReferer {
    */
   PROGRAM_IMAGE_UPLOAD_CREATION;
 
-  /** The referer to use as the default if the provided referer can't be found for some reason. */
+  /** The referer to use as the default if the referer can't be found for some reason. */
   public static final ProgramTranslationReferer DEFAULT_ACTION = PROGRAM_DASHBOARD;
 }

--- a/server/app/views/admin/programs/ProgramTranslationReferer.java
+++ b/server/app/views/admin/programs/ProgramTranslationReferer.java
@@ -1,0 +1,7 @@
+package views.admin.programs;
+
+public enum ProgramTranslationReferer {
+  PROGRAM_EDIT,
+  PROGRAM_IMAGE_UPLOAD,
+  PROGRAM_CREATION_IMAGE_UPLOAD,
+}

--- a/server/app/views/admin/programs/ProgramTranslationReferer.java
+++ b/server/app/views/admin/programs/ProgramTranslationReferer.java
@@ -1,7 +1,27 @@
 package views.admin.programs;
 
+/**
+ * An enum representing how an admin got to the program translations page. Used so that the "Back"
+ * button on the translations page goes back to the right place.
+ */
 public enum ProgramTranslationReferer {
-  PROGRAM_EDIT,
-  PROGRAM_IMAGE_UPLOAD,
-  PROGRAM_CREATION_IMAGE_UPLOAD,
+  /**
+   * The admin came from the program dashboard page (by clicking "Manage translations" on a specific
+   * program).
+   */
+  PROGRAM_DASHBOARD,
+  /** The admin came from the program statuses page. */
+  PROGRAM_STATUSES,
+  /**
+   * The admin came from the program image upload page, where they were editing an existing program.
+   */
+  PROGRAM_IMAGE_UPLOAD_EDIT,
+  /**
+   * The admin came from the program image upload page, where they were creating a program for the
+   * first time.
+   */
+  PROGRAM_IMAGE_UPLOAD_CREATION;
+
+  /** The referer to use as the default if the provided referer can't be found for some reason. */
+  public static final ProgramTranslationReferer DEFAULT_ACTION = PROGRAM_DASHBOARD;
 }

--- a/server/app/views/admin/programs/ProgramTranslationRefererWrapper.java
+++ b/server/app/views/admin/programs/ProgramTranslationRefererWrapper.java
@@ -1,0 +1,39 @@
+package views.admin.programs;
+
+import static views.admin.programs.ProgramTranslationReferer.PROGRAM_EDIT;
+
+import play.mvc.PathBindable;
+import util.PathBindableHelper;
+
+/** TODO */
+public class ProgramTranslationRefererWrapper
+    implements PathBindable<ProgramTranslationRefererWrapper> {
+  private final PathBindableHelper<ProgramTranslationReferer> pathBindableHelper =
+      new PathBindableHelper<>(/* defaultItem= */ PROGRAM_EDIT, ProgramTranslationReferer.class);
+
+  public ProgramTranslationRefererWrapper() {}
+
+  public ProgramTranslationRefererWrapper(ProgramTranslationReferer referer) {
+    pathBindableHelper.setItem(referer);
+  }
+
+  public ProgramTranslationReferer getReferer() {
+    return pathBindableHelper.getItem();
+  }
+
+  @Override
+  public ProgramTranslationRefererWrapper bind(String key, String txt) {
+    pathBindableHelper.bind(txt);
+    return this;
+  }
+
+  @Override
+  public String unbind(String key) {
+    return pathBindableHelper.unbind();
+  }
+
+  @Override
+  public String javascriptUnbind() {
+    return pathBindableHelper.unbind();
+  }
+}

--- a/server/app/views/admin/programs/ProgramTranslationRefererWrapper.java
+++ b/server/app/views/admin/programs/ProgramTranslationRefererWrapper.java
@@ -1,15 +1,19 @@
 package views.admin.programs;
 
-import static views.admin.programs.ProgramTranslationReferer.PROGRAM_EDIT;
+import static views.admin.programs.ProgramTranslationReferer.DEFAULT_ACTION;
 
 import play.mvc.PathBindable;
 import util.PathBindableHelper;
 
-/** TODO */
+/**
+ * This class allows us to include {@link ProgramTranslationReferer} directly in routes with type
+ * safety. See {@link PathBindableHelper} for more details on how this wrapping works and why we
+ * need it.
+ */
 public class ProgramTranslationRefererWrapper
     implements PathBindable<ProgramTranslationRefererWrapper> {
   private final PathBindableHelper<ProgramTranslationReferer> pathBindableHelper =
-      new PathBindableHelper<>(/* defaultItem= */ PROGRAM_EDIT, ProgramTranslationReferer.class);
+      new PathBindableHelper<>(ProgramTranslationReferer.class, DEFAULT_ACTION);
 
   public ProgramTranslationRefererWrapper() {}
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -46,18 +46,39 @@ public final class ProgramTranslationView extends TranslationFormView {
       Locale locale,
       ProgramDefinition program,
       ProgramTranslationForm translationForm,
-      Optional<ToastMessage> message) {
+      Optional<ToastMessage> message,
+      ProgramTranslationReferer referer) {
     String formAction =
         controllers.admin.routes.AdminProgramTranslationsController.update(
-                program.adminName(), locale.toLanguageTag())
+                program.adminName(),
+                locale.toLanguageTag(),
+                new ProgramTranslationRefererWrapper(referer))
             .url();
+
+    String backUrl;
+    switch (referer) {
+      case PROGRAM_EDIT:
+        backUrl = controllers.admin.routes.AdminProgramController.index().url();
+        break;
+      case PROGRAM_IMAGE_UPLOAD:
+        backUrl =
+            controllers.admin.routes.AdminProgramImageController.index(
+                    program.id(), ProgramEditStatus.EDIT.toString())
+                .url();
+        break;
+      case PROGRAM_CREATION_IMAGE_UPLOAD:
+        backUrl =
+            controllers.admin.routes.AdminProgramImageController.index(
+                    program.id(), ProgramEditStatus.CREATION_EDIT.toString())
+                .url();
+        break;
+      default:
+        throw new IllegalStateException("ProgramTranslationReferer not handled: " + referer);
+    }
+
     FormTag form =
         renderTranslationForm(
-            request,
-            locale,
-            formAction,
-            formFields(program, translationForm),
-            /* isProgramEdit= */ true);
+            request, locale, formAction, formFields(program, translationForm), backUrl);
 
     String title =
         String.format("Manage program translations: %s", program.localizedName().getDefault());
@@ -76,7 +97,10 @@ public final class ProgramTranslationView extends TranslationFormView {
 
   @Override
   protected String languageLinkDestination(String programName, Locale locale) {
-    return routes.AdminProgramTranslationsController.edit(programName, locale.toLanguageTag())
+    return routes.AdminProgramTranslationsController.edit(
+            programName,
+            locale.toLanguageTag(),
+            new ProgramTranslationRefererWrapper(ProgramTranslationReferer.PROGRAM_EDIT))
         .url();
   }
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -57,8 +57,8 @@ public final class ProgramTranslationView extends TranslationFormView {
                 new ProgramTranslationRefererWrapper(referer))
             .url();
 
-    // The referer tells us how the admin got to this translations page, so we need to use it so
-    // that the "Back" button redirects appropriately.
+    // The referer tells us how the admin got to this translations page, and we use it to make sure
+    // the "Back" button redirects appropriately.
     String backUrl;
     switch (referer) {
       case PROGRAM_DASHBOARD:

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -73,9 +73,9 @@ public final class QuestionTranslationView extends TranslationFormView {
       inputFieldsBuilder.add(questionTypeSpecificContent.get());
     }
 
+    String backUrl = controllers.admin.routes.AdminQuestionController.index().url();
     FormTag form =
-        renderTranslationForm(
-            request, locale, formAction, inputFieldsBuilder.build(), /* isProgramEdit= */ false);
+        renderTranslationForm(request, locale, formAction, inputFieldsBuilder.build(), backUrl);
 
     String title = String.format("Manage question translations: %s", question.getName());
 

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -6,10 +6,12 @@ import static j2html.TagCreator.span;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.DomContent;
+import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.apache.commons.lang3.tuple.Pair;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import services.LocalizedStrings;
@@ -90,8 +92,15 @@ public final class QuestionTranslationView extends TranslationFormView {
     return layout.renderCentered(htmlBundle);
   }
 
-  @Override
-  protected String languageLinkDestination(String questionName, Locale locale) {
+  private DivTag renderLanguageLinks(String questionName, Locale currentlySelected) {
+    ImmutableList<Pair<Locale, String>> localesAndDestinations =
+        translationLocales.translatableLocales().stream()
+            .map(locale -> Pair.of(locale, languageLinkDestination(questionName, locale)))
+            .collect(ImmutableList.toImmutableList());
+    return renderLanguageLinks(currentlySelected, localesAndDestinations);
+  }
+
+  private String languageLinkDestination(String questionName, Locale locale) {
     return controllers.admin.routes.AdminQuestionTranslationsController.edit(
             questionName, locale.toLanguageTag())
         .url();

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -41,9 +41,9 @@ GET     /admin/programs/:programId/statuses        controllers.admin.AdminProgra
 POST    /admin/programs/:programId/statuses/delete controllers.admin.AdminProgramStatusesController.delete(request: Request, programId: Long)
 
 # Routes for managing program localization
-GET     /admin/programs/:programName/translations/edit            controllers.admin.AdminProgramTranslationsController.redirectToFirstLocale(request: Request, programName: String)
-GET     /admin/programs/:programName/translations/:locale/edit    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programName: String, locale: String)
-POST    /admin/programs/:programName/translations/:locale         controllers.admin.AdminProgramTranslationsController.update(request: Request, programName: String, locale: String)
+GET     /admin/programs/:programName/translations/edit/:referer            controllers.admin.AdminProgramTranslationsController.redirectToFirstLocale(request: Request, programName: String, referer: views.admin.programs.ProgramTranslationRefererWrapper)
+GET     /admin/programs/:programName/translations/:locale/edit/:referer    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programName: String, locale: String, referer: views.admin.programs.ProgramTranslationRefererWrapper)
+POST    /admin/programs/:programName/translations/:locale/:referer         controllers.admin.AdminProgramTranslationsController.update(request: Request, programName: String, locale: String, referer: views.admin.programs.ProgramTranslationRefererWrapper)
 
 
 # A controller for pages for an admin to create and maintain blocks for a program


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

- From program dashboard page
- From Program statuses page
- Image upload, manage translations, choose different language, then go back
- Image upload in creation flow, manage transltaions, go back, verify "Continue" still appears

Question translations view "Back"

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
