### PR TITLE
Include applicant bundle in north star

### DIFF
--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -6,10 +6,10 @@
   <link th:href="${tailwindStylesheet}" type="text/css" rel="stylesheet" />
   <link th:href="${uswdsStylesheet}" type="text/css" rel="stylesheet" />
   <script th:src="${uswdsJsInit}" type="text/javascript"></script>
-  <script th:src="${adminJsBundle}" type="text/javascript"></script>
 </head>
 
 <footer th:fragment="pageFooter">
+  <script th:src="${applicantJsBundle}" type="text/javascript"></script>
   <script th:src="${uswdsJsBundle}" type="text/javascript"></script>
 </footer>
 

--- a/server/app/views/applicant/NorthStarApplicantBaseView.java
+++ b/server/app/views/applicant/NorthStarApplicantBaseView.java
@@ -29,7 +29,7 @@ public abstract class NorthStarApplicantBaseView {
     ThymeleafModule.PlayThymeleafContext context = playThymeleafContextFactory.create(request);
     context.setVariable("tailwindStylesheet", assetsFinder.path("stylesheets/tailwind.css"));
     context.setVariable("uswdsStylesheet", assetsFinder.path("dist/uswds.min.css"));
-    context.setVariable("adminJsBundle", assetsFinder.path("dist/admin.bundle.js"));
+    context.setVariable("applicantJsBundle", assetsFinder.path("dist/applicant.bundle.js"));
     context.setVariable("uswdsJsInit", assetsFinder.path("javascripts/uswds/uswds-init.min.js"));
     context.setVariable("uswdsJsBundle", assetsFinder.path("dist/uswds.bundle.js"));
     return context;


### PR DESCRIPTION
### Description

We were mistakenly including the admin js bundle instead of the applicant bundle in North Star code. Also moves it to the footer to match non-north star implementation
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)