### PR TITLE
Rename PDF export methods to be application-specific

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -270,7 +270,7 @@ public final class AdminApplicationController extends CiviFormController {
     }
     ApplicationModel application = applicationMaybe.get();
     PdfExporter.InMemoryPdf pdf =
-        pdfExporterService.generatePdf(
+        pdfExporterService.generateApplicationPdf(
             application, /* showEligibilityText= */ true, /* includeHiddenBlocks= */ true);
     return ok(pdf.getByteArray())
         .as("application/pdf")

--- a/server/app/controllers/admin/PredicateUtils.java
+++ b/server/app/controllers/admin/PredicateUtils.java
@@ -1,0 +1,45 @@
+package controllers.admin;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import services.program.predicate.PredicateDefinition;
+import services.program.predicate.PredicateExpressionNode;
+import services.question.types.QuestionDefinition;
+
+/** Utility methods for working with predicates on the admin side. */
+public final class PredicateUtils {
+  /** Returns the predicate in a human-readable form for admins. */
+  public static ReadablePredicate getReadablePredicateDescription(
+      String blockName,
+      PredicateDefinition predicate,
+      ImmutableList<QuestionDefinition> questionDefinitions) {
+    switch (predicate.predicateFormat()) {
+      case SINGLE_QUESTION:
+        return ReadablePredicate.create(
+            /* heading= */ predicate.toDisplayString(blockName, questionDefinitions),
+            /* conditionList= */ Optional.empty());
+      case OR_OF_SINGLE_LAYER_ANDS:
+        ImmutableList<PredicateExpressionNode> andNodes =
+            predicate.rootNode().getOrNode().children();
+        if (andNodes.size() == 1) {
+          return ReadablePredicate.create(
+              /* heading= */ blockName
+                  + " is "
+                  + predicate.action().toDisplayString()
+                  + " "
+                  + andNodes.get(0).getAndNode().toDisplayString(questionDefinitions),
+              /* conditionList= */ Optional.empty());
+        } else {
+          String heading = blockName + " is " + predicate.action().toDisplayString() + " any of:";
+          ImmutableList<String> conditionList =
+              andNodes.stream()
+                  .map(andNode -> andNode.getAndNode().toDisplayString(questionDefinitions))
+                  .collect(ImmutableList.toImmutableList());
+          return ReadablePredicate.create(heading, Optional.of(conditionList));
+        }
+      default:
+        throw new IllegalStateException(
+            String.format("Predicate format [%s] not handled", predicate.predicateFormat().name()));
+    }
+  }
+}

--- a/server/app/controllers/admin/PredicateUtils.java
+++ b/server/app/controllers/admin/PredicateUtils.java
@@ -19,18 +19,17 @@ public final class PredicateUtils {
             /* heading= */ predicate.toDisplayString(blockName, questionDefinitions),
             /* conditionList= */ Optional.empty());
       case OR_OF_SINGLE_LAYER_ANDS:
+        String headingPrefix = blockName + " is " + predicate.action().toDisplayString();
         ImmutableList<PredicateExpressionNode> andNodes =
             predicate.rootNode().getOrNode().children();
         if (andNodes.size() == 1) {
           return ReadablePredicate.create(
-              /* heading= */ blockName
-                  + " is "
-                  + predicate.action().toDisplayString()
+              /* heading= */ headingPrefix
                   + " "
                   + andNodes.get(0).getAndNode().toDisplayString(questionDefinitions),
               /* conditionList= */ Optional.empty());
         } else {
-          String heading = blockName + " is " + predicate.action().toDisplayString() + " any of:";
+          String heading = headingPrefix + " any of:";
           ImmutableList<String> conditionList =
               andNodes.stream()
                   .map(andNode -> andNode.getAndNode().toDisplayString(questionDefinitions))

--- a/server/app/controllers/admin/ReadablePredicate.java
+++ b/server/app/controllers/admin/ReadablePredicate.java
@@ -1,0 +1,33 @@
+package controllers.admin;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+
+/**
+ * Represents a predicate (eligibility or visibility condition) in a human-readable form for admins.
+ */
+@AutoValue
+public abstract class ReadablePredicate {
+  public static ReadablePredicate create(
+      String heading, Optional<ImmutableList<String>> conditionList) {
+    return new AutoValue_ReadablePredicate(heading, conditionList);
+  }
+
+  /**
+   * The main heading for the predicate. This could describe the whole predicate, or could just be a
+   * preface sentence that explains the {@link #conditionList()}.
+   */
+  public abstract String heading();
+
+  /**
+   * An optional list of conditions required for this predicate.
+   *
+   * <p>Only present for predicates with multiple AND statements, like "(household size is 2 AND
+   * income is <= $20) OR (household size is 3 AND income is <= $30)". Each AND statement will be a
+   * separate entry in the returned conditions list, so that example would be a list with two
+   * entries: ["household size is 2 and income is <= $20", "household size is 3 and income is <=
+   * $30"].
+   */
+  public abstract Optional<ImmutableList<String>> conditionList();
+}

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -208,7 +208,7 @@ public final class UpsellController extends CiviFormController {
         .thenApplyAsync(
             check -> {
               PdfExporter.InMemoryPdf pdf =
-                  pdfExporterService.generatePdf(
+                  pdfExporterService.generateApplicationPdf(
                       applicationMaybe.join().get(),
                       /* showEligibilityText= */ false,
                       /* includeHiddenBlocks= */ false);

--- a/server/app/services/applications/PdfExporterService.java
+++ b/server/app/services/applications/PdfExporterService.java
@@ -17,11 +17,17 @@ public final class PdfExporterService {
     this.pdfExporter = checkNotNull(pdfExporter);
   }
 
-  public PdfExporter.InMemoryPdf generatePdf(
+  /**
+   * Creates and returns a PDF containing the answers submitted in the given {@code application}.
+   *
+   * <p>Used for applicants to download a copy of their submitted application and for program admins
+   * to review applications.
+   */
+  public PdfExporter.InMemoryPdf generateApplicationPdf(
       ApplicationModel application, boolean showEligibilityText, boolean includeHiddenBlocks) {
     PdfExporter.InMemoryPdf pdf;
     try {
-      pdf = pdfExporter.export(application, showEligibilityText, includeHiddenBlocks);
+      pdf = pdfExporter.exportApplication(application, showEligibilityText, includeHiddenBlocks);
     } catch (DocumentException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -51,11 +51,11 @@ public final class PdfExporter {
 
   /**
    * Generates a byte array containing all the values present in the List of AnswerData using
-   * itextPDF.This function creates the output document in memory as a byte[] and is part of the
+   * itextPDF. This function creates the output document in memory as a byte[] and is part of the
    * inMemoryPDF object. The InMemoryPdf object is passed back to the AdminController Class to
    * generate the required PDF.
    */
-  public InMemoryPdf export(
+  public InMemoryPdf exportApplication(
       ApplicationModel application, boolean showEligibilityText, boolean includeHiddenBlocks)
       throws DocumentException, IOException {
     ReadOnlyApplicantProgramService roApplicantService =
@@ -77,7 +77,7 @@ public final class PdfExporter {
     String applicantNameWithApplicationId = String.format("%s (%d)", applicantName, application.id);
     String filename = String.format("%s-%s.pdf", applicantNameWithApplicationId, nowProvider.get());
     byte[] bytes =
-        buildPDF(
+        buildApplicationPdf(
             answersOnlyActive,
             answersOnlyHidden,
             applicantNameWithApplicationId,
@@ -94,7 +94,7 @@ public final class PdfExporter {
         : dateConverter.renderDateTimeHumanReadable(submitTime);
   }
 
-  private byte[] buildPDF(
+  private byte[] buildApplicationPdf(
       ImmutableList<AnswerData> answersOnlyActive,
       ImmutableList<AnswerData> answersOnlyHidden,
       String applicantNameWithApplicationId,

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -8,6 +8,8 @@ import static j2html.TagCreator.ul;
 import static views.style.AdminStyles.HEADER_BUTTON_STYLES;
 
 import com.google.common.collect.ImmutableList;
+import controllers.admin.PredicateUtils;
+import controllers.admin.ReadablePredicate;
 import controllers.admin.routes;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
@@ -16,7 +18,6 @@ import java.util.List;
 import play.mvc.Http;
 import services.program.ProgramDefinition;
 import services.program.predicate.PredicateDefinition;
-import services.program.predicate.PredicateExpressionNode;
 import services.question.types.QuestionDefinition;
 import views.BaseHtmlView;
 import views.ViewUtils;
@@ -109,41 +110,18 @@ abstract class ProgramBaseView extends BaseHtmlView {
                 "items-center",
                 StyleUtils.hover("text-gray-800", "bg-gray-100"));
 
-    if (predicateDefinition
-        .predicateFormat()
-        .equals(PredicateDefinition.PredicateFormat.SINGLE_QUESTION)) {
-      return container.with(
-          text(predicateDefinition.toDisplayString(blockName, questionDefinitions)));
-    } else if (!predicateDefinition
-        .predicateFormat()
-        .equals(PredicateDefinition.PredicateFormat.OR_OF_SINGLE_LAYER_ANDS)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Predicate type %s is unsupported.", predicateDefinition.predicateFormat()));
+    ReadablePredicate readablePredicate =
+        PredicateUtils.getReadablePredicateDescription(
+            blockName, predicateDefinition, questionDefinitions);
+
+    container.with(text(readablePredicate.heading()));
+    if (readablePredicate.conditionList().isPresent()) {
+      UlTag conditionList = ul().withClasses("list-disc", "ml-4", "mb-4");
+      readablePredicate.conditionList().get().stream()
+          .forEach(condition -> conditionList.with(li(condition)));
+      container.with(conditionList);
     }
-
-    ImmutableList<PredicateExpressionNode> andNodes =
-        predicateDefinition.rootNode().getOrNode().children();
-
-    if (andNodes.size() == 1) {
-      return container.with(
-          text(
-              blockName
-                  + " is "
-                  + predicateDefinition.action().toDisplayString()
-                  + " "
-                  + andNodes.get(0).getAndNode().toDisplayString(questionDefinitions)));
-    }
-
-    container.with(
-        text(blockName + " is " + predicateDefinition.action().toDisplayString() + " any of:"));
-    UlTag conditionList = ul().withClasses("list-disc", "ml-4", "mb-4");
-
-    andNodes.stream()
-        .map(PredicateExpressionNode::getAndNode)
-        .forEach(andNode -> conditionList.with(li(andNode.toDisplayString(questionDefinitions))));
-
-    return container.with(conditionList);
+    return container;
   }
 
   private ButtonTag renderHeaderButton(

--- a/server/test/controllers/admin/PredicateUtilsTest.java
+++ b/server/test/controllers/admin/PredicateUtilsTest.java
@@ -1,0 +1,141 @@
+package controllers.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import services.applicant.question.Scalar;
+import services.program.predicate.AndNode;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
+import services.program.predicate.OrNode;
+import services.program.predicate.PredicateAction;
+import services.program.predicate.PredicateDefinition;
+import services.program.predicate.PredicateExpressionNode;
+import services.program.predicate.PredicateValue;
+
+public class PredicateUtilsTest {
+  @Test
+  public void getReadablePredicateDescription_singleQuestion_headingOnly() {
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1000,
+                    Scalar.DATE,
+                    Operator.IS_ON_OR_BEFORE,
+                    PredicateValue.of(1000L))),
+            PredicateAction.SHOW_BLOCK);
+
+    ReadablePredicate readablePredicate =
+        PredicateUtils.getReadablePredicateDescription(
+            "My Test Block", predicate, ImmutableList.of());
+
+    assertThat(readablePredicate.heading()).contains("My Test Block");
+    assertThat(readablePredicate.heading()).contains("is shown if");
+    assertThat(readablePredicate.heading()).contains("is on or earlier than");
+
+    assertThat(readablePredicate.conditionList()).isEmpty();
+  }
+
+  @Test
+  public void getReadablePredicateDescription_singleAnd_headingOnly() {
+    ImmutableList<PredicateExpressionNode> andStatements =
+        ImmutableList.of(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1000,
+                    Scalar.DATE,
+                    Operator.IS_ON_OR_BEFORE,
+                    PredicateValue.of(1000L))),
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1001,
+                    Scalar.NUMBER,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of(4))),
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1002,
+                    Scalar.TEXT,
+                    Operator.NOT_EQUAL_TO,
+                    PredicateValue.of("hello"))));
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                OrNode.create(
+                    ImmutableList.of(
+                        PredicateExpressionNode.create(AndNode.create(andStatements))))),
+            PredicateAction.HIDE_BLOCK);
+
+    ReadablePredicate readablePredicate =
+        PredicateUtils.getReadablePredicateDescription(
+            "My Test Block", predicate, ImmutableList.of());
+
+    assertThat(readablePredicate.heading()).contains("My Test Block is hidden if");
+    assertThat(readablePredicate.heading()).contains("is on or earlier than");
+    assertThat(readablePredicate.heading()).contains("is equal to 4");
+    assertThat(readablePredicate.heading()).contains("is not equal to \"hello\"");
+
+    assertThat(readablePredicate.conditionList()).isEmpty();
+  }
+
+  @Test
+  public void getReadablePredicateDescription_multipleAnds_headingAndConditionList() {
+    // number == 4 && text == "four"
+    ImmutableList<PredicateExpressionNode> andStatements1 =
+        ImmutableList.of(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1001,
+                    Scalar.NUMBER,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of(4))),
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1002,
+                    Scalar.TEXT,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of("four"))));
+    // number == 5 && text == "five"
+    ImmutableList<PredicateExpressionNode> andStatements2 =
+        ImmutableList.of(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1001,
+                    Scalar.NUMBER,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of(5))),
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    /* questionId= */ 1002,
+                    Scalar.TEXT,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of("five"))));
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                OrNode.create(
+                    ImmutableList.of(
+                        PredicateExpressionNode.create(AndNode.create(andStatements1)),
+                        PredicateExpressionNode.create(AndNode.create(andStatements2))))),
+            PredicateAction.ELIGIBLE_BLOCK);
+
+    ReadablePredicate readablePredicate =
+        PredicateUtils.getReadablePredicateDescription(
+            "My Test Block", predicate, ImmutableList.of());
+
+    // Verify the heading has some introductory text, but not any predicate text
+    assertThat(readablePredicate.heading()).contains("My Test Block is eligible if any of:");
+    assertThat(readablePredicate.heading()).doesNotContain("is equal to 4");
+    assertThat(readablePredicate.heading()).doesNotContain("is equal to 5");
+
+    // Verify there's 1 condition item per AND statement
+    assertThat(readablePredicate.conditionList()).isPresent();
+    assertThat(readablePredicate.conditionList().get().size()).isEqualTo(2);
+    assertThat(readablePredicate.conditionList().get().get(0)).contains("is equal to 4");
+    assertThat(readablePredicate.conditionList().get().get(0)).contains("is equal to \"four\"");
+    assertThat(readablePredicate.conditionList().get().get(1)).contains("is equal to 5");
+    assertThat(readablePredicate.conditionList().get().get(1)).contains("is equal to \"five\"");
+  }
+}

--- a/server/test/controllers/admin/PredicateUtilsTest.java
+++ b/server/test/controllers/admin/PredicateUtilsTest.java
@@ -22,8 +22,8 @@ public class PredicateUtilsTest {
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.create(
                     /* questionId= */ 1000,
-                    Scalar.DATE,
-                    Operator.IS_ON_OR_BEFORE,
+                    Scalar.NUMBER,
+                    Operator.GREATER_THAN_OR_EQUAL_TO,
                     PredicateValue.of(1000L))),
             PredicateAction.SHOW_BLOCK);
 
@@ -31,10 +31,8 @@ public class PredicateUtilsTest {
         PredicateUtils.getReadablePredicateDescription(
             "My Test Block", predicate, ImmutableList.of());
 
-    assertThat(readablePredicate.heading()).contains("My Test Block");
-    assertThat(readablePredicate.heading()).contains("is shown if");
-    assertThat(readablePredicate.heading()).contains("is on or earlier than");
-
+    assertThat(readablePredicate.heading())
+        .isEqualTo("My Test Block is shown if number is greater than or equal to 1000");
     assertThat(readablePredicate.conditionList()).isEmpty();
   }
 
@@ -45,14 +43,14 @@ public class PredicateUtilsTest {
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.create(
                     /* questionId= */ 1000,
-                    Scalar.DATE,
-                    Operator.IS_ON_OR_BEFORE,
-                    PredicateValue.of(1000L))),
+                    Scalar.CITY,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of("Phoenix"))),
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.create(
                     /* questionId= */ 1001,
                     Scalar.NUMBER,
-                    Operator.EQUAL_TO,
+                    Operator.LESS_THAN,
                     PredicateValue.of(4))),
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.create(
@@ -72,11 +70,10 @@ public class PredicateUtilsTest {
         PredicateUtils.getReadablePredicateDescription(
             "My Test Block", predicate, ImmutableList.of());
 
-    assertThat(readablePredicate.heading()).contains("My Test Block is hidden if");
-    assertThat(readablePredicate.heading()).contains("is on or earlier than");
-    assertThat(readablePredicate.heading()).contains("is equal to 4");
-    assertThat(readablePredicate.heading()).contains("is not equal to \"hello\"");
-
+    assertThat(readablePredicate.heading())
+        .isEqualTo(
+            "My Test Block is hidden if city is equal to \"Phoenix\" and number is less than 4 and"
+                + " text is not equal to \"hello\"");
     assertThat(readablePredicate.conditionList()).isEmpty();
   }
 
@@ -125,17 +122,12 @@ public class PredicateUtilsTest {
         PredicateUtils.getReadablePredicateDescription(
             "My Test Block", predicate, ImmutableList.of());
 
-    // Verify the heading has some introductory text, but not any predicate text
-    assertThat(readablePredicate.heading()).contains("My Test Block is eligible if any of:");
-    assertThat(readablePredicate.heading()).doesNotContain("is equal to 4");
-    assertThat(readablePredicate.heading()).doesNotContain("is equal to 5");
-
-    // Verify there's 1 condition item per AND statement
+    assertThat(readablePredicate.heading()).isEqualTo("My Test Block is eligible if any of:");
     assertThat(readablePredicate.conditionList()).isPresent();
     assertThat(readablePredicate.conditionList().get().size()).isEqualTo(2);
-    assertThat(readablePredicate.conditionList().get().get(0)).contains("is equal to 4");
-    assertThat(readablePredicate.conditionList().get().get(0)).contains("is equal to \"four\"");
-    assertThat(readablePredicate.conditionList().get().get(1)).contains("is equal to 5");
-    assertThat(readablePredicate.conditionList().get().get(1)).contains("is equal to \"five\"");
+    assertThat(readablePredicate.conditionList().get().get(0))
+        .isEqualTo("number is equal to 4 and text is equal to \"four\"");
+    assertThat(readablePredicate.conditionList().get().get(1))
+        .isEqualTo("number is equal to 5 and text is equal to \"five\"");
   }
 }

--- a/server/test/services/applications/PdfExporterServiceTest.java
+++ b/server/test/services/applications/PdfExporterServiceTest.java
@@ -28,14 +28,14 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
   }
 
   @Test
-  public void generatePdf() throws IOException {
+  public void generateApplicationPdf() throws IOException {
     PdfExporterService service = instanceOf(PdfExporterService.class);
 
     String applicantName = "name-unavailable";
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        service.generatePdf(applicationOne, /* showEligibilityText= */ true, false);
+        service.generateApplicationPdf(applicationOne, /* showEligibilityText= */ true, false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -26,14 +26,14 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void validatePDFExport() throws IOException, DocumentException {
+  public void exportApplication() throws IOException, DocumentException {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     String applicantName = "name-unavailable";
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        exporter.export(
+        exporter.exportApplication(
             applicationOne, /* showEligibilityText= */ false, /* includeHiddenBlocks= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -72,7 +72,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void validatePDFExport_OptionalFileUploadWithFile() throws IOException, DocumentException {
+  public void exportApplication_optionalFileUploadWithFile() throws IOException, DocumentException {
     createFakeProgramWithOptionalQuestion();
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
@@ -83,7 +83,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result =
-        exporter.export(
+        exporter.exportApplication(
             applicationFive, /* showEligibilityText= */ false, /* includeHiddenBlocks= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -119,7 +119,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void validatePDFExport_OptionalFileUploadWithoutFile()
+  public void exportApplication_optionalFileUploadWithoutFile()
       throws IOException, DocumentException {
     createFakeProgramWithOptionalQuestion();
     PdfExporter exporter = instanceOf(PdfExporter.class);
@@ -128,7 +128,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationSix.id);
     PdfExporter.InMemoryPdf result =
-        exporter.export(
+        exporter.exportApplication(
             applicationSix, /* showEligibilityText= */ false, /* includeHiddenBlocks= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -154,7 +154,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void validatePDFExport_hiddenQuestionIncluded() throws IOException, DocumentException {
+  public void exportApplication_hiddenQuestionIncluded() throws IOException, DocumentException {
     createFakeProgramWithVisibilityPredicate();
 
     PdfExporter exporter = instanceOf(PdfExporter.class);
@@ -162,7 +162,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationSeven.id);
     PdfExporter.InMemoryPdf result =
-        exporter.export(
+        exporter.exportApplication(
             applicationSeven, /* showEligibilityText= */ false, /* includeHiddenBlocks= */ true);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -178,7 +178,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void validatePDFExport_eligibility() throws IOException, DocumentException {
+  public void exportApplication_eligibility() throws IOException, DocumentException {
     createFakeProgramWithEligibilityPredicate();
 
     PdfExporter exporter = instanceOf(PdfExporter.class);
@@ -187,7 +187,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationTwo.id);
     PdfExporter.InMemoryPdf result =
-        exporter.export(
+        exporter.exportApplication(
             applicationTwo, /* showEligibilityText= */ false, /* includeHiddenBlocks= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
@@ -200,7 +200,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
     assertThat(textFromPDF).doesNotContain("Meets eligibility");
     PdfExporter.InMemoryPdf resultWithEligibility =
-        exporter.export(
+        exporter.exportApplication(
             applicationTwo, /* showEligibilityText= */ true, /* includeHiddenBlocks= */ false);
     PdfReader pdfReaderTwo = new PdfReader(resultWithEligibility.getByteArray());
     StringBuilder textFromPDFTwo = new StringBuilder();


### PR DESCRIPTION
### Description

This PR renames the PDF export methods to include "application". We're going to add new methods that will export a PDF of a program's current blocks and questions to help admins see the program setup (see  https://github.com/civiform/civiform/issues/6440), so we need the current PDF export methods to make it clear that they're about applications.

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Part of #6440 .
