### PR TITLE
Create feature flag for shallow program definition cache

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -852,6 +852,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("QUESTION_CACHE_ENABLED");
   }
 
+  /** Enables caching for program definitions without associated question data. */
+  public boolean getShallowProgramDefCacheEnabled() {
+    return getBool("SHALLOW_PROGRAM_DEF_CACHE_ENABLED");
+  }
+
   /** Enables populating more fields in OIDC logout requests to admin identity provider. */
   public boolean getAdminOidcEnhancedLogoutEnabled() {
     return getBool("ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED");
@@ -1819,6 +1824,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                   SettingDescription.create(
                       "QUESTION_CACHE_ENABLED",
                       "Enables caching for questions and their associated data.",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.HIDDEN),
+                  SettingDescription.create(
+                      "SHALLOW_PROGRAM_DEF_CACHE_ENABLED",
+                      "Enables caching for program definitions without associated question data.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.HIDDEN),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -723,6 +723,11 @@
         "description": "Enables caching for questions and their associated data.",
         "type": "bool"
       },
+      "SHALLOW_PROGRAM_DEF_CACHE_ENABLED": {
+        "mode": "HIDDEN",
+        "description": "Enables caching for program definitions without associated question data.",
+        "type": "bool"
+      },
       "ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED": {
         "mode": "ADMIN_READABLE",
         "description": "Enables populating more fields in OIDC logout requests to admin identity provider.",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -38,6 +38,8 @@ program_cache_enabled = true
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}
 question_cache_enabled = false
 question_cache_enabled = ${?QUESTION_CACHE_ENABLED}
+shallow_program_def_cache_enabled = false
+shallow_program_def_cache_enabled = ${?SHALLOW_PROGRAM_DEF_CACHE_ENABLED}
 
 # OIDC logout
 admin_oidc_enhanced_logout_enabled = false


### PR DESCRIPTION
### Description

SHALLOW_PROGRAM_DEF_CACHE_ENABLED will cache the shallow program definition (one without question data) 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
