### PR TITLE
Make the durable jobs run hourly in browser and unit tests

### DIFF
--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -29,3 +29,7 @@ program_cache_enabled=true
 question_cache_enabled=true
 primary_applicant_info_questions_enabled=false
 universal_questions=true
+
+# In the test environment we don't need to have the jobs running at the
+# default 5 second interval
+durable_jobs.poll_interval_seconds = 3600

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -23,3 +23,7 @@ esri_find_address_candidates_url = ""
 esri_address_service_area_validation_urls = ["/query"]
 
 question_cache_enabled=true
+
+# In the test environment we don't need to have the jobs running at the
+# default 5 second interval
+durable_jobs.poll_interval_seconds = 3600


### PR DESCRIPTION
### Description

Durable Jobs default to run every five seconds. This is unneeded in a unit test or browser test environment that will come and go frequently.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
