### PR TITLE
Only regenerate the settings manifest if it needs it

### DIFF
--- a/bin/generate-settings-manifest
+++ b/bin/generate-settings-manifest
@@ -3,6 +3,14 @@
 # DOC: Generates the SettingsManifest.java file based on the contents of env_var_docs.json
 
 source bin/lib.sh
+
+# Check if we have an unstaged, staged, or committed changes to the env-var-docs.json
+# file or if we are running in CI. If not no need to re-run.
+if [[ -z "$(git diff --diff-filter=M origin/main -- server/conf/env-var-docs.json)" && -z "${CI}" ]]; then
+  echo "No changes detected to server/conf/env-var-docs.json. Not regenerating settings manifest."
+  exit 0
+fi
+
 docker::set_project_name_env_var_docs
 docker::compose_env_var_docs_up
 


### PR DESCRIPTION
### Description

Running `bin/fmt` makes a call to `bin/generate-settings-manifest` to rebuild the settings manifest java file. Most of the time this doesn't need to happen. This will now check if the `server/conf/env-var-docs.json` file has been modified (either in git's unstaged, staged, or committed states) compared to what is in `origin/main`. If it hasn't changed we won't waste the time running it. 

Not running it saves 1-1.5 seconds running `bin/fmt` when you already have the env-var-docs container running. It saves much more time if you don't have the container running.

Additionally this will run if the CI environment variable is set. This means it'll run via GitHub actions. I don't think we really need this, but it's more as a backup to catch changes if they make it in.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
