### PR TITLE
DOM text reinterpreted as HTML {Patch}

### DIFF
--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -227,7 +227,7 @@ class PreviewController {
         PreviewController.QUESTION_TEXT_SELECTOR,
       )
       if (contentParent) {
-        contentParent.innerHTML = ''
+        contentParent.innerText = ''
         contentParent.appendChild(contentElement)
       }
     } else {


### PR DESCRIPTION
Patch issue link:  https://issuetracker.google.com/issues/330971625

By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.