### PR TITLE
Get or set the shallow program definition when the flag is enabled

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -55,6 +55,7 @@ public final class ProgramRepository {
   private final SettingsManifest settingsManifest;
   private final SyncCacheApi programCache;
   private final SyncCacheApi programDefCache;
+  private final SyncCacheApi shallowProgramDefCache;
   private final SyncCacheApi versionsByProgramCache;
 
   @Inject
@@ -64,12 +65,14 @@ public final class ProgramRepository {
       SettingsManifest settingsManifest,
       @NamedCache("program") SyncCacheApi programCache,
       @NamedCache("full-program-definition") SyncCacheApi programDefCache,
+      @NamedCache("shallow-program-definition") SyncCacheApi shallowProgramDefCache,
       @NamedCache("program-versions") SyncCacheApi versionsByProgramCache) {
     this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);
     this.versionRepository = checkNotNull(versionRepository);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.programCache = checkNotNull(programCache);
+    this.shallowProgramDefCache = checkNotNull(shallowProgramDefCache);
     this.programDefCache = checkNotNull(programDefCache);
     this.versionsByProgramCache = checkNotNull(versionsByProgramCache);
   }
@@ -132,6 +135,10 @@ public final class ProgramRepository {
    * <p>This method should replace any calls to ProgramModel.getProgramDefinition()
    */
   public ProgramDefinition getShallowProgramDefinition(ProgramModel program) {
+    if (settingsManifest.getShallowProgramDefCacheEnabled()) {
+      return shallowProgramDefCache.getOrElseUpdate(
+          String.valueOf(program.id), () -> program.getProgramDefinition());
+    }
     return program.getProgramDefinition();
   }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -303,7 +303,7 @@ play.ws {
 #
 play.cache {
   # Specific caches can be injected using the @NamedCache annotation.
-  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions", "full-program-definition"]
+  bindCaches = ["api-keys", "monthly-reporting-data", "version-programs", "version-questions", "program", "program-versions", "shallow-program-definition", "full-program-definition"]
 }
 
 ## Security rules for play-pac4j SecurityFilter

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -54,6 +54,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
   private VersionRepository versionRepo;
   private SyncCacheApi programCache;
   private SyncCacheApi programDefCache;
+  private SyncCacheApi shallowProgramDefCache;
   private SyncCacheApi versionsByProgramCache;
   private SettingsManifest mockSettingsManifest;
 
@@ -62,6 +63,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
     versionRepo = instanceOf(VersionRepository.class);
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     programCache = instanceOf(SyncCacheApi.class);
+    shallowProgramDefCache = instanceOf(SyncCacheApi.class);
     versionsByProgramCache = instanceOf(SyncCacheApi.class);
 
     BindingKey<SyncCacheApi> programDefKey =
@@ -76,6 +78,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             mockSettingsManifest,
             programCache,
             programDefCache,
+            shallowProgramDefCache,
             versionsByProgramCache);
   }
 


### PR DESCRIPTION
### Description

When we have the shallow program definition cache turned on, we should get or set the shallow program definition when programRepository.getShallowProgramDefinition is called.

## Release notes

Turns on caching of the program definition behind the SHALLOW_PROGRAM_DEF_CACHE_ENABLED flag. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers).

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)


### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
