### PR TITLE
Browser Test Postgres Performance

### DIFF
--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -15,6 +15,11 @@ services:
       - 9457:9457
     command: ~runBrowserTestsServer
 
+  db:
+    volumes:
+      - ./browser-test/custom-postgres.conf:/etc/postgresql/postgresql.conf
+    command: -c 'config_file=/etc/postgresql/postgresql.conf'
+
 volumes:
   node_modules-data:
     driver: local

--- a/browser-test/custom-postgres.conf
+++ b/browser-test/custom-postgres.conf
@@ -1,0 +1,36 @@
+# Full sample file can be found in the docker container or in the postgres repo
+# https://github.com/postgres/postgres/blob/master/src/backend/utils/misc/postgresql.conf.sample
+#
+# Custom settings are based on postgres docs 
+# https://www.postgresql.org/docs/current/non-durability.html
+
+
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+listen_addresses = '*'     # Default, not commented out in the sample config
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+fsync = off                 # flush data to disk for crash safety
+synchronous_commit = off    # synchronization level
+full_page_writes = off      # recover from partial page writes
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+autovacuum = off			# Enable autovacuum subprocess


### PR DESCRIPTION
### Description

Configures browser test docker compose file to use custom postgres config file.

> [!CAUTION]
> These settings disable durability settings. Loss off data is possible. These settings **MUST NOT** be applied to staging or production environments, and this commit is specific local docker configuration and can't affect staging or production.
>
> Use on short lived data, such as running browser test, is the only acceptable use of these settings

This change turns off some of the durability settings in postgres on the browser test database. Changes are based on [postgres documentation](https://www.postgresql.org/docs/current/non-durability.html) and other writings on the internet. This speeds up clearing the database by an order of magnitude from around 250ms to around 25ms. This adds up quickly when we clear the database frequently in the browser tests.

![image](https://github.com/civiform/civiform/assets/195162/f9347678-f519-47f1-8d08-e2bce3bfc76b)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
