### PR TITLE
Fix JMeter github action

### DIFF
--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -21,14 +21,14 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout
-        # uses: actions/checkout@v4
-        # with:
-        #   ref: ${{ github.event.inputs.branch_name }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:
-          test-plan-path: ./load_test/${{ github.event.inputs.test_to_run }}.jmx
+          test-plan-path: $GITHUB_WORKSPACE/load_test/${{ github.event.inputs.test_to_run }}.jmx
           args: ""
       - name: Upload Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -23,10 +23,11 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch_name }}
+      # - name: Checkout
+      #   uses: actions/checkout@v4
+      #   with:
+      #     ref: ${{ github.event.inputs.branch_name }}
+      - uses: actions/checkout@v3
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -27,19 +27,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch_name }}
-          
       - name: List Directory Contents
         run: ls -lah load-test/ 
-      - name: List Directory Contents
-        run: ls -lah ../load-test/ 
-      # - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
-      #   uses: QAInsights/PerfAction@v5.6.2
-      #   with:
-      #     test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
-      #     results-file: results.jtl
-      # - name: Upload Results
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: jmeter-results
-      #     path: result.jtl
-      #     if-no-files-found: error
+      - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
+        uses: QAInsights/PerfAction@v5.6.2
+        with:
+          test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
+          results-file: results.jtl
+      - name: Upload Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmeter-results
+          path: result.jtl
+          if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -27,16 +27,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch_name }}
+          
       - name: List Directory Contents
-        run: ls -lah load_test/ 
-      - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
-        uses: QAInsights/PerfAction@v5.6.2
-        with:
-          test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
-          results-file: results.jtl
-      - name: Upload Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: jmeter-results
-          path: result.jtl
-          if-no-files-found: error
+        run: ls -lah load-test/ 
+      - name: List Directory Contents
+        run: ls -lah ../load-test/ 
+      # - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
+      #   uses: QAInsights/PerfAction@v5.6.2
+      #   with:
+      #     test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
+      #     results-file: results.jtl
+      # - name: Upload Results
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: jmeter-results
+      #     path: result.jtl
+      #     if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:
-          test-plan-path: load_test/applicant_submit_application.jmx
+          test-plan-path: ./load_test/${{ github.event.inputs.test_to_run }}.jmx
           args: ""
       - name: Upload Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -33,10 +33,10 @@ jobs:
         uses: QAInsights/PerfAction@v5.6.2
         with:
           test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
-          results-file: result.jtl
+          results-file: result.csv
       - name: Upload Results
         uses: actions/upload-artifact@v4
         with:
           name: jmeter-results
-          path: result.jtl
+          path: result.csv
           if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -16,6 +16,8 @@ on:
         - applicant_submit_application
         - applicant_landing_page
         - ti_landing_page
+        
+permissions: read-all
 
 jobs:
   testing:
@@ -28,7 +30,7 @@ jobs:
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:
-          test-plan-path: $GITHUB_WORKSPACE/load_test/${{ github.event.inputs.test_to_run }}.jmx
+          test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
           args: ""
       - name: Upload Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -27,8 +27,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch_name }}
-      - name: List Directory Contents
-        run: ls -lah load-test/ 
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -31,10 +31,10 @@ jobs:
         uses: QAInsights/PerfAction@v5.6.2
         with:
           test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
-          results-file: result.csv
+          results-file: result.jtl
       - name: Upload Results
         uses: actions/upload-artifact@v4
         with:
           name: jmeter-results
-          path: result.csv
+          path: result.jtl
           if-no-files-found: error

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -23,11 +23,12 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v4
-      #   with:
-      #     ref: ${{ github.event.inputs.branch_name }}
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+      - name: List Directory Contents
+        run: ls -lah load_test/ 
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -21,10 +21,10 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch_name }}
+      # - name: Checkout
+        # uses: actions/checkout@v4
+        # with:
+        #   ref: ${{ github.event.inputs.branch_name }}
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   testing:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
       - name: JMeter Test - ${{ github.event.inputs.test_to_run }}
         uses: QAInsights/PerfAction@v5.6.2
         with:
-          test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
+          test-plan-path: load_test/applicant_submit_application.jmx
           args: ""
       - name: Upload Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: QAInsights/PerfAction@v5.6.2
         with:
           test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
-          results-file: results.jtl
+          results-file: result.jtl
       - name: Upload Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: QAInsights/PerfAction@v5.6.2
         with:
           test-plan-path: load_test/${{ github.event.inputs.test_to_run }}.jmx
-          args: ""
+          results-file: results.jtl
       - name: Upload Results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description

Our github JMeter action was failing because of the incorrect directory name and missing `runs-on`. Added these and tested the action and it now works as expected.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)


### Issue(s) this completes

Fixes #6869