### PR TITLE
Adding script to summarize release messages

### DIFF
--- a/bin/summarize-release-messages
+++ b/bin/summarize-release-messages
@@ -71,7 +71,7 @@ class GitHub:
 
     def get_pull_requests(self):
         """
-        Get a list of GitHub commits since the specified tag
+        Get a list of closed GitHub commits
         """
         try:
             url = f"https://api.github.com/repos/civiform/civiform/pulls?state=closed&per_page=100"

--- a/bin/summarize-release-messages
+++ b/bin/summarize-release-messages
@@ -1,0 +1,176 @@
+#! /usr/bin/env python3
+
+# DOC: Summarize GitHub PR comments for Release Notes
+# DOC: Filters out PRs create by renovate or transifex-integration
+# DOC: Filters out PRs with ignore-for-release label
+# DOC: Takes the optional tag_name argument which should be a release tag.
+# DOC: If no tag_name is provided attempt to look up the latest release tag
+# DOC: from the GitHub API.
+
+import json
+import os
+import requests
+import sys
+
+
+class GitHub:
+    """
+    Interact with the GitHub API
+    """
+
+    def __init__(self, github_token):
+        if github_token is None:
+            raise Exception("'github_token' was not set")
+
+        self.github_headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {github_token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def get_latest_release_tag(self):
+        """
+        Get the latest github release tag
+        """
+        try:
+            url = f"https://api.github.com/repos/civiform/civiform/releases"
+            response = requests.get(url, headers=self.github_headers)
+            response_json = json.loads(response.text)
+            results = [x["tag_name"] for x in response_json]
+
+            if len(results) > 0:
+                return results[0]
+
+            return ""
+        except Exception as error:
+            print("Failed calling GitHub API")
+            print(f"Attempted calling: {url}")
+            print(error)
+            exit(1)
+
+    def get_commits_since_tag(self, tag_name):
+        """
+        Get a list of GitHub commits since the specified tag
+        """
+        try:
+            url = f"https://api.github.com/repos/civiform/civiform/compare/{tag_name}...main"
+            response = requests.get(url, headers=self.github_headers)
+            response_json = json.loads(response.text)
+            results = [
+                {"sha": x["sha"], "author": x["commit"]["author"]["name"]}
+                for x in response_json["commits"]
+                if x["commit"]["author"]["name"] != "renovate[bot]"
+                and x["commit"]["author"]["name"] != "transifex-integration[bot]"
+            ]
+            return results
+        except Exception as error:
+            print("Failed calling GitHub API")
+            print(f"Attempted calling: {url}")
+            print(error)
+            exit(1)
+
+    def get_pull_requests(self):
+        """
+        Get a list of GitHub commits since the specified tag
+        """
+        try:
+            url = f"https://api.github.com/repos/civiform/civiform/pulls?state=closed&per_page=100"
+            github_headers = self.github_headers
+            github_headers["Accept"] = "application/vnd.github.text+json"
+            response = requests.get(url, headers=github_headers)
+            response_json = json.loads(response.text)
+            results = [
+                {
+                    "merge_commit_sha": x["merge_commit_sha"],
+                    "body": x["body_text"],
+                    "url": x["url"],
+                    "user": x["user"]["login"],
+                    "title": x["title"],
+                    "labels": list(map(lambda z: z["name"], x["labels"])),
+                }
+                for x in response_json
+            ]
+            return results
+        except Exception as error:
+            print("Failed calling GitHub API")
+            print(f"Attempted calling: {url}")
+            print(error)
+            exit(1)
+
+
+class Runner:
+    """
+    Main app
+    """
+
+    def __init__(self):
+        self.github = GitHub(os.getenv("GITHUB_TOKEN"))
+
+    def filter(self, commits, pull_requests):
+        results = []
+
+        for _, pull_request in enumerate(pull_requests):
+            if any(x["sha"] == pull_request["merge_commit_sha"] for x in commits):
+                results.append(pull_request)
+
+        return results
+
+    def display_results(self, results):
+        for _, item in enumerate(results):
+            if "ignore-for-release" in item["labels"]:
+                continue
+
+            try:
+                end_index = item["body"].index("Checklist\n")
+            except ValueError:
+                end_index = len(item["body"])
+
+            output = item["body"][0:end_index]
+
+            if output.startswith("Description\n"):
+                output = output[len("Description\n") :]
+
+            print("********************************************************************************")
+            print(f'User:  {item["user"]}')
+            print(f'Title: {item["title"]}')
+            print(f'URL:   {item["url"]}')
+            print(f'Label: {item["labels"]}')
+            print("********************************************************************************")
+            print(output)
+            print("")
+
+    def get_tag_name(self):
+        if len(sys.argv) > 1:
+            tag_name = sys.argv[1]
+        else:
+            tag_name = self.github.get_latest_release_tag()
+
+        return tag_name
+
+    def run(self):
+        """
+        Run the application core
+        """
+        tag_name = self.get_tag_name()
+
+        if tag_name == "":
+            print("Could not determine tag name")
+            exit(1)
+
+        commits = self.github.get_commits_since_tag(tag_name)
+        pull_requests = self.github.get_pull_requests()
+        results = self.filter(commits, pull_requests)
+        self.display_results(results)
+
+
+def main():
+    runner = Runner()
+
+    try:
+        runner.run()
+    except KeyboardInterrupt:
+        print("\n\nYou pressed ctrl+c. Closing app.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/summarize-release-messages
+++ b/bin/summarize-release-messages
@@ -107,8 +107,13 @@ class Runner:
         self.github = GitHub(os.getenv("GITHUB_TOKEN"))
 
     def filter(self, commits, pull_requests):
+        """
+        Get the commits related to the requested release
+        """
         results = []
 
+        # Filter out any pull requests that are not part of the commits related
+        # to the release.
         for _, pull_request in enumerate(pull_requests):
             if any(x["sha"] == pull_request["merge_commit_sha"] for x in commits):
                 results.append(pull_request)
@@ -116,6 +121,9 @@ class Runner:
         return results
 
     def display_results(self, results):
+        """
+        Print the filtered results to screen
+        """
         for _, item in enumerate(results):
             if "ignore-for-release" in item["labels"]:
                 continue
@@ -127,6 +135,7 @@ class Runner:
 
             output = item["body"][0:end_index]
 
+            # If the PR body starts with  the description header just cut it out
             if output.startswith("Description\n"):
                 output = output[len("Description\n") :]
 
@@ -140,6 +149,10 @@ class Runner:
             print("")
 
     def get_tag_name(self):
+        """
+        Get the tag name to use from either the cli argument if there is one
+        or look it up from the github api
+        """
         if len(sys.argv) > 1:
             tag_name = sys.argv[1]
         else:

--- a/bin/summarize-release-messages
+++ b/bin/summarize-release-messages
@@ -135,7 +135,7 @@ class Runner:
 
             output = item["body"][0:end_index]
 
-            # If the PR body starts with  the description header just cut it out
+            # If the PR body starts with the description header just cut it out
             if output.startswith("Description\n"):
                 output = output[len("Description\n") :]
 


### PR DESCRIPTION
### Description

Script will pull commits since the supplied tag and output part of the commit messages. 

- It will cut out anything after the `Checklist` header.
- It will filter out PR authors of renovate and transifex
- It will filter out PRs tagged with ignore-for-release
- It will print the PR:
  - author username
  - title
  - url
  - labels
  - text version of the body of the message

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
