### PR TITLE
Update devcontainer extensions to add graphite and remove legacy github extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,6 @@
         "dbaeumer.vscode-eslint",
         "github.vscode-pull-request-github",
         "hashicorp.terraform",
-        "knisterpeter.vscode-github",
         "ms-azuretools.vscode-docker",
         "ms-ossdata.vscode-postgresql",
         "ms-playwright.playwright",
@@ -57,7 +56,8 @@
         "scala-lang.scala",
         "scalameta.metals",
         "vscjava.vscode-java-pack",
-        "vscode-icons-team.vscode-icons"
+        "vscode-icons-team.vscode-icons",
+        "Graphite.gti-vscode"
       ]
     },
     "launch": {


### PR DESCRIPTION
### Description

Got a message about the github extension being outdated, so removed that and adding graphite (from @avaleske's suggestion)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

#6999