### PR TITLE
Fix 404 page string parametrization

### DIFF
--- a/server/app/views/errors/NotFound.java
+++ b/server/app/views/errors/NotFound.java
@@ -1,13 +1,14 @@
 package views.errors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.p;
+import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.span;
 
 import com.google.inject.Inject;
+import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.H1Tag;
 import play.i18n.Messages;
@@ -18,7 +19,7 @@ import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.LanguageSelector;
 import views.applicant.ApplicantLayout;
-import views.style.BaseStyles;
+import views.components.LinkElement;
 import views.style.ErrorStyles;
 
 /**
@@ -47,11 +48,21 @@ public final class NotFound extends BaseHtmlView {
   }
 
   private DivTag descriptionContent(Messages messages) {
-    return div(p(
-                span(messages.at(MessageKey.ERROR_NOT_FOUND_DESCRIPTION.getKeyName())),
-                a(messages.at(MessageKey.ERROR_NOT_FOUND_DESCRIPTION_LINK.getKeyName()))
-                    .withHref("/")
-                    .withClasses(BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT))
+    ATag homepageLink =
+        new LinkElement()
+            .setStyles("underline")
+            .setText(messages.at(MessageKey.ERROR_NOT_FOUND_DESCRIPTION_LINK.getKeyName()))
+            .setHref("/")
+            .opensInNewTab()
+            .asAnchorText()
+            .attr(
+                "aria-label",
+                messages.at(MessageKey.ERROR_NOT_FOUND_DESCRIPTION_LINK.getKeyName()));
+
+    return div(p(span(
+                rawHtml(
+                    messages.at(
+                        MessageKey.ERROR_NOT_FOUND_DESCRIPTION.getKeyName(), homepageLink))))
             .withClasses(ErrorStyles.P_MOBILE_INLINE))
         .withClasses(ErrorStyles.P_DESCRIPTION);
   }


### PR DESCRIPTION
### Description

Fix 404 page string parametrization

It wasn't inserting the link into the string, now it is:
Before:
![image](https://github.com/civiform/civiform/assets/1295824/e79512a2-92f3-4656-9fa9-c80634e5a0c0)

Now:
![image](https://github.com/civiform/civiform/assets/1295824/1ab1c011-68c4-495d-a3dd-7d6ff6e61c3a)


## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [n/a] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #7077
