### PR TITLE
Merge playwright trace files

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,9 +138,46 @@ jobs:
           name: tests videos (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
           path: browser-test/tmp
         if: failure()
+
+      - name: Upload playwright reporting blobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-aws-shard-${{ matrix.shared_number }}-run-${{ github.run_attempt }}
+          path: browser-test/blob-report
+        if: always()
+
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs
+
+  merge_playwright_reports:
+    if: always()
+    needs: [run_browser_tests_aws]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Install playwright
+        run: npm install -g @playwright/test
+
+      - name: Download playwright blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: playwright-blob-aws-shard-*-run-${{ github.run_attempt }}
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --config=browser-test/merge.config.ts ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report-attempt-${{ github.run_attempt }}
+          path: playwright-report
 
   run_browser_tests_azure:
     if: false

--- a/bin/dev-show-trace-file
+++ b/bin/dev-show-trace-file
@@ -109,7 +109,7 @@ class GitHub:
             artifacts = [
                 {"id": x["id"], "name": x["name"], "url": x["archive_download_url"]}
                 for x in response_json["artifacts"]
-                if x["name"].startswith("tests videos")
+                if x["name"].startswith("html-report-attempt")
             ]
             return artifacts
         except Exception as error:
@@ -190,10 +190,15 @@ class Runner:
         for index, artifact_item in enumerate(artifacts_list):
             print(f'  {index: <4}| {artifact_item["id"]} | {artifact_item["name"]}')
 
-    def get_index(self):
+    def get_index(self, record_count_from_server):
         """
-        Ask the user for input, default to 0, the first option in the list
+        Ask the user for input, default to 0, the first option in the list. If
+        there is only a single result from the source list return index 0
+        without prompting the user
         """
+        if record_count_from_server == 1:
+            return 0
+
         inputValue = input("\nEnter Index (default=0): ")
         inputIndex = int(inputValue) if inputValue.isdigit() else None
 
@@ -223,14 +228,15 @@ class Runner:
         Run the application core
         """
         branch_name = self.get_branch_name()
-        print(f'Running on branch: {branch_name}')
+        print(f"Running on branch: {branch_name}")
 
         workflow_runs = self.github.get_failed_workflow_runs(branch_name)
 
         self.print_workflow_runs_table(workflow_runs)
 
         try:
-            inputIndex = self.get_index()
+            inputIndex = self.get_index(len(workflow_runs))
+
             artifacts_list = self.github.get_artifacts_list(workflow_runs[inputIndex])
             self.print_download_artifacts_table(artifacts_list)
         except IndexError:
@@ -238,7 +244,7 @@ class Runner:
             exit(1)
 
         try:
-            inputIndex = self.get_index()
+            inputIndex = self.get_index(len(artifacts_list))
             artifact_zip_file_path = self.github.download_artifact(artifacts_list[inputIndex], path)
             unzipped_artifact_path = self.unzip_artifact(artifact_zip_file_path, path)
         except IndexError:

--- a/browser-test/merge.config.ts
+++ b/browser-test/merge.config.ts
@@ -1,0 +1,4 @@
+export default {
+  testDir: 'e2e',
+  reporter: [['html', {open: 'never'}]],
+}

--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -31,8 +31,16 @@ export default defineConfig({
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'
   },
-  reporter: [
-    ['list', {printSteps: true}],
-    ['html', {open: 'never', outputFolder: 'tmp/html-output'}],
-  ],
+  reporter: process.env.CI
+    ? // CI
+      [
+        // Blob output used to stictch sharded tests into a single trace
+        ['blob'],
+        ['list', {printSteps: true}],
+      ]
+    : // Not CI
+      [
+        ['list', {printSteps: true}],
+        ['html', {open: 'never', outputFolder: 'tmp/html-output'}],
+      ],
 })

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -8,5 +8,5 @@
     "types": ["playwright", "node"],
     "sourceMap": true
   },
-  "include": [".", "../playwright.config.ts"]
+  "include": [".", "../playwright.config.ts", "../merge.config.ts"]
 }


### PR DESCRIPTION
### Description

This will have Playwright use the blob reporter in CI. Then a new GitHub action step will merge them into a single trace file.

Initial tests shows this may add a few minutes to the checks though. Not sure if I want to move forward with this at this time.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
