### PR TITLE
Fix for TI dashboard client cards needing to only show submitted applications

### DIFF
--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -688,7 +688,9 @@ test.describe('Trusted intermediaries', () => {
     // Create a program with 1 question.
     const program1 = 'Test program 1'
     const program2 = 'Test program 2'
+    const program3 = 'Test program 3'
     const emailQuestionId = 'ti-email-question'
+    const numberQuestionId = 'ti-number-question'
 
     test.beforeAll(async () => {
       const {page, adminQuestions, adminPrograms, tiDashboard} = ctx
@@ -698,9 +700,13 @@ test.describe('Trusted intermediaries', () => {
         questionName: emailQuestionId,
       })
 
+      await adminQuestions.addNumberQuestion({
+        questionName: numberQuestionId,
+      })
+
       // Create program 1
       await adminPrograms.addProgram(program1)
-      await adminPrograms.editProgramBlock(program1, 'first description', [
+      await adminPrograms.editProgramBlock(program1, 'description', [
         emailQuestionId,
       ])
 
@@ -709,12 +715,21 @@ test.describe('Trusted intermediaries', () => {
 
       // Create program 2
       await adminPrograms.addProgram(program2)
-      await adminPrograms.editProgramBlock(program2, 'first description', [
+      await adminPrograms.editProgramBlock(program2, 'description', [
         emailQuestionId,
       ])
 
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.publishProgram(program2)
+
+      // Create program 3
+      await adminPrograms.addProgram(program3)
+      await adminPrograms.editProgramBlock(program3, 'description', [
+        numberQuestionId,
+      ])
+
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishProgram(program3)
 
       await logout(page)
 
@@ -758,6 +773,23 @@ test.describe('Trusted intermediaries', () => {
       await applicantQuestions.clickSubmit()
 
       await tiDashboard.gotoTIDashboardPage(page)
+      await tiDashboard.expectClientContainsNumberOfApplications('2')
+      await tiDashboard.expectClientContainsProgramNames([
+        'Test program 1',
+        'Test program 2',
+      ])
+
+      // Start application to third program, but don't submit
+      await tiDashboard.clickOnViewApplications()
+
+      await applicantQuestions.clickApplyProgramButton(program3)
+      await applicantQuestions.clickContinue()
+      await applicantQuestions.answerNumberQuestion('1')
+      await applicantQuestions.clickNext()
+
+      await tiDashboard.gotoTIDashboardPage(page)
+
+      // Should only show submitted applications
       await tiDashboard.expectClientContainsNumberOfApplications('2')
       await tiDashboard.expectClientContainsProgramNames([
         'Test program 1',

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import models.AccountModel;
 import models.ApplicantModel;
 import models.ApplicationModel;
+import models.LifecycleStage;
 import models.TrustedIntermediaryGroupModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -367,11 +368,13 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
       return div();
     }
 
-    ImmutableList<ApplicationModel> newestApplicantApplications =
-        newestApplicant.get().getApplications();
-    int applicationCount = newestApplicantApplications.size();
+    ImmutableList<ApplicationModel> submittedApplications =
+        newestApplicant.get().getApplications().stream()
+            .filter(application -> application.getLifecycleStage() == LifecycleStage.ACTIVE)
+            .collect(ImmutableList.toImmutableList());
+    int applicationCount = submittedApplications.size();
     String programs =
-        newestApplicantApplications.stream()
+        submittedApplications.stream()
             .map(
                 application -> {
                   try {


### PR DESCRIPTION
### Description

On the TI dashboard client cards, "# submitted applications" was showing all started applications rather than just the submitted ones.  This fixes that.

![image](https://github.com/civiform/civiform/assets/134556723/5cf60df8-0b67-4afe-8bad-1995eaa93fb2)

### Instructions for manual testing

1. Log in as a TI.
2. Create a client if you don't already have one.
3. On the client card, click "View applications".
4. Submit an application.
5. Go back to the TI dashboard.
6. Note that the client card now says "1 application submitted" with the program name below.
7. Click "View applications" again.
8. Start an application and click "Save and Next" but don't click "Submit".
9. Go back to the TI dashboard.
10. Note that the client card still says "1 application submitted".

### Issue(s) this completes

Fixes #6834 
