### PR TITLE
Add string to warn user if their uploaded file is too large

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -150,6 +150,7 @@ public enum MessageKey {
   ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),
   FILEUPLOAD_VALIDATION_FILE_REQUIRED("validation.fileRequired"),
+  FILEUPLOAD_VALIDATION_FILE_TOO_LARGE("validation.fileTooLarge"),
   FOOTER_SUPPORT_LINK_DESCRIPTION("footer.supportLinkDescription"),
   GENERAL_LOGIN_MODAL_PROMPT("content.generalLoginModalPrompt"),
   GUEST("guest"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -371,6 +371,8 @@ placeholder.entityName={0} name
 #---------------------------------------------------------------------------------#
 
 validation.fileRequired=Please select a file.
+# An error shown to the user if they upload a file that's too large. The error also asks them to upload a smaller file. {0} will be a number specifying the maximum size the file can be in megabytes. For example, "Please choose a file under 100 MB".
+validation.fileTooLarge=The file you've chosen is too large. Please choose a file under {0} MB.
 button.chooseFile=Choose File
 
 #---------------------------------------------------------------------#

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -371,8 +371,8 @@ placeholder.entityName={0} name
 #---------------------------------------------------------------------------------#
 
 validation.fileRequired=Please select a file.
-# An error shown to the user if they upload a file that's too large. The error also asks them to upload a smaller file. {0} will be a number specifying the maximum size the file can be in megabytes. For example, "Please choose a file under 100 MB".
-validation.fileTooLarge=The file you''ve chosen is too large. Please choose a file under {0} MB.
+# An error shown to the user if they upload a file that's too large. The error also asks them to upload a smaller file. {0} will be a number specifying the maximum size the file can be in megabytes. For example, "Please choose a file less than 100 MB".
+validation.fileTooLarge=Your file is too large. Please choose a file less than {0} MB.
 button.chooseFile=Choose File
 
 #---------------------------------------------------------------------#

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -372,7 +372,7 @@ placeholder.entityName={0} name
 
 validation.fileRequired=Please select a file.
 # An error shown to the user if they upload a file that's too large. The error also asks them to upload a smaller file. {0} will be a number specifying the maximum size the file can be in megabytes. For example, "Please choose a file under 100 MB".
-validation.fileTooLarge=The file you've chosen is too large. Please choose a file under {0} MB.
+validation.fileTooLarge=The file you''ve chosen is too large. Please choose a file under {0} MB.
 button.chooseFile=Choose File
 
 #---------------------------------------------------------------------#


### PR DESCRIPTION
### Description

Adds a string that'll be displayed if a user uploads a file that's too big (currently 100MB for AWS). A future PR will use this string once it's been translated.

String was approved by @sijiayam  and Shannon.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).


#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)

### Issue(s) this completes

Part of #5675
