### PR TITLE
Migrate address tests to use fixtures

### DIFF
--- a/browser-test/src/applicant/questions/address.test.ts
+++ b/browser-test/src/applicant/questions/address.test.ts
@@ -8,14 +8,19 @@ import {
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
-import { Page } from '@playwright/test'
+import {Page} from '@playwright/test'
 
 test.describe('address applicant flow', () => {
   test.describe('single required address question', () => {
     const programName = 'Test program for single address'
 
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpProgramWithSingleAddressQuestion(page, adminQuestions, adminPrograms, programName)
+      await setUpProgramWithSingleAddressQuestion(
+        page,
+        adminQuestions,
+        adminPrograms,
+        programName,
+      )
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {
@@ -24,14 +29,20 @@ test.describe('address applicant flow', () => {
       await validateScreenshot(page, 'address')
     })
 
-    test('validate screenshot with errors', async ({page, applicantQuestions} ) => {
+    test('validate screenshot with errors', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'address-errors')
     })
 
-    test('does not show errors initially', async ({page, applicantQuestions}) => {
+    test('does not show errors initially', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -64,7 +75,10 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with empty address does not submit', async ({page, applicantQuestions}) => {
+    test('with empty address does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '')
       await applicantQuestions.clickNext()
@@ -79,7 +93,10 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeVisible()
     })
 
-    test('with invalid address does not submit', async ({page, applicantQuestions}) => {
+    test('with invalid address does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -138,7 +155,10 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with first invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '', 0)
       await applicantQuestions.answerAddressQuestion(
@@ -172,7 +192,10 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeHidden()
     })
 
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with second invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -206,7 +229,10 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeVisible()
     })
 
-    test('has no accessibility violations', async ({page, applicantQuestions} ) => {
+    test('has no accessibility violations', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -238,7 +264,9 @@ test.describe('address applicant flow', () => {
       await logout(page)
     })
 
-    test('with valid required address does submit', async ({applicantQuestions}) => {
+    test('with valid required address does submit', async ({
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -253,7 +281,10 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with invalid optional address does not submit', async ({page, applicantQuestions}) => {
+    test('with invalid optional address does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -323,10 +354,15 @@ test.describe('address applicant flow', () => {
 
       test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
-        await setUpProgramWithSingleAddressQuestion(page, adminQuestions, adminPrograms, programName)
+        await setUpProgramWithSingleAddressQuestion(
+          page,
+          adminQuestions,
+          adminPrograms,
+          programName,
+        )
       })
 
-      test('validate screenshot', async ({page, applicantQuestions} ) => {
+      test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
         await test.step('Screenshot without errors', async () => {
@@ -355,7 +391,8 @@ test.describe('address applicant flow', () => {
     page: Page,
     adminQuestions: AdminQuestions,
     adminPrograms: AdminPrograms,
-    programName: string) {
+    programName: string,
+  ) {
     await loginAsAdmin(page)
 
     await adminQuestions.addAddressQuestion({

--- a/browser-test/src/applicant/questions/address.test.ts
+++ b/browser-test/src/applicant/questions/address.test.ts
@@ -1,40 +1,37 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from '../../support/civiform_fixtures'
 import {
-  createTestContext,
+  AdminPrograms,
+  AdminQuestions,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
+import { Page } from '@playwright/test'
 
 test.describe('address applicant flow', () => {
-  const ctx = createTestContext(/* clearDb= */ false)
-
   test.describe('single required address question', () => {
     const programName = 'Test program for single address'
 
-    test.beforeAll(async () => {
-      await setUpProgramWithSingleAddressQuestion(programName)
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+      await setUpProgramWithSingleAddressQuestion(page, adminQuestions, adminPrograms, programName)
     })
 
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'address')
     })
 
-    test('validate screenshot with errors', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot with errors', async ({page, applicantQuestions} ) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'address-errors')
     })
 
-    test('does not show errors initially', async () => {
-      const {page, applicantQuestions} = ctx
+    test('does not show errors initially', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -53,8 +50,7 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeHidden()
     })
 
-    test('with valid address does submit', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid address does submit', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -68,8 +64,7 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with empty address does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with empty address does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '')
       await applicantQuestions.clickNext()
@@ -84,8 +79,7 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeVisible()
     })
 
-    test('with invalid address does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with invalid address does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -104,8 +98,7 @@ test.describe('address applicant flow', () => {
   test.describe('multiple address questions', () => {
     const programName = 'Test program for multiple addresses'
 
-    test.beforeAll(async () => {
-      const {page, adminPrograms, adminQuestions} = ctx
+    test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addAddressQuestion({
@@ -122,8 +115,7 @@ test.describe('address applicant flow', () => {
       await logout(page)
     })
 
-    test('with valid addresses does submit', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid addresses does submit', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -146,8 +138,7 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion('', '', '', '', '', 0)
       await applicantQuestions.answerAddressQuestion(
@@ -181,8 +172,7 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeHidden()
     })
 
-    test('with second invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -216,8 +206,7 @@ test.describe('address applicant flow', () => {
       await expect(error).toBeVisible()
     })
 
-    test('has no accessibility violations', async () => {
-      const {page, applicantQuestions} = ctx
+    test('has no accessibility violations', async ({page, applicantQuestions} ) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -228,8 +217,7 @@ test.describe('address applicant flow', () => {
   test.describe('optional address question', () => {
     const programName = 'Test program for optional address'
 
-    test.beforeAll(async () => {
-      const {page, adminPrograms, adminQuestions} = ctx
+    test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addAddressQuestion({
@@ -250,8 +238,7 @@ test.describe('address applicant flow', () => {
       await logout(page)
     })
 
-    test('with valid required address does submit', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid required address does submit', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -266,8 +253,7 @@ test.describe('address applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with invalid optional address does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with invalid optional address does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerAddressQuestion(
         '1234 St',
@@ -297,15 +283,13 @@ test.describe('address applicant flow', () => {
     })
 
     test.describe('with invalid required address', () => {
-      test.beforeEach(async () => {
-        const {applicantQuestions} = ctx
+      test.beforeEach(async ({applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerAddressQuestion('', '', '', '', '', 1)
         await applicantQuestions.clickNext()
       })
 
-      test('does not submit', async () => {
-        const {page} = ctx
+      test('does not submit', async ({page}) => {
         // Second question has errors.
         let error = page.locator('.cf-address-street-1-error >> nth=1')
         await expect(error).toBeVisible()
@@ -317,8 +301,7 @@ test.describe('address applicant flow', () => {
         await expect(error).toBeVisible()
       })
 
-      test('optional has no errors', async () => {
-        const {page} = ctx
+      test('optional has no errors', async ({page}) => {
         // First question has no errors.
         let error = page.locator('.cf-address-street-1-error >> nth=0')
         await expect(error).toBeHidden()
@@ -338,17 +321,12 @@ test.describe('address applicant flow', () => {
     () => {
       const programName = 'Test program for single address'
 
-      test.beforeAll(async () => {
-        await setUpProgramWithSingleAddressQuestion(programName)
-      })
-
-      test.beforeEach(async () => {
-        const {page} = ctx
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
+        await setUpProgramWithSingleAddressQuestion(page, adminQuestions, adminPrograms, programName)
       })
 
-      test('validate screenshot', async () => {
-        const {page, applicantQuestions} = ctx
+      test('validate screenshot', async ({page, applicantQuestions} ) => {
         await applicantQuestions.applyProgram(programName)
 
         await test.step('Screenshot without errors', async () => {
@@ -373,8 +351,11 @@ test.describe('address applicant flow', () => {
     },
   )
 
-  async function setUpProgramWithSingleAddressQuestion(programName: string) {
-    const {page, adminQuestions, adminPrograms} = ctx
+  async function setUpProgramWithSingleAddressQuestion(
+    page: Page,
+    adminQuestions: AdminQuestions,
+    adminPrograms: AdminPrograms,
+    programName: string) {
     await loginAsAdmin(page)
 
     await adminQuestions.addAddressQuestion({


### PR DESCRIPTION
### Description

Migrates address tests to use fixtures. This solves an issue where some teardown issues were occurring.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
