### PR TITLE
Add a github action to run jmeter test

### DIFF
--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch_name }}
-      - name: JMeter Test
+      - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:
           test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -28,7 +28,7 @@ jobs:
           test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
           args: ""
       - name: Upload Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jmeter-results
           path: result.jtl

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -27,7 +27,6 @@ jobs:
         with:
           test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
           args: ""
-          
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -1,12 +1,36 @@
-- name: JMeter Test
-  uses: QAInsights/PerfAction@v5.6.2
-  with:
-    test-plan-path: load_test/applicant_submit_application.jmx
-    args: ""
-    
-- name: Upload Results
-  uses: actions/upload-artifact@v3
-  with:
-    name: jmeter-results
-    path: result.jtl
-    if-no-files-found: error
+name: Run JMeter Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'The name of the branch to build from'
+        required: true
+
+      test_to_run:
+        description: 'The load test to run from load-test/'
+        type: choice
+        options:
+        - applicant_submit_application
+        - applicant_landing_page
+        - ti_landing_page
+
+jobs:
+  testing:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+      - name: JMeter Test
+        uses: QAInsights/PerfAction@v5.6.2
+        with:
+          test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
+          args: ""
+          
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: jmeter-results
+          path: result.jtl
+          if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -1,0 +1,12 @@
+- name: JMeter Test
+  uses: QAInsights/PerfAction@v5.6.2
+  with:
+    test-plan-path: load_test/applicant_submit_application.jmx
+    args: ""
+    
+- name: Upload Results
+  uses: actions/upload-artifact@v3
+  with:
+    name: jmeter-results
+    path: result.jtl
+    if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -5,11 +5,13 @@ on:
     inputs:
       branch_name:
         description: 'The name of the branch to build from'
+        default: main
         required: true
 
       test_to_run:
         description: 'The load test to run from load-test/'
         type: choice
+        default: applicant_submit_application
         options:
         - applicant_submit_application
         - applicant_landing_page


### PR DESCRIPTION
### Description

We added some jmeter tests to github, but these can currently only be run by installing jmeter and running locally. We should allow these to be run through a github action.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

#6869
