### PR TITLE
Pass in sbt version to dockerfiles

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
+        run: bin/build-dev
+
       - name: Build dev-oidc
         env:
           DOCKER_BUILDKIT: 1
@@ -46,10 +48,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
+        run: bin/build-dev
+
       - name: Run tests
         run: bin/run-ts-tests
 
@@ -64,10 +68,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
+        run: bin/build-dev
+
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -139,7 +145,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
+        run: bin/build-dev
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -195,10 +201,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build prod container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
+        run: bin/build-prod
+
+      - name: Set local prod container tag
+        run: docker tag civiform:latest civiform:prod
+
       - name: Build the stack
         run: docker compose -f test-support/prod-simulator-compose.yml up -d
       - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ FROM bellsoft/liberica-openjdk-alpine:11.0.19-7 as arm64
 
 FROM ${TARGETARCH}
 
-ENV SBT_VERSION "${SBT_VERSION:-1.8.2}"
+ARG SBT_VERSION
+ENV SBT_VERSION "${SBT_VERSION}"
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH "${PATH}:${SBT_HOME}/bin"

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -19,6 +19,7 @@ BUILD_ARGS=(--file "${DOCKERFILE}"
   --tag "${NAMESPACE}/${IMAGE}:latest"
   --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
+  --build-arg SBT_VERSION="${SBT_VERSION}"
   "${LOCATION}")
 
 PLATFORM_ARG=()

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -32,6 +32,7 @@ BUILD_ARGS=(--file "${DOCKERFILE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   --build-arg git_commit_sha="${GIT_SHA}"
   --build-arg image_tag="${SNAPSHOT_TAG}"
+  --build-arg SBT_VERSION="${SBT_VERSION}"
   "${LOCATION}")
 
 readonly PLATFORM="${PLATFORM:-"linux/amd64"}" # default to x86-64 when platform not specified

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -2,7 +2,8 @@
 # For production images, use the adoptium.net official JRE & JDK docker images.
 FROM --platform=linux/amd64 eclipse-temurin:11.0.22_7-jdk-alpine AS stage1
 
-ENV SBT_VERSION "${SBT_VERSION:-1.8.2}"
+ARG SBT_VERSION
+ENV SBT_VERSION "${SBT_VERSION}"
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH "${PATH}:${SBT_HOME}/bin"


### PR DESCRIPTION
### Description

Our dev and prod dockerfiles thought they were setting the sbt version from the environment variable defined in `bin/lib.sh`. Turns out they were not. This adds in the dockerfile arg needed as well as passing in the sbt version in the bin/build-nnnn scripts.

I am removing the fallback value. If it can't get the value from the SBT_VERSION environment variable (which comes from `server/project/build.properties`) I want it to fail to build. Not quietly use an old version.

In order for this to work in the GitHub actions I'm updating the test.yaml to call the build scripts instead of using direct docker build commands.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing
