### PR TITLE
Fixing currency precision

### DIFF
--- a/server/app/services/applicant/Currency.java
+++ b/server/app/services/applicant/Currency.java
@@ -1,5 +1,6 @@
 package services.applicant;
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -45,9 +46,9 @@ public final class Currency {
       throw new IllegalArgumentException(String.format("Currency is misformatted: %s", currency));
     }
     try {
-      double dollars = NumberFormat.getNumberInstance(Locale.US).parse(currency).doubleValue();
-      Double cents = dollars * 100;
-      return new Currency(cents.longValue());
+      BigDecimal bigDollars = BigDecimal.valueOf(NumberFormat.getNumberInstance(Locale.US).parse(currency).doubleValue());
+      long cents = bigDollars.multiply(new BigDecimal(100)).longValue();
+      return new Currency(cents);
     } catch (ParseException e) {
       throw new IllegalArgumentException(
           String.format("Currency is misformatted: %s", currency), e);

--- a/server/app/services/applicant/Currency.java
+++ b/server/app/services/applicant/Currency.java
@@ -46,7 +46,9 @@ public final class Currency {
       throw new IllegalArgumentException(String.format("Currency is misformatted: %s", currency));
     }
     try {
-      BigDecimal bigDollars = BigDecimal.valueOf(NumberFormat.getNumberInstance(Locale.US).parse(currency).doubleValue());
+      BigDecimal bigDollars =
+          BigDecimal.valueOf(
+              NumberFormat.getNumberInstance(Locale.US).parse(currency).doubleValue());
       long cents = bigDollars.multiply(new BigDecimal(100)).longValue();
       return new Currency(cents);
     } catch (ParseException e) {

--- a/server/test/services/applicant/CurrencyTest.java
+++ b/server/test/services/applicant/CurrencyTest.java
@@ -28,7 +28,6 @@ public class CurrencyTest {
         new Object[] {TestData.create("12345", "12,345.00", 12345, "12345.00", 12345 * 100)},
 
         // With comma
-
         new Object[] {TestData.create("12,345", "12,345.00", 12345, "12345.00", 12345 * 100)},
 
         // With cents.

--- a/server/test/services/applicant/CurrencyTest.java
+++ b/server/test/services/applicant/CurrencyTest.java
@@ -32,6 +32,8 @@ public class CurrencyTest {
 
         // With cents.
         new Object[] {TestData.create("12345.67", "12,345.67", 12345.67, "12345.67", 1234567)},
+
+        // With cents to demonstrate fixing a floating point issue
         new Object[] {TestData.create("18500.01", "18,500.01", 18500.01, "18500.01", 1850001)},
 
         // With comma and cents.

--- a/server/test/services/applicant/CurrencyTest.java
+++ b/server/test/services/applicant/CurrencyTest.java
@@ -15,24 +15,28 @@ public class CurrencyTest {
 
   private static ImmutableList<Object[]> getTestData() {
     return ImmutableList.of(
-        // Zero dollars
-        new Object[] {TestData.create("0", "0.00", 0, "0.00", 0)}, // Zero
-        new Object[] {TestData.create("0.00", "0.00", 0, "0.00", 0)}, // Zero with cents
-        // Non zero Single dollars.
-        new Object[] {TestData.create("1", "1.00", 1, "1.00", 100)}, // Single dollars
-        new Object[] {TestData.create("0.40", "0.40", 0.40, "0.40", 40)}, // Only cents
-        new Object[] {TestData.create("1.23", "1.23", 1.23, "1.23", 123)},
-        // Large values
-        new Object[] {TestData.create("12345", "12,345.00", 12345, "12345.00", 12345 * 100)},
-        new Object[] {
-          TestData.create("12,345", "12,345.00", 12345, "12345.00", 12345 * 100)
-        }, // With comma
-        new Object[] {
-          TestData.create("12345.67", "12,345.67", 12345.67, "12345.67", 1234567)
-        }, // With cents.
-        new Object[] {
-          TestData.create("12,345.67", "12,345.67", 12345.67, "12345.67", 1234567)
-        }); // With comma and cents.
+      // Zero dollars
+      new Object[]{TestData.create("0", "0.00", 0, "0.00", 0)}, // Zero
+      new Object[]{TestData.create("0.00", "0.00", 0, "0.00", 0)}, // Zero with cents
+
+      // Non zero Single dollars.
+      new Object[]{TestData.create("1", "1.00", 1, "1.00", 100)}, // Single dollars
+      new Object[]{TestData.create("0.40", "0.40", 0.40, "0.40", 40)}, // Only cents
+      new Object[]{TestData.create("1.23", "1.23", 1.23, "1.23", 123)},
+
+      // Large values
+      new Object[]{TestData.create("12345", "12,345.00", 12345, "12345.00", 12345 * 100)},
+
+      // With comma
+
+      new Object[]{TestData.create("12,345", "12,345.00", 12345, "12345.00", 12345 * 100)},
+
+      // With cents.
+      new Object[]{TestData.create("12345.67", "12,345.67", 12345.67, "12345.67", 1234567)},
+      new Object[]{TestData.create("18500.01", "18,500.01", 18500.01, "18500.01", 1850001)},
+
+      // With comma and cents.
+      new Object[]{TestData.create("12,345.67", "12,345.67", 12345.67, "12345.67", 1234567)});
   }
 
   @Test

--- a/server/test/services/applicant/CurrencyTest.java
+++ b/server/test/services/applicant/CurrencyTest.java
@@ -15,28 +15,28 @@ public class CurrencyTest {
 
   private static ImmutableList<Object[]> getTestData() {
     return ImmutableList.of(
-      // Zero dollars
-      new Object[]{TestData.create("0", "0.00", 0, "0.00", 0)}, // Zero
-      new Object[]{TestData.create("0.00", "0.00", 0, "0.00", 0)}, // Zero with cents
+        // Zero dollars
+        new Object[] {TestData.create("0", "0.00", 0, "0.00", 0)}, // Zero
+        new Object[] {TestData.create("0.00", "0.00", 0, "0.00", 0)}, // Zero with cents
 
-      // Non zero Single dollars.
-      new Object[]{TestData.create("1", "1.00", 1, "1.00", 100)}, // Single dollars
-      new Object[]{TestData.create("0.40", "0.40", 0.40, "0.40", 40)}, // Only cents
-      new Object[]{TestData.create("1.23", "1.23", 1.23, "1.23", 123)},
+        // Non zero Single dollars.
+        new Object[] {TestData.create("1", "1.00", 1, "1.00", 100)}, // Single dollars
+        new Object[] {TestData.create("0.40", "0.40", 0.40, "0.40", 40)}, // Only cents
+        new Object[] {TestData.create("1.23", "1.23", 1.23, "1.23", 123)},
 
-      // Large values
-      new Object[]{TestData.create("12345", "12,345.00", 12345, "12345.00", 12345 * 100)},
+        // Large values
+        new Object[] {TestData.create("12345", "12,345.00", 12345, "12345.00", 12345 * 100)},
 
-      // With comma
+        // With comma
 
-      new Object[]{TestData.create("12,345", "12,345.00", 12345, "12345.00", 12345 * 100)},
+        new Object[] {TestData.create("12,345", "12,345.00", 12345, "12345.00", 12345 * 100)},
 
-      // With cents.
-      new Object[]{TestData.create("12345.67", "12,345.67", 12345.67, "12345.67", 1234567)},
-      new Object[]{TestData.create("18500.01", "18,500.01", 18500.01, "18500.01", 1850001)},
+        // With cents.
+        new Object[] {TestData.create("12345.67", "12,345.67", 12345.67, "12345.67", 1234567)},
+        new Object[] {TestData.create("18500.01", "18,500.01", 18500.01, "18500.01", 1850001)},
 
-      // With comma and cents.
-      new Object[]{TestData.create("12,345.67", "12,345.67", 12345.67, "12345.67", 1234567)});
+        // With comma and cents.
+        new Object[] {TestData.create("12,345.67", "12,345.67", 12345.67, "12345.67", 1234567)});
   }
 
   @Test


### PR DESCRIPTION
### Description

We store the currency value as a whole number. In some cases the multiplication by 100 was ending up with a floating point precision issue losing a cent value.

Example: 18000.01
Expected: 1800001
Actual: 1800000

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
