### PR TITLE
Updating owasp html sanitizer to latest release

### DIFF
--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -124,7 +124,7 @@ public final class TextFormatter {
                 "stroke-width",
                 "aria-label",
                 "aria-hidden",
-                "viewbox",
+                "viewBox", // <--- This is for SVGs and it **IS** case-sensitive
                 "d")
             .globally()
             .toFactory();

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
       "org.thymeleaf" % "thymeleaf" % "3.1.2.RELEASE",
       "org.commonmark" % "commonmark" % "0.21.0",
       "org.commonmark" % "commonmark-ext-autolink" % "0.21.0",
-      "com.googlecode.owasp-java-html-sanitizer" % "owasp-java-html-sanitizer" % "20180219.1",
+      "com.googlecode.owasp-java-html-sanitizer" % "owasp-java-html-sanitizer" % "20220608.1",
 
       // Amazon AWS SDK
       "software.amazon.awssdk" % "s3" % "2.24.13",


### PR DESCRIPTION
### Description

Update owasp Java HTML sanitizer to latest version. 

> [!NOTE]
> Fixing a bug that caused SVG files to render differently after the owasp upgrade. The sanitizer used to treat the SVG `viewBox` attribute as __case-insensitive__ and keep it. The latest version is more strict and the casing for this attribute is now __case-sensitive__.



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Fixes #6355
