### PR TITLE
Rename JsonExporter to JsonExporterService

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -48,7 +48,7 @@ import services.applications.PdfExporterService;
 import services.applications.ProgramAdminApplicationService;
 import services.applications.StatusEmailNotFoundException;
 import services.export.CsvExporterService;
-import services.export.JsonExporter;
+import services.export.JsonExporterService;
 import services.export.PdfExporter;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
@@ -74,7 +74,7 @@ public final class AdminApplicationController extends CiviFormController {
   private final ProgramService programService;
   private final CsvExporterService exporterService;
   private final FormFactory formFactory;
-  private final JsonExporter jsonExporter;
+  private final JsonExporterService jsonExporterService;
   private final Provider<LocalDateTime> nowProvider;
   private final MessagesApi messagesApi;
   private final DateConverter dateConverter;
@@ -85,7 +85,7 @@ public final class AdminApplicationController extends CiviFormController {
       ApplicantService applicantService,
       CsvExporterService csvExporterService,
       FormFactory formFactory,
-      JsonExporter jsonExporter,
+      JsonExporterService jsonExporterService,
       PdfExporterService pdfExporterService,
       ProgramApplicationListView applicationListView,
       ProgramApplicationView applicationView,
@@ -104,7 +104,7 @@ public final class AdminApplicationController extends CiviFormController {
     this.nowProvider = checkNotNull(nowProvider);
     this.exporterService = checkNotNull(csvExporterService);
     this.formFactory = checkNotNull(formFactory);
-    this.jsonExporter = checkNotNull(jsonExporter);
+    this.jsonExporterService = checkNotNull(jsonExporterService);
     this.pdfExporterService = checkNotNull(pdfExporterService);
     this.messagesApi = checkNotNull(messagesApi);
     this.dateConverter = checkNotNull(dateConverter);
@@ -147,7 +147,7 @@ public final class AdminApplicationController extends CiviFormController {
 
     String filename = String.format("%s-%s.json", program.adminName(), nowProvider.get());
     String json =
-        jsonExporter.export(
+        jsonExporterService.export(
             program, IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG, filters);
 
     return ok(json)

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -25,7 +25,7 @@ import repository.VersionRepository;
 import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
 import services.PaginationResult;
-import services.export.JsonExporter;
+import services.export.JsonExporterService;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 
@@ -38,7 +38,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
   private final DateConverter dateConverter;
   private final ProgramService programService;
   private final HttpExecutionContext httpContext;
-  private final JsonExporter jsonExporter;
+  private final JsonExporterService jsonExporterService;
   private final int maxPageSize;
 
   @Inject
@@ -47,7 +47,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
       ApiPayloadWrapper apiPayloadWrapper,
       DateConverter dateConverter,
       ProfileUtils profileUtils,
-      JsonExporter jsonExporter,
+      JsonExporterService jsonExporterService,
       HttpExecutionContext httpContext,
       ProgramService programService,
       VersionRepository versionRepository,
@@ -55,7 +55,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
     super(apiPaginationTokenSerializer, apiPayloadWrapper, profileUtils, versionRepository);
     this.dateConverter = checkNotNull(dateConverter);
     this.httpContext = checkNotNull(httpContext);
-    this.jsonExporter = checkNotNull(jsonExporter);
+    this.jsonExporterService = checkNotNull(jsonExporterService);
     this.programService = checkNotNull(programService);
     this.maxPageSize = checkNotNull(config).getInt("civiform_api_applications_list_max_page_size");
   }
@@ -108,7 +108,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
                       programDefinition.id(), F.Either.Left(paginationSpec), filters);
 
               String applicationsJson =
-                  jsonExporter.exportPage(programDefinition, paginationResult);
+                  jsonExporterService.exportPage(programDefinition, paginationResult);
 
               String responseJson =
                   apiPayloadWrapper.wrapPayload(

--- a/server/app/services/export/JsonExporterService.java
+++ b/server/app/services/export/JsonExporterService.java
@@ -32,7 +32,7 @@ import services.program.ProgramDefinition;
 import services.program.ProgramService;
 
 /** Exports all applications for a given program as JSON. */
-public final class JsonExporter {
+public final class JsonExporterService {
 
   private final ApplicantService applicantService;
   private final ProgramService programService;
@@ -41,7 +41,7 @@ public final class JsonExporter {
   private static final String EMPTY_VALUE = "";
 
   @Inject
-  JsonExporter(
+  JsonExporterService(
       ApplicantService applicantService,
       ProgramService programService,
       DateConverter dateConverter,
@@ -299,7 +299,7 @@ public final class JsonExporter {
     public abstract ImmutableMap<Path, Optional<?>> applicationEntries();
 
     static Builder builder() {
-      return new AutoValue_JsonExporter_ApplicationExportData.Builder();
+      return new AutoValue_JsonExporterService_ApplicationExportData.Builder();
     }
 
     @AutoValue.Builder

--- a/server/app/services/export/ProgramJsonSampler.java
+++ b/server/app/services/export/ProgramJsonSampler.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import services.DeploymentType;
 import services.Path;
-import services.export.JsonExporter.ApplicationExportData;
+import services.export.JsonExporterService.ApplicationExportData;
 import services.export.enums.RevisionState;
 import services.export.enums.SubmitterType;
 import services.program.ProgramDefinition;
@@ -23,7 +23,7 @@ public final class ProgramJsonSampler {
 
   private final QuestionJsonSampler.Factory questionJsonSamplerFactory;
   private final ApiPayloadWrapper apiPayloadWrapper;
-  private final JsonExporter jsonExporter;
+  private final JsonExporterService jsonExporterService;
   private final DeploymentType deploymentType;
   private static final String EMPTY_VALUE = "";
 
@@ -31,11 +31,11 @@ public final class ProgramJsonSampler {
   ProgramJsonSampler(
       QuestionJsonSampler.Factory questionJsonSamplerFactory,
       ApiPayloadWrapper apiPayloadWrapper,
-      JsonExporter jsonExporter,
+      JsonExporterService jsonExporterService,
       DeploymentType deploymentType) {
     this.questionJsonSamplerFactory = questionJsonSamplerFactory;
     this.apiPayloadWrapper = apiPayloadWrapper;
-    this.jsonExporter = jsonExporter;
+    this.jsonExporterService = jsonExporterService;
     this.deploymentType = deploymentType;
   }
 
@@ -80,7 +80,7 @@ public final class ProgramJsonSampler {
     }
 
     return apiPayloadWrapper.wrapPayload(
-        jsonExporter
+        jsonExporterService
             .convertApplicationExportDataToJsonArray(ImmutableList.of(jsonExportData.build()))
             .jsonString(),
         /* paginationTokenPayload= */ Optional.empty());

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -52,7 +52,7 @@ import services.application.ApplicationEventDetails.StatusEvent;
 import services.applications.PdfExporterService;
 import services.applications.ProgramAdminApplicationService;
 import services.export.CsvExporterService;
-import services.export.JsonExporter;
+import services.export.JsonExporterService;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.program.StatusDefinitions;
@@ -595,7 +595,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         instanceOf(ApplicantService.class),
         instanceOf(CsvExporterService.class),
         instanceOf(FormFactory.class),
-        instanceOf(JsonExporter.class),
+        instanceOf(JsonExporterService.class),
         instanceOf(PdfExporterService.class),
         instanceOf(ProgramApplicationListView.class),
         instanceOf(ProgramApplicationView.class),

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -11,7 +11,7 @@ import services.CfJsonDocumentContext;
 import services.IdentifierBasedPaginationSpec;
 import services.Path;
 
-public class JsonExporterTest extends AbstractExporterTest {
+public class JsonExporterServiceTest extends AbstractExporterTest {
 
   // TODO(#5257): Refactor testAllQuestionTypesWithoutEnumerators() and
   // testQuestionTypesWithEnumerators()
@@ -26,7 +26,7 @@ public class JsonExporterTest extends AbstractExporterTest {
     createFakeProgram();
     createFakeApplications();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -106,7 +106,7 @@ public class JsonExporterTest extends AbstractExporterTest {
     createFakeProgram();
     createFakeApplications();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -122,7 +122,7 @@ public class JsonExporterTest extends AbstractExporterTest {
   @Test
   public void testQuestionTypesWithEnumerators() throws Exception {
     createFakeProgramWithEnumeratorAndAnswerQuestions();
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -184,7 +184,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .byTrustedIntermediary("ti@trusted_intermediaries.org", "TIs Inc.")
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -203,7 +203,7 @@ public class JsonExporterTest extends AbstractExporterTest {
     var fakeProgram = new FakeProgramBuilder().build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -226,7 +226,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerAddressQuestion("12345 E South St", "Apt 8i", "CityVille Township", "OR", "54321")
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -250,7 +250,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantAddress()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -280,7 +280,7 @@ public class JsonExporterTest extends AbstractExporterTest {
                 ))
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -304,7 +304,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -328,7 +328,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
     new FakeApplicationFiller(fakeProgram).answerCurrencyQuestion("5,444.33").submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -352,7 +352,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -376,7 +376,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
     new FakeApplicationFiller(fakeProgram).answerDateQuestion("2015-10-21").submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -400,7 +400,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -424,7 +424,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
     new FakeApplicationFiller(fakeProgram).answerDropdownQuestion(2L /* strawberry */).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -448,7 +448,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -474,7 +474,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerEmailQuestion("chell@aperturescience.com")
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -498,7 +498,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantEmail()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -522,7 +522,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
     new FakeApplicationFiller(fakeProgram).answerNumberQuestion(42).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -546,7 +546,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -570,7 +570,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
     new FakeApplicationFiller(fakeProgram).answerPhoneQuestion("US", "(555) 867-5309").submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -594,7 +594,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -618,7 +618,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
     new FakeApplicationFiller(fakeProgram).answerRadioButtonQuestion(3L /* summer */).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -642,7 +642,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -666,7 +666,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
     new FakeApplicationFiller(fakeProgram).answerEnumeratorQuestion(ImmutableList.of()).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -695,7 +695,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerRepeatedTextQuestion("carly rae", "stars")
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -734,7 +734,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -775,7 +775,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -827,7 +827,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerNestedEnumeratorQuestion("tswift", ImmutableList.of("performer", "composer"))
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -907,7 +907,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         .answerNestedRepeatedNumberQuestion("tswift", "composer", 14)
         .submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -975,7 +975,7 @@ public class JsonExporterTest extends AbstractExporterTest {
         new FakeProgramBuilder().withDateQuestionWithVisibilityPredicateOnTextQuestion().build();
     new FakeApplicationFiller(fakeProgram).answerTextQuestion("red").submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -1005,7 +1005,7 @@ public class JsonExporterTest extends AbstractExporterTest {
     var fakeProgram = new FakeProgramBuilder().build();
     new FakeApplicationFiller(fakeProgram).submit();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(
@@ -1022,7 +1022,7 @@ public class JsonExporterTest extends AbstractExporterTest {
     var fakeProgram = new FakeProgramBuilder().build();
     new FakeApplicationFiller(fakeProgram).submit().markObsolete();
 
-    JsonExporter exporter = instanceOf(JsonExporter.class);
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
     String resultJsonString =
         exporter.export(


### PR DESCRIPTION
### Description

Rename JsonExporter to JsonExporterService

This aligns it with the `CsvExporterService` class that does similar work.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Pre-work for [#5018](https://github.com/civiform/civiform/issues/5018)
