### PR TITLE
Migrate footer tests to use fixtures

### DIFF
--- a/browser-test/src/footer.test.ts
+++ b/browser-test/src/footer.test.ts
@@ -1,57 +1,35 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from './support/civiform_fixtures'
 import {
-  createTestContext,
   enableFeatureFlag,
   disableFeatureFlag,
   validateAccessibility,
   validateScreenshot,
-  TestContext,
 } from './support'
-import {Locator} from 'playwright'
 
-function sharedTests(ctx: TestContext, screenshotName: string) {
-  test('matches the expected screenshot', async () => {
-    const footer: Locator = ctx.page.locator('footer')
-    await validateScreenshot(footer, screenshotName)
-  })
+test.describe('the footer', {tag: ['@uses-fixtures']}, () => {
+  test('does not have civiform version when feature flag is disabled', async ({
+    page,
+  }) => {
+    const footerLocator = page.locator('footer')
 
-  test('has no accessibility violations', async () => {
-    await validateAccessibility(ctx.page)
-  })
-}
+    await disableFeatureFlag(page, 'show_civiform_image_tag_on_landing_page')
+    await validateScreenshot(footerLocator, 'footer-no-version')
+    await validateAccessibility(page)
 
-test.describe('the footer', () => {
-  const ctx = createTestContext()
-
-  test.describe('without civiform version feature flag', () => {
-    test.beforeEach(async () => {
-      await disableFeatureFlag(
-        ctx.page,
-        'show_civiform_image_tag_on_landing_page',
-      )
-    })
-
-    sharedTests(ctx, 'footer-no-version')
-
-    test('does not have civiform version', async () => {
-      expect(await ctx.page.textContent('html')).not.toContain(
-        'CiviForm version:',
-      )
+    await test.step('Footer does not have version text', async () => {
+      await expect(footerLocator).not.toContainText('CiviForm version:')
     })
   })
 
-  test.describe('with civiform version feature flag', () => {
-    test.beforeEach(async () => {
-      await enableFeatureFlag(
-        ctx.page,
-        'show_civiform_image_tag_on_landing_page',
-      )
-    })
+  test('has civiform version when feature flag is enabled', async ({page}) => {
+    const footerLocator = page.locator('footer')
 
-    sharedTests(ctx, 'footer-with-version')
+    await enableFeatureFlag(page, 'show_civiform_image_tag_on_landing_page')
+    await validateScreenshot(footerLocator, 'footer-with-version')
+    await validateAccessibility(page)
 
-    test('has civiform version', async () => {
-      expect(await ctx.page.textContent('html')).toContain('CiviForm version:')
+    await test.step('Footer does has version text', async () => {
+      await expect(footerLocator).toContainText('CiviForm version:')
     })
   })
 })

--- a/browser-test/src/support/civiform_fixtures.ts
+++ b/browser-test/src/support/civiform_fixtures.ts
@@ -75,10 +75,15 @@ export const test = base.extend<CiviformFixtures>({
 
   page: async ({page, request}, use) => {
     // BeforeEach
-    await request.post('/dev/seed/clear')
-    await page.goto('/programs')
-    await waitForPageJsLoad(page)
-    await page.locator('#warning-message-dismiss').click()
+    await test.step('Clear database', async () => {
+      await request.post('/dev/seed/clear')
+    })
+
+    await test.step('Go to home page before test starts', async () => {
+      await page.goto('/programs')
+      await waitForPageJsLoad(page)
+      await page.locator('#warning-message-dismiss').click()
+    })
 
     // Run the Test
     await use(page)

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -308,27 +308,35 @@ export const logout = async (page: Page, closeToast = true) => {
 }
 
 export const loginAsAdmin = async (page: Page) => {
-  await page.click('#debug-content-modal-button')
-  await page.click('#admin')
-  await waitForPageJsLoad(page)
+  await test.step('Login as Civiform Admin', async () => {
+    await page.click('#debug-content-modal-button')
+    await page.click('#admin')
+    await waitForPageJsLoad(page)
+  })
 }
 
 export const loginAsProgramAdmin = async (page: Page) => {
-  await page.click('#debug-content-modal-button')
-  await page.click('#program-admin')
-  await waitForPageJsLoad(page)
+  await test.step('Login as Program Admin', async () => {
+    await page.click('#debug-content-modal-button')
+    await page.click('#program-admin')
+    await waitForPageJsLoad(page)
+  })
 }
 
 export const loginAsCiviformAndProgramAdmin = async (page: Page) => {
-  await page.click('#debug-content-modal-button')
-  await page.click('#dual-admin')
-  await waitForPageJsLoad(page)
+  await test.step('Login as Civiform and Program Admin', async () => {
+    await page.click('#debug-content-modal-button')
+    await page.click('#dual-admin')
+    await waitForPageJsLoad(page)
+  })
 }
 
 export const loginAsTrustedIntermediary = async (page: Page) => {
-  await page.click('#debug-content-modal-button')
-  await page.click('#trusted-intermediary')
-  await waitForPageJsLoad(page)
+  await test.step('Login as Trusted Intermediary', async () => {
+    await page.click('#debug-content-modal-button')
+    await page.click('#trusted-intermediary')
+    await waitForPageJsLoad(page)
+  })
 }
 
 /**
@@ -344,26 +352,28 @@ export const loginAsTestUser = async (
   isTi = false,
   displayName: string = '',
 ) => {
-  switch (TEST_USER_AUTH_STRATEGY) {
-    case AuthStrategy.FAKE_OIDC:
-      await loginAsTestUserFakeOidc(page, loginButton, isTi)
-      break
-    case AuthStrategy.AWS_STAGING:
-      await loginAsTestUserAwsStaging(page, loginButton, isTi)
-      break
-    case AuthStrategy.SEATTLE_STAGING:
-      await loginAsTestUserSeattleStaging(page, loginButton)
-      break
-    default:
-      throw new Error(
-        `Unrecognized or unset TEST_USER_AUTH_STRATEGY environment variable of '${TEST_USER_AUTH_STRATEGY}'`,
-      )
-  }
-  await waitForPageJsLoad(page)
-  if (displayName === '') {
-    displayName = testUserDisplayName()
-  }
-  await page.waitForSelector(`:has-text("Logged in as ${displayName}")`)
+  await test.step('Login as Test User', async () => {
+    switch (TEST_USER_AUTH_STRATEGY) {
+      case AuthStrategy.FAKE_OIDC:
+        await loginAsTestUserFakeOidc(page, loginButton, isTi)
+        break
+      case AuthStrategy.AWS_STAGING:
+        await loginAsTestUserAwsStaging(page, loginButton, isTi)
+        break
+      case AuthStrategy.SEATTLE_STAGING:
+        await loginAsTestUserSeattleStaging(page, loginButton)
+        break
+      default:
+        throw new Error(
+          `Unrecognized or unset TEST_USER_AUTH_STRATEGY environment variable of '${TEST_USER_AUTH_STRATEGY}'`,
+        )
+    }
+    await waitForPageJsLoad(page)
+    if (displayName === '') {
+      displayName = testUserDisplayName()
+    }
+    await page.waitForSelector(`:has-text("Logged in as ${displayName}")`)
+  })
 }
 
 async function loginAsTestUserSeattleStaging(page: Page, loginButton: string) {
@@ -481,11 +491,15 @@ export const seedPrograms = async (page: Page) => {
 }
 
 export const disableFeatureFlag = async (page: Page, flag: string) => {
-  await page.goto(BASE_URL + `/dev/feature/${flag}/disable`)
+  await test.step(`Disable feature flag: ${flag}`, async () => {
+    await page.goto(`/dev/feature/${flag}/disable`)
+  })
 }
 
 export const enableFeatureFlag = async (page: Page, flag: string) => {
-  await page.goto(BASE_URL + `/dev/feature/${flag}/enable`)
+  await test.step(`Enable feature flag: ${flag}`, async () => {
+    await page.goto(`/dev/feature/${flag}/enable`)
+  })
 }
 
 export const closeWarningMessage = async (page: Page) => {
@@ -504,14 +518,16 @@ export const closeWarningMessage = async (page: Page) => {
 }
 
 export const validateAccessibility = async (page: Page) => {
-  const results = await new AxeBuilder({page}).analyze()
-  const errorMessage = `Found ${results.violations.length} axe accessibility violations:\n ${JSON.stringify(
-    results.violations,
-    null,
-    2,
-  )}`
+  await test.step('Validate accessiblity', async () => {
+    const results = await new AxeBuilder({page}).analyze()
+    const errorMessage = `Found ${results.violations.length} axe accessibility violations:\n ${JSON.stringify(
+      results.violations,
+      null,
+      2,
+    )}`
 
-  expect(results.violations, errorMessage).toEqual([])
+    expect(results.violations, errorMessage).toEqual([])
+  })
 }
 
 /**

--- a/browser-test/src/support/wait.ts
+++ b/browser-test/src/support/wait.ts
@@ -1,3 +1,4 @@
+import {test} from './civiform_fixtures'
 import {ElementHandle, Frame, Page} from 'playwright'
 
 /**
@@ -10,11 +11,13 @@ export const waitForPageJsLoad = async (page: Page | Frame | null) => {
     throw new Error('waitForPageJsLoad received null!')
   }
 
-  await page.waitForLoadState('load')
+  await test.step(`Wait for page to be fully loaded`, async () => {
+    await page.waitForLoadState('load')
 
-  // Wait for main.ts and modal.ts to signal that they're done initializing
-  await page.waitForSelector('body[data-load-main="true"]')
-  await page.waitForSelector('body[data-load-modal="true"]')
+    // Wait for main.ts and modal.ts to signal that they're done initializing
+    await page.waitForSelector('body[data-load-main="true"]')
+    await page.waitForSelector('body[data-load-modal="true"]')
+  })
 }
 
 /**


### PR DESCRIPTION
### Description

Migrates the footer browser tests to use Playwright fixtures.

Adding steps around various common functions

> [!TIP]
> You'll want to hide whitespace changes
>
> ![image](https://github.com/civiform/civiform/assets/195162/58417fc9-4a6b-4a04-8a86-8e06844086d1)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
