### PR TITLE
DOM text reinterpreted as HTML {Patch-2}

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -46,7 +46,7 @@ export function init() {
     blockForm.addEventListener('change', (event) => {
       const files = (event.target! as HTMLInputElement).files
       const file = assertNotNull(files)[0]
-      uploadedDiv.innerHTML = uploadText.replace('{0}', file.name)
+      uploadedDiv.innerText = uploadText.replace('{0}', file.name)
       validateFileUploadQuestion(blockForm)
     })
   }


### PR DESCRIPTION
Patch issue link: https://issuetracker.google.com/issues/331062387

By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.