### PR TITLE
[Refactor] Rename getActiveProgramDefinitionAsync to getActiveFullProgramDefinitionAsync for clarity

### DIFF
--- a/server/app/controllers/admin/AdminReportingController.java
+++ b/server/app/controllers/admin/AdminReportingController.java
@@ -59,7 +59,7 @@ public final class AdminReportingController extends CiviFormController {
   public Result show(Http.Request request, String programSlug) {
     String programName =
         programService
-            .getActiveProgramDefinitionAsync(programSlug)
+            .getActiveFullProgramDefinitionAsync(programSlug)
             .toCompletableFuture()
             .join()
             .adminName();
@@ -79,7 +79,7 @@ public final class AdminReportingController extends CiviFormController {
   public Result downloadProgramCsv(String programSlug) {
     String programName =
         programService
-            .getActiveProgramDefinitionAsync(programSlug)
+            .getActiveFullProgramDefinitionAsync(programSlug)
             .toCompletableFuture()
             .join()
             .adminName();

--- a/server/app/controllers/api/ApiDocsController.java
+++ b/server/app/controllers/api/ApiDocsController.java
@@ -70,7 +70,7 @@ public final class ApiDocsController {
       if (useActiveVersion) {
         ProgramDefinition activeProgramDefinition =
             programService
-                .getActiveProgramDefinitionAsync(programSlug)
+                .getActiveFullProgramDefinitionAsync(programSlug)
                 .toCompletableFuture()
                 .join();
         return Optional.of(activeProgramDefinition);

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -100,7 +100,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
             .orElse(new IdentifierBasedPaginationSpec<>(pageSize, Long.MAX_VALUE));
 
     return programService
-        .getActiveProgramDefinitionAsync(programSlug)
+        .getActiveFullProgramDefinitionAsync(programSlug)
         .thenApplyAsync(
             programDefinition -> {
               PaginationResult<ApplicationModel> paginationResult =

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -97,7 +97,7 @@ public final class ProgramSlugHandler {
                                       () -> new MissingOptionalException(CiviFormProfile.class))));
                         } else {
                           return programService
-                              .getActiveProgramDefinitionAsync(programSlug)
+                              .getActiveFullProgramDefinitionAsync(programSlug)
                               .thenApply(
                                   activeProgramDefinition ->
                                       redirectToReviewPage(

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -217,7 +217,8 @@ public final class ProgramService {
    *     RuntimeException} is thrown when the future completes and slug does not correspond to a
    *     real Program
    */
-  public CompletionStage<ProgramDefinition> getActiveProgramDefinitionAsync(String programSlug) {
+  public CompletionStage<ProgramDefinition> getActiveFullProgramDefinitionAsync(
+      String programSlug) {
     return programRepository
         .getActiveProgramFromSlug(programSlug)
         .thenComposeAsync(this::getFullProgramDefinition, httpExecutionContext.current());

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -1123,7 +1123,7 @@ public class ProgramServiceTest extends ResetPostgres {
         ProgramBuilder.newActiveProgram("Test Program").buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
-        ps.getActiveProgramDefinitionAsync(programDefinition.slug());
+        ps.getActiveFullProgramDefinitionAsync(programDefinition.slug());
 
     assertThat(found.toCompletableFuture().join().id()).isEqualTo(programDefinition.id());
   }
@@ -1133,7 +1133,7 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram("Test Program").buildDefinition();
 
     CompletionStage<ProgramDefinition> found =
-        ps.getActiveProgramDefinitionAsync("non-existent-program");
+        ps.getActiveFullProgramDefinitionAsync("non-existent-program");
 
     assertThatThrownBy(() -> found.toCompletableFuture().join())
         .isInstanceOf(CompletionException.class)


### PR DESCRIPTION
### Description

Rename getActiveProgramDefinitionAsync to getActiveFullProgramDefinitionAsync for clarity that we're getting the full program definition (with question data). See [TDD](https://docs.google.com/document/d/1out9Sg5y7gVQISzB5212P1SJB8saT9XDYFoEVcAkvZk/edit)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6711
