### PR TITLE
Add north star tag to number input test

### DIFF
--- a/browser-test/src/applicant/questions/number_input.test.ts
+++ b/browser-test/src/applicant/questions/number_input.test.ts
@@ -164,42 +164,46 @@ test.describe('Number question for applicant flow', () => {
     })
   })
 
-  test.describe('single number question with North Star flag enabled', () => {
-    const programName = 'Test program for single number'
+  test.describe(
+    'single number question with North Star flag enabled',
+    {tag: ['@northstar']},
+    () => {
+      const programName = 'Test program for single number'
 
-    test.beforeAll(async () => {
-      await setUpForSingleQuestion(programName)
-    })
-
-    test.beforeEach(async () => {
-      const {page} = ctx
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
-      await applicantQuestions.applyProgram(programName)
-
-      await test.step('Screenshot without errors', async () => {
-        await validateScreenshot(
-          page,
-          'number-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
+      test.beforeAll(async () => {
+        await setUpForSingleQuestion(programName)
       })
 
-      await test.step('Screenshot with errors', async () => {
-        await applicantQuestions.clickContinue()
-        await validateScreenshot(
-          page,
-          'number-errors-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
+      test.beforeEach(async () => {
+        const {page} = ctx
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
-    })
-  })
+
+      test('validate screenshot', async () => {
+        const {page, applicantQuestions} = ctx
+        await applicantQuestions.applyProgram(programName)
+
+        await test.step('Screenshot without errors', async () => {
+          await validateScreenshot(
+            page,
+            'number-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
+
+        await test.step('Screenshot with errors', async () => {
+          await applicantQuestions.clickContinue()
+          await validateScreenshot(
+            page,
+            'number-errors-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
+      })
+    },
+  )
 
   async function setUpForSingleQuestion(programName: string) {
     const {page, adminQuestions, adminPrograms} = ctx


### PR DESCRIPTION
### Description

Add the north star tag to the number test so they don't get tested in staging

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)

