### PR TITLE
Fixing prefer-web-first-assertion lint errors #4

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -261,7 +261,8 @@ test.describe('program creation', () => {
       '.cf-program-question:has-text("apc-name") >> .cf-remove-question-button',
     )
     await adminPrograms.addQuestionFromQuestionBank('apc-enumerator')
-    expect(await page.innerText('id=question-bank-nonuniversal')).toBe('')
+
+    await expect(page.locator('id=question-bank-nonuniversal')).toHaveText('')
 
     // Create a repeated block. The repeated question should be the only option.
     await page.click('#create-repeated-block-button')
@@ -293,11 +294,11 @@ test.describe('program creation', () => {
 
     const addressCorrectionInput = adminPrograms.getAddressCorrectionToggle()
 
-    expect(await addressCorrectionInput.inputValue()).toBe('false')
+    await expect(addressCorrectionInput).toHaveValue('false')
 
     await adminPrograms.clickAddressCorrectionToggle()
 
-    expect(await addressCorrectionInput.inputValue()).toBe('true')
+    await expect(addressCorrectionInput).toHaveValue('true')
 
     await validateScreenshot(
       page,
@@ -346,16 +347,16 @@ test.describe('program creation', () => {
     const addressCorrectionHelpText2 =
       adminPrograms.getAddressCorrectionHelpTextByName('ace-address-two')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('false')
-    expect(await addressCorrectionInput2.inputValue()).toBe('false')
+    await expect(addressCorrectionInput1).toHaveValue('false')
+    await expect(addressCorrectionInput2).toHaveValue('false')
 
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).not.toContain(helpText)
 
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-one')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('true')
-    expect(await addressCorrectionInput2.inputValue()).toBe('false')
+    await expect(addressCorrectionInput1).toHaveValue('true')
+    await expect(addressCorrectionInput2).toHaveValue('false')
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).toContain(helpText)
 
@@ -367,8 +368,8 @@ test.describe('program creation', () => {
     // Trying to toggle the other one should not do anything
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-two')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('true')
-    expect(await addressCorrectionInput2.inputValue()).toBe('false')
+    await expect(addressCorrectionInput1).toHaveValue('true')
+    await expect(addressCorrectionInput2).toHaveValue('false')
     expect(await addressCorrectionHelpText1.innerText()).not.toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).toContain(helpText)
 
@@ -381,8 +382,8 @@ test.describe('program creation', () => {
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-one')
     await adminPrograms.clickAddressCorrectionToggleByName('ace-address-two')
 
-    expect(await addressCorrectionInput1.inputValue()).toBe('false')
-    expect(await addressCorrectionInput2.inputValue()).toBe('true')
+    await expect(addressCorrectionInput1).toHaveValue('false')
+    await expect(addressCorrectionInput2).toHaveValue('true')
     expect(await addressCorrectionHelpText1.innerText()).toContain(helpText)
     expect(await addressCorrectionHelpText2.innerText()).not.toContain(helpText)
 
@@ -415,11 +416,11 @@ test.describe('program creation', () => {
 
     const addressCorrectionInput = adminPrograms.getAddressCorrectionToggle()
 
-    expect(await addressCorrectionInput.inputValue()).toBe('false')
+    await expect(addressCorrectionInput).toHaveValue('false')
 
     await adminPrograms.clickAddressCorrectionToggle()
     // should be the same as before with button submit disabled
-    expect(await addressCorrectionInput.inputValue()).toBe('false')
+    await expect(addressCorrectionInput).toHaveValue('false')
   })
 
   test('change questions order within block', async () => {
@@ -757,14 +758,14 @@ test.describe('program creation', () => {
       'program-description-page-with-intake-form-false',
     )
     const commonIntakeFormInput = adminPrograms.getCommonIntakeFormToggle()
-    expect(await commonIntakeFormInput.isChecked()).toBe(false)
+    await expect(commonIntakeFormInput).not.toBeChecked()
 
     await adminPrograms.clickCommonIntakeFormToggle()
     await validateScreenshot(
       page,
       'program-description-page-with-intake-form-true',
     )
-    expect(await commonIntakeFormInput.isChecked()).toBe(true)
+    await expect(commonIntakeFormInput).toBeChecked()
     await page.click('#program-update-button')
     await waitForPageJsLoad(page)
     await adminPrograms.expectProgramBlockEditPage(programName)

--- a/browser-test/src/admin_program_settings.test.ts
+++ b/browser-test/src/admin_program_settings.test.ts
@@ -59,17 +59,15 @@ test.describe('program settings', () => {
 
     await validateScreenshot(page, 'dropdown-with-settings')
 
-    expect(
-      await page
-        .locator(
-          adminPrograms.withinProgramCardSelector(
-            programName,
-            'Draft',
-            ':text("Settings")',
-          ),
-        )
-        .isVisible(),
-    ).toBe(true)
+    await expect(
+      page.locator(
+        adminPrograms.withinProgramCardSelector(
+          programName,
+          'Draft',
+          ':text("Settings")',
+        ),
+      ),
+    ).toBeVisible()
   })
 
   test('back button on program settings page navigates correctly', async () => {
@@ -128,16 +126,14 @@ test.describe('program settings', () => {
       ),
     )
 
-    expect(
-      await page
-        .locator(
-          adminPrograms.withinProgramCardSelector(
-            programName,
-            'Draft',
-            ':text("Settings")',
-          ),
-        )
-        .isVisible(),
-    ).toBe(false)
+    await expect(
+      page.locator(
+        adminPrograms.withinProgramCardSelector(
+          programName,
+          'Draft',
+          ':text("Settings")',
+        ),
+      ),
+    ).toBeHidden()
   })
 })

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -460,6 +460,14 @@ test.describe('Admin can manage translations', () => {
     expect(await page.inputValue('text=Question text')).toContain(
       'something different',
     )
+
+    // Fix me! ESLint: playwright/prefer-web-first-assertions
+    // Directly switching to the best practice method fails
+    // because of a locator stict mode violation. That is it
+    // returns multiple elements.
+    //
+    // Recommended prefer-web-first-assertions fix:
+    //   await expect(page.locator('text=Question help text')).toHaveText('')
     expect(await page.inputValue('text=Question help text')).toEqual('')
   })
 

--- a/browser-test/src/number_input.test.ts
+++ b/browser-test/src/number_input.test.ts
@@ -74,7 +74,8 @@ test.describe('Number question for applicant flow', () => {
       for (const testValue of testValues) {
         await applicantQuestions.answerNumberQuestion(testValue)
         await applicantQuestions.clickNext()
-        expect(await page.isHidden(numberInputError)).toEqual(false)
+
+        await expect(page.locator(numberInputError)).toBeVisible()
         await applicantQuestions.answerNumberQuestion('')
       }
     })
@@ -133,6 +134,13 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.answerNumberQuestion('33', 1)
       await applicantQuestions.clickNext()
 
+      // Fix me! ESLint: playwright/prefer-web-first-assertions
+      // Directly switching to the best practice method fails
+      // because of a locator stict mode violation. That is it
+      // returns multiple elements.
+      //
+      // Recommended prefer-web-first-assertions fix:
+      //   await expect(page.locator(numberInputError)).toBeVisible()
       expect(await page.isHidden(numberInputError)).toEqual(false)
     })
 
@@ -143,6 +151,13 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.answerNumberQuestion('-5', 1)
       await applicantQuestions.clickNext()
 
+      // Fix me! ESLint: playwright/prefer-web-first-assertions
+      // Directly switching to the best practice method fails
+      // because of a locator stict mode violation. That is it
+      // returns multiple elements.
+      //
+      // Recommended prefer-web-first-assertions fix:
+      //   await expect(page.locator(numberInputError + ' >> nth=1')).toBeVisible()
       expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(false)
     })
 

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -414,11 +414,12 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
-    expect(
-      await page.isChecked(
+
+    await expect(
+      page.locator(
         adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION),
       ),
-    ).toBeTruthy()
+    ).toBeChecked()
 
     const questionName = 'textQuestionWithObfuscatedExport'
     await adminQuestions.addTextQuestion({
@@ -428,19 +429,27 @@ test.describe('normal question lifecycle', () => {
 
     // Confirm that the previously selected export option was propagated.
     await adminQuestions.gotoQuestionEditPage(questionName)
-    expect(
-      await page.isChecked(
+    await expect(
+      page.locator(
         adminQuestions.selectorForExportOption(
           AdminQuestions.EXPORT_OBFUSCATED_OPTION,
         ),
       ),
-    ).toBeTruthy()
+    ).toBeChecked()
 
     // Edit the result and confirm that the new value is propagated.
     await adminQuestions.selectExportOption(AdminQuestions.EXPORT_VALUE_OPTION)
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
     await adminQuestions.gotoQuestionEditPage(questionName)
+
+    // Fix me! ESLint: playwright/prefer-web-first-assertions
+    // Directly switching to the best practice method fails
+    // because of a locator stict mode violation. That is it
+    // returns multiple elements.
+    //
+    // Recommended prefer-web-first-assertions fix:
+    // await expect(page.locator(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION))).toBeChecked()
     expect(
       await page.isChecked(
         adminQuestions.selectorForExportOption(
@@ -532,8 +541,6 @@ test.describe('normal question lifecycle', () => {
     // Wait for debounce
     await page.waitForTimeout(300) // ms
 
-    expect(await page.locator('#formatted-name').innerText()).toEqual(
-      'my_test_question',
-    )
+    await expect(page.locator('#formatted-name')).toHaveText('my_test_question')
   })
 })

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -100,7 +100,7 @@ export class AdminQuestions {
   }
 
   async expectAdminQuestionsPage() {
-    expect(await this.page.innerText('h1')).toEqual('All questions')
+    await expect(this.page.locator('h1')).toHaveText('All questions')
   }
 
   selectorForExportOption(exportOption: string) {
@@ -134,9 +134,9 @@ export class AdminQuestions {
     // The order of the options array corresponds to the order of the errors array.
     for (let i = 0; i < options.length; i++) {
       if (blankIndices.includes(i)) {
-        expect(await errors.nth(i).isHidden()).toEqual(false)
+        await expect(errors.nth(i)).toBeVisible()
       } else {
-        expect(await errors.nth(i).isHidden()).toEqual(true)
+        await expect(errors.nth(i)).toBeHidden()
       }
     }
   }
@@ -152,9 +152,9 @@ export class AdminQuestions {
     // The order of the options array corresponds to the order of the errors array.
     for (let i = 0; i < options.length; i++) {
       if (invalidIndices.includes(i)) {
-        expect(await errors.nth(i).isHidden()).toEqual(false)
+        await expect(errors.nth(i)).toBeVisible()
       } else {
-        expect(await errors.nth(i).isHidden()).toEqual(true)
+        await expect(errors.nth(i)).toBeHidden()
       }
     }
   }
@@ -423,13 +423,13 @@ export class AdminQuestions {
       await this.openDropdownMenu(questionName)
       // Ensure that the page has been reloaded and the "Restore archive" link
       // appears.
-      const restoreArchiveIsVisible = await this.page.isVisible(
+      const restoreArchiveIsVisible = this.page.locator(
         this.selectWithinQuestionTableRow(
           questionName,
           ':text("Restore archived")',
         ),
       )
-      expect(restoreArchiveIsVisible).toBe(true)
+      await expect(restoreArchiveIsVisible).toBeVisible()
     }
   }
 
@@ -454,7 +454,7 @@ export class AdminQuestions {
 
   async expectQuestionEditPage(questionName: string) {
     expect(await this.page.innerText('h1')).toContain('Edit')
-    expect(await this.page.innerText('#question-name-input')).toEqual(
+    await expect(this.page.locator('#question-name-input')).toHaveText(
       questionName,
     )
   }
@@ -892,21 +892,15 @@ export class AdminQuestions {
     option: QuestionOption,
     adminNameIsEditable: boolean,
   ) {
-    expect(
-      await this.page
-        .locator(AdminQuestions.multiOptionInputSelector(index))
-        .inputValue(),
-    ).toEqual(option.text)
-    expect(
-      await this.page
-        .locator(AdminQuestions.multiOptionAdminInputSelector(index))
-        .inputValue(),
-    ).toEqual(option.adminName)
-    expect(
-      await this.page
-        .locator(AdminQuestions.multiOptionAdminInputSelector(index))
-        .isEditable(),
-    ).toEqual(adminNameIsEditable)
+    await expect(
+      this.page.locator(AdminQuestions.multiOptionInputSelector(index)),
+    ).toHaveValue(option.text)
+    await expect(
+      this.page.locator(AdminQuestions.multiOptionAdminInputSelector(index)),
+    ).toHaveValue(option.adminName)
+    await expect(
+      this.page.locator(AdminQuestions.multiOptionAdminInputSelector(index)),
+    ).toBeEditable({editable: adminNameIsEditable})
   }
 
   async addCurrencyQuestion({
@@ -1248,22 +1242,22 @@ export class AdminQuestions {
     visible: boolean,
   ) {
     const alert = this.page.locator(type.valueOf())
-    expect(await alert.isVisible()).toEqual(visible)
+    await expect(alert).toBeVisible({visible: visible})
   }
 
   async expectPrimaryApplicantInfoSectionVisible(visible: boolean) {
-    expect(
-      await this.page.locator('#primary-applicant-info').isVisible(),
-    ).toEqual(visible)
+    await expect(this.page.locator('#primary-applicant-info')).toBeVisible({
+      visible: visible,
+    })
   }
 
   async expectPrimaryApplicantInfoToggleVisible(
     fieldName: string,
     visible: boolean,
   ) {
-    expect(await this.page.locator(`#${fieldName}-toggle`).isVisible()).toEqual(
-      visible,
-    )
+    await expect(this.page.locator(`#${fieldName}-toggle`)).toBeVisible({
+      visible: visible,
+    })
   }
 
   async expectPrimaryApplicantInfoToggleValue(
@@ -1364,6 +1358,21 @@ export class AdminQuestions {
     deleteEntityButtonText: string
     addEntityButtonText: string
   }) {
+    // Fix me! ESLint: playwright/prefer-web-first-assertions
+    // Directly switching to the best practice method fails
+    // because of a locator stict mode violation. That is it
+    // returns multiple elements.
+    //
+    // Recommended prefer-web-first-assertions fix:
+    // await expect(this.page.locator('.cf-entity-name-input label')).toHaveText(
+    //   entityNameInputLabelText,
+    // )
+    // await expect(this.page.locator('.cf-enumerator-delete-button')).toHaveText(
+    //   deleteEntityButtonText,
+    // )
+    // await expect(this.page.locator('#enumerator-field-add-button')).toHaveText(
+    //   addEntityButtonText,
+    // )
     expect(await this.page.innerText('.cf-entity-name-input label')).toBe(
       entityNameInputLabelText,
     )
@@ -1382,12 +1391,12 @@ export class AdminQuestions {
     questionText: string
     questionHelpText: string
   }) {
-    expect(await this.page.innerText('.cf-applicant-question-text')).toBe(
+    await expect(this.page.locator('.cf-applicant-question-text')).toHaveText(
       questionText,
     )
-    expect(await this.page.innerText('.cf-applicant-question-help-text')).toBe(
-      questionHelpText,
-    )
+    await expect(
+      this.page.locator('.cf-applicant-question-help-text'),
+    ).toHaveText(questionHelpText)
   }
 
   async expectPreviewOptions(options: string[]) {


### PR DESCRIPTION
### Description

Continuing the slog work through cleaning up playwright lint issues.

Fixing some lint errors: prefer-web-first-assertions

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
- [x] Created unit and/or browser tests which fail without the change (if possible)
