### PR TITLE
Using 'test' instead of 'it' in browser tests

### DIFF
--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -27,14 +27,14 @@ describe('address applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'address')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -42,7 +42,7 @@ describe('address applicant flow', () => {
       await validateScreenshot(page, 'address-errors')
     })
 
-    it('does not show errors initially', async () => {
+    test('does not show errors initially', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -62,7 +62,7 @@ describe('address applicant flow', () => {
       expect(await error.isHidden()).toEqual(true)
     })
 
-    it('with valid address does submit', async () => {
+    test('with valid address does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -77,7 +77,7 @@ describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty address does not submit', async () => {
+    test('with empty address does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '')
@@ -93,7 +93,7 @@ describe('address applicant flow', () => {
       expect(await error.isHidden()).toEqual(false)
     })
 
-    it('with invalid address does not submit', async () => {
+    test('with invalid address does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -131,7 +131,7 @@ describe('address applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid addresses does submit', async () => {
+    test('with valid addresses does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -155,7 +155,7 @@ describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '', 0)
@@ -190,7 +190,7 @@ describe('address applicant flow', () => {
       expect(await error.isHidden()).toEqual(true)
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -225,7 +225,7 @@ describe('address applicant flow', () => {
       expect(await error.isHidden()).toEqual(false)
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -259,7 +259,7 @@ describe('address applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid required address does submit', async () => {
+    test('with valid required address does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -275,7 +275,7 @@ describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with invalid optional address does not submit', async () => {
+    test('with invalid optional address does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
@@ -313,7 +313,7 @@ describe('address applicant flow', () => {
         await applicantQuestions.clickNext()
       })
 
-      it('does not submit', async () => {
+      test('does not submit', async () => {
         const {page} = ctx
         // Second question has errors.
         let error = page.locator('.cf-address-street-1-error >> nth=1')
@@ -326,7 +326,7 @@ describe('address applicant flow', () => {
         expect(await error.isHidden()).toEqual(false)
       })
 
-      it('optional has no errors', async () => {
+      test('optional has no errors', async () => {
         const {page} = ctx
         // First question has no errors.
         let error = page.locator('.cf-address-street-1-error >> nth=0')

--- a/browser-test/src/admin_api_keys.test.ts
+++ b/browser-test/src/admin_api_keys.test.ts
@@ -3,7 +3,7 @@ import {createTestContext, loginAsAdmin, validateScreenshot} from './support'
 describe('Managing API keys', () => {
   const ctx = createTestContext()
 
-  it('Creates, views and retires new API key', async () => {
+  test('Creates, views and retires new API key', async () => {
     const {page, adminApiKeys, adminPrograms} = ctx
     await loginAsAdmin(page)
 

--- a/browser-test/src/admin_application_statuses.test.ts
+++ b/browser-test/src/admin_application_statuses.test.ts
@@ -42,11 +42,11 @@ describe('view program statuses', () => {
       await adminPrograms.viewApplicationForApplicant('Guest')
     })
 
-    it('does not show status options', async () => {
+    test('does not show status options', async () => {
       expect(await ctx.adminPrograms.isStatusSelectorVisible()).toBe(false)
     })
 
-    it('does not show application status in list', async () => {
+    test('does not show application status in list', async () => {
       const {adminPrograms} = ctx
       await adminPrograms.expectApplicationStatusDoesntContain(
         'Guest',
@@ -54,7 +54,7 @@ describe('view program statuses', () => {
       )
     })
 
-    it('does not show edit note', async () => {
+    test('does not show edit note', async () => {
       expect(await ctx.adminPrograms.isEditNoteVisible()).toBe(false)
     })
   })
@@ -102,41 +102,41 @@ describe('view program statuses', () => {
       await adminPrograms.viewApplicationForApplicant('Guest')
     })
 
-    it('shows status selector', async () => {
+    test('shows status selector', async () => {
       expect(await ctx.adminPrograms.isStatusSelectorVisible()).toBe(true)
     })
 
-    it('shows placeholder option', async () => {
+    test('shows placeholder option', async () => {
       expect(await ctx.adminPrograms.getStatusOption()).toBe(
         'Choose an option:',
       )
     })
 
-    it('renders', async () => {
+    test('renders', async () => {
       await validateScreenshot(ctx.page, 'application-view-with-statuses')
     })
 
-    it('shows "None" value in application list if no status is set', async () => {
+    test('shows "None" value in application list if no status is set', async () => {
       const {adminPrograms} = ctx
       await adminPrograms.viewApplications(programWithStatusesName)
       await adminPrograms.expectApplicationHasStatusString('Guest', 'None')
     })
 
     describe('when a status is changed, a confirmation dialog is shown', () => {
-      it('renders', async () => {
+      test('renders', async () => {
         const {page, adminPrograms} = ctx
         await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await validateScreenshot(page, 'change-status-modal')
       })
 
-      it('when rejecting, the selected status is not changed', async () => {
+      test('when rejecting, the selected status is not changed', async () => {
         const {adminPrograms} = ctx
         await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await dismissModal(adminPrograms.applicationFrame())
         expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
       })
 
-      it('when confirmed, the page is redirected with a success toast and preserves the selected application', async () => {
+      test('when confirmed, the page is redirected with a success toast and preserves the selected application', async () => {
         const {adminPrograms} = ctx
         const modal =
           await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
@@ -155,13 +155,13 @@ describe('view program statuses', () => {
         expect(applicationText).toContain('Guest')
       })
 
-      it('when no email is configured for the status, a warning is shown', async () => {
+      test('when no email is configured for the status, a warning is shown', async () => {
         const {adminPrograms} = ctx
         await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await dismissModal(adminPrograms.applicationFrame())
       })
 
-      it('when no email is configured for the applicant, a warning is shown', async () => {
+      test('when no email is configured for the applicant, a warning is shown', async () => {
         const {adminPrograms} = ctx
         const modal =
           await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
@@ -171,7 +171,7 @@ describe('view program statuses', () => {
         await dismissModal(adminPrograms.applicationFrame())
       })
 
-      it('when changing status, the previous status is shown', async () => {
+      test('when changing status, the previous status is shown', async () => {
         const {adminPrograms} = ctx
         expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         const modal =
@@ -182,7 +182,7 @@ describe('view program statuses', () => {
         await dismissModal(adminPrograms.applicationFrame())
       })
 
-      it('when changing status, the updated application status is reflected in the application list', async () => {
+      test('when changing status, the updated application status is reflected in the application list', async () => {
         const {adminPrograms} = ctx
         await adminPrograms.expectApplicationHasStatusString(
           'Guest',
@@ -204,7 +204,7 @@ describe('view program statuses', () => {
           await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
         })
 
-        it('choosing not to notify applicant changes status and does not send email', async () => {
+        test('choosing not to notify applicant changes status and does not send email', async () => {
           const {page, adminPrograms} = ctx
           const emailsBefore = supportsEmailInspection()
             ? await extractEmailsForRecipient(page, testUserDisplayName())
@@ -230,7 +230,7 @@ describe('view program statuses', () => {
           }
         })
 
-        it('checkbox is checked by default and email is sent', async () => {
+        test('checkbox is checked by default and email is sent', async () => {
           const {page, adminPrograms} = ctx
           const emailsBefore = supportsEmailInspection()
             ? await extractEmailsForRecipient(page, testUserDisplayName())
@@ -263,7 +263,7 @@ describe('view program statuses', () => {
       })
     })
 
-    it('allows editing a note and preserves the selected application', async () => {
+    test('allows editing a note and preserves the selected application', async () => {
       const {adminPrograms} = ctx
       await adminPrograms.editNote('Some note content')
       await adminPrograms.expectNoteUpdatedToast()
@@ -276,7 +276,7 @@ describe('view program statuses', () => {
       expect(applicationText).toContain('Guest')
     })
 
-    it('renders the note dialog', async () => {
+    test('renders the note dialog', async () => {
       const {page, adminPrograms} = ctx
       await adminPrograms.awaitEditNoteModal()
       await page.evaluate(() => {
@@ -285,7 +285,7 @@ describe('view program statuses', () => {
       await validateScreenshot(page, 'edit-note-modal')
     })
 
-    it('shows the current note content', async () => {
+    test('shows the current note content', async () => {
       const {adminPrograms} = ctx
       const noteText = 'Some note content'
       await adminPrograms.editNote(noteText)
@@ -298,7 +298,7 @@ describe('view program statuses', () => {
       expect(await adminPrograms.getNoteContent()).toBe(noteText)
     })
 
-    it('allows updating a note', async () => {
+    test('allows updating a note', async () => {
       const {adminPrograms} = ctx
       const noteText = 'Some note content'
       await adminPrograms.editNote('first note content')
@@ -313,7 +313,7 @@ describe('view program statuses', () => {
       expect(await adminPrograms.getNoteContent()).toBe(noteText)
     })
 
-    it('preserves newlines in notes', async () => {
+    test('preserves newlines in notes', async () => {
       const {adminPrograms} = ctx
       const noteText = 'Some note content\nwithseparatelines'
       await adminPrograms.editNote(noteText)
@@ -378,7 +378,7 @@ describe('view program statuses', () => {
       await adminPrograms.viewApplications(programWithDefaultStatusName)
     })
 
-    it('when a default status is set, applications with that status show (default)', async () => {
+    test('when a default status is set, applications with that status show (default)', async () => {
       const {page, adminPrograms} = ctx
       await adminPrograms.expectApplicationHasStatusString(
         'Guest',
@@ -461,7 +461,7 @@ describe('view program statuses', () => {
       await loginAsProgramAdmin(page)
     })
 
-    it('application without status appears in default filter and without statuses filter', async () => {
+    test('application without status appears in default filter and without statuses filter', async () => {
       const {adminPrograms} = ctx
       await adminPrograms.viewApplications(programForFilteringName)
       // Default page shows all applications.
@@ -492,7 +492,7 @@ describe('view program statuses', () => {
       await adminPrograms.expectApplicationCount(1)
     })
 
-    it('applied application status filter is used when downloading', async () => {
+    test('applied application status filter is used when downloading', async () => {
       const {adminPrograms} = ctx
       const applyFilters = true
       // Ensure that the application is included if the filter includes it.
@@ -526,7 +526,7 @@ describe('view program statuses', () => {
       expect(approvedStatusFilteredJsonContent.length).toEqual(0)
     })
 
-    it('application with status shows in default filter and status-specific filter', async () => {
+    test('application with status shows in default filter and status-specific filter', async () => {
       const {adminPrograms} = ctx
       // Explicitly set a status for the application.
       await adminPrograms.viewApplications(programForFilteringName)
@@ -562,7 +562,7 @@ describe('view program statuses', () => {
       await adminPrograms.expectApplicationCount(1)
     })
 
-    it('shows the application on reload after the status is updated to something no longer in the filter', async () => {
+    test('shows the application on reload after the status is updated to something no longer in the filter', async () => {
       const {adminPrograms} = ctx
 
       await adminPrograms.viewApplications(programForFilteringName)
@@ -657,7 +657,7 @@ describe('view program statuses', () => {
       await logout(page)
     })
 
-    it('application list shows eligibility statuses', async () => {
+    test('application list shows eligibility statuses', async () => {
       const {page, adminPrograms} = ctx
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(eligibilityProgramName)

--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -3,7 +3,7 @@ import {createTestContext, loginAsAdmin, waitForPageJsLoad} from './support'
 describe('create dropdown question with options', () => {
   const ctx = createTestContext()
 
-  it('add remove buttons work correctly', async () => {
+  test('add remove buttons work correctly', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe('create and edit predicates', () => {
   const ctx = createTestContext()
-  it('add a hide predicate', async () => {
+  test('add a hide predicate', async () => {
     const {
       page,
       adminQuestions,
@@ -110,7 +110,7 @@ describe('create and edit predicates', () => {
     expect(applicationText).not.toContain('Screen 2')
   })
 
-  it('add a show predicate', async () => {
+  test('add a show predicate', async () => {
     const {
       page,
       adminQuestions,
@@ -205,7 +205,7 @@ describe('create and edit predicates', () => {
     ).toContain('Screen 2')
   })
 
-  it('add an eligibility predicate', async () => {
+  test('add an eligibility predicate', async () => {
     const {
       page,
       adminQuestions,
@@ -357,7 +357,7 @@ describe('create and edit predicates', () => {
 
   // TODO(https://github.com/civiform/civiform/issues/4167): Enable integration testing of ESRI functionality
   if (isHermeticTestEnvironment()) {
-    it('add a service area validation predicate', async () => {
+    test('add a service area validation predicate', async () => {
       const {page, adminQuestions, adminPrograms, adminPredicates} = ctx
 
       await loginAsAdmin(page)
@@ -448,7 +448,7 @@ describe('create and edit predicates', () => {
       await logout(page)
     })
 
-    it('eligibility multiple values and multiple questions', async () => {
+    test('eligibility multiple values and multiple questions', async () => {
       const {page, adminPrograms, adminPredicates} = ctx
 
       await loginAsAdmin(page)
@@ -548,7 +548,7 @@ describe('create and edit predicates', () => {
       )
     })
 
-    it('visibility multiple values and multiple questions', async () => {
+    test('visibility multiple values and multiple questions', async () => {
       const {page, adminPrograms, adminPredicates} = ctx
 
       await loginAsAdmin(page)
@@ -629,7 +629,7 @@ describe('create and edit predicates', () => {
       )
     })
 
-    it('every visibility right hand type evaluates correctly', async () => {
+    test('every visibility right hand type evaluates correctly', async () => {
       const {page, adminPrograms, applicantQuestions, adminPredicates} = ctx
 
       await loginAsAdmin(page)
@@ -855,7 +855,7 @@ describe('create and edit predicates', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('every eligibility right hand type evaluates correctly', async () => {
+    test('every eligibility right hand type evaluates correctly', async () => {
       const {page, adminPrograms, applicantQuestions, adminPredicates} = ctx
 
       await loginAsAdmin(page)

--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -3,7 +3,7 @@ import {createTestContext, loginAsAdmin, validateScreenshot} from './support'
 describe('manage program admins', () => {
   const ctx = createTestContext()
 
-  it('does not add a program admin that does not exist', async () => {
+  test('does not add a program admin that does not exist', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -13,7 +13,7 @@ import {Page} from 'playwright'
 describe('program creation', () => {
   const ctx = createTestContext()
 
-  it('create program page with images flag off', async () => {
+  test('create program page with images flag off', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
     await disableFeatureFlag(page, 'program_card_images')
@@ -39,7 +39,7 @@ describe('program creation', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  it('create program page with images flag on', async () => {
+  test('create program page with images flag on', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -65,7 +65,7 @@ describe('program creation', () => {
     await adminProgramImage.expectProgramImagePage()
   })
 
-  it('create program then go back prevents URL edits', async () => {
+  test('create program then go back prevents URL edits', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -97,7 +97,7 @@ describe('program creation', () => {
     expect(await page.locator('#program-name-input').count()).toEqual(0)
   })
 
-  it('create program then go back can still go forward', async () => {
+  test('create program then go back can still go forward', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -117,7 +117,7 @@ describe('program creation', () => {
     await adminProgramImage.expectProgramImagePage()
   })
 
-  it('program details page screenshot', async () => {
+  test('program details page screenshot', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -127,7 +127,7 @@ describe('program creation', () => {
     await validateScreenshot(page, 'program-description-page')
   })
 
-  it('program details page redirects to block page', async () => {
+  test('program details page redirects to block page', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -139,7 +139,7 @@ describe('program creation', () => {
     await adminPrograms.expectProgramBlockEditPage()
   })
 
-  it('shows correct formatting during question creation', async () => {
+  test('shows correct formatting during question creation', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -161,7 +161,7 @@ describe('program creation', () => {
     )
   })
 
-  it('create program and search for questions', async () => {
+  test('create program and search for questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -206,7 +206,7 @@ describe('program creation', () => {
     )
   })
 
-  it('create program with enumerator and repeated questions', async () => {
+  test('create program with enumerator and repeated questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -269,7 +269,7 @@ describe('program creation', () => {
     )
   })
 
-  it('create program with address and address correction feature enabled', async () => {
+  test('create program with address and address correction feature enabled', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -311,7 +311,7 @@ describe('program creation', () => {
     ).not.toContain('Address correction')
   })
 
-  it('create program with multiple address questions, address correction feature enabled, and can only enable correction on one address', async () => {
+  test('create program with multiple address questions, address correction feature enabled, and can only enable correction on one address', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     const helpText =
       'This screen already contains a question with address correction enabled'
@@ -398,7 +398,7 @@ describe('program creation', () => {
     ).not.toContain('Address correction')
   })
 
-  it('create program with address and address correction feature disabled', async () => {
+  test('create program with address and address correction feature disabled', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -421,7 +421,7 @@ describe('program creation', () => {
     expect(await addressCorrectionInput.inputValue()).toBe('false')
   })
 
-  it('change questions order within block', async () => {
+  test('change questions order within block', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -466,7 +466,7 @@ describe('program creation', () => {
     await validateScreenshot(page, 'program-creation')
   })
 
-  it('create question from question bank', async () => {
+  test('create question from question bank', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -528,7 +528,7 @@ describe('program creation', () => {
     ])
   })
 
-  it('all questions shown on question bank before filtering, then filters based on different attributes correctly', async () => {
+  test('all questions shown on question bank before filtering, then filters based on different attributes correctly', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -686,7 +686,7 @@ describe('program creation', () => {
    * and then go to edit the program, it would error
    * because it would go to the block with ID == 1
    */
-  it('delete first block and edit', async () => {
+  test('delete first block and edit', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -702,7 +702,7 @@ describe('program creation', () => {
     await adminPrograms.gotoViewActiveProgramPageAndStartEditing(programName)
   })
 
-  it('delete last block and edit', async () => {
+  test('delete last block and edit', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -714,7 +714,7 @@ describe('program creation', () => {
     await adminPrograms.gotoEditDraftProgramPage(programName)
   })
 
-  it('correctly renders delete screen confirmation modal', async () => {
+  test('correctly renders delete screen confirmation modal', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -740,7 +740,7 @@ describe('program creation', () => {
     }
   }
 
-  it('create common intake form with intake form feature enabled', async () => {
+  test('create common intake form with intake form feature enabled', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -768,7 +768,7 @@ describe('program creation', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  it('correctly renders common intake form change confirmation modal', async () => {
+  test('correctly renders common intake form change confirmation modal', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -818,7 +818,7 @@ describe('program creation', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  it('regular program has eligibility conditions', async () => {
+  test('regular program has eligibility conditions', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -838,7 +838,7 @@ describe('program creation', () => {
     expect(await page.innerText('main')).toContain('Eligibility')
   })
 
-  it('common intake form does not have eligibility conditions', async () => {
+  test('common intake form does not have eligibility conditions', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -858,7 +858,7 @@ describe('program creation', () => {
     expect(await page.innerText('main')).not.toContain('Eligibility')
   })
 
-  it('create program with universal questions', async () => {
+  test('create program with universal questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/admin_program_image.test.ts
+++ b/browser-test/src/admin_program_image.test.ts
@@ -10,7 +10,7 @@ import {
 describe('Admin can manage program image', () => {
   const ctx = createTestContext()
 
-  it('views a program without an image', async () => {
+  test('views a program without an image', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -24,7 +24,7 @@ describe('Admin can manage program image', () => {
   })
 
   describe('back button', () => {
-    it('back button redirects to block page if came from block page', async () => {
+    test('back button redirects to block page if came from block page', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -40,7 +40,7 @@ describe('Admin can manage program image', () => {
       await adminPrograms.expectProgramBlockEditPage()
     })
 
-    it('back button redirects to details page if came from create program page', async () => {
+    test('back button redirects to details page if came from create program page', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -57,7 +57,7 @@ describe('Admin can manage program image', () => {
       await adminPrograms.expectProgramEditPage(programName)
     })
 
-    it('back button preserves location after interaction', async () => {
+    test('back button preserves location after interaction', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -81,7 +81,7 @@ describe('Admin can manage program image', () => {
   })
 
   describe('continue button', () => {
-    it('continue button shows if from program creation page', async () => {
+    test('continue button shows if from program creation page', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -94,7 +94,7 @@ describe('Admin can manage program image', () => {
       await validateScreenshot(page, 'program-image-with-continue')
     })
 
-    it('continue button redirects to program blocks page', async () => {
+    test('continue button redirects to program blocks page', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -109,7 +109,7 @@ describe('Admin can manage program image', () => {
       await adminPrograms.expectProgramBlockEditPage()
     })
 
-    it('continue button hides if from edit program image page', async () => {
+    test('continue button hides if from edit program image page', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -135,7 +135,7 @@ describe('Admin can manage program image', () => {
       await adminPrograms.goToProgramImagePage(programName)
     })
 
-    it('sets new description', async () => {
+    test('sets new description', async () => {
       const {page, adminProgramImage} = ctx
 
       await adminProgramImage.setImageDescription('Fake image description')
@@ -158,7 +158,7 @@ describe('Admin can manage program image', () => {
       await validateScreenshot(page, 'program-image-with-description')
     })
 
-    it('updates existing description', async () => {
+    test('updates existing description', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -179,7 +179,7 @@ describe('Admin can manage program image', () => {
       )
     })
 
-    it('removes description with empty', async () => {
+    test('removes description with empty', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -196,7 +196,7 @@ describe('Admin can manage program image', () => {
       )
     })
 
-    it('removes description with blank', async () => {
+    test('removes description with blank', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -216,7 +216,7 @@ describe('Admin can manage program image', () => {
       )
     })
 
-    it('does not remove description if image present (description set to empty)', async () => {
+    test('does not remove description if image present (description set to empty)', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Original description',
@@ -234,7 +234,7 @@ describe('Admin can manage program image', () => {
       )
     })
 
-    it('does not remove description if image present (description set to blank)', async () => {
+    test('does not remove description if image present (description set to blank)', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Original description',
@@ -252,7 +252,7 @@ describe('Admin can manage program image', () => {
       )
     })
 
-    it('can remove description after deleting image', async () => {
+    test('can remove description after deleting image', async () => {
       const {adminProgramImage} = ctx
 
       // Set a description and image
@@ -273,7 +273,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDescriptionIs('')
     })
 
-    it('disables submit button after save', async () => {
+    test('disables submit button after save', async () => {
       const {adminProgramImage} = ctx
 
       await adminProgramImage.setImageDescriptionAndSubmit(
@@ -285,7 +285,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageDescriptionSubmit()
     })
 
-    it('disables submit button when no text change', async () => {
+    test('disables submit button when no text change', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -302,7 +302,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageDescriptionSubmit()
     })
 
-    it('enables submit button when change', async () => {
+    test('enables submit button when change', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -313,7 +313,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectEnabledImageDescriptionSubmit()
     })
 
-    it('enables submit button when text removed', async () => {
+    test('enables submit button when text removed', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -326,7 +326,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectEnabledImageDescriptionSubmit()
     })
 
-    it('disables translation button when no description', async () => {
+    test('disables translation button when no description', async () => {
       const {adminProgramImage} = ctx
 
       await adminProgramImage.expectProgramImagePage()
@@ -335,7 +335,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledTranslationButton()
     })
 
-    it('enables translation button when description exists', async () => {
+    test('enables translation button when description exists', async () => {
       const {adminProgramImage} = ctx
 
       await adminProgramImage.setImageDescriptionAndSubmit(
@@ -346,7 +346,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectEnabledTranslationButton()
     })
 
-    it('translation button redirects to translations page', async () => {
+    test('translation button redirects to translations page', async () => {
       const {adminPrograms, adminProgramImage} = ctx
 
       await adminProgramImage.setImageDescriptionAndSubmit(
@@ -370,7 +370,7 @@ describe('Admin can manage program image', () => {
       await adminPrograms.goToProgramImagePage(programName)
     })
 
-    it('form is correctly formatted', async () => {
+    test('form is correctly formatted', async () => {
       const {page} = ctx
 
       const formInputs = await page
@@ -383,7 +383,7 @@ describe('Admin can manage program image', () => {
       expect(await lastFormInput.getAttribute('type')).toBe('file')
     })
 
-    it('shows uploaded image before submitting', async () => {
+    test('shows uploaded image before submitting', async () => {
       const {page, adminProgramImage} = ctx
 
       await adminProgramImage.setImageFile(
@@ -393,7 +393,7 @@ describe('Admin can manage program image', () => {
       await validateScreenshot(page, 'program-image-with-image-before-save')
     })
 
-    it('prevents image upload when no description', async () => {
+    test('prevents image upload when no description', async () => {
       const {adminProgramImage} = ctx
 
       await adminProgramImage.expectProgramImagePage()
@@ -403,7 +403,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageFileUploadSubmit()
     })
 
-    it('disables submit button when no image', async () => {
+    test('disables submit button when no image', async () => {
       const {adminProgramImage} = ctx
       // The submit button will also be disabled if there's no description,
       // which we don't want to test here. So, set a description to rule
@@ -415,7 +415,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageFileUploadSubmit()
     })
 
-    it('disables submit button when too large image', async () => {
+    test('disables submit button when too large image', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -428,7 +428,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageFileUploadSubmit()
     })
 
-    it('enables submit button when small enough image', async () => {
+    test('enables submit button when small enough image', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -441,7 +441,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectEnabledImageFileUploadSubmit()
     })
 
-    it('disables submit button when image removed', async () => {
+    test('disables submit button when image removed', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -456,7 +456,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectDisabledImageFileUploadSubmit()
     })
 
-    it('shows error when too large image', async () => {
+    test('shows error when too large image', async () => {
       const {page, adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -471,7 +471,7 @@ describe('Admin can manage program image', () => {
       await validateScreenshot(page, 'program-image-with-too-large-error')
     })
 
-    it('hides error when too large image replaced with smaller image', async () => {
+    test('hides error when too large image replaced with smaller image', async () => {
       const {adminProgramImage} = ctx
       await adminProgramImage.setImageDescriptionAndSubmit(
         'Fake image description',
@@ -489,7 +489,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectTooLargeErrorHidden()
     })
 
-    it('adds new image', async () => {
+    test('adds new image', async () => {
       const {page, adminProgramImage} = ctx
 
       await adminProgramImage.expectNoImagePreview()
@@ -507,7 +507,7 @@ describe('Admin can manage program image', () => {
       await adminProgramImage.expectImagePreview()
     })
 
-    it('deletes existing image', async () => {
+    test('deletes existing image', async () => {
       const {page, adminProgramImage} = ctx
 
       await adminProgramImage.setImageFileAndSubmit(

--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -12,7 +12,7 @@ import {ProgramVisibility} from './support/admin_programs'
 describe('Program list page.', () => {
   const ctx = createTestContext()
 
-  it('view draft program', async () => {
+  test('view draft program', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -22,7 +22,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-one-draft-program')
   })
 
-  it('view active program', async () => {
+  test('view active program', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -33,7 +33,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-one-active-program')
   })
 
-  it('view program with active and draft versions', async () => {
+  test('view program with active and draft versions', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -47,7 +47,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-active-and-draft-versions')
   })
 
-  it('sorts by last updated, preferring draft over active', async () => {
+  test('sorts by last updated, preferring draft over active', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -79,7 +79,7 @@ describe('Program list page.', () => {
     ])
   })
 
-  it('shows which program is the common intake when enabled', async () => {
+  test('shows which program is the common intake when enabled', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -102,7 +102,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'intake-form-indicator')
   })
 
-  it('shows information about universal questions when the flag is enabled and at least one universal question is set', async () => {
+  test('shows information about universal questions when the flag is enabled and at least one universal question is set', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -155,7 +155,7 @@ describe('Program list page.', () => {
     expect(programListNames).toEqual(expectedPrograms)
   }
 
-  it('publishes a single program', async () => {
+  test('publishes a single program', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -180,7 +180,7 @@ describe('Program list page.', () => {
     await adminPrograms.expectActiveProgram(programOne)
   })
 
-  it('publishing a single program shows a modal with conditional warning about universal questions', async () => {
+  test('publishing a single program shows a modal with conditional warning about universal questions', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -244,7 +244,7 @@ describe('Program list page.', () => {
     await adminPrograms.expectActiveProgram(programOne)
   })
 
-  it('program list has current image if images flag on', async () => {
+  test('program list has current image if images flag on', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -261,7 +261,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-with-image-flag-on')
   })
 
-  it('program list does not show current image if images flag off', async () => {
+  test('program list does not show current image if images flag off', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     // Enable the flag to set a program image
@@ -282,7 +282,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-with-image-flag-off')
   })
 
-  it('program list with no image', async () => {
+  test('program list with no image', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -295,7 +295,7 @@ describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-no-image')
   })
 
-  it('program list with new image in draft', async () => {
+  test('program list with new image in draft', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -321,7 +321,7 @@ describe('Program list page.', () => {
   // This test is flaky in staging prober tests, so only run it locally and on
   // GitHub actions. See issue #6624 for more details.
   if (isLocalDevEnvironment()) {
-    it('program list with different active and draft image', async () => {
+    test('program list with different active and draft image', async () => {
       const {page, adminPrograms, adminProgramImage} = ctx
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_card_images')
@@ -349,7 +349,7 @@ describe('Program list page.', () => {
     })
   }
 
-  it('program list with same active and draft image', async () => {
+  test('program list with same active and draft image', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')

--- a/browser-test/src/admin_program_preview.test.ts
+++ b/browser-test/src/admin_program_preview.test.ts
@@ -8,7 +8,7 @@ import {
 describe('admin program preview', () => {
   const ctx = createTestContext()
 
-  it('preview draft program and submit', async () => {
+  test('preview draft program and submit', async () => {
     const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
     await loginAsAdmin(page)
 
@@ -33,7 +33,7 @@ describe('admin program preview', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  it('preview active program and submit', async () => {
+  test('preview active program and submit', async () => {
     const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
     await loginAsAdmin(page)
 
@@ -57,7 +57,7 @@ describe('admin program preview', () => {
     await adminPrograms.expectProgramBlockReadOnlyPage()
   })
 
-  it('preview program and use back button', async () => {
+  test('preview program and use back button', async () => {
     const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
     await loginAsAdmin(page)
 

--- a/browser-test/src/admin_program_settings.test.ts
+++ b/browser-test/src/admin_program_settings.test.ts
@@ -10,7 +10,7 @@ import {ProgramVisibility} from './support/admin_programs'
 describe('program settings', () => {
   const ctx = createTestContext()
 
-  it('program settings page', async () => {
+  test('program settings page', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -35,7 +35,7 @@ describe('program settings', () => {
     await validateScreenshot(page, 'nongating-eligibility')
   })
 
-  it('program index shows settings in dropdown', async () => {
+  test('program index shows settings in dropdown', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -71,7 +71,7 @@ describe('program settings', () => {
     ).toBe(true)
   })
 
-  it('back button on program settings page navigates correctly', async () => {
+  test('back button on program settings page navigates correctly', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')
@@ -99,7 +99,7 @@ describe('program settings', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  it('program index hides settings in dropdown for common intake form', async () => {
+  test('program index hides settings in dropdown for common intake form', async () => {
     const {page, adminPrograms} = ctx
 
     await enableFeatureFlag(page, 'intake_form_enabled')

--- a/browser-test/src/admin_program_statuses.test.ts
+++ b/browser-test/src/admin_program_statuses.test.ts
@@ -16,7 +16,7 @@ describe('modify program statuses', () => {
   })
 
   describe('statuses list', () => {
-    it('creates a new program and has no statuses', async () => {
+    test('creates a new program and has no statuses', async () => {
       const {page, adminPrograms, adminProgramStatuses} = ctx
       // Add a draft program, no questions are needed.
       const programName = 'Test program without statuses'
@@ -41,7 +41,7 @@ describe('modify program statuses', () => {
       await ctx.adminPrograms.gotoDraftProgramManageStatusesPage(programName)
     })
 
-    it('renders create new status modal', async () => {
+    test('renders create new status modal', async () => {
       const {page} = ctx
       await page.click('button:has-text("Create a new status")')
 
@@ -50,7 +50,7 @@ describe('modify program statuses', () => {
       await validateScreenshot(page, 'create-new-status-modal')
     })
 
-    it('creates a new status with no email', async () => {
+    test('creates a new status with no email', async () => {
       const {adminProgramStatuses} = ctx
       await adminProgramStatuses.createStatus('Status with no email')
       await adminProgramStatuses.expectProgramManageStatusesPage(programName)
@@ -60,7 +60,7 @@ describe('modify program statuses', () => {
       })
     })
 
-    it('creates a new status with email', async () => {
+    test('creates a new status with email', async () => {
       const {adminProgramStatuses} = ctx
       await adminProgramStatuses.createStatus('Status with email', {
         emailBody: 'An email',
@@ -72,7 +72,7 @@ describe('modify program statuses', () => {
       })
     })
 
-    it('fails to create status with an empty name', async () => {
+    test('fails to create status with an empty name', async () => {
       const {page, adminProgramStatuses} = ctx
       await adminProgramStatuses.createStatus('')
       await adminProgramStatuses.expectProgramManageStatusesPage(programName)
@@ -82,7 +82,7 @@ describe('modify program statuses', () => {
       await dismissModal(page)
     })
 
-    it('fails to create status with an existing name', async () => {
+    test('fails to create status with an existing name', async () => {
       const {page, adminProgramStatuses} = ctx
       await adminProgramStatuses.createStatus('Existing status')
       await adminProgramStatuses.expectProgramManageStatusesPage(programName)
@@ -125,12 +125,12 @@ describe('modify program statuses', () => {
       await ctx.adminPrograms.gotoDraftProgramManageStatusesPage(programName)
     })
 
-    it('renders existing statuses', async () => {
+    test('renders existing statuses', async () => {
       const {page} = ctx
       await validateScreenshot(page, 'status-list-with-statuses')
     })
 
-    it('fails to edit status when providing an existing status name', async () => {
+    test('fails to edit status when providing an existing status name', async () => {
       const {page, adminProgramStatuses} = ctx
       await adminProgramStatuses.editStatus(firstStatusName, {
         editedStatusName: secondStatusName,
@@ -142,7 +142,7 @@ describe('modify program statuses', () => {
       await dismissModal(page)
     })
 
-    it('fails to edit status with an empty name', async () => {
+    test('fails to edit status with an empty name', async () => {
       const {page, adminProgramStatuses} = ctx
       await adminProgramStatuses.editStatus(firstStatusName, {
         editedStatusName: '',
@@ -154,7 +154,7 @@ describe('modify program statuses', () => {
       await dismissModal(page)
     })
 
-    it('edits an existing status name', async () => {
+    test('edits an existing status name', async () => {
       const {adminProgramStatuses} = ctx
       await adminProgramStatuses.editStatus(secondStatusName, {
         editedStatusName: 'Updated status name',
@@ -172,7 +172,7 @@ describe('modify program statuses', () => {
       expect(emailWarningVisible).toBe(false)
     })
 
-    it('edits an existing status, configures email, and deletes the configured email', async () => {
+    test('edits an existing status, configures email, and deletes the configured email', async () => {
       const {adminProgramStatuses} = ctx
       await adminProgramStatuses.editStatus(firstStatusName, {
         editedStatusName: firstStatusName,
@@ -251,7 +251,7 @@ describe('modify program statuses', () => {
       })
     })
 
-    it('deletes an existing status', async () => {
+    test('deletes an existing status', async () => {
       const {adminPrograms, adminProgramStatuses} = ctx
       await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
       await adminProgramStatuses.deleteStatus(firstStatusName)
@@ -278,7 +278,7 @@ describe('modify program statuses', () => {
       await ctx.adminPrograms.gotoDraftProgramManageStatusesPage(programName)
     })
 
-    it('creates a new status as default', async () => {
+    test('creates a new status as default', async () => {
       const {page, adminProgramStatuses} = ctx
       const statusName = 'Test Status 1'
 
@@ -301,7 +301,7 @@ describe('modify program statuses', () => {
       await validateScreenshot(page, 'status-list-with-default-status')
     })
 
-    it('dismissing the confirmation dialog does not create the new status', async () => {
+    test('dismissing the confirmation dialog does not create the new status', async () => {
       const {page, adminProgramStatuses} = ctx
       const oldDefault = 'Test Status 1'
       const statusName = 'Test Status 2'
@@ -321,7 +321,7 @@ describe('modify program statuses', () => {
       await validateScreenshot(page, 'status-list-test-1-remains-default')
     })
 
-    it('creating a new status as default changes default to the new status', async () => {
+    test('creating a new status as default changes default to the new status', async () => {
       const {page, adminProgramStatuses} = ctx
       const oldDefault = 'Test Status 1'
       const statusName = 'Test Status 2'
@@ -345,7 +345,7 @@ describe('modify program statuses', () => {
       await validateScreenshot(page, 'status-list-test-2-default')
     })
 
-    it('changes the default status', async () => {
+    test('changes the default status', async () => {
       const {page, adminProgramStatuses} = ctx
       const oldDefault = 'Test Status 2'
       const newDefault = 'Test Status 1'
@@ -366,7 +366,7 @@ describe('modify program statuses', () => {
       await validateScreenshot(page, 'status-list-test-1-as-default-again')
     })
 
-    it('unsets the default status', async () => {
+    test('unsets the default status', async () => {
       const {page, adminProgramStatuses} = ctx
       const statusName = 'Test Status 1'
 

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -11,7 +11,7 @@ import {
 describe('Admin can manage translations', () => {
   const ctx = createTestContext()
 
-  it('creates a program without statuses and adds translation', async () => {
+  test('creates a program without statuses and adds translation', async () => {
     const {page, adminPrograms, adminTranslations} = ctx
 
     await loginAsAdmin(page)
@@ -58,7 +58,7 @@ describe('Admin can manage translations', () => {
     expect(cardText).toContain('Spanish description')
   })
 
-  it('creates a program with statuses and adds translations for program statuses', async () => {
+  test('creates a program with statuses and adds translations for program statuses', async () => {
     const {page, adminPrograms, adminProgramStatuses, adminTranslations} = ctx
 
     await loginAsAdmin(page)
@@ -151,7 +151,7 @@ describe('Admin can manage translations', () => {
     })
   })
 
-  it('creates a program with summary image description and adds translations', async () => {
+  test('creates a program with summary image description and adds translations', async () => {
     const {page, adminPrograms, adminProgramImage, adminTranslations} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -192,7 +192,7 @@ describe('Admin can manage translations', () => {
     await adminTranslations.expectProgramImageDescriptionTranslation('')
   })
 
-  it('editing summary image description does not clobber translations', async () => {
+  test('editing summary image description does not clobber translations', async () => {
     const {page, adminPrograms, adminProgramImage, adminTranslations} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -229,7 +229,7 @@ describe('Admin can manage translations', () => {
     )
   })
 
-  it('deleting summary image description deletes all translations', async () => {
+  test('deleting summary image description deletes all translations', async () => {
     const {page, adminPrograms, adminProgramImage, adminTranslations} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -264,7 +264,7 @@ describe('Admin can manage translations', () => {
     await adminTranslations.expectNoProgramImageDescription()
   })
 
-  it('creates a question and adds translations', async () => {
+  test('creates a question and adds translations', async () => {
     const {
       page,
       adminPrograms,
@@ -318,7 +318,7 @@ describe('Admin can manage translations', () => {
     )
   })
 
-  it('create a multi-option question and add translations for options', async () => {
+  test('create a multi-option question and add translations for options', async () => {
     const {
       page,
       adminPrograms,
@@ -366,7 +366,7 @@ describe('Admin can manage translations', () => {
     expect(await page.innerText('main form')).toContain('tres')
   })
 
-  it('create an enumerator question and add translations for entity type', async () => {
+  test('create an enumerator question and add translations for entity type', async () => {
     const {
       page,
       adminPrograms,
@@ -402,7 +402,7 @@ describe('Admin can manage translations', () => {
     expect(await page.innerText('main form')).toContain('family member')
   })
 
-  it('updating a question does not clobber translations', async () => {
+  test('updating a question does not clobber translations', async () => {
     const {page, adminQuestions, adminTranslations} = ctx
 
     await loginAsAdmin(page)
@@ -430,7 +430,7 @@ describe('Admin can manage translations', () => {
     )
   })
 
-  it('deleting help text in question edit view deletes all help text translations', async () => {
+  test('deleting help text in question edit view deletes all help text translations', async () => {
     const {page, adminQuestions, adminTranslations} = ctx
 
     await loginAsAdmin(page)
@@ -462,7 +462,7 @@ describe('Admin can manage translations', () => {
     expect(await page.inputValue('text=Question help text')).toEqual('')
   })
 
-  it('Applicant sees toast message warning translation is not complete', async () => {
+  test('Applicant sees toast message warning translation is not complete', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     // Add a new program with one non-translated question

--- a/browser-test/src/admin_program_viewing.test.ts
+++ b/browser-test/src/admin_program_viewing.test.ts
@@ -9,7 +9,7 @@ import {
 describe('admin program view page', () => {
   const ctx = createTestContext()
 
-  it('view active program shows read only view', async () => {
+  test('view active program shows read only view', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -20,7 +20,7 @@ describe('admin program view page', () => {
     await validateScreenshot(page, 'program-read-only-view')
   })
 
-  it('view draft program has edit image button if images flag on', async () => {
+  test('view draft program has edit image button if images flag on', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'program_card_images')
@@ -32,7 +32,7 @@ describe('admin program view page', () => {
     await validateScreenshot(page, 'program-draft-view-images-flag-on')
   })
 
-  it('view draft program has no edit image button if images flag off', async () => {
+  test('view draft program has no edit image button if images flag off', async () => {
     const {page, adminPrograms} = ctx
     await loginAsAdmin(page)
     await disableFeatureFlag(page, 'program_card_images')
@@ -44,7 +44,7 @@ describe('admin program view page', () => {
     await validateScreenshot(page, 'program-draft-view-images-flag-off')
   })
 
-  it('view program with universal questions', async () => {
+  test('view program with universal questions', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
     await loginAsAdmin(page)
 
@@ -88,7 +88,7 @@ describe('admin program view page', () => {
     await validateScreenshot(page, 'program-view-universal-questions')
   })
 
-  it('view program, view multiple blocks, then start editing with extra long screen name and description', async () => {
+  test('view program, view multiple blocks, then start editing with extra long screen name and description', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'esri_address_correction_enabled')
@@ -138,7 +138,7 @@ describe('admin program view page', () => {
     )
   })
 
-  it('view program, view multiple blocks, then start editing', async () => {
+  test('view program, view multiple blocks, then start editing', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'esri_address_correction_enabled')

--- a/browser-test/src/admin_program_visibility.test.ts
+++ b/browser-test/src/admin_program_visibility.test.ts
@@ -14,7 +14,7 @@ import {ProgramVisibility} from './support/admin_programs'
 
 describe('Validate program visibility is correct for applicants and TIs', () => {
   const ctx = createTestContext()
-  it('Create a new hidden program, verify applicants cannot see it on the home page', async () => {
+  test('Create a new hidden program, verify applicants cannot see it on the home page', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -42,7 +42,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await logout(page)
   })
 
-  it('create a public program, verify applicants can see it on the home page', async () => {
+  test('create a public program, verify applicants can see it on the home page', async () => {
     const {page, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -69,7 +69,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     await validateScreenshot(page, 'program-visibility-public')
   })
 
-  it('create a program visible only to TIs, verify TIs can see it and other applicants cannot', async () => {
+  test('create a program visible only to TIs, verify TIs can see it and other applicants cannot', async () => {
     const {page, tiDashboard, adminPrograms} = ctx
 
     await loginAsAdmin(page)
@@ -114,7 +114,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     )
     await validateScreenshot(page, 'program-visibility-ti-only-visible-to-ti')
   })
-  it('create a program visible only for Selected TIs, verify those TIs can see it and other applicants/TIs cannot', async () => {
+  test('create a program visible only for Selected TIs, verify those TIs can see it and other applicants/TIs cannot', async () => {
     const {page, tiDashboard, adminPrograms, adminTiGroups} = ctx
 
     await loginAsAdmin(page)
@@ -190,7 +190,7 @@ describe('Validate program visibility is correct for applicants and TIs', () => 
     )
     await validateScreenshot(page, 'program-visibility-for-selected-tis')
   })
-  it('create a program visible only for Selected TIs, then choose TI_Only, all TIs can see the program', async () => {
+  test('create a program visible only for Selected TIs, then choose TI_Only, all TIs can see the program', async () => {
     const {page, tiDashboard, adminPrograms, adminTiGroups} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/admin_publish.test.ts
+++ b/browser-test/src/admin_publish.test.ts
@@ -66,7 +66,7 @@ describe('publishing all draft questions and programs', () => {
     await adminPrograms.gotoAdminProgramsPage()
   })
 
-  it('shows programs and questions that will be published in the modal', async () => {
+  test('shows programs and questions that will be published in the modal', async () => {
     await adminPrograms.expectProgramReferencesModalContains({
       expectedQuestionsContents: [`${draftQuestionText} - Edit`],
       expectedProgramsContents: [
@@ -76,7 +76,7 @@ describe('publishing all draft questions and programs', () => {
     })
   })
 
-  it('validate screenshot', async () => {
+  test('validate screenshot', async () => {
     await adminPrograms.openPublishAllDraftsModal()
     await validateScreenshot(
       adminPrograms.publishAllProgramsModalLocator(),
@@ -85,7 +85,7 @@ describe('publishing all draft questions and programs', () => {
     await dismissModal(pageObject)
   })
 
-  it('publishing all programs with universal questions feature flag on shows a modal with information about universal questions', async () => {
+  test('publishing all programs with universal questions feature flag on shows a modal with information about universal questions', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
     await loginAsAdmin(page)
     // Create programs and questions (including universal questions)

--- a/browser-test/src/admin_question_list.test.ts
+++ b/browser-test/src/admin_question_list.test.ts
@@ -8,7 +8,7 @@ import {
 } from './support'
 describe('Admin question list', () => {
   const ctx = createTestContext()
-  it('sorts by last updated, preferring draft over active', async () => {
+  test('sorts by last updated, preferring draft over active', async () => {
     const {page, adminPrograms, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -83,7 +83,7 @@ describe('Admin question list', () => {
     ])
   })
 
-  it('filters question list with search query', async () => {
+  test('filters question list with search query', async () => {
     const {page, adminQuestions} = ctx
     await loginAsAdmin(page)
     await adminQuestions.addTextQuestion({
@@ -110,7 +110,7 @@ describe('Admin question list', () => {
     ])
   })
 
-  it('sorts question list based on selection', async () => {
+  test('sorts question list based on selection', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
     // Set the questionText to the same as questionName to make validation easier since questionBankNames()
@@ -158,7 +158,7 @@ describe('Admin question list', () => {
     await validateScreenshot(page, 'questions-list-sort-dropdown-lastmodified')
   })
 
-  it('shows if questions are marked for archival', async () => {
+  test('shows if questions are marked for archival', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -190,7 +190,7 @@ describe('Admin question list', () => {
     await validateScreenshot(page, 'questions-list-with-archived-questions')
   })
 
-  it('does not sort archived questions', async () => {
+  test('does not sort archived questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -235,7 +235,7 @@ describe('Admin question list', () => {
     ])
   })
 
-  it('persists universal state and orders questions correctly', async () => {
+  test('persists universal state and orders questions correctly', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/admin_question_references.test.ts
+++ b/browser-test/src/admin_question_references.test.ts
@@ -3,7 +3,7 @@ import {createTestContext, loginAsAdmin, validateScreenshot} from './support'
 describe('view program references from question view', () => {
   const ctx = createTestContext()
 
-  it('shows no results for an unreferenced question', async () => {
+  test('shows no results for an unreferenced question', async () => {
     const {page, adminQuestions} = ctx
     await loginAsAdmin(page)
     const questionName = 'unreferenced-q'
@@ -15,7 +15,7 @@ describe('view program references from question view', () => {
     })
   })
 
-  it('shows results for referencing programs', async () => {
+  test('shows results for referencing programs', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     const questionName = 'question-references-q'
     await loginAsAdmin(page)

--- a/browser-test/src/admin_settings.test.ts
+++ b/browser-test/src/admin_settings.test.ts
@@ -8,7 +8,7 @@ import {
 describe('Managing system-wide settings', () => {
   const ctx = createTestContext()
 
-  it('Displays the settings page', async () => {
+  test('Displays the settings page', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
 
@@ -26,7 +26,7 @@ describe('Managing system-wide settings', () => {
     )
   })
 
-  it('Displays the settings page in a narrow viewport', async () => {
+  test('Displays the settings page in a narrow viewport', async () => {
     const {page} = ctx
 
     // We know the header will start to wrap at smaller widths
@@ -42,7 +42,7 @@ describe('Managing system-wide settings', () => {
     await validateScreenshot(page, 'admin-settings-page-narrow')
   })
 
-  it('Updates settings on save', async () => {
+  test('Updates settings on save', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
 

--- a/browser-test/src/api_docs.test.ts
+++ b/browser-test/src/api_docs.test.ts
@@ -18,7 +18,7 @@ describe('Viewing API docs', () => {
     await seedPrograms(page)
   })
 
-  it('Views active API docs', async () => {
+  test('Views active API docs', async () => {
     // TODO: fix the problem with these test on probers
     // https://github.com/civiform/civiform/issues/6158
     if (isHermeticTestEnvironment()) {
@@ -55,7 +55,7 @@ describe('Viewing API docs', () => {
     }
   })
 
-  it('Views active API docs without logging in', async () => {
+  test('Views active API docs without logging in', async () => {
     const {page, adminPrograms, browserContext} = ctx
 
     await page.goto(BASE_URL)
@@ -91,7 +91,7 @@ describe('Viewing API docs', () => {
     )
   })
 
-  it('Views draft API docs when available', async () => {
+  test('Views draft API docs when available', async () => {
     if (isHermeticTestEnvironment()) {
       const {page} = ctx
 
@@ -108,7 +108,7 @@ describe('Viewing API docs', () => {
     }
   })
 
-  it('Shows error on draft API docs when no draft available', async () => {
+  test('Shows error on draft API docs when no draft available', async () => {
     if (isHermeticTestEnvironment()) {
       const {page, adminPrograms} = ctx
 
@@ -126,7 +126,7 @@ describe('Viewing API docs', () => {
     }
   })
 
-  it('Opens help accordion with a click', async () => {
+  test('Opens help accordion with a click', async () => {
     const {page, adminPrograms} = ctx
 
     await page.goto(BASE_URL)

--- a/browser-test/src/applicant_application_index.test.ts
+++ b/browser-test/src/applicant_application_index.test.ts
@@ -53,7 +53,7 @@ describe('applicant program index page', () => {
     await logout(page)
   })
 
-  it('shows log in button for guest users', async () => {
+  test('shows log in button for guest users', async () => {
     const {page, applicantQuestions} = ctx
     await validateAccessibility(page)
 
@@ -67,7 +67,7 @@ describe('applicant program index page', () => {
     await logout(page)
   })
 
-  it('shows login prompt for guest users when they click apply', async () => {
+  test('shows login prompt for guest users when they click apply', async () => {
     const {page} = ctx
     await validateAccessibility(page)
 
@@ -103,7 +103,7 @@ describe('applicant program index page', () => {
     )
   })
 
-  it('categorizes programs for draft and applied applications', async () => {
+  test('categorizes programs for draft and applied applications', async () => {
     const {page, applicantQuestions} = ctx
     await loginAsTestUser(page)
     // Navigate to the applicant's program index and validate that both programs appear in the
@@ -147,7 +147,7 @@ describe('applicant program index page', () => {
     })
   })
 
-  it('common intake form enabled but not present', async () => {
+  test('common intake form enabled but not present', async () => {
     const {page} = ctx
     await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -155,7 +155,7 @@ describe('applicant program index page', () => {
     await validateAccessibility(page)
   })
 
-  it('shows common intake form when enabled and present', async () => {
+  test('shows common intake form when enabled and present', async () => {
     const {page, adminPrograms, applicantQuestions} = ctx
     await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -187,7 +187,7 @@ describe('applicant program index page', () => {
     await validateAccessibility(page)
   })
 
-  it('shows a different title for the common intake form', async () => {
+  test('shows a different title for the common intake form', async () => {
     const {page, applicantQuestions} = ctx
     await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -201,7 +201,7 @@ describe('applicant program index page', () => {
     )
   })
 
-  it('shows previously answered on text for questions that had been answered', async () => {
+  test('shows previously answered on text for questions that had been answered', async () => {
     const {page, applicantQuestions} = ctx
 
     // Fill out application with one question and confirm it shows previously answered at the end.
@@ -256,7 +256,7 @@ describe('applicant program index page', () => {
 describe('applicant program index page with images', () => {
   const ctx = createTestContext()
 
-  it('shows program with wide image', async () => {
+  test('shows program with wide image', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     const programName = 'Wide Image Program'
     await loginAsAdmin(page)
@@ -273,7 +273,7 @@ describe('applicant program index page with images', () => {
     await validateAccessibility(page)
   })
 
-  it('shows program with tall image', async () => {
+  test('shows program with tall image', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     const programName = 'Tall Image Program'
     await loginAsAdmin(page)
@@ -289,7 +289,7 @@ describe('applicant program index page with images', () => {
     await validateScreenshot(page, 'program-image-tall')
   })
 
-  it('no program image if flag off', async () => {
+  test('no program image if flag off', async () => {
     const {page, adminPrograms, adminProgramImage} = ctx
     const programName = 'Image Flag Off Program'
     await loginAsAdmin(page)
@@ -309,7 +309,7 @@ describe('applicant program index page with images', () => {
     await validateScreenshot(page, 'program-image-flag-off')
   })
 
-  it('shows program with image and status', async () => {
+  test('shows program with image and status', async () => {
     const {page, adminPrograms, adminProgramStatuses, adminProgramImage} = ctx
     const programName = 'Image And Status Program'
     await loginAsAdmin(page)
@@ -337,7 +337,7 @@ describe('applicant program index page with images', () => {
 
   // This test puts programs with different specs in the different sections of the homepage
   // to verify that different card formats appear correctly next to each other and across sections.
-  it('shows programs with and without images in all sections', async () => {
+  test('shows programs with and without images in all sections', async () => {
     const {
       page,
       adminPrograms,

--- a/browser-test/src/applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant_application_statuses.test.ts
@@ -42,7 +42,7 @@ describe('with program statuses', () => {
     await logout(page)
   })
 
-  it('displays status and passes accessibility checks', async () => {
+  test('displays status and passes accessibility checks', async () => {
     const {page} = ctx
     await loginAsTestUser(page)
     await validateAccessibility(page)

--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -20,7 +20,7 @@ describe('csv export for multioption question', () => {
     await dropTables(page)
     await seedQuestions(page)
   })
-  it('test multioption csv into its own column', async () => {
+  test('test multioption csv into its own column', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     const noApplyFilters = false
@@ -117,7 +117,7 @@ describe('normal application flow', () => {
     await seedQuestions(page)
   })
 
-  it('all major steps', async () => {
+  test('all major steps', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     const noApplyFilters = false
@@ -368,7 +368,7 @@ describe('normal application flow', () => {
     }
   })
 
-  it('download finished application', async () => {
+  test('download finished application', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -82,7 +82,7 @@ describe('Applicant navigation flow', () => {
     })
 
     describe('previous button', () => {
-      it('clicking previous on first block goes to summary page', async () => {
+      test('clicking previous on first block goes to summary page', async () => {
         const {applicantQuestions} = ctx
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.clickPrevious()
@@ -91,7 +91,7 @@ describe('Applicant navigation flow', () => {
         await applicantQuestions.expectReviewPage()
       })
 
-      it('clicking previous on later blocks goes to previous blocks', async () => {
+      test('clicking previous on later blocks goes to previous blocks', async () => {
         const {applicantQuestions} = ctx
         await applicantQuestions.applyProgram(programName)
 
@@ -137,7 +137,7 @@ describe('Applicant navigation flow', () => {
         await applicantQuestions.expectReviewPage()
       })
 
-      it('clicking previous does not save when flag off', async () => {
+      test('clicking previous does not save when flag off', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await disableFeatureFlag(page, 'save_on_all_actions')
@@ -158,7 +158,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('clicking previous with correct form shows previous page and saves answers', async () => {
+      test('clicking previous with correct form shows previous page and saves answers', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -193,7 +193,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('clicking previous with missing answers shows modal', async () => {
+      test('clicking previous with missing answers shows modal', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -210,7 +210,7 @@ describe('Applicant navigation flow', () => {
         await validateScreenshot(page, 'error-on-previous-modal')
       })
 
-      it('error on previous modal > click go back and edit > shows block', async () => {
+      test('error on previous modal > click go back and edit > shows block', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -247,7 +247,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('error on previous modal > click previous without saving > answers not saved', async () => {
+      test('error on previous modal > click previous without saving > answers not saved', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -273,7 +273,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('error on previous modal > click previous without saving > shows previous block', async () => {
+      test('error on previous modal > click previous without saving > shows previous block', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -308,7 +308,7 @@ describe('Applicant navigation flow', () => {
     })
 
     describe('review button', () => {
-      it('clicking review does not save when flag off', async () => {
+      test('clicking review does not save when flag off', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await disableFeatureFlag(page, 'save_on_all_actions')
@@ -329,7 +329,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('clicking review with correct form shows review page with saved answers', async () => {
+      test('clicking review with correct form shows review page with saved answers', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -352,7 +352,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('clicking review with missing answers shows modal', async () => {
+      test('clicking review with missing answers shows modal', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -369,7 +369,7 @@ describe('Applicant navigation flow', () => {
         await validateScreenshot(page, 'error-on-review-modal')
       })
 
-      it('error on review modal > click go back and edit > shows block', async () => {
+      test('error on review modal > click go back and edit > shows block', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -404,7 +404,7 @@ describe('Applicant navigation flow', () => {
         )
       })
 
-      it('error on review modal > click review without saving > shows review page without saved answers', async () => {
+      test('error on review modal > click review without saving > shows review page without saved answers', async () => {
         const {page, applicantQuestions} = ctx
         await loginAsAdmin(page)
         await enableFeatureFlag(page, 'save_on_all_actions')
@@ -437,7 +437,7 @@ describe('Applicant navigation flow', () => {
       })
     })
 
-    it('verify program details page', async () => {
+    test('verify program details page', async () => {
       const {page} = ctx
       // Begin waiting for the popup before clicking the link, otherwise
       // the popup may fire before the wait is registered, causing the test to flake.
@@ -452,7 +452,7 @@ describe('Applicant navigation flow', () => {
       expect(popupURL).toMatch('https://www.usa.gov')
     })
 
-    it('verify program list page', async () => {
+    test('verify program list page', async () => {
       const {page, adminPrograms} = ctx
       await loginAsAdmin(page)
       // create second program that has an external link and markdown in the program description.
@@ -507,7 +507,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('verify program preview page', async () => {
+    test('verify program preview page', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.clickApplyProgramButton(programName)
 
@@ -522,7 +522,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('can answer third question directly', async () => {
+    test('can answer third question directly', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.clickApplyProgramButton(programName)
       await applicantQuestions.answerQuestionFromReviewPage(
@@ -565,7 +565,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('verify program review page', async () => {
+    test('verify program review page', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -598,7 +598,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('verify program submission page for guest', async () => {
+    test('verify program submission page for guest', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -647,7 +647,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('verify program submission page for logged in user', async () => {
+    test('verify program submission page for logged in user', async () => {
       const {page, applicantQuestions} = ctx
       await loginAsTestUser(page)
       await applicantQuestions.applyProgram(programName)
@@ -685,7 +685,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('verify program submission page for guest multiple programs', async () => {
+    test('verify program submission page for guest multiple programs', async () => {
       const {page, applicantQuestions, adminPrograms} = ctx
 
       // Login as an admin and add a bunch of programs
@@ -728,7 +728,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows error with incomplete submission', async () => {
+    test('shows error with incomplete submission', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.clickApplyProgramButton(programName)
 
@@ -758,7 +758,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows "no changes" page when a duplicate application is submitted', async () => {
+    test('shows "no changes" page when a duplicate application is submitted', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -891,7 +891,7 @@ describe('Applicant navigation flow', () => {
       await dropTables(page)
     })
 
-    it('does not show eligible programs or upsell on confirmation page when no programs are eligible and signed in', async () => {
+    test('does not show eligible programs or upsell on confirmation page when no programs are eligible and signed in', async () => {
       const {page, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -918,7 +918,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    it('shows eligible programs and no upsell on confirmation page when programs are eligible and signed in', async () => {
+    test('shows eligible programs and no upsell on confirmation page when programs are eligible and signed in', async () => {
       const {page, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -945,7 +945,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    it('does not show eligible programs and shows upsell on confirmation page when no programs are eligible and a guest user', async () => {
+    test('does not show eligible programs and shows upsell on confirmation page when no programs are eligible and a guest user', async () => {
       const {page, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -971,7 +971,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    it('shows eligible programs and upsell on confirmation page when programs are eligible and a guest user', async () => {
+    test('shows eligible programs and upsell on confirmation page when programs are eligible and a guest user', async () => {
       const {page, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -1005,7 +1005,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows intake form as submitted after completion', async () => {
+    test('shows intake form as submitted after completion', async () => {
       const {page, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -1032,7 +1032,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('does not show eligible programs and shows TI text on confirmation page when no programs are eligible and a TI', async () => {
+    test('does not show eligible programs and shows TI text on confirmation page when no programs are eligible and a TI', async () => {
       const {page, tiDashboard, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -1072,7 +1072,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows eligible programs and TI text on confirmation page when programs are eligible and a TI', async () => {
+    test('shows eligible programs and TI text on confirmation page when programs are eligible and a TI', async () => {
       const {page, tiDashboard, applicantQuestions} = ctx
       await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -1157,7 +1157,7 @@ describe('Applicant navigation flow', () => {
       await adminPrograms.publishProgram(fullProgramName)
     })
 
-    it('does not show Not Eligible when there is no answer', async () => {
+    test('does not show Not Eligible when there is no answer', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.clickApplyProgramButton(fullProgramName)
 
@@ -1166,7 +1166,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows not eligible with ineligible answer', async () => {
+    test('shows not eligible with ineligible answer', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(fullProgramName)
 
@@ -1196,7 +1196,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    it('shows may be eligible with an eligible answer', async () => {
+    test('shows may be eligible with an eligible answer', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(fullProgramName)
 
@@ -1237,7 +1237,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows not eligible with ineligible answer from another application', async () => {
+    test('shows not eligible with ineligible answer from another application', async () => {
       const {page, adminPrograms, applicantQuestions} = ctx
       const overlappingOneQProgramName =
         'Test program with one overlapping question for eligibility navigation flows'
@@ -1286,7 +1286,7 @@ describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    it('shows not eligible upon submit with ineligible answer', async () => {
+    test('shows not eligible upon submit with ineligible answer', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(fullProgramName)
 
@@ -1316,7 +1316,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.expectIneligiblePage()
     })
 
-    it('shows not eligible upon submit with ineligible answer with gating eligibility', async () => {
+    test('shows not eligible upon submit with ineligible answer with gating eligibility', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(fullProgramName)
 
@@ -1346,7 +1346,7 @@ describe('Applicant navigation flow', () => {
       await applicantQuestions.expectIneligiblePage()
     })
 
-    it('ineligible page renders markdown', async () => {
+    test('ineligible page renders markdown', async () => {
       const {
         page,
         adminQuestions,
@@ -1400,7 +1400,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('shows may be eligible with nongating eligibility', async () => {
+    test('shows may be eligible with nongating eligibility', async () => {
       const {page, adminPrograms, applicantQuestions} = ctx
 
       await loginAsAdmin(page)
@@ -1423,7 +1423,7 @@ describe('Applicant navigation flow', () => {
       )
     })
 
-    it('does not show not eligible with nongating eligibility', async () => {
+    test('does not show not eligible with nongating eligibility', async () => {
       const {page, adminPrograms, applicantQuestions} = ctx
 
       await loginAsAdmin(page)
@@ -1561,7 +1561,7 @@ describe('Applicant navigation flow', () => {
     })
 
     if (isLocalDevEnvironment()) {
-      it('can correct address multi-block, multi-address program', async () => {
+      test('can correct address multi-block, multi-address program', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'esri_address_correction_enabled')
         await applicantQuestions.applyProgram(multiBlockMultiAddressProgram)
@@ -1596,7 +1596,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('can correct address single-block, multi-address program', async () => {
+      test('can correct address single-block, multi-address program', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'esri_address_correction_enabled')
         await applicantQuestions.applyProgram(singleBlockMultiAddressProgram)
@@ -1629,7 +1629,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('can correct address single-block, single-address program', async () => {
+      test('can correct address single-block, single-address program', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'esri_address_correction_enabled')
         await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
@@ -1664,7 +1664,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('prompts user to edit if no suggestions are returned', async () => {
+      test('prompts user to edit if no suggestions are returned', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'esri_address_correction_enabled')
         await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
@@ -1694,7 +1694,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('prompts user to edit if an error is returned from the Esri service', async () => {
+      test('prompts user to edit if an error is returned from the Esri service', async () => {
         // This is currently the same as when no suggestions are returend.
         // We may change this later.
         const {page, applicantQuestions} = ctx
@@ -1726,7 +1726,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('skips the address correction screen if the user enters an address that exactly matches one of the returned suggestions', async () => {
+      test('skips the address correction screen if the user enters an address that exactly matches one of the returned suggestions', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'esri_address_correction_enabled')
         await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
@@ -1745,7 +1745,7 @@ describe('Applicant navigation flow', () => {
       })
 
       describe('previous button', () => {
-        it('clicking previous on address correction page takes you back to address entry page (save flag off)', async () => {
+        test('clicking previous on address correction page takes you back to address entry page (save flag off)', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await disableFeatureFlag(page, 'save_on_all_actions')
@@ -1769,7 +1769,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous on address correction page takes you back to address entry page (save flag on)', async () => {
+        test('clicking previous on address correction page takes you back to address entry page (save flag on)', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1793,7 +1793,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous on address correction page saves original address when selected', async () => {
+        test('clicking previous on address correction page saves original address when selected', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1824,7 +1824,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous on address correction page saves suggested address when selected', async () => {
+        test('clicking previous on address correction page saves suggested address when selected', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1856,7 +1856,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous on address correction page saves original address when no suggestions offered', async () => {
+        test('clicking previous on address correction page saves original address when no suggestions offered', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1883,7 +1883,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous on address correction page does not save selection when flag off', async () => {
+        test('clicking previous on address correction page does not save selection when flag off', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await disableFeatureFlag(page, 'save_on_all_actions')
@@ -1917,7 +1917,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking previous saves address and goes to previous block if the user enters an address that exactly matches suggestions', async () => {
+        test('clicking previous saves address and goes to previous block if the user enters an address that exactly matches suggestions', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1948,7 +1948,7 @@ describe('Applicant navigation flow', () => {
       })
 
       describe('review button', () => {
-        it('clicking review on block with address navigates to address correction page (no suggestions)', async () => {
+        test('clicking review on block with address navigates to address correction page (no suggestions)', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1967,7 +1967,7 @@ describe('Applicant navigation flow', () => {
           await applicantQuestions.expectVerifyAddressPage(false)
         })
 
-        it('clicking review on block with address navigates to address correction page (has suggestions)', async () => {
+        test('clicking review on block with address navigates to address correction page (has suggestions)', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -1986,7 +1986,7 @@ describe('Applicant navigation flow', () => {
           await applicantQuestions.expectVerifyAddressPage(true)
         })
 
-        it('clicking review on block with address skips address correction screen if the user enters exact match of suggestion', async () => {
+        test('clicking review on block with address skips address correction screen if the user enters exact match of suggestion', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -2014,7 +2014,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking review on address correction page saves original address when selected', async () => {
+        test('clicking review on address correction page saves original address when selected', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -2044,7 +2044,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking review on address correction page saves suggested address when selected', async () => {
+        test('clicking review on address correction page saves suggested address when selected', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -2076,7 +2076,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking review on address correction page saves original address when no suggestions offered', async () => {
+        test('clicking review on address correction page saves original address when no suggestions offered', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await enableFeatureFlag(page, 'save_on_all_actions')
@@ -2102,7 +2102,7 @@ describe('Applicant navigation flow', () => {
           await logout(page)
         })
 
-        it('clicking review on address correction page does not save selection when flag off', async () => {
+        test('clicking review on address correction page does not save selection when flag off', async () => {
           const {page, applicantQuestions} = ctx
           await enableFeatureFlag(page, 'esri_address_correction_enabled')
           await disableFeatureFlag(page, 'save_on_all_actions')
@@ -2137,7 +2137,7 @@ describe('Applicant navigation flow', () => {
       })
     }
 
-    it('address correction page does not show if feature is disabled', async () => {
+    test('address correction page does not show if feature is disabled', async () => {
       const {page, applicantQuestions} = ctx
       await disableFeatureFlag(page, 'esri_address_correction_enabled')
       await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
@@ -2263,7 +2263,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('when address is eligible show hidden screen', async () => {
+      test('when address is eligible show hidden screen', async () => {
         const {page, applicantQuestions} = ctx
         await applicantQuestions.applyProgram(programName)
 
@@ -2294,7 +2294,7 @@ describe('Applicant navigation flow', () => {
         await logout(page)
       })
 
-      it('when address is not eligible do not show hidden screen', async () => {
+      test('when address is not eligible do not show hidden screen', async () => {
         const {page, applicantQuestions} = ctx
         await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -11,7 +11,7 @@ import {
 describe('view an application in an older version', () => {
   const ctx = createTestContext()
 
-  it('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
+  test('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
 

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -14,7 +14,7 @@ import {
 describe('Program admin review of submitted applications', () => {
   const ctx = createTestContext()
 
-  it('all major steps', async () => {
+  test('all major steps', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -315,7 +315,7 @@ describe('Program admin review of submitted applications', () => {
     }
   })
 
-  it('program applications listed most recent first', async () => {
+  test('program applications listed most recent first', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     // Create a simple one question program application.
@@ -363,7 +363,7 @@ describe('Program admin review of submitted applications', () => {
     }
   })
 
-  it('program application filters cleared', async () => {
+  test('program application filters cleared', async () => {
     const {page, adminQuestions, adminPrograms, applicantQuestions} = ctx
 
     const noApplyFilters = false

--- a/browser-test/src/auth.test.ts
+++ b/browser-test/src/auth.test.ts
@@ -13,7 +13,7 @@ import {TEST_USER_AUTH_STRATEGY} from './support/config'
 describe('applicant auth', () => {
   const ctx = createTestContext()
 
-  it('applicant can login', async () => {
+  test('applicant can login', async () => {
     const {page} = ctx
     await loginAsTestUser(page)
     await validateScreenshot(page, 'logged-in')
@@ -24,7 +24,7 @@ describe('applicant auth', () => {
     expect(await ctx.page.textContent('html')).toContain('Logout')
   })
 
-  it('applicant can login as guest', async () => {
+  test('applicant can login as guest', async () => {
     const {page} = ctx
     await validateScreenshot(page, 'logged-in-guest')
     expect(await ctx.page.textContent('html')).toContain("You're a guest user.")
@@ -35,7 +35,7 @@ describe('applicant auth', () => {
   // logout. AWS staging uses Auth0 which doesn't. And Seattle staging uses
   // IDCS which at the moment doesn't have central logout enabled.
   if (TEST_USER_AUTH_STRATEGY === AuthStrategy.FAKE_OIDC) {
-    it('applicant can confirm central provider logout', async () => {
+    test('applicant can confirm central provider logout', async () => {
       const {page} = ctx
       await loginAsTestUser(page)
       expect(await ctx.page.textContent('html')).toContain(
@@ -51,7 +51,7 @@ describe('applicant auth', () => {
     })
   }
 
-  it('applicant can logout', async () => {
+  test('applicant can logout', async () => {
     const {page} = ctx
     await loginAsTestUser(page)
     expect(await ctx.page.textContent('html')).toContain(
@@ -70,7 +70,7 @@ describe('applicant auth', () => {
     )
   })
 
-  it('applicant can logout (end session) from guest', async () => {
+  test('applicant can logout (end session) from guest', async () => {
     const {page} = ctx
     expect(await ctx.page.textContent('html')).toContain("You're a guest user.")
 
@@ -78,7 +78,7 @@ describe('applicant auth', () => {
     expect(await ctx.page.textContent('html')).toContain('Find programs')
   })
 
-  it('toast is shown when either guest or logged-in user end their session', async () => {
+  test('toast is shown when either guest or logged-in user end their session', async () => {
     const {page} = ctx
     await logout(page, /* closeToast=*/ false)
     await validateScreenshot(page, 'guest-just-ended-session')
@@ -90,7 +90,7 @@ describe('applicant auth', () => {
     await validateAccessibility(page)
   })
 
-  it('guest login followed by auth login stores submitted applications', async () => {
+  test('guest login followed by auth login stores submitted applications', async () => {
     const {page, adminPrograms, applicantQuestions} = ctx
     await loginAsAdmin(page)
     const programName = 'Test program'

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -36,7 +36,7 @@ describe('Checkbox question for applicant flow', () => {
       await logout(page)
     })
 
-    it('Updates options in preview', async () => {
+    test('Updates options in preview', async () => {
       const {page, adminQuestions} = ctx
       await loginAsAdmin(page)
 
@@ -80,14 +80,14 @@ describe('Checkbox question for applicant flow', () => {
       await adminQuestions.expectPreviewOptions(['Sample question option'])
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'checkbox')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -95,7 +95,7 @@ describe('Checkbox question for applicant flow', () => {
       await validateScreenshot(page, 'checkbox-errors')
     })
 
-    it('with single checked box submits successfully', async () => {
+    test('with single checked box submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['blue'])
@@ -104,7 +104,7 @@ describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with no checked boxes does not submit', async () => {
+    test('with no checked boxes does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -123,7 +123,7 @@ describe('Checkbox question for applicant flow', () => {
       )
     })
 
-    it('with greater than max allowed checked boxes does not submit', async () => {
+    test('with greater than max allowed checked boxes does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const checkBoxError = '.cf-applicant-question-errors'
@@ -185,7 +185,7 @@ describe('Checkbox question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid checkboxes submits successfully', async () => {
+    test('with valid checkboxes submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['blue'])
@@ -195,7 +195,7 @@ describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer required question.
       await applicantQuestions.applyProgram(programName)
@@ -205,7 +205,7 @@ describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
@@ -224,7 +224,7 @@ describe('Checkbox question for applicant flow', () => {
       expect(await page.isHidden(checkboxError)).toEqual(false)
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
@@ -243,7 +243,7 @@ describe('Checkbox question for applicant flow', () => {
       expect(await page.isHidden(checkboxError)).toEqual(false)
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -28,14 +28,14 @@ describe('currency applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'currency')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -43,7 +43,7 @@ describe('currency applicant flow', () => {
       await validateScreenshot(page, 'currency-errors')
     })
 
-    it('with valid currency does submit', async () => {
+    test('with valid currency does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCurrencyQuestion(validCurrency)
@@ -52,7 +52,7 @@ describe('currency applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with invalid currency does not submit', async () => {
+    test('with invalid currency does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error'
@@ -94,7 +94,7 @@ describe('currency applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid currencies does submit', async () => {
+    test('with valid currencies does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCurrencyQuestion(validCurrency, 0)
@@ -104,7 +104,7 @@ describe('currency applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits', async () => {
+    test('with unanswered optional question submits', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCurrencyQuestion(validCurrency, 1)
@@ -113,7 +113,7 @@ describe('currency applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=0'
@@ -127,7 +127,7 @@ describe('currency applicant flow', () => {
       expect(await page.isHidden(currencyError)).toEqual(false)
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=1'
@@ -141,7 +141,7 @@ describe('currency applicant flow', () => {
       expect(await page.isHidden(currencyError)).toEqual(false)
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -26,14 +26,14 @@ describe('Date question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'date')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -41,7 +41,7 @@ describe('Date question for applicant flow', () => {
       await validateScreenshot(page, 'date-errors')
     })
 
-    it('with filled in date submits successfully', async () => {
+    test('with filled in date submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerDateQuestion('2022-05-02')
@@ -50,7 +50,7 @@ describe('Date question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with no answer does not submit', async () => {
+    test('with no answer does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       // Click next without selecting anything.
@@ -86,7 +86,7 @@ describe('Date question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid dates submits successfully', async () => {
+    test('with valid dates submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerDateQuestion('2022-07-04', 0)
@@ -96,7 +96,7 @@ describe('Date question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question.
       await applicantQuestions.applyProgram(programName)
@@ -106,7 +106,7 @@ describe('Date question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/dev_tools.test.ts
+++ b/browser-test/src/dev_tools.test.ts
@@ -8,7 +8,7 @@ import {Locator} from 'playwright'
 describe('developer tools', () => {
   const ctx = createTestContext()
 
-  it('link shown in the header', async () => {
+  test('link shown in the header', async () => {
     const header: Locator = ctx.page.locator('nav')
     await validateScreenshot(header, 'dev-tools-in-header')
 
@@ -17,7 +17,7 @@ describe('developer tools', () => {
     await validateAccessibility(ctx.page)
   })
 
-  it('modal appears on click', async () => {
+  test('modal appears on click', async () => {
     await ctx.page.click('#debug-content-modal-button')
     await validateScreenshot(ctx.page, 'dev-tools-modal')
   })

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -34,7 +34,7 @@ describe('Dropdown question for applicant flow', () => {
       await logout(page)
     })
 
-    it('Updates options in preview', async () => {
+    test('Updates options in preview', async () => {
       const {page, adminQuestions} = ctx
       await loginAsAdmin(page)
 
@@ -78,14 +78,14 @@ describe('Dropdown question for applicant flow', () => {
       await adminQuestions.expectPreviewOptions(['Sample question option'])
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'dropdown')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -93,7 +93,7 @@ describe('Dropdown question for applicant flow', () => {
       await validateScreenshot(page, 'dropdown-errors')
     })
 
-    it('with selected option submits successfully', async () => {
+    test('with selected option submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerDropdownQuestion('green')
@@ -102,7 +102,7 @@ describe('Dropdown question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with no selection does not submit', async () => {
+    test('with no selection does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       // Click next without selecting anything.
@@ -153,7 +153,7 @@ describe('Dropdown question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with selected options submits successfully', async () => {
+    test('with selected options submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerDropdownQuestion('beach', 0)
@@ -163,7 +163,7 @@ describe('Dropdown question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -173,7 +173,7 @@ describe('Dropdown question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -26,14 +26,14 @@ describe('Email question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'email')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -41,7 +41,7 @@ describe('Email question for applicant flow', () => {
       await validateScreenshot(page, 'email-errors')
     })
 
-    it('with email input submits successfully', async () => {
+    test('with email input submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerEmailQuestion('my_email@civiform.gov')
@@ -50,7 +50,7 @@ describe('Email question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with no email input does not submit', async () => {
+    test('with no email input does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       // Click next without inputting anything.
@@ -86,7 +86,7 @@ describe('Email question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with email inputs submits successfully', async () => {
+    test('with email inputs submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerEmailQuestion('your_email@civiform.gov', 0)
@@ -96,7 +96,7 @@ describe('Email question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -106,7 +106,7 @@ describe('Email question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -13,7 +13,7 @@ describe('End to end enumerator test', () => {
   const programName = 'Ete enumerator program'
   const ctx = createTestContext(/* clearDb= */ false)
 
-  it('Updates enumerator elements in preview', async () => {
+  test('Updates enumerator elements in preview', async () => {
     const {page, adminQuestions} = ctx
     await loginAsAdmin(page)
 
@@ -46,7 +46,7 @@ describe('End to end enumerator test', () => {
     })
   })
 
-  it('Create nested enumerator and repeated questions as admin', async () => {
+  test('Create nested enumerator and repeated questions as admin', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -162,7 +162,7 @@ describe('End to end enumerator test', () => {
     await logout(page)
   })
 
-  it('has no accessibility violations', async () => {
+  test('has no accessibility violations', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -189,7 +189,7 @@ describe('End to end enumerator test', () => {
     await validateAccessibility(page)
   })
 
-  it('validate screenshot', async () => {
+  test('validate screenshot', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -201,7 +201,7 @@ describe('End to end enumerator test', () => {
     await validateScreenshot(page, 'enumerator')
   })
 
-  it('validate screenshot with errors', async () => {
+  test('validate screenshot with errors', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -213,7 +213,7 @@ describe('End to end enumerator test', () => {
     await validateScreenshot(page, 'enumerator-errors')
   })
 
-  it('Renders the correct indexes for labels and buttons', async () => {
+  test('Renders the correct indexes for labels and buttons', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -232,7 +232,7 @@ describe('End to end enumerator test', () => {
     await validateScreenshot(page, 'enumerator-indexes-after-removing-field')
   })
 
-  it('Applicant can fill in lots of blocks, and then go back and delete some repeated entities', async () => {
+  test('Applicant can fill in lots of blocks, and then go back and delete some repeated entities', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -363,7 +363,7 @@ describe('End to end enumerator test', () => {
     await logout(page)
   })
 
-  it('Applicant can navigate to previous blocks', async () => {
+  test('Applicant can navigate to previous blocks', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
@@ -414,7 +414,7 @@ describe('End to end enumerator test', () => {
     await logout(page)
   })
 
-  it('Create new version of enumerator and update repeated questions and programs', async () => {
+  test('Create new version of enumerator and update repeated questions and programs', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)

--- a/browser-test/src/error_pages.test.ts
+++ b/browser-test/src/error_pages.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('error pages', () => {
   const ctx = createTestContext()
-  it('test 404 page', async () => {
+  test('test 404 page', async () => {
     const {page} = ctx
 
     const notFound = new NotFoundPage(ctx)

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -41,14 +41,14 @@ describe('file upload applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'file-required')
     })
 
-    it('form is correctly formatted', async () => {
+    test('form is correctly formatted', async () => {
       const {page, applicantQuestions} = ctx
 
       await applicantQuestions.applyProgram(programName)
@@ -64,7 +64,7 @@ describe('file upload applicant flow', () => {
       expect(await lastFormInput.getAttribute('type')).toBe('file')
     })
 
-    it('does not show errors initially', async () => {
+    test('does not show errors initially', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
 
       await applicantQuestions.applyProgram(programName)
@@ -72,7 +72,7 @@ describe('file upload applicant flow', () => {
       await applicantFileQuestion.expectFileSelectionErrorHidden()
     })
 
-    it('no continue button initially', async () => {
+    test('no continue button initially', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
 
       await applicantQuestions.applyProgram(programName)
@@ -80,7 +80,7 @@ describe('file upload applicant flow', () => {
       await applicantFileQuestion.expectNoContinueButton()
     })
 
-    it('does not show skip button for required question', async () => {
+    test('does not show skip button for required question', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
 
       await applicantQuestions.applyProgram(programName)
@@ -88,7 +88,7 @@ describe('file upload applicant flow', () => {
       await applicantFileQuestion.expectNoSkipButton()
     })
 
-    it('can upload file', async () => {
+    test('can upload file', async () => {
       const {page, applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -99,7 +99,7 @@ describe('file upload applicant flow', () => {
     })
 
     /** Regression test for https://github.com/civiform/civiform/issues/6221. */
-    it('can replace file', async () => {
+    test('can replace file', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -124,7 +124,7 @@ describe('file upload applicant flow', () => {
       )
     })
 
-    it('can download file content', async () => {
+    test('can download file content', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const fileContent = 'some sample text'
@@ -137,7 +137,7 @@ describe('file upload applicant flow', () => {
     })
 
     /** Regression test for https://github.com/civiform/civiform/issues/6516. */
-    it('missing file error disappears when file uploaded', async () => {
+    test('missing file error disappears when file uploaded', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -148,14 +148,14 @@ describe('file upload applicant flow', () => {
       await applicantFileQuestion.expectFileSelectionErrorHidden()
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
     })
 
-    it('re-answering question shows previously uploaded file name on review and block pages', async () => {
+    test('re-answering question shows previously uploaded file name on review and block pages', async () => {
       // Answer the file upload question
       const {page, applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
@@ -182,7 +182,7 @@ describe('file upload applicant flow', () => {
       await validateScreenshot(page, 'file-required-re-answered')
     })
 
-    it('re-answering question shows continue button but no delete button', async () => {
+    test('re-answering question shows continue button but no delete button', async () => {
       // Answer the file upload question
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
@@ -229,14 +229,14 @@ describe('file upload applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'file-optional')
     })
 
-    it('with missing file shows error and does not proceed if Save&next', async () => {
+    test('with missing file shows error and does not proceed if Save&next', async () => {
       const {page, applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -251,7 +251,7 @@ describe('file upload applicant flow', () => {
       )
     })
 
-    it('with missing file can be skipped', async () => {
+    test('with missing file can be skipped', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantFileQuestion.expectHasSkipButton()
@@ -266,7 +266,7 @@ describe('file upload applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('can upload file', async () => {
+    test('can upload file', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -276,7 +276,7 @@ describe('file upload applicant flow', () => {
     })
 
     /** Regression test for https://github.com/civiform/civiform/issues/6221. */
-    it('can replace file', async () => {
+    test('can replace file', async () => {
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -301,7 +301,7 @@ describe('file upload applicant flow', () => {
       )
     })
 
-    it('can download file content', async () => {
+    test('can download file content', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const fileContent = 'some sample text'
@@ -313,7 +313,7 @@ describe('file upload applicant flow', () => {
       expect(downloadedFileContent).toEqual(fileContent)
     })
 
-    it('can submit application', async () => {
+    test('can submit application', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerFileUploadQuestion('some sample text')
@@ -324,14 +324,14 @@ describe('file upload applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('has no accessibility violations', async () => {
+    test('has no accessibility violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
     })
 
-    it('re-answering question shows previously uploaded file name on review and block pages', async () => {
+    test('re-answering question shows previously uploaded file name on review and block pages', async () => {
       // Answer the file upload question
       const {page, applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
@@ -358,7 +358,7 @@ describe('file upload applicant flow', () => {
       await validateScreenshot(page, 'file-optional-re-answered')
     })
 
-    it('re-answering question shows continue and delete buttons', async () => {
+    test('re-answering question shows continue and delete buttons', async () => {
       // Answer the file upload question
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
@@ -378,7 +378,7 @@ describe('file upload applicant flow', () => {
       await applicantFileQuestion.expectHasDeleteButton()
     })
 
-    it('delete button removes file and redirects to next block', async () => {
+    test('delete button removes file and redirects to next block', async () => {
       // Answer the file upload question
       const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
@@ -479,7 +479,7 @@ describe('file upload applicant flow', () => {
     })
 
     describe('review button', () => {
-      it('clicking review without file redirects to review page (flag off)', async () => {
+      test('clicking review without file redirects to review page (flag off)', async () => {
         const {page, applicantQuestions} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -493,7 +493,7 @@ describe('file upload applicant flow', () => {
         await applicantQuestions.expectReviewPage()
       })
 
-      it('clicking review without file redirects to review page (flag on)', async () => {
+      test('clicking review without file redirects to review page (flag on)', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -507,7 +507,7 @@ describe('file upload applicant flow', () => {
         await applicantQuestions.expectReviewPage()
       })
 
-      it('clicking review with file discards file and redirects to review page (flag off)', async () => {
+      test('clicking review with file discards file and redirects to review page (flag off)', async () => {
         const {page, applicantQuestions} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -532,7 +532,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking review with file saves file and redirects to review page (flag on)', async () => {
+      test('clicking review with file saves file and redirects to review page (flag on)', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -560,7 +560,7 @@ describe('file upload applicant flow', () => {
     })
 
     describe('previous button', () => {
-      it('clicking previous without file redirects to previous page (flag off)', async () => {
+      test('clicking previous without file redirects to previous page (flag off)', async () => {
         const {page, applicantQuestions} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -577,7 +577,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking previous without file redirects to previous page (flag on)', async () => {
+      test('clicking previous without file redirects to previous page (flag on)', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -594,7 +594,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking previous with file discards file and redirects to previous page (flag off)', async () => {
+      test('clicking previous with file discards file and redirects to previous page (flag off)', async () => {
         const {page, applicantQuestions} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -623,7 +623,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking previous with file saves file and redirects to previous page (flag on)', async () => {
+      test('clicking previous with file saves file and redirects to previous page (flag on)', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -656,7 +656,7 @@ describe('file upload applicant flow', () => {
     })
 
     describe('save & next button', () => {
-      it('clicking save&next without file shows error on same page (flag off)', async () => {
+      test('clicking save&next without file shows error on same page (flag off)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -676,7 +676,7 @@ describe('file upload applicant flow', () => {
         await validateScreenshot(page, 'file-errors')
       })
 
-      it('clicking save&next without file shows error on same page (flag on)', async () => {
+      test('clicking save&next without file shows error on same page (flag on)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -695,7 +695,7 @@ describe('file upload applicant flow', () => {
         await applicantFileQuestion.expectFileSelectionErrorShown()
       })
 
-      it('clicking save&next with file saves file and redirects to next page (flag off)', async () => {
+      test('clicking save&next with file saves file and redirects to next page (flag off)', async () => {
         const {page, applicantQuestions} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -725,7 +725,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking save&next with file saves file and redirects to next page (flag on)', async () => {
+      test('clicking save&next with file saves file and redirects to next page (flag on)', async () => {
         const {page, applicantQuestions} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -757,7 +757,7 @@ describe('file upload applicant flow', () => {
     })
 
     describe('continue button', () => {
-      it('clicking continue button redirects to first unseen block', async () => {
+      test('clicking continue button redirects to first unseen block', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
 
         // Answer the file upload question
@@ -799,7 +799,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking continue without new file redirects to next page (flag off)', async () => {
+      test('clicking continue without new file redirects to next page (flag off)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -840,7 +840,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking continue without new file redirects to next page (flag on)', async () => {
+      test('clicking continue without new file redirects to next page (flag on)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 
@@ -888,7 +888,7 @@ describe('file upload applicant flow', () => {
         )
       })
 
-      it('clicking continue with new file does *not* save new file and redirects to next page (flag off)', async () => {
+      test('clicking continue with new file does *not* save new file and redirects to next page (flag off)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await disableFeatureFlag(page, 'save_on_all_actions')
 
@@ -940,7 +940,7 @@ describe('file upload applicant flow', () => {
         expect(downloadedFileContent).toEqual('some old text')
       })
 
-      it('clicking continue with new file does *not* save new file and redirects to next page (flag on)', async () => {
+      test('clicking continue with new file does *not* save new file and redirects to next page (flag on)', async () => {
         const {page, applicantQuestions, applicantFileQuestion} = ctx
         await enableFeatureFlag(page, 'save_on_all_actions')
 

--- a/browser-test/src/footer.test.ts
+++ b/browser-test/src/footer.test.ts
@@ -9,12 +9,12 @@ import {
 import {Locator} from 'playwright'
 
 function sharedTests(ctx: TestContext, screenshotName: string) {
-  it('matches the expected screenshot', async () => {
+  test('matches the expected screenshot', async () => {
     const footer: Locator = ctx.page.locator('footer')
     await validateScreenshot(footer, screenshotName)
   })
 
-  it('has no accessibility violations', async () => {
+  test('has no accessibility violations', async () => {
     await validateAccessibility(ctx.page)
   })
 }
@@ -32,7 +32,7 @@ describe('the footer', () => {
 
     sharedTests(ctx, 'footer-no-version')
 
-    it('does not have civiform version', async () => {
+    test('does not have civiform version', async () => {
       expect(await ctx.page.textContent('html')).not.toContain(
         'CiviForm version:',
       )
@@ -49,7 +49,7 @@ describe('the footer', () => {
 
     sharedTests(ctx, 'footer-with-version')
 
-    it('has civiform version', async () => {
+    test('has civiform version', async () => {
       expect(await ctx.page.textContent('html')).toContain('CiviForm version:')
     })
   })

--- a/browser-test/src/header.test.ts
+++ b/browser-test/src/header.test.ts
@@ -8,7 +8,7 @@ import {
 describe('Header', () => {
   const ctx = createTestContext(/* clearDb= */ false)
 
-  it('Not logged in, guest mode enabled', async () => {
+  test('Not logged in, guest mode enabled', async () => {
     const {page} = ctx
     await validateScreenshot(
       page.getByRole('navigation'),
@@ -20,25 +20,25 @@ describe('Header', () => {
   // can get to the programs page without logging in, for an entity without
   // guest mode.
 
-  it('Logged in', async () => {
+  test('Logged in', async () => {
     const {page} = ctx
     await loginAsTestUser(page)
     await validateScreenshot(page.getByRole('navigation'), 'logged-in')
   })
 
-  it('Passes accessibility test', async () => {
+  test('Passes accessibility test', async () => {
     const {page} = ctx
     await validateAccessibility(page)
   })
 
-  it('Displays the government banner', async () => {
+  test('Displays the government banner', async () => {
     const {page} = ctx
     expect(await page.textContent('section')).toContain(
       'This is an official government website.',
     )
   })
 
-  it('Government banner expands when clicked and closes when clicked again', async () => {
+  test('Government banner expands when clicked and closes when clicked again', async () => {
     const {page} = ctx
     // The banner is initially closed
     expect(await page.locator('.usa-banner__content').isVisible()).toEqual(

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -30,14 +30,14 @@ describe('Id question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'id')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -45,7 +45,7 @@ describe('Id question for applicant flow', () => {
       await validateScreenshot(page, 'id-errors')
     })
 
-    it('with id submits successfully', async () => {
+    test('with id submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('12345')
@@ -54,7 +54,7 @@ describe('Id question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty id does not submit', async () => {
+    test('with empty id does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -67,7 +67,7 @@ describe('Id question for applicant flow', () => {
       )
     })
 
-    it('with too short id does not submit', async () => {
+    test('with too short id does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('123')
@@ -79,7 +79,7 @@ describe('Id question for applicant flow', () => {
       )
     })
 
-    it('with too long id does not submit', async () => {
+    test('with too long id does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('123456')
@@ -91,7 +91,7 @@ describe('Id question for applicant flow', () => {
       )
     })
 
-    it('with non-numeric characters does not submit', async () => {
+    test('with non-numeric characters does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('abcde')
@@ -130,7 +130,7 @@ describe('Id question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with both id inputs submits successfully', async () => {
+    test('with both id inputs submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('12345', 0)
@@ -140,7 +140,7 @@ describe('Id question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -150,7 +150,7 @@ describe('Id question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('abcde', 0)
@@ -163,7 +163,7 @@ describe('Id question for applicant flow', () => {
       )
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerIdQuestion('67890', 0)
@@ -176,7 +176,7 @@ describe('Id question for applicant flow', () => {
       )
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -29,14 +29,14 @@ describe('name applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'name')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -44,7 +44,7 @@ describe('name applicant flow', () => {
       await validateScreenshot(page, 'name-errors')
     })
 
-    it('does not show errors initially', async () => {
+    test('does not show errors initially', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '')
@@ -54,7 +54,7 @@ describe('name applicant flow', () => {
       expect(await error?.isHidden()).toEqual(true)
     })
 
-    it('with valid name does submit', async () => {
+    test('with valid name does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '')
@@ -63,7 +63,7 @@ describe('name applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty name does not submit', async () => {
+    test('with empty name does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '')
@@ -97,7 +97,7 @@ describe('name applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid name does submit', async () => {
+    test('with valid name does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 0)
@@ -107,7 +107,7 @@ describe('name applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '', 0)
@@ -127,7 +127,7 @@ describe('name applicant flow', () => {
       expect(await error?.isHidden()).toEqual(true)
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 0)
@@ -147,7 +147,7 @@ describe('name applicant flow', () => {
       expect(await error?.isHidden()).toEqual(false)
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -181,7 +181,7 @@ describe('name applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid required name does submit', async () => {
+    test('with valid required name does submit', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 1)
@@ -190,7 +190,7 @@ describe('name applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with invalid optional name does not submit', async () => {
+    test('with invalid optional name does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', '', '', 0)
@@ -210,7 +210,7 @@ describe('name applicant flow', () => {
         await applicantQuestions.clickNext()
       })
 
-      it('does not submit', async () => {
+      test('does not submit', async () => {
         const {page} = ctx
         // Second question has errors.
         let error = await page.$(`${NAME_FIRST}-error >> nth=1`)
@@ -219,7 +219,7 @@ describe('name applicant flow', () => {
         expect(await error?.isHidden()).toEqual(false)
       })
 
-      it('optional has no errors', async () => {
+      test('optional has no errors', async () => {
         const {page} = ctx
         // First question has no errors.
         let error = await page.$(`${NAME_FIRST}-error >> nth=0`)

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -29,14 +29,14 @@ describe('Number question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'number')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -44,7 +44,7 @@ describe('Number question for applicant flow', () => {
       await validateScreenshot(page, 'number-errors')
     })
 
-    it('with valid number submits successfully', async () => {
+    test('with valid number submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('8')
@@ -53,7 +53,7 @@ describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with no input does not submit', async () => {
+    test('with no input does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       // Leave field blank.
@@ -65,7 +65,7 @@ describe('Number question for applicant flow', () => {
       )
     })
 
-    it('with non-numeric inputs does not submit', async () => {
+    test('with non-numeric inputs does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       const testValues = ['12e3', '12E3', '-123', '1.23']
@@ -105,7 +105,7 @@ describe('Number question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with valid numbers submits successfully', async () => {
+    test('with valid numbers submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('100', 0)
@@ -115,7 +115,7 @@ describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer required question.
       await applicantQuestions.applyProgram(programName)
@@ -125,7 +125,7 @@ describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('-10', 0)
@@ -135,7 +135,7 @@ describe('Number question for applicant flow', () => {
       expect(await page.isHidden(numberInputError)).toEqual(false)
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('10', 0)
@@ -145,7 +145,7 @@ describe('Number question for applicant flow', () => {
       expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(false)
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/phone.test.ts
+++ b/browser-test/src/phone.test.ts
@@ -28,14 +28,14 @@ describe('phone question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'phone')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -43,7 +43,7 @@ describe('phone question for applicant flow', () => {
       await validateScreenshot(page, 'phone-errors')
     })
 
-    it('with phone submits successfully', async () => {
+    test('with phone submits successfully', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('4256373270')
@@ -53,7 +53,7 @@ describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with canada phone submits successfully', async () => {
+    test('with canada phone submits successfully', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212')
@@ -64,7 +64,7 @@ describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty phone does not submit', async () => {
+    test('with empty phone does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -75,7 +75,7 @@ describe('phone question for applicant flow', () => {
       expect(await page.innerText(textId)).toContain('Phone number is required')
     })
 
-    it('invalid phone numbers', async () => {
+    test('invalid phone numbers', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('1234567890')
@@ -88,7 +88,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('555 fake phone numbers', async () => {
+    test('555 fake phone numbers', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('5553231234')
@@ -100,7 +100,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('invalid length of phone number when only valid characters are included', async () => {
+    test('invalid length of phone number when only valid characters are included', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('123###1212')
@@ -112,7 +112,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('invalid characters in phone numbers', async () => {
+    test('invalid characters in phone numbers', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('123###1212121')
@@ -124,7 +124,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('incorrect length of phone number', async () => {
+    test('incorrect length of phone number', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('615974')
@@ -136,7 +136,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('hitting enter on phone does not trigger submission', async () => {
+    test('hitting enter on phone does not trigger submission', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212.')
@@ -160,7 +160,7 @@ describe('phone question for applicant flow', () => {
       await applicantQuestions.expectReviewPage()
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -194,7 +194,7 @@ describe('phone question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with both selections submits successfully', async () => {
+    test('with both selections submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212', 0)
@@ -204,7 +204,7 @@ describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -214,7 +214,7 @@ describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('1234567320', 0)
@@ -229,7 +229,7 @@ describe('phone question for applicant flow', () => {
       )
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('4256373270', 0)

--- a/browser-test/src/primary_applicant_info.test.ts
+++ b/browser-test/src/primary_applicant_info.test.ts
@@ -13,7 +13,7 @@ import {
 describe('primary applicant info questions', () => {
   const ctx = createTestContext()
 
-  it('shows primary applicant info toggles/alerts correctly when creating a new question, and tag is persisted', async () => {
+  test('shows primary applicant info toggles/alerts correctly when creating a new question, and tag is persisted', async () => {
     const {page, adminQuestions} = ctx
     await enableFeatureFlag(page, 'primary_applicant_info_questions_enabled')
 
@@ -80,7 +80,7 @@ describe('primary applicant info questions', () => {
     await adminQuestions.expectPrimaryApplicantInfoToggleValue(nameField, true)
   })
 
-  it('shows primary applicant info toggles/alerts correctly when editing an existing question, and tag is persisted', async () => {
+  test('shows primary applicant info toggles/alerts correctly when editing an existing question, and tag is persisted', async () => {
     const {page, adminQuestions} = ctx
     await enableFeatureFlag(page, 'primary_applicant_info_questions_enabled')
 
@@ -188,7 +188,7 @@ describe('primary applicant info questions', () => {
     await adminQuestions.expectPrimaryApplicantInfoToggleValue(nameField, false)
   })
 
-  it('shows the alert when a different question has the primary applicant info tag', async () => {
+  test('shows the alert when a different question has the primary applicant info tag', async () => {
     const {page, adminQuestions} = ctx
     await enableFeatureFlag(page, 'primary_applicant_info_questions_enabled')
 

--- a/browser-test/src/profile_stability.test.ts
+++ b/browser-test/src/profile_stability.test.ts
@@ -14,7 +14,7 @@ describe('user HTTP sessions', () => {
   // is recognized and properly deserialized by the server.
   //
   // This guards against changes that unexpectedly affect serialization.
-  it('recognizes the profile from a frozen cookie', async () => {
+  test('recognizes the profile from a frozen cookie', async () => {
     // Play encrypts cookies with the server secret:
     // https://www.playframework.com/documentation/2.8.x/ApplicationSecret
     //

--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -40,7 +40,7 @@ describe('navigating to a deep link', () => {
     await logout(page)
   })
 
-  it('shows a login prompt for guest users', async () => {
+  test('shows a login prompt for guest users', async () => {
     await resetContext(ctx)
     const {page} = ctx
 
@@ -54,7 +54,7 @@ describe('navigating to a deep link', () => {
     )
   })
 
-  it('does not show login prompt for logged in users', async () => {
+  test('does not show login prompt for logged in users', async () => {
     await resetContext(ctx)
     const {page} = ctx
 
@@ -65,7 +65,7 @@ describe('navigating to a deep link', () => {
     )
   })
 
-  it('takes guests and logged in users through the flow correctly', async () => {
+  test('takes guests and logged in users through the flow correctly', async () => {
     await resetContext(ctx)
     const {page} = ctx
 
@@ -92,7 +92,7 @@ describe('navigating to a deep link', () => {
     )
   })
 
-  it('Non-logged in user should get redirected to the program page and not an error', async () => {
+  test('Non-logged in user should get redirected to the program page and not an error', async () => {
     await resetContext(ctx)
     const {page, browserContext} = ctx
 
@@ -111,7 +111,7 @@ describe('navigating to a deep link', () => {
     await logout(page)
   })
 
-  it('Logging in to an existing account after opening a deep link in a new browser session', async () => {
+  test('Logging in to an existing account after opening a deep link in a new browser session', async () => {
     await resetContext(ctx)
     const {page, browserContext} = ctx
 
@@ -133,7 +133,7 @@ describe('navigating to a deep link', () => {
     await logout(page)
   })
 
-  it('Going to a deep link does not retain redirect in session', async () => {
+  test('Going to a deep link does not retain redirect in session', async () => {
     await resetContext(ctx)
     const {page, browserContext} = ctx
     await browserContext.clearCookies()

--- a/browser-test/src/question_delete.test.ts
+++ b/browser-test/src/question_delete.test.ts
@@ -4,7 +4,7 @@ import {QuestionType} from './support/admin_questions'
 describe('deleting question lifecycle', () => {
   const ctx = createTestContext()
 
-  it('create, publish, delete unused questions', async () => {
+  test('create, publish, delete unused questions', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -13,7 +13,7 @@ import {BASE_URL} from './support/config'
 describe('normal question lifecycle', () => {
   const ctx = createTestContext()
 
-  it('sample question seeding works', async () => {
+  test('sample question seeding works', async () => {
     const {page, adminQuestions} = ctx
     await dropTables(page)
     await seedQuestions(page)
@@ -103,7 +103,7 @@ describe('normal question lifecycle', () => {
     })
   }
 
-  it('allows re-ordering options in dropdown question', async () => {
+  test('allows re-ordering options in dropdown question', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -185,7 +185,7 @@ describe('normal question lifecycle', () => {
     expect(await adminNames[4].inputValue()).toContain('option4_admin')
   })
 
-  it('shows markdown format correctly in the preview when creating a new question', async () => {
+  test('shows markdown format correctly in the preview when creating a new question', async () => {
     const {page, adminQuestions} = ctx
     const questionName = 'markdown formatted question'
 
@@ -213,7 +213,7 @@ describe('normal question lifecycle', () => {
     await validateScreenshot(page, 'question-with-markdown-formatted-preview')
   })
 
-  it('shows error when creating a dropdown question and admin left an option field blank', async () => {
+  test('shows error when creating a dropdown question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -244,7 +244,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithCreateSuccessToast()
   })
 
-  it('shows error when creating a radio question and admin left an option field blank', async () => {
+  test('shows error when creating a radio question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -274,7 +274,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithCreateSuccessToast()
   })
 
-  it('shows error when updating a dropdown question and admin left an option field blank', async () => {
+  test('shows error when updating a dropdown question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -300,7 +300,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  it('shows error when updating a radio question and admin left an option field blank', async () => {
+  test('shows error when updating a radio question and admin left an option field blank', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -328,7 +328,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  it('shows error when updating a radio question and admin left an adminName field blank', async () => {
+  test('shows error when updating a radio question and admin left an adminName field blank', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -359,7 +359,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  it('shows error when updating a radio question and admin used invalid characters in the admin name', async () => {
+  test('shows error when updating a radio question and admin used invalid characters in the admin name', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -402,7 +402,7 @@ describe('normal question lifecycle', () => {
     )
   })
 
-  it('persists export state', async () => {
+  test('persists export state', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -449,7 +449,7 @@ describe('normal question lifecycle', () => {
     ).toBeTruthy()
   })
 
-  it('shows the "Remove from universal questions" confirmation modal in the right circumstances and navigation works', async () => {
+  test('shows the "Remove from universal questions" confirmation modal in the right circumstances and navigation works', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)
@@ -484,7 +484,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
   })
 
-  it('redirects to draft question when trying to edit original question', async () => {
+  test('redirects to draft question when trying to edit original question', async () => {
     const {page, adminQuestions, adminPrograms} = ctx
     await loginAsAdmin(page)
 
@@ -512,7 +512,7 @@ describe('normal question lifecycle', () => {
     )
   })
 
-  it('shows preview of formatted question name when creating a new question', async () => {
+  test('shows preview of formatted question name when creating a new question', async () => {
     const {page, adminQuestions} = ctx
 
     await loginAsAdmin(page)

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -33,7 +33,7 @@ describe('Radio button question for applicant flow', () => {
       await logout(page)
     })
 
-    it('Updates options in preview', async () => {
+    test('Updates options in preview', async () => {
       const {page, adminQuestions} = ctx
       await loginAsAdmin(page)
 
@@ -77,14 +77,14 @@ describe('Radio button question for applicant flow', () => {
       await adminQuestions.expectPreviewOptions(['Sample question option'])
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'radio-button')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -92,7 +92,7 @@ describe('Radio button question for applicant flow', () => {
       await validateScreenshot(page, 'radio-button-errors')
     })
 
-    it('with selection submits successfully', async () => {
+    test('with selection submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerRadioButtonQuestion('matcha')
@@ -101,7 +101,7 @@ describe('Radio button question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty selection does not submit', async () => {
+    test('with empty selection does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -154,7 +154,7 @@ describe('Radio button question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with both selections submits successfully', async () => {
+    test('with both selections submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerRadioButtonQuestion('matcha')
@@ -164,7 +164,7 @@ describe('Radio button question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -174,7 +174,7 @@ describe('Radio button question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -4,7 +4,7 @@ import {BASE_URL} from './support/config'
 describe('applicant security', () => {
   const ctx = createTestContext()
 
-  it('applicant cannot access admin pages', async () => {
+  test('applicant cannot access admin pages', async () => {
     const {page} = ctx
     // this test visits page that returns 401 which triggers BrowserErrorWatcher.
     // Silencing error on that page.
@@ -13,7 +13,7 @@ describe('applicant security', () => {
     expect(response!.status()).toBe(403)
   })
 
-  it('redirects to program index page when not logged in (guest)', async () => {
+  test('redirects to program index page when not logged in (guest)', async () => {
     const {page} = ctx
     await page.goto(BASE_URL)
     expect(await page.innerHTML('body')).toMatch(
@@ -21,7 +21,7 @@ describe('applicant security', () => {
     )
   })
 
-  it('redirects to program dashboard when logged in as admin', async () => {
+  test('redirects to program dashboard when logged in as admin', async () => {
     const {page} = ctx
     await loginAsAdmin(page)
     await page.goto(BASE_URL)

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -39,21 +39,21 @@ describe('Static text question for applicant flow', () => {
     )
   })
 
-  it('displays static text', async () => {
+  test('displays static text', async () => {
     const {applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
     await applicantQuestions.seeStaticQuestion(staticText)
   })
 
-  it('has no accessiblity violations', async () => {
+  test('has no accessiblity violations', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
 
     await validateAccessibility(page)
   })
 
-  it('parses markdown', async () => {
+  test('parses markdown', async () => {
     const {page, applicantQuestions} = ctx
     await applicantQuestions.applyProgram(programName)
     await validateScreenshot(page, 'markdown-text')

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -170,7 +170,7 @@ export interface TestContext {
  * describe('some test', () => {
  *   const ctx = createTestContext()
  *
- *   it('should do foo', async () => {
+ *   test('should do foo', async () => {
  *     await ctx.page.click('#some-button')
  *   })
  * })

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -30,14 +30,14 @@ describe('Text question for applicant flow', () => {
       await logout(page)
     })
 
-    it('validate screenshot', async () => {
+    test('validate screenshot', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'text')
     })
 
-    it('validate screenshot with errors', async () => {
+    test('validate screenshot with errors', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
@@ -45,7 +45,7 @@ describe('Text question for applicant flow', () => {
       await validateScreenshot(page, 'text-errors')
     })
 
-    it('with text submits successfully', async () => {
+    test('with text submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!')
@@ -54,7 +54,7 @@ describe('Text question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with empty text does not submit', async () => {
+    test('with empty text does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 
@@ -67,7 +67,7 @@ describe('Text question for applicant flow', () => {
       )
     })
 
-    it('with too short text does not submit', async () => {
+    test('with too short text does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('hi')
@@ -79,7 +79,7 @@ describe('Text question for applicant flow', () => {
       )
     })
 
-    it('with too long text does not submit', async () => {
+    test('with too long text does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion(
@@ -93,7 +93,7 @@ describe('Text question for applicant flow', () => {
       )
     })
 
-    it('hitting enter on text does not trigger submission', async () => {
+    test('hitting enter on text does not trigger submission', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
@@ -139,7 +139,7 @@ describe('Text question for applicant flow', () => {
       await logout(page)
     })
 
-    it('text that is too long is cut off at 10k characters', async () => {
+    test('text that is too long is cut off at 10k characters', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       let largeString = ''
@@ -193,7 +193,7 @@ describe('Text question for applicant flow', () => {
       await logout(page)
     })
 
-    it('with both selections submits successfully', async () => {
+    test('with both selections submits successfully', async () => {
       const {applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
@@ -203,7 +203,7 @@ describe('Text question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with unanswered optional question submits successfully', async () => {
+    test('with unanswered optional question submits successfully', async () => {
       const {applicantQuestions} = ctx
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
@@ -213,7 +213,7 @@ describe('Text question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    it('with first invalid does not submit', async () => {
+    test('with first invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion(
@@ -229,7 +229,7 @@ describe('Text question for applicant flow', () => {
       )
     })
 
-    it('with second invalid does not submit', async () => {
+    test('with second invalid does not submit', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
@@ -245,7 +245,7 @@ describe('Text question for applicant flow', () => {
       )
     })
 
-    it('has no accessiblity violations', async () => {
+    test('has no accessiblity violations', async () => {
       const {page, applicantQuestions} = ctx
       await applicantQuestions.applyProgram(programName)
 

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -15,7 +15,7 @@ import {
 describe('Trusted intermediaries', () => {
   const ctx = createTestContext()
 
-  it('expect Client Date Of Birth to be Updated', async () => {
+  test('expect Client Date Of Birth to be Updated', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -40,7 +40,7 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardContainClient(updatedClient)
   })
 
-  it('expect client cannot be added with invalid date of birth', async () => {
+  test('expect client cannot be added with invalid date of birth', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -58,7 +58,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'dashboard-add-client-invalid-dob')
   })
 
-  it('expect Dashboard Contain New Client', async () => {
+  test('expect Dashboard Contain New Client', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -76,7 +76,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'dashboard-with-one-client')
   })
 
-  it('expect clients can be added without an email address', async () => {
+  test('expect clients can be added without an email address', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -109,7 +109,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'dashboard-add-clients-no-email')
   })
 
-  it('expect client email address to be updated', async () => {
+  test('expect client email address to be updated', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -135,7 +135,7 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardContainClient(updatedClient)
   })
 
-  it('expect client ti notes and phone to be updated', async () => {
+  test('expect client ti notes and phone to be updated', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -166,7 +166,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'edit-client-information-with-all-fields')
   })
 
-  it('expect client email to be updated to empty', async () => {
+  test('expect client email to be updated to empty', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -191,7 +191,7 @@ describe('Trusted intermediaries', () => {
     expect(cardText).toContain(client.dobDate)
   })
 
-  it('expect back button to land in dashboard in the edit client page', async () => {
+  test('expect back button to land in dashboard in the edit client page', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -218,7 +218,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'back-link-leads-to-ti-dashboard')
   })
 
-  it('expect cancel button should not update client information', async () => {
+  test('expect cancel button should not update client information', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -250,7 +250,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'cancel-leads-to-dashboard')
   })
 
-  it('expect field errors', async () => {
+  test('expect field errors', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -276,7 +276,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'edit-client-information-with-field-errors')
   })
 
-  it('expect client cannot be added with invalid email address', async () => {
+  test('expect client cannot be added with invalid email address', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -299,13 +299,13 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'dashboard-add-client-invalid-email')
   })
 
-  it('ti landing page is the TI Dashboard', async () => {
+  test('ti landing page is the TI Dashboard', async () => {
     const {page} = ctx
     await loginAsTrustedIntermediary(page)
     await validateScreenshot(page, 'ti')
   })
 
-  it('dashboard contains required indicator note and optional marker', async () => {
+  test('dashboard contains required indicator note and optional marker', async () => {
     const {page} = ctx
     await loginAsTrustedIntermediary(page)
     expect(await page.textContent('html')).toContain('Email address (optional)')
@@ -314,7 +314,7 @@ describe('Trusted intermediaries', () => {
     )
   })
 
-  it('Applicant sees the program review page fully translated', async () => {
+  test('Applicant sees the program review page fully translated', async () => {
     const {
       page,
       adminQuestions,
@@ -364,7 +364,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'applicant-program-spanish')
   })
 
-  it('search For Client In TI Dashboard', async () => {
+  test('search For Client In TI Dashboard', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -409,7 +409,7 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardNotContainClient(client2)
   })
 
-  it('incomplete dob and no name in the client search returns an error', async () => {
+  test('incomplete dob and no name in the client search returns an error', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -442,7 +442,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'incomplete-dob')
   })
 
-  it('incomplete dob with name in the client search returns client by name', async () => {
+  test('incomplete dob with name in the client search returns client by name', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -472,7 +472,7 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardNotContainClient(client2)
   })
 
-  it('empty search parameters returns all clients', async () => {
+  test('empty search parameters returns all clients', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
 
@@ -501,7 +501,7 @@ describe('Trusted intermediaries', () => {
     await tiDashboard.expectDashboardContainClient(client2)
   })
 
-  it('managing trusted intermediary ', async () => {
+  test('managing trusted intermediary ', async () => {
     const {page, adminTiGroups} = ctx
     await loginAsAdmin(page)
     await adminTiGroups.gotoAdminTIPage()
@@ -515,7 +515,7 @@ describe('Trusted intermediaries', () => {
     await validateScreenshot(page, 'manage-ti-group-members-page')
   })
 
-  it('logging in as a trusted intermediary', async () => {
+  test('logging in as a trusted intermediary', async () => {
     const {page} = ctx
     await loginAsTrustedIntermediary(page)
     expect(await page.innerText('#ti-dashboard-link')).toContain(
@@ -523,7 +523,7 @@ describe('Trusted intermediaries', () => {
     )
   })
 
-  it('sees client name in sub-banner while applying for them', async () => {
+  test('sees client name in sub-banner while applying for them', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -545,7 +545,7 @@ describe('Trusted intermediaries', () => {
     )
   })
 
-  it('returns to TI dashboard from application when clicks the sub-banner link', async () => {
+  test('returns to TI dashboard from application when clicks the sub-banner link', async () => {
     const {page, tiDashboard} = ctx
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
@@ -631,7 +631,7 @@ describe('Trusted intermediaries', () => {
       await tiDashboard.expectDashboardContainClient(client)
     })
 
-    it('correctly handles eligibility', async () => {
+    test('correctly handles eligibility', async () => {
       const {page, tiDashboard, applicantQuestions} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -721,7 +721,7 @@ describe('Trusted intermediaries', () => {
       await tiDashboard.expectDashboardContainClient(client)
     })
 
-    it('shows correct number of submitted applications in the client list', async () => {
+    test('shows correct number of submitted applications in the client list', async () => {
       const {page, tiDashboard, applicantQuestions} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -755,7 +755,7 @@ describe('Trusted intermediaries', () => {
   })
 
   describe('client list pagination', () => {
-    it('shows 1 page and no previous or next buttons when there are 10 clients', async () => {
+    test('shows 1 page and no previous or next buttons when there are 10 clients', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -790,7 +790,7 @@ describe('Trusted intermediaries', () => {
       )
     })
 
-    it('shows 2 pages when there are 11 clients', async () => {
+    test('shows 2 pages when there are 11 clients', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -843,7 +843,7 @@ describe('Trusted intermediaries', () => {
       expect(await page.innerHTML('.usa-current')).toContain('2')
     })
 
-    it('shows 7 pages and no ellipses when there are 65 clients ', async () => {
+    test('shows 7 pages and no ellipses when there are 65 clients ', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -879,7 +879,7 @@ describe('Trusted intermediaries', () => {
       )
     })
 
-    it('shows one ellipses on the right when more than 7 pages and current page is < 5', async () => {
+    test('shows one ellipses on the right when more than 7 pages and current page is < 5', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -919,7 +919,7 @@ describe('Trusted intermediaries', () => {
       )
     })
 
-    it('shows two ellipses when there are 9 pages and there is overflow on both sides', async () => {
+    test('shows two ellipses when there are 9 pages and there is overflow on both sides', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)
@@ -954,7 +954,7 @@ describe('Trusted intermediaries', () => {
       )
     })
 
-    it('shows one ellipses on the left when more than 7 pages and current page is one of the last 4 pages', async () => {
+    test('shows one ellipses on the left when more than 7 pages and current page is one of the last 4 pages', async () => {
       const {page, tiDashboard} = ctx
       await loginAsTrustedIntermediary(page)
       await tiDashboard.gotoTIDashboardPage(page)


### PR DESCRIPTION
### Description

First step in removing Jest in the browser tests. Playwright and Jest both use `test` for the method name. The Jest `it` is an alias for `test`. This will make it easier to move forward removing constant conflicts I get when merging.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

