### PR TITLE
Hide build.properties from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "ignorePaths": ["**/server/project/build.properties"],
   "labels": ["dependencies"],
   "docker-compose": {
     "fileMatch": [


### PR DESCRIPTION
### Description

Starting yesterday renovate began failing. After a lot of trial and error I found renovate is failing to parse `server/project/build.properties`. This was recently updated, but rolling back doesn't solve the problem. It seems more like a recent bug in renovate. I have an nearly empty repository that repros the error and I'll be submitting a ticket to the project.

For now I'm just having renovate ignore the build.properties file. I'll create an issue in civiform shortly.

Tested locally with:
```shell
npm install -g renovate
LOG_LEVEL=info npx renovate --platform=local
```

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
