### PR TITLE
[Refactor] Rename getAllProgramDefinitionVersions to getAllVersionsFullProgramDefinition for clarity 

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -521,7 +521,7 @@ public final class AdminApplicationController extends CiviFormController {
   }
 
   private ImmutableList<String> getAllApplicationStatusesForProgram(long programId) {
-    return programService.getAllProgramDefinitionVersions(programId).stream()
+    return programService.getAllVersionsFullProgramDefinition(programId).stream()
         .map(pdef -> pdef.statusDefinitions().getStatuses())
         .flatMap(ImmutableList::stream)
         .map(StatusDefinitions.Status::statusText)

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -91,7 +91,7 @@ public final class CsvExporterService {
   public String getProgramAllVersionsCsv(long programId, SubmittedApplicationFilter filters)
       throws ProgramNotFoundException {
     ImmutableList<ProgramDefinition> allProgramVersions =
-        programService.getAllProgramDefinitionVersions(programId).stream()
+        programService.getAllVersionsFullProgramDefinition(programId).stream()
             .collect(ImmutableList.toImmutableList());
     ProgramDefinition currentProgram = programService.getFullProgramDefinition(programId);
     CsvExportConfig exportConfig =

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -241,7 +241,7 @@ public final class ProgramService {
    * Get the program matching programId as well as all other versions of the program (i.e. all
    * programs with the same name).
    */
-  public ImmutableList<ProgramDefinition> getAllProgramDefinitionVersions(long programId) {
+  public ImmutableList<ProgramDefinition> getAllVersionsFullProgramDefinition(long programId) {
     return programRepository.getAllProgramVersions(programId).stream()
         .map(p -> getFullProgramDefinition(p).toCompletableFuture().join())
         .collect(ImmutableList.toImmutableList());


### PR DESCRIPTION
### Description

Rename getAllProgramDefinitionVersions to getAllVersionsFullProgramDefinition for clarity that we're getting the full program definition (with question data). 

I thought `getAllVersionsFullProgramDefinition` sounded a little clearer than `getAllFullProgramDefinitionVersions`, but going back and forth a bit if you think the second is clearer

See [TDD](https://docs.google.com/document/d/1out9Sg5y7gVQISzB5212P1SJB8saT9XDYFoEVcAkvZk/edit)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6711
