### PR TITLE
Allow Question Help Text to Not Require $this

### DIFF
--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -271,11 +271,11 @@ public abstract class QuestionDefinition {
         errors.add(CiviFormError.of("Enumerator question must have specified entity type"));
       }
     }
-    if (isRepeated() && !questionTextAndHelpTextContainsRepeatedEntityNameFormatString()) {
-      errors.add(
-          CiviFormError.of(
-              "Repeated questions must reference '$this' in the text and help text (if present)"));
+
+    if (isRepeated() && !questionTextContainsRepeatedEntityNameFormatString()) {
+      errors.add(CiviFormError.of("Repeated questions must reference '$this' in the text"));
     }
+
     if (getQuestionType().isMultiOptionType()) {
       MultiOptionQuestionDefinition multiOptionQuestionDefinition =
           (MultiOptionQuestionDefinition) this;
@@ -421,14 +421,9 @@ public abstract class QuestionDefinition {
     return false;
   }
 
-  private boolean questionTextAndHelpTextContainsRepeatedEntityNameFormatString() {
-    boolean textMissingFormatString =
-        getQuestionText().translations().values().stream()
-            .anyMatch(text -> !text.contains("$this"));
-    boolean helpTextMissingFormatString =
-        getQuestionHelpText().translations().values().stream()
-            .anyMatch(helpText -> !helpText.contains("$this"));
-    return !textMissingFormatString && !helpTextMissingFormatString;
+  private boolean questionTextContainsRepeatedEntityNameFormatString() {
+    return getQuestionText().translations().values().stream()
+        .allMatch(text -> text.contains("$this"));
   }
 
   /**

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -2,13 +2,16 @@ package views.admin.questions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.em;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h2;
 import static j2html.TagCreator.input;
+import static j2html.TagCreator.join;
 import static j2html.TagCreator.legend;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
+import static j2html.TagCreator.strong;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -668,22 +671,38 @@ public final class QuestionEditView extends BaseHtmlView {
   }
 
   private DivTag repeatedQuestionInformation() {
-    return div("By selecting an enumerator, you are creating a repeated question - a question that"
-            + " is asked for each repeated entity enumerated by the applicant. Please"
-            + " reference the applicant-defined repeated entity name to give the applicant"
-            + " context on which repeated entity they are answering the question for by"
-            + " using \"$this\" in the question's text and help text. To reference the"
-            + " repeated entities containing this one, use \"$this.parent\","
-            + " \"this.parent.parent\", etc.")
+    return div()
+        .with(
+            p(
+                "By selecting an enumerator, you are creating a repeated question - a question that"
+                    + " is asked for each repeated entity enumerated by the applicant."),
+            p(
+                join(
+                    "Please reference the applicant-defined repeated entity name to give the"
+                        + " applicant context on which repeated entity they are answering the"
+                        + " question for by using ",
+                    em("\"$this\""),
+                    "in the ",
+                    strong("question's text"),
+                    " and optionally the ",
+                    strong("help text. "))),
+            p(
+                join(
+                    "To reference the repeated entities containing this one, use ",
+                    em("\"$this.parent\""),
+                    ", ",
+                    em("\"$this.parent.parent\""),
+                    ", etc.")))
         .withId("repeated-question-information")
         .withClasses(
             "hidden",
-            "text-blue-500",
+            "text-blue-600",
             "text-sm",
             "p-2",
             "font-mono",
             "border-4",
-            "border-blue-400");
+            "border-blue-400",
+            "space-y-4");
   }
 
   private DivTag administrativeNameField(String adminName, boolean editExistingQuestion) {

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -306,10 +306,7 @@ public class QuestionDefinitionTest {
     QuestionDefinition question = builder.setEnumeratorId(Optional.of(1L)).build();
 
     assertThat(question.validate())
-        .containsOnly(
-            CiviFormError.of(
-                "Repeated questions must reference '$this' in the text and help text (if"
-                    + " present)"));
+        .containsOnly(CiviFormError.of("Repeated questions must reference '$this' in the text"));
   }
 
   @Test
@@ -320,18 +317,50 @@ public class QuestionDefinitionTest {
         builder
             .setQuestionText(
                 LocalizedStrings.of(
-                    Locale.US, "$this is present", Locale.FRANCE, "$this is also present"))
+                    Locale.US, "$this is present", Locale.FRANCE, "this is not present"))
             .setQuestionHelpText(
                 LocalizedStrings.of(
-                    Locale.US, "$this is present", Locale.FRANCE, "this is not present"))
+                    Locale.US, "$this is present", Locale.FRANCE, "$this is also present"))
             .setEnumeratorId(Optional.of(1L))
             .build();
 
     assertThat(question.validate())
-        .containsOnly(
-            CiviFormError.of(
-                "Repeated questions must reference '$this' in the text and help text (if"
-                    + " present)"));
+        .containsOnly(CiviFormError.of("Repeated questions must reference '$this' in the text"));
+  }
+
+  @Test
+  public void validate_withRepeatedQuestion_withHelpTextThatDoesHaveFormatString_returnsNoErrors()
+      throws Exception {
+    QuestionDefinition question =
+        builder
+            .setQuestionText(
+                LocalizedStrings.of(
+                    Locale.US, "$this is present", Locale.FRANCE, "$this is present"))
+            .setQuestionHelpText(
+                LocalizedStrings.of(
+                    Locale.US, "$this is present", Locale.FRANCE, "$this is present"))
+            .setEnumeratorId(Optional.of(1L))
+            .build();
+
+    assertThat(question.validate()).isEmpty();
+  }
+
+  @Test
+  public void
+      validate_withRepeatedQuestion_withHelpTextThatDoesNotHaveFormatString_returnsNoErrors()
+          throws Exception {
+    QuestionDefinition question =
+        builder
+            .setQuestionText(
+                LocalizedStrings.of(
+                    Locale.US, "$this is present", Locale.FRANCE, "$this is present"))
+            .setQuestionHelpText(
+                LocalizedStrings.of(
+                    Locale.US, "this is not present", Locale.FRANCE, "this is not present"))
+            .setEnumeratorId(Optional.of(1L))
+            .build();
+
+    assertThat(question.validate()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
### Description

Remove the requirement that a question that is part of an enumerator have help text containing the text `$this`. It can still be used, but isn't required. 

Updates the on screen instructions to align with the change. Also adds a modicum of formatting to make the instructions more legible.

Will update the docs repo after this goes in.

Example of the one screen Instructions 
![image](https://github.com/civiform/civiform/assets/195162/a0dae357-f2cb-403b-a5fb-b966cd8115aa)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #6784