### PR TITLE
DOM text reinterpreted as HTML Added encodeURIComponent  {Patch}

### DIFF
--- a/server/app/assets/javascripts/api_docs.ts
+++ b/server/app/assets/javascripts/api_docs.ts
@@ -23,7 +23,11 @@ class ApiDocs {
       const versionDropdown = event.currentTarget as HTMLSelectElement
       const versionValue: string = versionDropdown.value
 
-      window.location.href = `/api/docs/v1/${slugValue}/${versionValue}`
+      const encodedSlug = encodeURIComponent(slugValue);
+      const encodedVersion = encodeURIComponent(versionValue);
+
+      window.location.href = `/api/docs/v1/${encodedSlug}/${encodedVersion}`;
+
     })
   }
 }


### PR DESCRIPTION


By using `encodeURIComponent()`, it will prevent the risk of unintended interpretation of special characters in the URL construction. This method automatically encodes special characters, ensuring that they are treated as part of the URL string rather than being interpreted as HTML or JavaScript code. This helps prevent potential security vulnerabilities, such as injection attacks or unexpected behavior, by encoding the input as part of the URL path.
