### PR TITLE
Make one less db call on TI dashboard

### DIFF
--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -346,10 +346,12 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
     if (newestApplicant.isEmpty()) {
       return div();
     }
-    int applicationCount = newestApplicant.get().getApplications().size();
 
+    ImmutableList<ApplicationModel> newestApplicantApplications =
+        newestApplicant.get().getApplications();
+    int applicationCount = newestApplicantApplications.size();
     String programs =
-        newestApplicant.get().getApplications().stream()
+        newestApplicantApplications.stream()
             .map(
                 application ->
                     programRepository

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import models.AccountModel;
 import models.ApplicantModel;
+import models.ApplicationModel;
 import models.TrustedIntermediaryGroupModel;
 import org.slf4j.LoggerFactory;
 import play.i18n.Messages;


### PR DESCRIPTION
### Description

We call getApplications twice, which will make a database call each time. Instead, we can set this to a variable and use it in each place.

This won't fix the Seattle prod issue, but will reduce load on the database

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

### Issue(s) this completes

#6813