### PR TITLE
Enable QUESTION_CACHE_ENABLED flag by default

### DIFF
--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -36,7 +36,7 @@ version_cache_enabled = true
 version_cache_enabled = ${?VERSION_CACHE_ENABLED}
 program_cache_enabled = true
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}
-question_cache_enabled = false
+question_cache_enabled = true
 question_cache_enabled = ${?QUESTION_CACHE_ENABLED}
 
 # OIDC logout


### PR DESCRIPTION
### Description

Enable the QUESTION_CACHE_ENABLED by default. This has been enabled in staging and in Seattle for a while now.

## Release notes

Enable the QUESTION_CACHE_ENABLED flag by default. This doesn't change any functional behavior, but locally caches the full program definition for active programs to reduce calls to the database to increase the speed of page loads. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

#5746