### PR TITLE
Add #validateQuestionIsOnPage helper method to browser tests

### DIFF
--- a/browser-test/src/application_navigation.test.ts
+++ b/browser-test/src/application_navigation.test.ts
@@ -530,9 +530,7 @@ test.describe('Applicant navigation flow', () => {
         'address question text',
       )
       await waitForPageJsLoad(page)
-      expect(await page.innerText('.cf-applicant-question-text')).toContain(
-        'address question text',
-      )
+      await applicantQuestions.validateQuestionIsOnPage('address question text')
       // Should focus on the question the applicant clicked on when answering for the first time
       expect(await page.innerHTML('.cf-address-street-1')).toContain(
         'autofocus',
@@ -557,9 +555,7 @@ test.describe('Applicant navigation flow', () => {
         '.cf-applicant-summary-row:has(div:has-text("address question text")) a:has-text("Edit")',
       )
       await waitForPageJsLoad(page)
-      expect(await page.innerText('.cf-applicant-question-text')).toContain(
-        'address question text',
-      )
+      await applicantQuestions.validateQuestionIsOnPage('address question text')
       // Should focus on the question the applicant clicked on when editing previous answer
       expect(await page.innerHTML('.cf-address-street-1')).toContain(
         'autofocus',

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -247,9 +247,7 @@ test.describe('file upload applicant flow', () => {
       // Then we should still show the error, even for an optional question
       await applicantFileQuestion.expectFileSelectionErrorShown()
       // Verify we're still on the file upload question block
-      expect(await page.innerText('.cf-applicant-question-text')).toContain(
-        fileUploadQuestionText,
-      )
+      await applicantQuestions.validateQuestionIsOnPage(fileUploadQuestionText)
     })
 
     test('with missing file can be skipped', async () => {
@@ -573,9 +571,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickPrevious()
 
         // Verify we're taken to the previous page, which has the email question
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          emailQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
       })
 
       test('clicking previous without file redirects to previous page (flag on)', async () => {
@@ -590,9 +586,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickPrevious()
 
         // Verify we're taken to the previous page, which has the email question
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          emailQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
       })
 
       test('clicking previous with file discards file and redirects to previous page (flag off)', async () => {
@@ -612,9 +606,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickPrevious()
 
         // Verify we're taken to the previous page, which has the email question
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          emailQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
 
         // Verify the file was *not* saved (because the flag is off)
         await applicantQuestions.clickReview()
@@ -641,9 +633,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickPrevious()
 
         // Verify we're taken to the previous page, which has the email question
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          emailQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
 
         // Verify the file *was* saved (because the flag is on)
         await applicantQuestions.clickReview()
@@ -670,9 +660,10 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickNext()
 
         // Verify we're still on the file upload question block and an error is shown
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
+        await applicantQuestions.validateQuestionIsOnPage(
           fileUploadQuestionText,
         )
+
         await applicantFileQuestion.expectFileSelectionErrorShown()
         await validateScreenshot(page, 'file-errors')
       })
@@ -690,7 +681,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickNext()
 
         // Verify we're still on the file upload question block and an error is shown
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
+        await applicantQuestions.validateQuestionIsOnPage(
           fileUploadQuestionText,
         )
         await applicantFileQuestion.expectFileSelectionErrorShown()
@@ -713,9 +704,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickNext()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the file was saved
         await applicantQuestions.clickReview()
@@ -743,9 +732,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.clickNext()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the file was saved
         await applicantQuestions.clickReview()
@@ -787,9 +774,7 @@ test.describe('file upload applicant flow', () => {
         // block an applicant should see is the first block that hasn't ever been seen.
         // In this case, because we never opened the very first block with the email
         // question, clicking "Continue" should take us back to that email question.
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          emailQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
 
         // Verify the old file is still present
         await applicantQuestions.clickReview()
@@ -828,9 +813,7 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.clickContinue()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still present
         await applicantQuestions.clickReview()
@@ -876,9 +859,7 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.clickContinue()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still present
         await applicantQuestions.clickReview()
@@ -925,9 +906,7 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.clickContinue()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still used
         await applicantQuestions.clickReview()
@@ -984,9 +963,7 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.clickContinue()
 
         // Verify we're taken to the next page
-        expect(await page.innerText('.cf-applicant-question-text')).toContain(
-          numberQuestionText,
-        )
+        await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still used
         await applicantQuestions.clickReview()

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -238,7 +238,7 @@ test.describe('file upload applicant flow', () => {
     })
 
     test('with missing file shows error and does not proceed if Save&next', async () => {
-      const {page, applicantQuestions, applicantFileQuestion} = ctx
+      const {applicantQuestions, applicantFileQuestion} = ctx
       await applicantQuestions.applyProgram(programName)
 
       // When the applicant clicks "Save & next"
@@ -746,7 +746,7 @@ test.describe('file upload applicant flow', () => {
 
     test.describe('continue button', () => {
       test('clicking continue button redirects to first unseen block', async () => {
-        const {page, applicantQuestions, applicantFileQuestion} = ctx
+        const {applicantQuestions, applicantFileQuestion} = ctx
 
         // Answer the file upload question
         await applicantQuestions.clickApplyProgramButton(programName)

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -663,7 +663,6 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.validateQuestionIsOnPage(
           fileUploadQuestionText,
         )
-
         await applicantFileQuestion.expectFileSelectionErrorShown()
         await validateScreenshot(page, 'file-errors')
       })

--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -68,7 +68,7 @@ test.describe('navigating to a deep link', () => {
 
   test('takes guests and logged in users through the flow correctly', async () => {
     await resetContext(ctx)
-    const {page} = ctx
+    const {page, applicantQuestions} = ctx
 
     // Exercise guest path
     // Act
@@ -76,9 +76,7 @@ test.describe('navigating to a deep link', () => {
     await page.click('text="Continue to application"')
     // Assert
     await page.click('#continue-application-button')
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      questionText,
-    )
+    await applicantQuestions.validateQuestionIsOnPage(questionText)
 
     await logout(page)
 
@@ -88,14 +86,12 @@ test.describe('navigating to a deep link', () => {
     await loginAsTestUser(page, 'button:has-text("Log in")')
     // Assert
     await page.click('#continue-application-button')
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      questionText,
-    )
+    await applicantQuestions.validateQuestionIsOnPage(questionText)
   })
 
   test('Non-logged in user should get redirected to the program page and not an error', async () => {
     await resetContext(ctx)
-    const {page, browserContext} = ctx
+    const {page, applicantQuestions, browserContext} = ctx
 
     await logout(page)
     await browserContext.clearCookies()
@@ -105,16 +101,14 @@ test.describe('navigating to a deep link', () => {
 
     // Assert
     await page.click('#continue-application-button')
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      questionText,
-    )
+    await applicantQuestions.validateQuestionIsOnPage(questionText)
 
     await logout(page)
   })
 
   test('Logging in to an existing account after opening a deep link in a new browser session', async () => {
     await resetContext(ctx)
-    const {page, browserContext} = ctx
+    const {page, applicantQuestions, browserContext} = ctx
 
     // Log in and log out to establish the test user in the database.
     await loginAsTestUser(page)
@@ -127,9 +121,7 @@ test.describe('navigating to a deep link', () => {
     await loginAsTestUser(page, 'button:has-text("Log in")')
 
     await page.click('#continue-application-button')
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      questionText,
-    )
+    await applicantQuestions.validateQuestionIsOnPage(questionText)
 
     await logout(page)
   })

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -542,6 +542,12 @@ export class ApplicantQuestions {
     )
   }
 
+  async validateQuestionIsOnPage(questionText: string) {
+    await expect(
+      this.page.locator('.cf-applicant-question-text'),
+    ).toContainText(questionText)
+  }
+
   async validatePreviouslyAnsweredText(questionText: string) {
     const questionLocator = this.page.locator('.cf-applicant-summary-row', {
       has: this.page.locator(`:text("${questionText}")`),


### PR DESCRIPTION
### Description

Adds a new `validateQuestionIsOnPage` helper method to the `applicantQuestions` helper class so that we don't copy paste the `cf-applicant-question-text` class everywhere.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).
