### PR TITLE
Error if Playwright 'Only' used in CI"

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -1,8 +1,13 @@
 import {defineConfig} from '@playwright/test'
 
+// For details see: https://playwright.dev/docs/api/class-testconfig
+
 export default defineConfig({
   timeout: 180000,
   testDir: './src',
+  // Exit with error immediately if test.only() or test.describe.only()
+  // was committed
+  forbidOnly: !!process.env.CI,
   snapshotPathTemplate: './image_snapshots/{arg}{ext}',
   globalSetup: './src/setup/global-setup.ts',
   globalTeardown: './src/setup/global-teardown.ts',


### PR DESCRIPTION
### Description

Playwright lets you use `test.only()` and `test.describe.only()` as annotations to only run tests with that method. This is one way of many for a dev to specify a small set of tests to run. The downside is that this could be committed, thus blocking out most of the tests.

This sets the config property blocking the use of `only` when being run with the `CI` environment variable set, such as when running in a GitHub action.

> [!NOTE]
> Using the double bang `!!` is how the Playwright docs set the value.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
