### PR TITLE
Add port to devcontainer for bin/dev-psql

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -91,5 +91,5 @@
   "onCreateCommand": "bin/vscode-setup",
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [9000,5432]
+  "forwardPorts": [9000, 5432]
 }


### PR DESCRIPTION
### Description

Adding the database port makes bin/dev-psql work in github codespaces

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Instructions for manual testing

Create a devcontainer in this branch and then run bin/dev-psql and see it work. Without this change it gives an error.

### Issue(s) this completes

#6999
