### PR TITLE
Add new string for confirmation message when deleting an enumerator answer

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -146,6 +146,7 @@ public enum MessageKey {
   ENUMERATOR_BUTTON_ADD_ENTITY("button.addEntity"),
   ENUMERATOR_BUTTON_REMOVE_ENTITY("button.removeEntity"),
   ENUMERATOR_DIALOG_CONFIRM_DELETE("dialog.confirmDelete"),
+  ENUMERATOR_DIALOG_CONFIRM_DELETE_ALL_BUTTONS_SAVE("dialog.confirmDeleteAllButtonsSave"),
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),
   ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -170,6 +170,9 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
       entityNameInputField.forceAriaInvalid();
       entityNameInputField.focusOnError();
     }
+    // TODO(#6844): Replace this with {@link
+    // MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE_ALL_BUTTONS_SAVE} once the
+    // SAVE_ON_ALL_ACTIONS flag is enabled.
     String confirmationMessage =
         messages.at(MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE.getKeyName(), localizedEntityType);
     ButtonTag removeEntityButton =

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -362,6 +362,8 @@ validation.invalidDateFormat=Please enter a date in the correct format
 button.addEntity=Add {0}
 button.removeEntity=Remove {0}
 dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
+# Dialog text shown to the user when they choose to delete an entry that they added previously. The dialog asks them to confirm if they want to delete the entry and all data associated with it. {0} represents the type of entry being deleted. For example, users may be asked to list all cars they own or all children in their household, so {0} could be "car" or "child".
+dialog.confirmDeleteAllButtonsSave=Are you sure you want to remove this {0}? This change will be saved when you click "Review", "Previous", or "Next" and all data associated with this {0} will be lost.
 validation.entityNameRequired=Please enter a value for each line.
 validation.duplicateEntityName=Please enter a unique value for each line.
 placeholder.entityName={0} name


### PR DESCRIPTION
### Description

If you're an applicant and you delete one of your answers to an enumerator question, the alert that currently appears only says that the data will be deleted when you click "Next". However, when the `SAVE_ON_ALL_ACTIONS` flag is on, the data will also be deleted if you click "Review" or "Previous". This PR adds a new string that also mentions those buttons. Once translations are on and the `SAVE_ON_ALL_ACTIONS` flag is enabled, we can use this new string and delete the old one.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)

### Issue(s) this completes

Part of #6844
