### PR TITLE
Allow disabling of errorprone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,4 +129,5 @@ services:
       - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
+      - DISABLE_ERRORPRONE=${DISABLE_ERRORPRONE:-false}
     entrypoint: /bin/bash

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -109,25 +109,38 @@ lazy val root = (project in file("."))
       // compatible with sl4j 2.0 because the latter pulled in by pac4j.
       "ch.qos.logback" % "logback-classic" % "1.4.8"
     ),
-    javacOptions ++= Seq(
-      "-encoding",
-      "UTF-8",
-      "-parameters",
-      "-Xlint:unchecked",
-      "-Xlint:deprecation",
-      "-XDcompilePolicy=simple",
-      // Turn off the AutoValueSubclassLeaked error since the generated
-      // code contains it - we can't control that.
-      "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR -Xep:ThrowsUncheckedException:ERROR",
-      "-implicit:class",
-      "-Werror",
-      // The compile option below is a hack that preserves generated files. Normally,
-      // AutoValue generates .java files, compiles them into .class files, and then deletes
-      // the .java files. This option keeps the .java files in the specified directory,
-      // which allows an IDE to recognize the symbols.
-      "-s",
-      generateSourcePath(scalaVersion = scalaVersion.value)
-    ),
+    javacOptions ++= {
+      val defaultCompilerOptions = Seq(
+        "-encoding",
+        "UTF-8",
+        "-parameters",
+        "-Xlint:unchecked",
+        "-Xlint:deprecation",
+        "-XDcompilePolicy=simple",
+        "-implicit:class",
+        // The compile option below is a hack that preserves generated files. Normally,
+        // AutoValue generates .java files, compiles them into .class files, and then deletes
+        // the .java files. This option keeps the .java files in the specified directory,
+        // which allows an IDE to recognize the symbols.
+        "-s",
+        generateSourcePath(scalaVersion = scalaVersion.value)
+      )
+
+      // Disable errorprone checking if the DISABLE_ERRORPRONE environment variable
+      // is set to true
+      val errorProneCompilerOptions = Option(System.getenv("DISABLE_ERRORPRONE"))
+        .filter(_ != "true")
+        .map(_ => Seq(
+          // Turn off the AutoValueSubclassLeaked error since the generated
+          // code contains it - we can't control that.
+          "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR -Xep:ThrowsUncheckedException:ERROR",
+          "-Werror"
+        ))
+        .getOrElse(Seq.empty)
+
+      defaultCompilerOptions ++ errorProneCompilerOptions
+    },
+
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
     // Recompile everything if >30% files have changed, to help avoid infinate
     // incremental compilation.

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -130,12 +130,14 @@ lazy val root = (project in file("."))
       // is set to true
       val errorProneCompilerOptions = Option(System.getenv("DISABLE_ERRORPRONE"))
         .filter(_ != "true")
-        .map(_ => Seq(
-          // Turn off the AutoValueSubclassLeaked error since the generated
-          // code contains it - we can't control that.
-          "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR -Xep:ThrowsUncheckedException:ERROR",
-          "-Werror"
-        ))
+        .map(_ =>
+          Seq(
+            // Turn off the AutoValueSubclassLeaked error since the generated
+            // code contains it - we can't control that.
+            "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -XepDisableWarningsInGeneratedCode -Xep:WildcardImport:ERROR -Xep:CatchingUnchecked:ERROR -Xep:ThrowsUncheckedException:ERROR",
+            "-Werror"
+          )
+        )
         .getOrElse(Seq.empty)
 
       defaultCompilerOptions ++ errorProneCompilerOptions


### PR DESCRIPTION
### Description

Errorprone does a great job keeping us from writing code that could be problematic. However it can cause friction while actively developing. For example I can't quickly comment something out temporarily if it leaves an unused variable.

This will allow for running `DISABLE_ERRORPRONE=true bin/run-dev` and to disable error prone on your local machine thus bypassing Errorprone checks.

If not set, the default remains to enforce Errorprone and the CI environment won't override it thus catching anything if someone accidentally pushes code that doesn't pass Errorprone.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

