### PR TITLE
Export questions from all program versions via JSON API

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -348,6 +348,7 @@ public final class ProgramRepository {
                 queryProfileLocationBuilder.create("getApplicationsForAllProgramVersions"))
             .fetch("program")
             .fetch("applicant")
+            .fetch("applicant.account.managedByGroup")
             .orderBy("id desc")
             .where()
             .in("program_id", allProgramVersionsQuery(programId))

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -92,8 +92,7 @@ public final class CsvExporterService {
       long programId, SubmittedApplicationFilter filters, Request request)
       throws ProgramNotFoundException {
     ImmutableList<ProgramDefinition> allProgramVersions =
-        programService.getAllVersionsFullProgramDefinition(programId).stream()
-            .collect(ImmutableList.toImmutableList());
+        programService.getAllVersionsFullProgramDefinition(programId);
 
     ProgramDefinition currentProgram = programService.getFullProgramDefinition(programId);
     CsvExportConfig exportConfig =

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -23,6 +23,11 @@ import services.applicant.question.Scalar;
 import services.application.ApplicationEventDetails.StatusEvent;
 import services.applications.ProgramAdminApplicationService;
 import services.program.EligibilityDefinition;
+import services.program.IllegalPredicateOrderingException;
+import services.program.ProgramDefinition;
+import services.program.ProgramNeedsABlockException;
+import services.program.ProgramNotFoundException;
+import services.program.ProgramService;
 import services.program.StatusDefinitions;
 import services.program.StatusDefinitions.Status;
 import services.program.predicate.LeafOperationExpressionNode;
@@ -51,6 +56,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   public static final Instant FAKE_SUBMIT_TIME = Instant.parse("2022-12-09T10:30:30.00Z");
 
   private ProgramAdminApplicationService programAdminApplicationService;
+  private static ProgramService programService;
 
   protected ProgramModel fakeProgramWithEnumerator;
   protected ProgramModel fakeProgramWithVisibility;
@@ -74,6 +80,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   @Before
   public void setup() {
     programAdminApplicationService = instanceOf(ProgramAdminApplicationService.class);
+    programService = instanceOf(ProgramService.class);
   }
 
   protected void answerQuestion(
@@ -586,12 +593,37 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       fakeProgramBuilder = ProgramBuilder.newActiveProgram(name);
     }
 
-    static FakeProgramBuilder newActiveProgram() {
-      return newActiveProgram("Fake Program");
+    private FakeProgramBuilder(ProgramBuilder builder) {
+      fakeProgramBuilder = builder;
     }
 
-    static FakeProgramBuilder newActiveProgram(String name) {
-      return new FakeProgramBuilder(name);
+    static FakeProgramBuilder newActiveProgram() {
+      return new FakeProgramBuilder("Fake Program");
+    }
+
+    static FakeProgramBuilder newDraftOf(ProgramModel program) throws ProgramNotFoundException {
+      ProgramDefinition draft = programService.newDraftOf(program.id);
+      return new FakeProgramBuilder(ProgramBuilder.newBuilderFor(draft));
+    }
+
+    static FakeProgramBuilder removeBlockWithQuestion(
+        ProgramModel program, QuestionModel questionToRemove)
+        throws ProgramNotFoundException,
+            ProgramNeedsABlockException,
+            IllegalPredicateOrderingException {
+      ProgramDefinition draft = programService.newDraftOf(program.id);
+      var blockToDelete =
+          draft.blockDefinitions().stream()
+              .filter(
+                  b ->
+                      b.programQuestionDefinitions().stream()
+                          .anyMatch(q -> q.id() == questionToRemove.id))
+              .findFirst()
+              .get()
+              .id();
+
+      ProgramDefinition draftWithoutBlock = programService.deleteBlock(draft.id(), blockToDelete);
+      return new FakeProgramBuilder(ProgramBuilder.newBuilderFor(draftWithoutBlock));
     }
 
     FakeProgramBuilder withQuestion(QuestionModel question) {

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -106,6 +106,17 @@ public class ProgramBuilder {
   }
 
   /**
+   * Wrap the provided {@link ProgramDefinition} in a {@link ProgramBuilder}.
+   *
+   * @param programDefinition the {@link ProgramDefinition} to create a {@link ProgramBuilder} for
+   * @return the {@link ProgramBuilder}.
+   */
+  public static ProgramBuilder newBuilderFor(ProgramDefinition programDefinition) {
+    ProgramDefinition.Builder builder = programDefinition.toBuilder();
+    return new ProgramBuilder(programDefinition.id(), builder);
+  }
+
+  /**
    * Creates a {@link ProgramBuilder} with a new {@link ProgramModel} in active state, with blank
    * description and name.
    */


### PR DESCRIPTION
### Description

Export questions from all program versions in the JSON API

Details
- Retrieves all program versions from the database
- Updates the query to eagerly fetch applicant accounts to reduce n+1 queries
- Loops over every program definition and retrieves answers for all questions for all program versions from the applicants, storing the first `AnswerData` it encounters for each path
- Adds tests to `JsonExporterServiceTest`
- Adds methods for working with drafts and removing programs to `FakeProgramBuilder`

This is not a breaking API change because it only adds additional fields to the API response.

## Release notes

Applications exported via the JSON API now include all questions that have ever been part of a program, not just the questions in the most recent version of the program. This prevents changes to programs from breaking code that consumes the API, and ensures historical answers are always available even after the question is removed from the program.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #5018
