### PR TITLE
In feature flag issue template, add separate line item for enabling the flag in browser tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -22,7 +22,7 @@ What feature is this flag guarding?
 - [ ] Flag [enabled in dev](https://github.com/civiform/civiform/blob/main/server/conf/application.dev.conf)
 - [ ] Flag [disabled for browser tests](https://github.com/civiform/civiform/blob/main/server/conf/application.dev-browser-tests.conf)
 - [ ] Feature fully written and guarded with flag, including unit and browser tests that manipulate the state of the flag as needed.
-- [ ] Flag [enabled for browser tests](https://github.com/civiform/civiform/blob/main/server/conf/application.dev-browser-tests.conf) when it's ready to be tested.
+- [ ] Flag [enabled for browser tests](https://github.com/civiform/civiform/blob/main/server/conf/application.dev-browser-tests.conf) when it's ready to be tested. (Note: If the flag is already enabled in the dev config, you can just remove the flag override in the browser tests config because the browser tests config inherits from the dev config.)
 - [ ] Flag enabled in staging (See [example PR](https://github.com/civiform/civiform-staging-deploy/pull/90))
 - [ ] Coordinated with @shreyachatterjee00 to notify CEs of new feature and ask them to turn it on and try it out in their staging
 - [ ] Coordinated with @shreyachatterjee00 to communicate to CEs that we are going to turn the flag on in production by default, ensuring CEs have had a chance to test out the feature and provide feedback.

--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -21,7 +21,8 @@ What feature is this flag guarding?
 - [ ] Feature flag created as `ADMIN_WRITEABLE`, feature guarded with flag in code
 - [ ] Flag [enabled in dev](https://github.com/civiform/civiform/blob/main/server/conf/application.dev.conf)
 - [ ] Flag [disabled for browser tests](https://github.com/civiform/civiform/blob/main/server/conf/application.dev-browser-tests.conf)
-- [ ] Feature fully written and guarded with flag, including unit and browser tests that manipulate the state of the flag as needed. Enable the flag for browser tests when it's ready to be tested.
+- [ ] Feature fully written and guarded with flag, including unit and browser tests that manipulate the state of the flag as needed.
+- [ ] Flag [enabled for browser tests](https://github.com/civiform/civiform/blob/main/server/conf/application.dev-browser-tests.conf) when it's ready to be tested.
 - [ ] Flag enabled in staging (See [example PR](https://github.com/civiform/civiform-staging-deploy/pull/90))
 - [ ] Coordinated with @shreyachatterjee00 to notify CEs of new feature and ask them to turn it on and try it out in their staging
 - [ ] Coordinated with @shreyachatterjee00 to communicate to CEs that we are going to turn the flag on in production by default, ensuring CEs have had a chance to test out the feature and provide feedback.


### PR DESCRIPTION
### Description

When I enabled the `PROGRAM_CARD_IMAGES` flag in dev and staging, I'd forgotten that I had overridden it to be false in the browser tests. This meant that the browser tests were passing locally and on GitHub actions, but failing on staging prober tests because staging now had the flag set to true (see https://civiform.slack.com/archives/C046D5BPVJ9/p1709061594232309). This PR updates our feature flag template to add a separate line item for explicitly re-enabling a flag in browser tests once it's ready.
