### PR TITLE
Allow decimals to be entered for age younger than / older than predicates

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -1028,7 +1028,7 @@ test.describe('create and edit predicates', () => {
         /* action= */ null,
         'date',
         'age is younger than',
-        '50',
+        '50.5',
       )
 
       // ensure the edit page renders without errors

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -1182,7 +1182,7 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerDateQuestion('1930-01-01')
       await applicantQuestions.clickNext()
 
-      // Age less than 50 is allowed
+      // Age less than 50.5 is allowed
       await applicantQuestions.answerDateQuestion('1930-12-31')
       await applicantQuestions.clickNext()
       await applicantQuestions.expectIneligiblePage()

--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -353,6 +353,8 @@ class AdminPredicateConfiguration {
           ) {
             // Age-related operators should have number input value
             valueInput.setAttribute('type', 'number')
+            // We should allow for decimals to account for month intervals
+            valueInput.setAttribute('step', '.01')
           } else if (operatorValue.toUpperCase() === 'AGE_BETWEEN') {
             // BETWEEN operates on lists of longs, which must be entered as a comma-separated list
             valueInput.setAttribute('type', 'text')

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -134,7 +134,7 @@ public final class DateConverter {
     Double fullYear = Math.floor(age);
     LocalDate dateFromAge = LocalDate.now(clock).minusYears(fullYear.longValue());
     if ((age - fullYear) > 0) {
-      dateFromAge.minusMonths((long) Math.floor((age - fullYear) * 12));
+      dateFromAge = dateFromAge.minusMonths((long) Math.floor((age - fullYear) * 12));
     }
     return dateFromAge.atStartOfDay(zoneId).toInstant().toEpochMilli();
   }

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -127,9 +127,9 @@ public final class DateConverter {
   }
 
   /** Gets the {@link Long} timestamp from an age, by subtracting the age from today's date, when the age may not be a whole number. */
-  public long getDateTimestampFromAge(Float age) {
-    Float fullYear = (float) Math.floor(age);
-    if (fullYear == age) {
+  public long getDateTimestampFromAge(Double age) {
+    Double fullYear = Math.floor(age);
+    if (fullYear.equals(age)) {
       return LocalDate.now(clock).minusYears(fullYear.longValue()).atStartOfDay(zoneId).toInstant().toEpochMilli();
     }
     Long months = (long) Math.floor((age - fullYear) * 12);

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -126,13 +126,16 @@ public final class DateConverter {
     return LocalDate.now(clock).minusYears(age).atStartOfDay(zoneId).toInstant().toEpochMilli();
   }
 
-  /** Gets the {@link Long} timestamp from an age, by subtracting the age from today's date, when the age may not be a whole number. */
+  /**
+   * Gets the {@link Long} timestamp from an age, by subtracting the age from today's date, when the
+   * age may not be a whole number.
+   */
   public long getDateTimestampFromAge(Double age) {
     Double fullYear = Math.floor(age);
-    if (fullYear.equals(age)) {
-      return LocalDate.now(clock).minusYears(fullYear.longValue()).atStartOfDay(zoneId).toInstant().toEpochMilli();
+    LocalDate dateFromAge = LocalDate.now(clock).minusYears(fullYear.longValue());
+    if ((age - fullYear) > 0) {
+      dateFromAge.minusMonths((long) Math.floor((age - fullYear) * 12));
     }
-    Long months = (long) Math.floor((age - fullYear) * 12);
-    return LocalDate.now(clock).minusYears(fullYear.longValue()).minusMonths(months).atStartOfDay(zoneId).toInstant().toEpochMilli();
+    return dateFromAge.atStartOfDay(zoneId).toInstant().toEpochMilli();
   }
 }

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -125,4 +125,14 @@ public final class DateConverter {
   public long getDateTimestampFromAge(Long age) {
     return LocalDate.now(clock).minusYears(age).atStartOfDay(zoneId).toInstant().toEpochMilli();
   }
+
+  /** Gets the {@link Long} timestamp from an age, by subtracting the age from today's date, when the age may not be a whole number. */
+  public long getDateTimestampFromAge(Float age) {
+    Float fullYear = (float) Math.floor(age);
+    if (fullYear == age) {
+      return LocalDate.now(clock).minusYears(fullYear.longValue()).atStartOfDay(zoneId).toInstant().toEpochMilli();
+    }
+    Long months = (long) Math.floor((age - fullYear) * 12);
+    return LocalDate.now(clock).minusYears(fullYear.longValue()).minusMonths(months).atStartOfDay(zoneId).toInstant().toEpochMilli();
+  }
 }

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -144,7 +144,8 @@ public final class JsonPathPredicateGenerator {
             String.format(
                 "%s[?(%s %s @.%s)]",
                 getPath(node).predicateFormat(),
-                dateConverter.getDateTimestampFromAge(Double.parseDouble(node.comparedValue().value())),
+                dateConverter.getDateTimestampFromAge(
+                    Double.parseDouble(node.comparedValue().value())),
                 node.operator().toJsonPathOperator(),
                 node.scalar().name().toLowerCase(Locale.ROOT)));
       default:

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -144,7 +144,7 @@ public final class JsonPathPredicateGenerator {
             String.format(
                 "%s[?(%s %s @.%s)]",
                 getPath(node).predicateFormat(),
-                dateConverter.getDateTimestampFromAge(Float.parseFloat(node.comparedValue().value())),
+                dateConverter.getDateTimestampFromAge(Double.parseDouble(node.comparedValue().value())),
                 node.operator().toJsonPathOperator(),
                 node.scalar().name().toLowerCase(Locale.ROOT)));
       default:

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -144,7 +144,7 @@ public final class JsonPathPredicateGenerator {
             String.format(
                 "%s[?(%s %s @.%s)]",
                 getPath(node).predicateFormat(),
-                dateConverter.getDateTimestampFromAge(Long.parseLong(node.comparedValue().value())),
+                dateConverter.getDateTimestampFromAge(Float.parseFloat(node.comparedValue().value())),
                 node.operator().toJsonPathOperator(),
                 node.scalar().name().toLowerCase(Locale.ROOT)));
       default:

--- a/server/app/services/program/predicate/Operator.java
+++ b/server/app/services/program/predicate/Operator.java
@@ -16,12 +16,12 @@ public enum Operator {
       ">=",
       "age is older than",
       ImmutableSet.of(ScalarType.DATE),
-      ImmutableSet.of(OperatorRightHandType.DOUBLE)),
+      ImmutableSet.of(OperatorRightHandType.LONG, OperatorRightHandType.DOUBLE)),
   AGE_YOUNGER_THAN(
       "<",
       "age is younger than",
       ImmutableSet.of(ScalarType.DATE),
-      ImmutableSet.of(OperatorRightHandType.DOUBLE)),
+      ImmutableSet.of(OperatorRightHandType.LONG, OperatorRightHandType.DOUBLE)),
   ANY_OF(
       "anyof",
       "contains any of",

--- a/server/app/services/program/predicate/Operator.java
+++ b/server/app/services/program/predicate/Operator.java
@@ -16,12 +16,12 @@ public enum Operator {
       ">=",
       "age is older than",
       ImmutableSet.of(ScalarType.DATE),
-      ImmutableSet.of(OperatorRightHandType.LONG)),
+      ImmutableSet.of(OperatorRightHandType.DOUBLE)),
   AGE_YOUNGER_THAN(
       "<",
       "age is younger than",
       ImmutableSet.of(ScalarType.DATE),
-      ImmutableSet.of(OperatorRightHandType.LONG)),
+      ImmutableSet.of(OperatorRightHandType.DOUBLE)),
   ANY_OF(
       "anyof",
       "contains any of",

--- a/server/app/services/program/predicate/OperatorRightHandType.java
+++ b/server/app/services/program/predicate/OperatorRightHandType.java
@@ -14,6 +14,7 @@ package services.program.predicate;
  */
 public enum OperatorRightHandType {
   DATE,
+  DOUBLE,
   LIST_OF_LONGS,
   LIST_OF_STRINGS,
   LONG,

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -300,7 +300,7 @@ public final class PredicateGenerator {
         // Age values are inputted as numbers.
         if (operator.equals(Operator.AGE_OLDER_THAN)
             || operator.equals(Operator.AGE_YOUNGER_THAN)) {
-          return PredicateValue.of(Long.parseLong(value));
+          return PredicateValue.of(Float.parseFloat(value));
           // Take the string input with the comma separating the two age values and make a list of
           // longs.
         } else if (operator.equals(Operator.AGE_BETWEEN)) {

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -300,7 +300,12 @@ public final class PredicateGenerator {
         // Age values are inputted as numbers.
         if (operator.equals(Operator.AGE_OLDER_THAN)
             || operator.equals(Operator.AGE_YOUNGER_THAN)) {
-          return PredicateValue.of(Float.parseFloat(value));
+          Float ageVal = Float.parseFloat(value);
+          // If the age is a whole number, store it as a long
+          if (ageVal == Math.round(ageVal)) {
+            return PredicateValue.of(ageVal.longValue());
+          }
+          return PredicateValue.of(ageVal);
           // Take the string input with the comma separating the two age values and make a list of
           // longs.
         } else if (operator.equals(Operator.AGE_BETWEEN)) {

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -300,7 +300,7 @@ public final class PredicateGenerator {
         // Age values are inputted as numbers.
         if (operator.equals(Operator.AGE_OLDER_THAN)
             || operator.equals(Operator.AGE_YOUNGER_THAN)) {
-          Float ageVal = Float.parseFloat(value);
+          Double ageVal = Double.parseDouble(value);
           // If the age is a whole number, store it as a long
           if (ageVal == Math.round(ageVal)) {
             return PredicateValue.of(ageVal.longValue());

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -6,6 +6,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.math.DoubleMath;
 import controllers.BadRequestException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -302,7 +303,7 @@ public final class PredicateGenerator {
             || operator.equals(Operator.AGE_YOUNGER_THAN)) {
           Double ageVal = Double.parseDouble(value);
           // If the age is a whole number, store it as a long
-          if (ageVal == Math.round(ageVal)) {
+          if (DoubleMath.isMathematicalInteger(ageVal)) {
             return PredicateValue.of(ageVal.longValue());
           }
           return PredicateValue.of(ageVal);

--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -29,7 +29,7 @@ public abstract class PredicateValue {
   }
 
   public static PredicateValue of(double value) {
-    return create(String.valueOf(value), OperatorRightHandType.LONG);
+    return create(String.valueOf(value), OperatorRightHandType.DOUBLE);
   }
 
   public static PredicateValue of(String value) {

--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -28,7 +28,7 @@ public abstract class PredicateValue {
     return create(String.valueOf(value), OperatorRightHandType.LONG);
   }
 
-  public static PredicateValue of(float value) {
+  public static PredicateValue of(double value) {
     return create(String.valueOf(value), OperatorRightHandType.LONG);
   }
 

--- a/server/app/services/program/predicate/PredicateValue.java
+++ b/server/app/services/program/predicate/PredicateValue.java
@@ -28,6 +28,10 @@ public abstract class PredicateValue {
     return create(String.valueOf(value), OperatorRightHandType.LONG);
   }
 
+  public static PredicateValue of(float value) {
+    return create(String.valueOf(value), OperatorRightHandType.LONG);
+  }
+
   public static PredicateValue of(String value) {
     // Escape the string value
     return create(surroundWithQuotes(value), OperatorRightHandType.STRING);

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -97,7 +97,10 @@ public class JsonPathPredicateGeneratorTest {
   public void fromLeafNode_generatesCorrectStringForAgeOlderFloatValue() throws Exception {
     LeafOperationExpressionNode node =
         LeafOperationExpressionNode.create(
-            dateQuestion.getId(), Scalar.DATE, Operator.AGE_OLDER_THAN, PredicateValue.of((float) 18.5));
+            dateQuestion.getId(),
+            Scalar.DATE,
+            Operator.AGE_OLDER_THAN,
+            PredicateValue.of((float) 18.5));
 
     JsonPathPredicate predicate =
         JsonPathPredicate.create("$.applicant.applicant_birth_date[?(1309478400000 >= @.date)]");

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -94,6 +94,23 @@ public class JsonPathPredicateGeneratorTest {
   }
 
   @Test
+  public void fromLeafNode_generatesCorrectStringForAgeOlderFloatValue() throws Exception {
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            dateQuestion.getId(), Scalar.DATE, Operator.AGE_OLDER_THAN, PredicateValue.of((float) 18.5));
+
+    JsonPathPredicate predicate =
+        JsonPathPredicate.create("$.applicant.applicant_birth_date[?(1309478400000 >= @.date)]");
+
+    assertThat(generator.fromLeafNode(node)).isEqualTo(predicate);
+
+    ApplicantData data = new ApplicantData();
+    data.putDate(Path.create("applicant.applicant_birth_date.date"), "2012-01-01");
+
+    assertThat(data.evalPredicate(predicate)).isTrue();
+  }
+
+  @Test
   public void fromLeafNode_generatesCorrectStringForAgeYoungerValue() throws Exception {
     LeafOperationExpressionNode node =
         LeafOperationExpressionNode.create(

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -94,7 +94,7 @@ public class JsonPathPredicateGeneratorTest {
   }
 
   @Test
-  public void fromLeafNode_generatesCorrectStringForAgeOlderFloatValue() throws Exception {
+  public void fromLeafNode_generatesCorrectStringForAgeOlderDoubleValue() throws Exception {
     LeafOperationExpressionNode node =
         LeafOperationExpressionNode.create(
             dateQuestion.getId(),

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -100,7 +100,7 @@ public class JsonPathPredicateGeneratorTest {
             dateQuestion.getId(),
             Scalar.DATE,
             Operator.AGE_OLDER_THAN,
-            PredicateValue.of((float) 18.5));
+            PredicateValue.of((double) 18.5));
 
     JsonPathPredicate predicate =
         JsonPathPredicate.create("$.applicant.applicant_birth_date[?(1309478400000 >= @.date)]");

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -108,7 +108,7 @@ public class JsonPathPredicateGeneratorTest {
     assertThat(generator.fromLeafNode(node)).isEqualTo(predicate);
 
     ApplicantData data = new ApplicantData();
-    data.putDate(Path.create("applicant.applicant_birth_date.date"), "2012-01-01");
+    data.putDate(Path.create("applicant.applicant_birth_date.date"), "2011-07-01");
 
     assertThat(data.evalPredicate(predicate)).isTrue();
   }

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -165,7 +165,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
                 "DATE",
                 String.format("question-%d-operator", testQuestionBank.applicantDate().id),
-                "AGE_LESS_THAN",
+                "AGE_YOUNGER_THAN",
                 String.format(
                     "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
                 "10.5"));

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -153,6 +153,44 @@ public class PredicateGeneratorTest extends ResetPostgres {
             "Invalid age range: 14,18,24. Age range value must be two integers separated by - or"
                 + " ,");
   }
+  
+  @Test
+  public void generatePredicateDefinition_singleQuestion_singleValue_ageLessThan() throws Exception {
+    DynamicForm form =
+        buildForm(
+            ImmutableMap.of(
+                "predicateAction",
+                "HIDE_BLOCK",
+                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                "DATE",
+                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                "AGE_LESS_THAN",
+                String.format(
+                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                "10.5"));
+
+    PredicateDefinition predicateDefinition =
+        predicateGenerator.generatePredicateDefinition(
+            programDefinition, form, readOnlyQuestionService);
+
+    assertThat(predicateDefinition.predicateFormat())
+        .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
+    assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
+    assertThat(predicateDefinition.getQuestions())
+        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+    assertThat(predicateDefinition.rootNode())
+        .isEqualTo(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.builder()
+                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setScalar(Scalar.DATE)
+                    .setOperator(Operator.AGE_YOUNGER_THAN)
+                    .setComparedValue(
+                        PredicateGenerator.parsePredicateValue(
+                            Scalar.DATE, Operator.AGE_YOUNGER_THAN, "10.5", null))
+                    .build()));
+  }
+
 
   @Test
   public void generatePredicateDefinition_singleQuestion_serviceArea() throws Exception {

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -153,9 +153,10 @@ public class PredicateGeneratorTest extends ResetPostgres {
             "Invalid age range: 14,18,24. Age range value must be two integers separated by - or"
                 + " ,");
   }
-  
+
   @Test
-  public void generatePredicateDefinition_singleQuestion_singleValue_ageLessThan() throws Exception {
+  public void generatePredicateDefinition_singleQuestion_singleValue_ageLessThan()
+      throws Exception {
     DynamicForm form =
         buildForm(
             ImmutableMap.of(
@@ -190,7 +191,6 @@ public class PredicateGeneratorTest extends ResetPostgres {
                             Scalar.DATE, Operator.AGE_YOUNGER_THAN, "10.5", null))
                     .build()));
   }
-
 
   @Test
   public void generatePredicateDefinition_singleQuestion_serviceArea() throws Exception {


### PR DESCRIPTION
### Description

Currently only a whole number is accepted for age younger than and age older than, but we should allow for decimals.

This is to allow Charlotte to create a predicate for lived in a house less than 6 months. The admin can create a date question "When did you move into your house?" and can set eligibility on that question for age less than .5.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #7049
