### PR TITLE
Enable perf speed on all browser test compose files

### DIFF
--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -15,11 +15,6 @@ services:
       - 9457:9457
     command: ~runBrowserTestsServer
 
-  db:
-    volumes:
-      - ./browser-test/custom-postgres.conf:/etc/postgresql/postgresql.conf
-    command: -c 'config_file=/etc/postgresql/postgresql.conf'
-
 volumes:
   node_modules-data:
     driver: local

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -2,6 +2,8 @@
 version: '3.4'
 
 services:
+  # Load custom postgres config that disables durability for performance
+  # Not for use in a production environment
   db:
     volumes:
       - ./browser-test/custom-postgres.conf:/etc/postgresql/postgresql.conf

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -2,6 +2,11 @@
 version: '3.4'
 
 services:
+  db:
+    volumes:
+      - ./browser-test/custom-postgres.conf:/etc/postgresql/postgresql.conf
+    command: -c 'config_file=/etc/postgresql/postgresql.conf'
+
   localstack:
     ports:
       - 6645:4566


### PR DESCRIPTION
### Description

Making the postgres perf settings available on all browser test compose files.

This worked locally fine, but turns out CI loaded a different browser test compose file. While the time savings from around 250ms to 25ms is accurate the run on GitHub that appeared faster was probably due to lower weekend usage of resources.




### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
