### PR TITLE
Make one less db call on TI dashboard

### DIFF
--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -346,10 +346,10 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
     if (newestApplicant.isEmpty()) {
       return div();
     }
-    int applicationCount = newestApplicant.get().getApplications().size();
-
+    ImmutableList<ApplicationModel> newestApplicantApplications = newestApplicant.get().getApplications();
+    int applicationCount = newestApplicantApplications.size();
     String programs =
-        newestApplicant.get().getApplications().stream()
+        newestApplicantApplications.stream()
             .map(
                 application ->
                     programRepository


### PR DESCRIPTION
### Description

We call getApplications twice, which will make a database call each time. Instead, we can set this to a variable and use it in each place.

This won't fix the Seattle prod issue, but will reduce load on the database

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

#6813
