### PR TITLE
Remove extra test-output folder in artifacts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -136,7 +136,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tests videos (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
-          path: browser-test/tmp
+          path: |
+            browser-test/tmp/html-output/
+            browser-test/tmp/videos/
         if: failure()
       - name: Print logs on failure
         if: failure()

--- a/browser-test/src/pagination.test.ts
+++ b/browser-test/src/pagination.test.ts
@@ -16,7 +16,7 @@ test.describe('Pagination', () => {
     await waitForPageJsLoad(page)
 
     await tiDashboard.createMultipleClients('myname', 10)
-    const cardCount = await page.locator('.usa-card__containerTEMP').count()
+    const cardCount = await page.locator('.usa-card__container').count()
     expect(cardCount).toBe(10)
 
     // No 'Previous' button

--- a/browser-test/src/pagination.test.ts
+++ b/browser-test/src/pagination.test.ts
@@ -16,7 +16,7 @@ test.describe('Pagination', () => {
     await waitForPageJsLoad(page)
 
     await tiDashboard.createMultipleClients('myname', 10)
-    const cardCount = await page.locator('.usa-card__container').count()
+    const cardCount = await page.locator('.usa-card__containerTEMP').count()
     expect(cardCount).toBe(10)
 
     // No 'Previous' button


### PR DESCRIPTION
Current artifact containing Playwright trace and video files is also including the Playwright output working directory which is taking up space for no reason.

### Description

Please explain the changes you made here.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
