### PR TITLE
Fixing prefer-web-first-assertions lint errors #3

### DIFF
--- a/browser-test/src/admin_program_image.test.ts
+++ b/browser-test/src/admin_program_image.test.ts
@@ -381,7 +381,7 @@ test.describe('Admin can manage program image', () => {
       const lastFormInput = formInputs[formInputs.length - 1]
 
       // AWS requires that the <input type="file"> element to be the last <input> in the <form>
-      expect(await lastFormInput.getAttribute('type')).toBe('file')
+      await expect(lastFormInput).toHaveAttribute('type', 'file')
     })
 
     test('shows uploaded image before submitting', async () => {

--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -2219,7 +2219,7 @@ test.describe('Applicant navigation flow', () => {
         const addressCorrectionInput =
           adminPrograms.getAddressCorrectionToggleByName(questionAddress)
 
-        expect(await addressCorrectionInput.inputValue()).toBe('true')
+        await expect(addressCorrectionInput).toHaveValue('true')
 
         // Set thing to soft eligibilty
         await adminPrograms.toggleEligibilityGating()

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -150,24 +150,22 @@ test.describe('Program admin review of submitted applications', () => {
 
     // Application doesn't progress because of name and address question errors.
     // Verify that address error messages are visible.
-    expect(await page.innerText('.cf-address-street-1-error:visible')).toEqual(
+    await expect(page.locator('.cf-address-street-1-error:visible')).toHaveText(
       'Error: Please enter valid street name and number.',
     )
-    expect(await page.innerText('.cf-address-city-error:visible')).toEqual(
+    await expect(page.locator('.cf-address-city-error:visible')).toHaveText(
       'Error: Please enter city.',
     )
-    expect(await page.innerText('.cf-address-state-error:visible')).toEqual(
+    await expect(page.locator('.cf-address-state-error:visible')).toHaveText(
       'Error: Please enter state.',
     )
-    expect(await page.innerText('.cf-address-zip-error:visible')).toEqual(
+    await expect(page.locator('.cf-address-zip-error:visible')).toHaveText(
       'Error: Please enter valid 5-digit ZIP code.',
     )
-
-    // Verify that name question error messages are visible.
-    expect(await page.innerText('.cf-name-first-error:visible')).toEqual(
+    await expect(page.locator('.cf-name-first-error:visible')).toHaveText(
       'Error: Please enter your first name.',
     )
-    expect(await page.innerText('.cf-name-last-error:visible')).toEqual(
+    await expect(page.locator('.cf-name-last-error:visible')).toHaveText(
       'Error: Please enter your last name.',
     )
 

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -62,7 +62,7 @@ test.describe('file upload applicant flow', () => {
       const lastFormInput = formInputs[formInputs.length - 1]
 
       // AWS requires that the <input type="file"> element to be the last <input> in the <form>
-      expect(await lastFormInput.getAttribute('type')).toBe('file')
+      await expect(lastFormInput).toHaveAttribute('type', 'file')
     })
 
     test('does not show errors initially', async () => {

--- a/browser-test/src/header.test.ts
+++ b/browser-test/src/header.test.ts
@@ -42,19 +42,15 @@ test.describe('Header', () => {
   test('Government banner expands when clicked and closes when clicked again', async () => {
     const {page} = ctx
     // The banner is initially closed
-    expect(await page.locator('.usa-banner__content').isVisible()).toEqual(
-      false,
-    )
+    await expect(page.locator('.usa-banner__content')).toBeHidden()
     // Click to expand the banner
     await page.click('.usa-banner__button')
 
-    expect(await page.locator('.usa-banner__content').isVisible()).toEqual(true)
+    await expect(page.locator('.usa-banner__content')).toBeVisible()
     await validateScreenshot(page.getByRole('navigation'), 'banner-expanded')
     // Click again to close the banner
     await page.click('.usa-banner__button')
 
-    expect(await page.locator('.usa-banner__content').isVisible()).toEqual(
-      false,
-    )
+    await expect(page.locator('.usa-banner__content')).toBeHidden()
   })
 })


### PR DESCRIPTION
### Description

Continuing the slog work through cleaning up playwright lint issues.

Fixing some lint errors: prefer-web-first-assertions

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
