### PR TITLE
Linting: Prefer web-first assertions

### DIFF
--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -54,13 +54,13 @@ test.describe('address applicant flow', () => {
         '54321',
       )
       let error = page.locator('.cf-address-street-1-error')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-city-error')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-state-error')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-zip-error')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
     })
 
     test('with valid address does submit', async () => {
@@ -85,13 +85,13 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.clickNext()
 
       let error = page.locator('.cf-address-street-1-error')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-city-error')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-state-error')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-zip-error')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
     })
 
     test('with invalid address does not submit', async () => {
@@ -107,7 +107,7 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.clickNext()
 
       const error = page.locator('.cf-address-zip-error')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
     })
   })
 
@@ -172,23 +172,23 @@ test.describe('address applicant flow', () => {
 
       // First question has errors.
       let error = page.locator('.cf-address-street-1-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-city-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-state-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-zip-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
 
       // Second question has no errors.
       error = page.locator('.cf-address-street-1-error >> nth=1')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-city-error >> nth=1')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-state-error >> nth=1')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-zip-error >> nth=1')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
     })
 
     test('with second invalid does not submit', async () => {
@@ -207,23 +207,23 @@ test.describe('address applicant flow', () => {
 
       // First question has no errors.
       let error = page.locator('.cf-address-street-1-error >> nth=0')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-city-error >> nth=0')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-state-error >> nth=0')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
       error = page.locator('.cf-address-zip-error >> nth=0')
-      expect(await error.isHidden()).toEqual(true)
+      await expect(error).toBeHidden()
 
       // Second question has errors.
       error = page.locator('.cf-address-street-1-error >> nth=1')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-city-error >> nth=1')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-state-error >> nth=1')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-zip-error >> nth=1')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
     })
 
     test('has no accessibility violations', async () => {
@@ -299,11 +299,11 @@ test.describe('address applicant flow', () => {
 
       // First question has errors.
       let error = page.locator('.cf-address-city-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-state-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
       error = page.locator('.cf-address-zip-error >> nth=0')
-      expect(await error.isHidden()).toEqual(false)
+      await expect(error).toBeVisible()
     })
 
     test.describe('with invalid required address', () => {
@@ -318,26 +318,26 @@ test.describe('address applicant flow', () => {
         const {page} = ctx
         // Second question has errors.
         let error = page.locator('.cf-address-street-1-error >> nth=1')
-        expect(await error.isHidden()).toEqual(false)
+        await expect(error).toBeVisible()
         error = page.locator('.cf-address-city-error >> nth=1')
-        expect(await error.isHidden()).toEqual(false)
+        await expect(error).toBeVisible()
         error = page.locator('.cf-address-state-error >> nth=1')
-        expect(await error.isHidden()).toEqual(false)
+        await expect(error).toBeVisible()
         error = page.locator('.cf-address-zip-error >> nth=1')
-        expect(await error.isHidden()).toEqual(false)
+        await expect(error).toBeVisible()
       })
 
       test('optional has no errors', async () => {
         const {page} = ctx
         // First question has no errors.
         let error = page.locator('.cf-address-street-1-error >> nth=0')
-        expect(await error.isHidden()).toEqual(true)
+        await expect(error).toBeHidden()
         error = page.locator('.cf-address-city-error >> nth=0')
-        expect(await error.isHidden()).toEqual(true)
+        await expect(error).toBeHidden()
         error = page.locator('.cf-address-state-error >> nth=0')
-        expect(await error.isHidden()).toEqual(true)
+        await expect(error).toBeHidden()
         error = page.locator('.cf-address-zip-error >> nth=0')
-        expect(await error.isHidden()).toEqual(true)
+        await expect(error).toBeHidden()
       })
     })
   })

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -111,13 +111,14 @@ test.describe('Checkbox question for applicant flow', () => {
 
       // No validation errors on first page load.
       const checkBoxError = '.cf-applicant-question-errors'
-      expect(await page.isHidden(checkBoxError)).toEqual(true)
+      await expect(page.locator(checkBoxError)).toBeHidden()
 
       // Click next without selecting anything.
       await applicantQuestions.clickNext()
 
       // Check checkbox error and required error are present.
-      expect(await page.isHidden(checkBoxError)).toEqual(false)
+      await expect(page.locator(checkBoxError)).toBeVisible()
+
       const checkboxId = '.cf-question-checkbox'
       expect(await page.innerText(checkboxId)).toContain(
         'This question is required.',
@@ -129,7 +130,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const checkBoxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
-      expect(await page.isHidden(checkBoxError)).toEqual(true)
+      await expect(page.locator(checkBoxError)).toBeHidden()
 
       // Max of two checked boxes are allowed, but we select three.
       await applicantQuestions.answerCheckboxQuestion([
@@ -140,7 +141,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.clickNext()
 
       // Check error is shown.
-      expect(await page.isHidden(checkBoxError)).toEqual(false)
+      await expect(page.locator(checkBoxError)).toBeVisible()
     })
   })
 
@@ -211,7 +212,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
-      expect(await page.isHidden(checkboxError)).toEqual(true)
+      await expect(page.locator(checkboxError)).toBeHidden()
 
       // Max of 2 answers allowed.
       await applicantQuestions.answerCheckboxQuestion([
@@ -222,7 +223,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.answerCheckboxQuestion(['beach'])
       await applicantQuestions.clickNext()
 
-      expect(await page.isHidden(checkboxError)).toEqual(false)
+      await expect(page.locator(checkboxError)).toBeVisible()
     })
 
     test('with second invalid does not submit', async () => {
@@ -230,7 +231,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
-      expect(await page.isHidden(checkboxError)).toEqual(true)
+      await expect(page.locator(checkboxError)).toBeHidden()
 
       await applicantQuestions.answerCheckboxQuestion(['red'])
       // Max of 2 answers allowed.
@@ -241,7 +242,7 @@ test.describe('Checkbox question for applicant flow', () => {
       ])
       await applicantQuestions.clickNext()
 
-      expect(await page.isHidden(checkboxError)).toEqual(false)
+      await expect(page.locator(checkboxError)).toBeVisible()
     })
 
     test('has no accessibility violations', async () => {

--- a/browser-test/src/currency.test.ts
+++ b/browser-test/src/currency.test.ts
@@ -58,14 +58,14 @@ test.describe('currency applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error'
       // When there are no validation errors, the div still exists but is hidden.
-      expect(await page.isHidden(currencyError)).toEqual(true)
+      await expect(page.locator(currencyError)).toBeHidden()
 
       // Input has not enough decimal points.
       await applicantQuestions.answerCurrencyQuestion(invalidCurrency)
       await applicantQuestions.clickNext()
 
       // The block should be displayed still with the error shown.
-      expect(await page.isHidden(currencyError)).toEqual(false)
+      await expect(page.locator(currencyError)).toBeVisible()
     })
   })
 
@@ -119,13 +119,13 @@ test.describe('currency applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=0'
       // When there are no validation errors, the div still exists but is hidden.
-      expect(await page.isHidden(currencyError)).toEqual(true)
+      await expect(page.locator(currencyError)).toBeHidden()
 
       await applicantQuestions.answerCurrencyQuestion(invalidCurrency, 0)
       await applicantQuestions.answerCurrencyQuestion(validCurrency, 1)
       await applicantQuestions.clickNext()
 
-      expect(await page.isHidden(currencyError)).toEqual(false)
+      await expect(page.locator(currencyError)).toBeVisible()
     })
 
     test('with second invalid does not submit', async () => {
@@ -133,13 +133,13 @@ test.describe('currency applicant flow', () => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=1'
       // When there are no validation errors, the div still exists but is hidden.
-      expect(await page.isHidden(currencyError)).toEqual(true)
+      await expect(page.locator(currencyError)).toBeHidden()
 
       await applicantQuestions.answerCurrencyQuestion(validCurrency, 0)
       await applicantQuestions.answerCurrencyQuestion(invalidCurrency, 1)
       await applicantQuestions.clickNext()
 
-      expect(await page.isHidden(currencyError)).toEqual(false)
+      await expect(page.locator(currencyError)).toBeVisible()
     })
 
     test('has no accessibility violations', async () => {

--- a/browser-test/src/phone.test.ts
+++ b/browser-test/src/phone.test.ts
@@ -146,7 +146,7 @@ test.describe('phone question for applicant flow', () => {
       // submission.
       await page.focus('input[type=text]')
       await page.keyboard.press('Enter')
-      expect(await page.locator('input[type=text]').isVisible()).toEqual(true)
+      await expect(page.locator('input[type=text]')).toBeVisible()
 
       // Check that pressing Enter on button works.
       await page.focus('button:has-text("Save and next")')

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -103,7 +103,7 @@ test.describe('Text question for applicant flow', () => {
       // submission.
       await page.focus('input[type=text]')
       await page.keyboard.press('Enter')
-      expect(await page.locator('input[type=text]').isVisible()).toEqual(true)
+      await expect(page.locator('input[type=text]')).toBeVisible()
 
       // Check that pressing Enter on button works.
       await page.focus('button:has-text("Save and next")')


### PR DESCRIPTION
### Description

Fixing eslint issues to align with playwright best practices. Rule: prefer-web-first-assertions.

Fun fact: The original code uses `page.isHidden(selector)` which returns the first match even if there are multiple. Probably not what most people would expect.

Both `page.isHidden` and `page.isVisible` are [deprecated](https://playwright.dev/docs/api/class-page#deprecated).

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
