### PR TITLE
Access program ids directly instead of through the ProgramDefinition

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -671,7 +671,7 @@ public final class VersionRepository {
                           .getQuestionIdsInProgram()
                           .stream()
                           .anyMatch(id -> missingQuestionIds.contains(id)))
-              .map(program -> programRepository.getShallowProgramDefinition(program).id())
+              .map(program -> program.id)
               .collect(ImmutableSet.toImmutableSet());
       throw new IllegalStateException(
           String.format(

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -275,7 +275,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
     ProgramModel updated = repo.updateProgramSync(updates);
 
-    assertThat(updated.getProgramDefinition().id()).isEqualTo(existing.id);
+    assertThat(updated.id).isEqualTo(existing.id);
     assertThat(updated.getProgramDefinition().localizedName())
         .isEqualTo(LocalizedStrings.of(Locale.US, "new name"));
   }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -831,21 +831,17 @@ public class VersionRepositoryTest extends ResetPostgres {
   @Test
   public void testIsDraftProgram() {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram("draft program").build();
-    assertThat(versionRepository.isDraftProgram(draftProgram.getProgramDefinition().id()))
-        .isEqualTo(true);
+    assertThat(versionRepository.isDraftProgram(draftProgram.id)).isEqualTo(true);
     ProgramModel activeProgram = ProgramBuilder.newActiveProgram("active program").build();
-    assertThat(versionRepository.isDraftProgram(activeProgram.getProgramDefinition().id()))
-        .isEqualTo(false);
+    assertThat(versionRepository.isDraftProgram(activeProgram.id)).isEqualTo(false);
   }
 
   @Test
   public void testIsActiveProgram() {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram("draft program").build();
-    assertThat(versionRepository.isActiveProgram(draftProgram.getProgramDefinition().id()))
-        .isEqualTo(false);
+    assertThat(versionRepository.isActiveProgram(draftProgram.id)).isEqualTo(false);
     ProgramModel activeProgram = ProgramBuilder.newActiveProgram("active program").build();
-    assertThat(versionRepository.isActiveProgram(activeProgram.getProgramDefinition().id()))
-        .isEqualTo(true);
+    assertThat(versionRepository.isActiveProgram(activeProgram.id)).isEqualTo(true);
   }
 
   @Test

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -810,8 +810,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
 
     assertThat(application.getApplicant()).isEqualTo(applicant);
-    assertThat(application.getProgram().getProgramDefinition().id())
-        .isEqualTo(programDefinition.id());
+    assertThat(application.getProgram().id).isEqualTo(programDefinition.id());
     assertThat(application.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
     assertThat(application.getApplicantData().asJsonString()).contains("Alice", "Doe");
   }
@@ -918,7 +917,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     applicant.refresh();
     assertThat(application.getApplicant()).isEqualTo(applicant);
-    assertThat(application.getProgram().getProgramDefinition().id()).isEqualTo(progDef.id());
+    assertThat(application.getProgram().id).isEqualTo(progDef.id());
     assertThat(application.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
     assertThat(applicant.getFirstName().get()).isEqualTo("Jean");
     assertThat(applicant.getMiddleName().get()).isEqualTo("Luc");
@@ -1032,14 +1031,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     oldApplication.refresh();
     assertThat(oldApplication.getApplicant()).isEqualTo(applicant);
-    assertThat(oldApplication.getProgram().getProgramDefinition().id())
-        .isEqualTo(programDefinition.id());
+    assertThat(oldApplication.getProgram().id).isEqualTo(programDefinition.id());
     assertThat(oldApplication.getLifecycleStage()).isEqualTo(LifecycleStage.OBSOLETE);
     assertThat(oldApplication.getApplicantData().asJsonString()).contains("Alice", "Doe");
 
     assertThat(newApplication.getApplicant()).isEqualTo(applicant);
-    assertThat(newApplication.getProgram().getProgramDefinition().id())
-        .isEqualTo(programDefinition.id());
+    assertThat(newApplication.getProgram().id).isEqualTo(programDefinition.id());
     assertThat(newApplication.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
     assertThat(newApplication.getApplicantData().asJsonString()).contains("Bob", "Elisa");
   }
@@ -1423,8 +1420,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
 
     assertThat(application.getApplicant()).isEqualTo(applicant);
-    assertThat(application.getProgram().getProgramDefinition().id())
-        .isEqualTo(programDefinition.id());
+    assertThat(application.getProgram().id).isEqualTo(programDefinition.id());
     assertThat(application.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
   }
 

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2028,7 +2028,7 @@ public class ProgramServiceTest extends ResetPostgres {
         .isEqualTo(program.getProgramDefinition().blockDefinitions());
     assertThat(newDraft.localizedDescription())
         .isEqualTo(program.getProgramDefinition().localizedDescription());
-    assertThat(newDraft.id()).isNotEqualTo(program.getProgramDefinition().id());
+    assertThat(newDraft.id()).isNotEqualTo(program.id);
 
     ProgramDefinition secondNewDraft = ps.newDraftOf(program.id);
     assertThat(secondNewDraft.id()).isEqualTo(newDraft.id());


### PR DESCRIPTION
### Description

Access program IDs directly instead of through the ProgramDefinition

Nothing in this PR should have a significant performance change, but it removes this pattern from our codebase so it doesn't get copied to somewhere where it might have a large cost.

As an example of somewhere with a large cost see:
https://github.com/civiform/civiform/commit/d280fe4c59650f44a8fabae73170fcc78388e370#diff-b96e47e7b318d0c8fbd715bfabd93bab7112c8994dcd46d64a13760cabb58ddaL140

The program ID is set on every exported application. It was originally accessed via `application.getProgram().getProgramDefinition().id()`, but is now accessed via `application.getProgram().id`

Details:
- In a few places, we only care about the program ID but we're loading a the full ProgramDefinition to get it
- If we only access the `.id` on the model, ebeans will do the right thing and won't load the full entity (if it wasn't already fetched)
- If the full entity wasn't already eagerly fetched, ebeans fetches the full entity if anything else is accessed.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [n/a] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary


### Instructions for manual testing

n/a

### Issue(s) this completes

None, found in the course of #5018
