### PR TITLE
Fix Getting Branch Name

### DIFF
--- a/bin/dev-show-trace-file
+++ b/bin/dev-show-trace-file
@@ -51,8 +51,7 @@ class Git:
         Get the current branch name
         """
         try:
-            process = subprocess.call(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=subprocess.PIPE)
-            return process.stdout.decode("utf-8")
+            return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True)
         except Exception as error:
             print("Unable to run `git`. Make sure `git` is installed and you are in a git folder.")
             print(error)
@@ -154,7 +153,7 @@ class Runner:
         """
         branch_name = ""
 
-        if len(sys.argv) > 0:
+        if len(sys.argv) > 1:
             branch_name = sys.argv[1]
         else:
             branch_name = self.git.get_current_branch()
@@ -224,6 +223,8 @@ class Runner:
         Run the application core
         """
         branch_name = self.get_branch_name()
+        print(f'Running on branch: {branch_name}')
+
         workflow_runs = self.github.get_failed_workflow_runs(branch_name)
 
         self.print_workflow_runs_table(workflow_runs)


### PR DESCRIPTION
### Description

Fixes getting branch name in the playwright trace viewer script.

Not sure why it was working before, but failed now.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
