### PR TITLE
Make `AbstractExporterTest`'s inner util classes static

### DIFF
--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -577,19 +577,21 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   }
 
   /** A Builder to build a fake program */
-  class FakeProgramBuilder {
+  static class FakeProgramBuilder {
     ProgramBuilder fakeProgramBuilder;
     boolean addEnumeratorQuestion = false;
     boolean addNestedEnumeratorQuestion = false;
 
-    FakeProgramBuilder() {
-      fakeProgramBuilder = ProgramBuilder.newActiveProgram().withName("Fake Program");
+    private FakeProgramBuilder(String name) {
+      fakeProgramBuilder = ProgramBuilder.newActiveProgram(name);
     }
 
-    FakeProgramBuilder withAllQuestionTypes() {
-      fakeQuestions.forEach(
-          question -> fakeProgramBuilder.withBlock().withRequiredQuestion(question).build());
-      return this;
+    static FakeProgramBuilder newActiveProgram() {
+      return newActiveProgram("Fake Program");
+    }
+
+    static FakeProgramBuilder newActiveProgram(String name) {
+      return new FakeProgramBuilder(name);
     }
 
     FakeProgramBuilder withQuestion(QuestionModel question) {
@@ -669,20 +671,24 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     Optional<AccountModel> trustedIntermediary = Optional.empty();
     ApplicationModel application;
 
-    public FakeApplicationFiller(ProgramModel program) {
+    private FakeApplicationFiller(ProgramModel program) {
       this.program = program;
       this.applicant = resourceCreator.insertApplicantWithAccount();
       this.admin = resourceCreator.insertAccount();
     }
 
-    public FakeApplicationFiller byTrustedIntermediary(String tiEmail, String tiOrganization) {
+    static FakeApplicationFiller newFillerFor(ProgramModel program) {
+      return new FakeApplicationFiller(program);
+    }
+
+    FakeApplicationFiller byTrustedIntermediary(String tiEmail, String tiOrganization) {
       var tiGroup = resourceCreator.insertTiGroup(tiOrganization);
       this.trustedIntermediary = Optional.of(resourceCreator.insertAccountWithEmail(tiEmail));
       this.applicant.getAccount().setManagedByGroup(tiGroup).save();
       return this;
     }
 
-    public FakeApplicationFiller answerAddressQuestion(
+    FakeApplicationFiller answerAddressQuestion(
         String street, String line2, String city, String state, String zip) {
       Path answerPath =
           testQuestionBank
@@ -696,7 +702,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerCheckboxQuestion(ImmutableList<Long> optionIds) {
+    FakeApplicationFiller answerCheckboxQuestion(ImmutableList<Long> optionIds) {
       Path answerPath =
           testQuestionBank
               .applicantKitchenTools()
@@ -711,7 +717,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerCurrencyQuestion(String answer) {
+    FakeApplicationFiller answerCurrencyQuestion(String answer) {
       Path answerPath =
           testQuestionBank
               .applicantMonthlyIncome()
@@ -723,7 +729,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerDateQuestion(String answer) {
+    FakeApplicationFiller answerDateQuestion(String answer) {
       Path answerPath =
           testQuestionBank
               .applicantDate()
@@ -735,7 +741,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerDropdownQuestion(Long optionId) {
+    FakeApplicationFiller answerDropdownQuestion(Long optionId) {
       Path answerPath =
           testQuestionBank
               .applicantIceCream()
@@ -748,7 +754,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerRadioButtonQuestion(Long optionId) {
+    FakeApplicationFiller answerRadioButtonQuestion(Long optionId) {
       Path answerPath =
           testQuestionBank
               .applicantSeason()
@@ -761,7 +767,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerEmailQuestion(String answer) {
+    FakeApplicationFiller answerEmailQuestion(String answer) {
       Path answerPath =
           testQuestionBank
               .applicantEmail()
@@ -773,7 +779,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerTextQuestion(String answer) {
+    FakeApplicationFiller answerTextQuestion(String answer) {
       Path answerPath =
           testQuestionBank
               .applicantFavoriteColor()
@@ -785,7 +791,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerRepeatedTextQuestion(String entityName, String answer) {
+    FakeApplicationFiller answerRepeatedTextQuestion(String entityName, String answer) {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
               (EnumeratorQuestionDefinition)
@@ -804,7 +810,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerNestedRepeatedNumberQuestion(
+    FakeApplicationFiller answerNestedRepeatedNumberQuestion(
         String parentEntityName, String entityName, long answer) {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
@@ -837,7 +843,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerNumberQuestion(long answer) {
+    FakeApplicationFiller answerNumberQuestion(long answer) {
       Path answerPath =
           testQuestionBank
               .applicantJugglingNumber()
@@ -849,7 +855,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerPhoneQuestion(String countryCode, String phoneNumber) {
+    FakeApplicationFiller answerPhoneQuestion(String countryCode, String phoneNumber) {
       Path answerPath =
           testQuestionBank
               .applicantPhone()
@@ -862,7 +868,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerEnumeratorQuestion(ImmutableList<String> householdMembers) {
+    FakeApplicationFiller answerEnumeratorQuestion(ImmutableList<String> householdMembers) {
       Path answerPath =
           testQuestionBank
               .applicantHouseholdMembers()
@@ -875,7 +881,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller answerNestedEnumeratorQuestion(
+    FakeApplicationFiller answerNestedEnumeratorQuestion(
         String parentEntityName, ImmutableList<String> jobNames) {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
@@ -897,7 +903,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller submit() {
+    FakeApplicationFiller submit() {
       application = new ApplicationModel(applicant, program, LifecycleStage.ACTIVE);
       application.setApplicantData(applicant.getApplicantData());
       trustedIntermediary.ifPresent(
@@ -913,7 +919,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       return this;
     }
 
-    public FakeApplicationFiller markObsolete() {
+    FakeApplicationFiller markObsolete() {
       if (application == null) {
         throw new IllegalStateException(
             "Cannot mark an application as obsolete unless it has been submitted.");

--- a/server/test/services/export/CsvExporterServiceTest.java
+++ b/server/test/services/export/CsvExporterServiceTest.java
@@ -37,7 +37,7 @@ import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
-public class CsvExporterTest extends AbstractExporterTest {
+public class CsvExporterServiceTest extends AbstractExporterTest {
 
   private static final CSVFormat DEFAULT_FORMAT = CSVFormat.DEFAULT.builder().setHeader().build();
   private static final String SECRET_SALT = "super secret";
@@ -68,8 +68,10 @@ public class CsvExporterTest extends AbstractExporterTest {
   public void programCsv_TestNotAnOptionAtProgramVersionInCheckBoxExport() throws Exception {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerCheckboxQuestion(
             ImmutableList.of(
                 2L, // "pepper_grinder"
@@ -426,8 +428,8 @@ public class CsvExporterTest extends AbstractExporterTest {
 
   @Test
   public void getProgramCsv_whenSubmitterIsTi_TiFieldsAreSet() throws Exception {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram)
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .byTrustedIntermediary("ti@trusted_intermediaries.org", "TIs Inc.")
         .submit();
 
@@ -442,8 +444,8 @@ public class CsvExporterTest extends AbstractExporterTest {
 
   @Test
   public void getProgramCsv_whenSubmitterIsApplicant_TiFieldsAreNotSet() throws Exception {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram).submit();
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     CSVParser parser =
         CSVParser.parse(exporterService.getProgramCsv(fakeProgram.id), DEFAULT_FORMAT);
@@ -456,8 +458,8 @@ public class CsvExporterTest extends AbstractExporterTest {
 
   @Test
   public void getDemographicsCsv_whenSubmitterIsTi_TiFieldsAreSet() throws Exception {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram)
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .byTrustedIntermediary("ti@trusted_intermediaries.org", "TIs Inc.")
         .submit();
 
@@ -480,8 +482,8 @@ public class CsvExporterTest extends AbstractExporterTest {
 
   @Test
   public void getDemographicsCsv_whenSubmitterIsApplicant_TiFieldsAreNotSet() throws Exception {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram).submit();
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     CSVParser parser =
         CSVParser.parse(exporterService.getDemographicsCsv(TimeFilter.EMPTY), DEFAULT_FORMAT);

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -183,8 +183,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
   @Test
   public void export_whenSubmitterIsTi_tiTopLevelFieldsAreSet() {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram)
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .byTrustedIntermediary("ti@trusted_intermediaries.org", "TIs Inc.")
         .submit();
 
@@ -205,8 +205,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
   @Test
   public void export_whenSubmitterIsApplicant_tiTopLevelFieldsAreNotSet() {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram).submit();
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -227,8 +227,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenAddressQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantAddress()).build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantAddress())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerAddressQuestion("12345 E South St", "Apt 8i", "CityVille Township", "OR", "54321")
         .submit();
 
@@ -254,8 +256,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenAddressQuestionIsNotAnswered_valuesInResponseAreNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantAddress()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantAddress())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -279,8 +283,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenCheckboxQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerCheckboxQuestion(
             ImmutableList.of(
                 2L, // "pepper_grinder"
@@ -310,8 +316,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenCheckboxQuestionIsNotAnswered_valueInResponseIsEmptyArray() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantKitchenTools()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -335,8 +343,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenCurrencyQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
-    new FakeApplicationFiller(fakeProgram).answerCurrencyQuestion("5,444.33").submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantMonthlyIncome())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).answerCurrencyQuestion("5,444.33").submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -360,8 +370,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenCurrencyQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantMonthlyIncome()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantMonthlyIncome())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -385,8 +397,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenDateQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
-    new FakeApplicationFiller(fakeProgram).answerDateQuestion("2015-10-21").submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantDate())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).answerDateQuestion("2015-10-21").submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -410,8 +424,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenDateQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantDate()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantDate())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -435,8 +451,12 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenDropdownQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
-    new FakeApplicationFiller(fakeProgram).answerDropdownQuestion(2L /* strawberry */).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantIceCream())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerDropdownQuestion(2L /* strawberry */)
+        .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -460,8 +480,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenDropdownQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantIceCream()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantIceCream())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -485,8 +507,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenEmailQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantEmail()).build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantEmail())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEmailQuestion("chell@aperturescience.com")
         .submit();
 
@@ -512,8 +536,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenEmailQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantEmail()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantEmail())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -537,8 +563,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenNumberQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
-    new FakeApplicationFiller(fakeProgram).answerNumberQuestion(42).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).answerNumberQuestion(42).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -562,8 +590,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenNumberQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantJugglingNumber()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -587,8 +617,12 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenPhoneQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
-    new FakeApplicationFiller(fakeProgram).answerPhoneQuestion("US", "(555) 867-5309").submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantPhone())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerPhoneQuestion("US", "(555) 867-5309")
+        .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -612,8 +646,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenPhoneQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantPhone()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantPhone())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -637,8 +673,12 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenRadioButtonQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
-    new FakeApplicationFiller(fakeProgram).answerRadioButtonQuestion(3L /* summer */).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantSeason())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerRadioButtonQuestion(3L /* summer */)
+        .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -662,8 +702,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenRadioButtonQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        new FakeProgramBuilder().withQuestion(testQuestionBank.applicantSeason()).build();
-    new FakeApplicationFiller(fakeProgram).submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.applicantSeason())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -687,8 +729,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenEnumeratorQuestionIsNotAnswered_valueInResponseIsEmptyArray() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
-    new FakeApplicationFiller(fakeProgram).answerEnumeratorQuestion(ImmutableList.of()).submit();
+        FakeProgramBuilder.newActiveProgram().withHouseholdMembersEnumeratorQuestion().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerEnumeratorQuestion(ImmutableList.of())
+        .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -713,8 +757,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
       export_whenEnumeratorAndRepeatedQuestionsAreAnswered_repeatedQuestionsHaveAnswerInResponse() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram().withHouseholdMembersEnumeratorQuestion().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .answerRepeatedTextQuestion("tswift", "hearts")
         .answerRepeatedTextQuestion("carly rae", "stars")
@@ -755,8 +799,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
       export_whenEnumeratorQuestionIsAnsweredAndRepeatedQuestionIsNot_repeatedQuestionsHaveNullAnswers() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder().withHouseholdMembersEnumeratorQuestion().build();
-    new FakeApplicationFiller(fakeProgram)
+        FakeProgramBuilder.newActiveProgram().withHouseholdMembersEnumeratorQuestion().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .submit();
 
@@ -794,11 +838,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenNestedEnumeratorQuestionsAreNotAnswered_valueInResponseIsEmptyArray() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder()
+        FakeProgramBuilder.newActiveProgram()
             .withHouseholdMembersEnumeratorQuestion()
             .withHouseholdMembersJobsNestedEnumeratorQuestion()
             .build();
-    new FakeApplicationFiller(fakeProgram)
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .submit();
 
@@ -845,11 +889,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
       export_whenNestedEnumeratorQuestionsAreAnsweredAndRepeatedQuestionsAreNot_theyAllHaveEntityNames() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder()
+        FakeProgramBuilder.newActiveProgram()
             .withHouseholdMembersEnumeratorQuestion()
             .withHouseholdMembersJobsNestedEnumeratorQuestion()
             .build();
-    new FakeApplicationFiller(fakeProgram)
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .answerNestedEnumeratorQuestion("carly rae", ImmutableList.of("singer", "songwriter"))
         .answerNestedEnumeratorQuestion("tswift", ImmutableList.of("performer", "composer"))
@@ -922,11 +966,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
       export_whenNestedEnumeratorAndRepeatedQuestionsAreAnswered_theyHaveAnswersInResponse() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder()
+        FakeProgramBuilder.newActiveProgram()
             .withHouseholdMembersEnumeratorQuestion()
             .withHouseholdMembersJobsNestedEnumeratorQuestion()
             .build();
-    new FakeApplicationFiller(fakeProgram)
+    FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEnumeratorQuestion(ImmutableList.of("carly rae", "tswift"))
         .answerNestedEnumeratorQuestion("carly rae", ImmutableList.of("singer", "songwriter"))
         .answerNestedRepeatedNumberQuestion("carly rae", "singer", 34)
@@ -1002,8 +1046,10 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_questionWithVisibilityPredicate_isInResponseWhenHiddenFromApplicant() {
     createFakeQuestions();
     ProgramModel fakeProgram =
-        new FakeProgramBuilder().withDateQuestionWithVisibilityPredicateOnTextQuestion().build();
-    new FakeApplicationFiller(fakeProgram).answerTextQuestion("red").submit();
+        FakeProgramBuilder.newActiveProgram()
+            .withDateQuestionWithVisibilityPredicateOnTextQuestion()
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).answerTextQuestion("red").submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -1033,8 +1079,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
   @Test
   public void export_whenApplicationIsActive_revisionStateIsCurrent() {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram).submit();
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 
@@ -1051,8 +1097,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
   @Test
   public void export_whenApplicationIsObsolete_revisionStateIsObsolete() {
-    var fakeProgram = new FakeProgramBuilder().build();
-    new FakeApplicationFiller(fakeProgram).submit().markObsolete();
+    var fakeProgram = FakeProgramBuilder.newActiveProgram().build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit().markObsolete();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
 


### PR DESCRIPTION
### Description

Make `AbstractExporterTest`'s inner util classes static
- Makes inner util classes in `AbstractExporterTest` static so we can instantiate them with a factory-like pattern.
- Also renames `CsvExporterTest` to `CsvExporterServiceTest` to align it with the name of the class it tests.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)


### Instructions for manual testing

N/A

### Issue(s) this completes

Prework for #5018
