### PR TITLE
Stop ignoring build.properties in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:base"],
-  "ignorePaths": ["**/server/project/build.properties"],
   "labels": ["dependencies"],
   "docker-compose": {
     "fileMatch": [


### PR DESCRIPTION
### Description

Stop ignoring build.properties in renovate. They pushed a fix and doing a dry run passes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

Fixes #6792