### PR TITLE
Migrating more browser tests to use fixtures

### DIFF
--- a/browser-test/src/admin/admin_publish.test.ts
+++ b/browser-test/src/admin/admin_publish.test.ts
@@ -1,138 +1,150 @@
-import {test, expect} from '@playwright/test'
-import {
-  AdminPrograms,
-  AdminQuestions,
-  dismissModal,
-  dropTables,
-  gotoEndpoint,
-  loginAsAdmin,
-  startSession,
-  validateScreenshot,
-  createTestContext,
-} from '../support'
-import {Page} from 'playwright'
+import {test, expect} from '../support/civiform_fixtures'
+import {loginAsAdmin, validateScreenshot} from '../support'
 import {ProgramVisibility} from '../support/admin_programs'
 
-test.describe('publishing all draft questions and programs', () => {
-  const ctx = createTestContext()
-  let pageObject: Page
-  let adminPrograms: AdminPrograms
-  let adminQuestions: AdminQuestions
+test.describe(
+  'publishing all draft questions and programs',
+  {tag: ['@uses-fixtures']},
+  () => {
+    const hiddenProgramNoQuestions = 'Public test program hidden no questions'
+    const visibleProgramWithQuestion =
+      'Public test program visible with question'
+    const questionName = 'publish-test-address-q'
+    const questionText = 'publish-test-address-q'
+    // CreateNewVersion implicitly updates the question text to be suffixed with " new version".
+    const draftQuestionText = `${questionText} new version`
 
-  const hiddenProgramNoQuestions = 'Public test program hidden no questions'
-  const visibleProgramWithQuestion = 'Public test program visible with question'
-  const questionName = 'publish-test-address-q'
-  const questionText = 'publish-test-address-q'
-  // CreateNewVersion implicitly updates the question text to be suffixed with " new version".
-  const draftQuestionText = `${questionText} new version`
+    test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
+      // beforeAll
+      await loginAsAdmin(page)
 
-  test.beforeAll(async () => {
-    const session = await startSession()
-    pageObject = session.page
+      // Create a hidden program with no questions
+      await adminPrograms.addProgram(
+        hiddenProgramNoQuestions,
+        'program description',
+        'https://usa.gov',
+        ProgramVisibility.HIDDEN,
+      )
 
-    await dropTables(pageObject)
-    await gotoEndpoint(pageObject)
+      // Create a new question referenced by a program.
+      await adminQuestions.addAddressQuestion({questionName, questionText})
+      await adminPrograms.addProgram(visibleProgramWithQuestion)
+      await adminPrograms.editProgramBlock(
+        visibleProgramWithQuestion,
+        'dummy description',
+        [questionName],
+      )
 
-    adminPrograms = new AdminPrograms(pageObject)
-    adminQuestions = new AdminQuestions(pageObject)
+      // Publish.
+      await adminPrograms.publishAllDrafts()
 
-    await loginAsAdmin(pageObject)
+      // Make an edit to the program with no questions.
+      await adminPrograms.createNewVersion(hiddenProgramNoQuestions)
 
-    // Create a hidden program with no questions
-    await adminPrograms.addProgram(
-      hiddenProgramNoQuestions,
-      'program description',
-      'https://usa.gov',
-      ProgramVisibility.HIDDEN,
-    )
+      // Make an edit to the shared question.
+      await adminQuestions.createNewVersion(questionName)
 
-    // Create a new question referenced by a program.
-    await adminQuestions.addAddressQuestion({questionName, questionText})
-    await adminPrograms.addProgram(visibleProgramWithQuestion)
-    await adminPrograms.editProgramBlock(
-      visibleProgramWithQuestion,
-      'dummy description',
-      [questionName],
-    )
-
-    // Publish.
-    await adminPrograms.publishAllDrafts()
-
-    // Make an edit to the program with no questions.
-    await adminPrograms.createNewVersion(hiddenProgramNoQuestions)
-
-    // Make an edit to the shared question.
-    await adminQuestions.createNewVersion(questionName)
-
-    await adminPrograms.gotoAdminProgramsPage()
-  })
-
-  test('shows programs and questions that will be published in the modal', async () => {
-    await adminPrograms.expectProgramReferencesModalContains({
-      expectedQuestionsContents: [`${draftQuestionText} - Edit`],
-      expectedProgramsContents: [
-        `${hiddenProgramNoQuestions} (Hidden from applicants) Edit`,
-        `${visibleProgramWithQuestion} (Publicly visible) Edit`,
-      ],
+      await adminPrograms.gotoAdminProgramsPage()
+      // beforeEach
     })
-  })
 
-  test('validate screenshot', async () => {
-    await adminPrograms.openPublishAllDraftsModal()
-    await validateScreenshot(
-      adminPrograms.publishAllProgramsModalLocator(),
-      'publish-modal',
-    )
-    await dismissModal(pageObject)
-  })
+    test('shows programs and questions that will be published in the modal', async ({
+      adminPrograms,
+    }) => {
+      await adminPrograms.expectProgramReferencesModalContains({
+        expectedQuestionsContents: [`${draftQuestionText} - Edit`],
+        expectedProgramsContents: [
+          `${hiddenProgramNoQuestions} (Hidden from applicants) Edit`,
+          `${visibleProgramWithQuestion} (Publicly visible) Edit`,
+        ],
+      })
+    })
 
-  test('publishing all programs with universal questions feature flag on shows a modal with information about universal questions', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
-    await loginAsAdmin(page)
-    // Create programs and questions (including universal questions)
-    const programOne = 'program one'
-    await adminPrograms.addProgram(programOne)
-    const programTwo = 'program two'
-    await adminPrograms.addProgram(programTwo)
-    const nameQuestion = 'name'
-    await adminQuestions.addNameQuestion({
-      questionName: nameQuestion,
-      universal: true,
+    test('validate screenshot', async ({adminPrograms}) => {
+      await adminPrograms.openPublishAllDraftsModal()
+      await validateScreenshot(
+        adminPrograms.publishAllProgramsModalLocator(),
+        'publish-modal',
+      )
     })
-    const textQuestion = 'text'
-    await adminQuestions.addTextQuestion({
-      questionName: textQuestion,
-      universal: true,
+  },
+)
+
+test.describe(
+  'publishing all programs with universal questions feature flag on',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test('shows a modal with information about universal questions', async ({
+      page,
+      adminPrograms,
+      adminQuestions,
+    }) => {
+      const programOne = 'program one'
+      const programTwo = 'program two'
+      const nameQuestion = 'name'
+      const textQuestion = 'text'
+      const addressQuestion = 'address'
+
+      await loginAsAdmin(page)
+
+      await test.step('Create programs', async () => {
+        await adminPrograms.addProgram(programOne)
+        await adminPrograms.addProgram(programTwo)
+      })
+
+      await test.step('Create questions', async () => {
+        await adminQuestions.addNameQuestion({
+          questionName: nameQuestion,
+          universal: true,
+        })
+
+        await adminQuestions.addTextQuestion({
+          questionName: textQuestion,
+          universal: true,
+        })
+
+        await adminQuestions.addAddressQuestion({
+          questionName: addressQuestion,
+          universal: false,
+        })
+      })
+
+      await test.step('Add questions to programs', async () => {
+        await adminPrograms.gotoEditDraftProgramPage(programOne)
+        await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
+        await adminPrograms.addQuestionFromQuestionBank(textQuestion)
+        await adminPrograms.gotoEditDraftProgramPage(programTwo)
+        await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
+        await adminPrograms.addQuestionFromQuestionBank(addressQuestion)
+      })
+
+      await test.step('Trigger the modal', async () => {
+        await adminPrograms.gotoAdminProgramsPage()
+        await page.click('#publish-all-programs-modal-button')
+
+        expect(await page.innerText('#publish-all-programs-modal')).toContain(
+          'program one (Publicly visible) - Contains all universal questions',
+        )
+
+        expect(await page.innerText('#publish-all-programs-modal')).toContain(
+          'program two (Publicly visible) - Contains 1 of 2 universal questions',
+        )
+
+        await validateScreenshot(page, 'publish-all-programs-modal-with-uq')
+      })
+
+      await test.step('Publish the programs', async () => {
+        await adminQuestions.clickSubmitButtonAndNavigate(
+          'Publish all draft programs and questions',
+        )
+      })
+
+      await test.step('Assert program data', async () => {
+        await adminPrograms.expectDoesNotHaveDraftProgram(programOne)
+        await adminPrograms.expectDoesNotHaveDraftProgram(programTwo)
+        await adminPrograms.expectActiveProgram(programOne)
+        await adminPrograms.expectActiveProgram(programTwo)
+      })
     })
-    const addressQuestion = 'address'
-    await adminQuestions.addAddressQuestion({
-      questionName: addressQuestion,
-      universal: false,
-    })
-    // Add questions to programs
-    await adminPrograms.gotoEditDraftProgramPage(programOne)
-    await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
-    await adminPrograms.addQuestionFromQuestionBank(textQuestion)
-    await adminPrograms.gotoEditDraftProgramPage(programTwo)
-    await adminPrograms.addQuestionFromQuestionBank(nameQuestion)
-    await adminPrograms.addQuestionFromQuestionBank(addressQuestion)
-    // Trigger the modal
-    await adminPrograms.gotoAdminProgramsPage()
-    await page.click('#publish-all-programs-modal-button')
-    expect(await page.innerText('#publish-all-programs-modal')).toContain(
-      'program one (Publicly visible) - Contains all universal questions',
-    )
-    expect(await page.innerText('#publish-all-programs-modal')).toContain(
-      'program two (Publicly visible) - Contains 1 of 2 universal questions',
-    )
-    await validateScreenshot(page, 'publish-all-programs-modal-with-uq')
-    // Publish the programs
-    await adminQuestions.clickSubmitButtonAndNavigate(
-      'Publish all draft programs and questions',
-    )
-    await adminPrograms.expectDoesNotHaveDraftProgram(programOne)
-    await adminPrograms.expectDoesNotHaveDraftProgram(programTwo)
-    await adminPrograms.expectActiveProgram(programOne)
-    await adminPrograms.expectActiveProgram(programTwo)
-  })
-})
+  },
+)

--- a/browser-test/src/admin/admin_question_references.test.ts
+++ b/browser-test/src/admin/admin_question_references.test.ts
@@ -1,84 +1,125 @@
-import {test} from '@playwright/test'
-import {createTestContext, loginAsAdmin, validateScreenshot} from '../support'
+import {test} from '../support/civiform_fixtures'
+import {loginAsAdmin, validateScreenshot} from '../support'
 
-test.describe('view program references from question view', () => {
-  const ctx = createTestContext()
-
-  test('shows no results for an unreferenced question', async () => {
-    const {page, adminQuestions} = ctx
-    await loginAsAdmin(page)
-    const questionName = 'unreferenced-q'
-    await adminQuestions.addAddressQuestion({questionName})
-    await adminQuestions.expectQuestionProgramReferencesText({
-      questionName,
-      expectedProgramReferencesText: 'Used in 0 programs',
-      version: 'draft',
-    })
-  })
-
-  test('shows results for referencing programs', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
-    const questionName = 'question-references-q'
-    await loginAsAdmin(page)
-    await adminQuestions.addAddressQuestion({questionName})
-
-    // Add a reference to the question in the second block. We'll later assert
-    // that the links in the modal takes us to the correct block.
-    const firstProgramName = 'First program'
-    await adminPrograms.addProgram(firstProgramName)
-    await adminPrograms.addProgramBlock(firstProgramName, 'first block', [])
-    await adminPrograms.addProgramBlock(firstProgramName, 'second block', [
-      questionName,
-    ])
-
-    const secondProgramName = 'Second program'
-    await adminPrograms.addProgram(secondProgramName)
-    await adminPrograms.addProgramBlock(secondProgramName, 'first block', [
-      questionName,
-    ])
-
-    await adminQuestions.gotoAdminQuestionsPage()
-    await adminQuestions.expectQuestionProgramReferencesText({
-      questionName,
-      expectedProgramReferencesText: 'Added to 2 programs.',
-      version: 'draft',
+test.describe(
+  'view program references from question view',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test('shows no results for an unreferenced question', async ({
+      page,
+      adminQuestions,
+    }) => {
+      await loginAsAdmin(page)
+      const questionName = 'unreferenced-q'
+      await adminQuestions.addAddressQuestion({questionName})
+      await adminQuestions.expectQuestionProgramReferencesText({
+        questionName,
+        expectedProgramReferencesText: 'Used in 0 programs',
+        version: 'draft',
+      })
     })
 
-    // Publish.
-    await adminPrograms.publishAllDrafts()
+    test('shows results for referencing programs', async ({
+      page,
+      adminQuestions,
+      adminPrograms,
+    }) => {
+      const firstProgramName = 'First program'
+      const secondProgramName = 'Second program'
+      const questionName = 'question-references-q'
 
-    // Add a reference from a new program in the draft version.
-    const thirdProgramName = 'Third program'
-    await adminPrograms.addProgram(thirdProgramName)
-    await adminPrograms.addProgramBlock(thirdProgramName, 'first block', [
-      questionName,
-    ])
+      await loginAsAdmin(page)
+      await adminQuestions.addAddressQuestion({questionName})
 
-    // Remove question from an existing published program.
-    await adminPrograms.createNewVersion(secondProgramName)
-    await adminPrograms.removeQuestionFromProgram(
-      secondProgramName,
-      'Screen 2',
-      [questionName],
-    )
+      await test.step(`Create two programs and add ${questionName}`, async () => {
+        // Add a reference to the question in the second block. We'll later assert
+        // that the links in the modal takes us to the correct block.
+        await adminPrograms.addProgram(firstProgramName)
+        await adminPrograms.addProgramBlockUsingSpec(
+          firstProgramName,
+          'first block',
+          [],
+        )
+        await adminPrograms.addProgramBlockUsingSpec(
+          firstProgramName,
+          'second block',
+          [
+            {
+              name: questionName,
+              isOptional: false,
+            },
+          ],
+        )
 
-    await adminQuestions.gotoAdminQuestionsPage()
-    await validateScreenshot(page, 'question-used-in-programs')
-    await adminQuestions.expectQuestionProgramReferencesText({
-      questionName,
-      expectedProgramReferencesText:
-        'Used in 1 program.\n\nAdded to 1 program.\n\nRemoved from 1 program.',
-      version: 'active',
+        await adminPrograms.addProgram(secondProgramName)
+        await adminPrograms.addProgramBlockUsingSpec(
+          secondProgramName,
+          'first block',
+          [
+            {
+              name: questionName,
+              isOptional: false,
+            },
+          ],
+        )
+      })
+
+      await test.step('Verify draft question and publish', async () => {
+        await adminQuestions.gotoAdminQuestionsPage()
+        await adminQuestions.expectQuestionProgramReferencesText({
+          questionName,
+          expectedProgramReferencesText: 'Added to 2 programs.',
+          version: 'draft',
+        })
+
+        await adminPrograms.publishAllDrafts()
+      })
+
+      await test.step('Add a reference from a new program in the draft version', async () => {
+        const thirdProgramName = 'Third program'
+        await adminPrograms.addProgram(thirdProgramName)
+        await adminPrograms.addProgramBlockUsingSpec(
+          thirdProgramName,
+          'first block',
+          [
+            {
+              name: questionName,
+              isOptional: false,
+            },
+          ],
+        )
+      })
+
+      await test.step('Remove question from an existing published program', async () => {
+        await adminPrograms.createNewVersion(secondProgramName)
+        await adminPrograms.removeQuestionFromProgram(
+          secondProgramName,
+          'Screen 2',
+          [questionName],
+        )
+      })
+
+      await test.step('Verify question and program', async () => {
+        await adminQuestions.gotoAdminQuestionsPage()
+        await validateScreenshot(page, 'question-used-in-programs')
+
+        await adminQuestions.expectQuestionProgramReferencesText({
+          questionName,
+          expectedProgramReferencesText:
+            'Used in 1 program.\n\nAdded to 1 program.\n\nRemoved from 1 program.',
+          version: 'active',
+        })
+
+        await adminQuestions.expectProgramReferencesModalContains({
+          questionName,
+          expectedUsedProgramReferences: ['first-program'],
+          expectedAddedProgramReferences: ['third-program'],
+          expectedRemovedProgramReferences: ['second-program'],
+        })
+
+        await adminQuestions.clickOnProgramReferencesModal(questionName)
+        await validateScreenshot(page, 'question-program-modal')
+      })
     })
-
-    await adminQuestions.expectProgramReferencesModalContains({
-      questionName,
-      expectedUsedProgramReferences: ['first-program'],
-      expectedAddedProgramReferences: ['third-program'],
-      expectedRemovedProgramReferences: ['second-program'],
-    })
-
-    await adminQuestions.clickOnProgramReferencesModal(questionName)
-    await validateScreenshot(page, 'question-program-modal')
-  })
-})
+  },
+)

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -1,64 +1,57 @@
-import {test} from '@playwright/test'
-import {
-  createTestContext,
-  loginAsAdmin,
-  validateScreenshot,
-  AdminSettings,
-} from '../support'
+import {test} from '../support/civiform_fixtures'
+import {loginAsAdmin, validateScreenshot} from '../support'
 
-test.describe('Managing system-wide settings', () => {
-  const ctx = createTestContext()
+test.describe(
+  'Managing system-wide settings',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test('Displays the settings page', async ({page, adminSettings}) => {
+      await loginAsAdmin(page)
 
-  test('Displays the settings page', async () => {
-    const {page} = ctx
-    await loginAsAdmin(page)
+      await test.step('Go to admin settings page and take screenshot', async () => {
+        await adminSettings.gotoAdminSettings()
+        await validateScreenshot(page, 'admin-settings-page')
+      })
 
-    const adminSettings = new AdminSettings(page)
-    await adminSettings.gotoAdminSettings()
+      await test.step('Jump to a specific section', async () => {
+        await page.click('a:has-text("Branding")')
+        await validateScreenshot(
+          page,
+          'admin-settings-page-scrolled',
+          /* fullPage= */ false,
+        )
+      })
 
-    await validateScreenshot(page, 'admin-settings-page')
+      await test.step('Set viewport to a narrow width and take screenshot', async () => {
+        // We know the header will start to wrap at smaller widths
+        await page.setViewportSize({
+          width: 768,
+          height: 720,
+        })
 
-    // Jump to a specfific section
-    await page.click('a:has-text("Branding")')
-    await validateScreenshot(
-      page,
-      'admin-settings-page-scrolled',
-      /* fullPage= */ false,
-    )
-  })
+        await page.reload()
 
-  test('Displays the settings page in a narrow viewport', async () => {
-    const {page} = ctx
-
-    // We know the header will start to wrap at smaller widths
-    await page.setViewportSize({
-      width: 768,
-      height: 720,
+        await validateScreenshot(page, 'admin-settings-page-narrow')
+      })
     })
 
-    await loginAsAdmin(page)
-    const adminSettings = new AdminSettings(page)
-    await adminSettings.gotoAdminSettings()
+    test('Updates settings on save', async ({page, adminSettings}) => {
+      await loginAsAdmin(page)
 
-    await validateScreenshot(page, 'admin-settings-page-narrow')
-  })
+      await adminSettings.gotoAdminSettings()
 
-  test('Updates settings on save', async () => {
-    const {page} = ctx
-    await loginAsAdmin(page)
+      await test.step('button check', async () => {
+        await adminSettings.disableSetting('CF_OPTIONAL_QUESTIONS')
+        await adminSettings.saveChanges()
+        await adminSettings.expectDisabled('CF_OPTIONAL_QUESTIONS')
 
-    const adminSettings = new AdminSettings(page)
-    await adminSettings.gotoAdminSettings()
+        await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
+        await adminSettings.saveChanges()
+        await adminSettings.expectEnabled('CF_OPTIONAL_QUESTIONS')
 
-    await adminSettings.disableSetting('CF_OPTIONAL_QUESTIONS')
-    await adminSettings.saveChanges()
-    await adminSettings.expectDisabled('CF_OPTIONAL_QUESTIONS')
-
-    await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
-    await adminSettings.saveChanges()
-    await adminSettings.expectEnabled('CF_OPTIONAL_QUESTIONS')
-
-    await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
-    await adminSettings.saveChanges(/* expectUpdated= */ false)
-  })
-})
+        await adminSettings.enableSetting('CF_OPTIONAL_QUESTIONS')
+        await adminSettings.saveChanges(/* expectUpdated= */ false)
+      })
+    })
+  },
+)

--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -1,25 +1,19 @@
-import {test, expect} from '@playwright/test'
-import {
-  createTestContext,
-  validateAccessibility,
-  validateScreenshot,
-} from '../support'
-import {Locator} from 'playwright'
+import {test, expect} from '../support/civiform_fixtures'
+import {validateAccessibility, validateScreenshot} from '../support'
 
-test.describe('developer tools', () => {
-  const ctx = createTestContext()
+test.describe('developer tools', {tag: ['@uses-fixtures']}, () => {
+  test('dev link exists', async ({page}) => {
+    const header = page.locator('nav')
 
-  test('link shown in the header', async () => {
-    const header: Locator = ctx.page.locator('nav')
-    await validateScreenshot(header, 'dev-tools-in-header')
+    await test.step('link shown in the header', async () => {
+      await expect(header.getByText('DevTools')).toBeInViewport()
+      await validateScreenshot(header, 'dev-tools-in-header')
+      await validateAccessibility(page)
+    })
 
-    expect(await ctx.page.textContent('nav')).toContain('DevTools')
-
-    await validateAccessibility(ctx.page)
-  })
-
-  test('modal appears on click', async () => {
-    await ctx.page.click('#debug-content-modal-button')
-    await validateScreenshot(ctx.page, 'dev-tools-modal')
+    await test.step('modal appears on click', async () => {
+      await header.getByText('DevTools').click()
+      await validateScreenshot(page, 'dev-tools-modal')
+    })
   })
 })

--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -7,7 +7,7 @@ import {
   validateScreenshot,
 } from './support'
 
-test.describe('navigating to a deep link', () => {
+test.describe('navigating to a deep link', {tag: ['@uses-fixtures']}, () => {
   const questionText = 'What is your address?'
 
   test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {

--- a/browser-test/src/support/civiform_fixtures.ts
+++ b/browser-test/src/support/civiform_fixtures.ts
@@ -1,6 +1,5 @@
 import {test as base} from '@playwright/test'
 import {
-  AdminApiKeys,
   AdminPrograms,
   AdminQuestions,
   AdminProgramStatuses,
@@ -12,7 +11,9 @@ import {
   TIDashboard,
   AdminTIGroups,
   waitForPageJsLoad,
+  AdminSettings,
 } from '.'
+import {AdminApiKeys} from './admin_api_keys'
 
 type CiviformFixtures = {
   adminApiKeys: AdminApiKeys
@@ -23,6 +24,7 @@ type CiviformFixtures = {
   adminPredicates: AdminPredicates
   adminTranslations: AdminTranslations
   adminProgramImage: AdminProgramImage
+  adminSettings: AdminSettings
   applicantFileQuestion: ApplicantFileQuestion
   tiDashboard: TIDashboard
   adminTiGroups: AdminTIGroups
@@ -59,6 +61,10 @@ export const test = base.extend<CiviformFixtures>({
 
   adminProgramImage: async ({page}, use) => {
     await use(new AdminProgramImage(page))
+  },
+
+  adminSettings: async ({page}, use) => {
+    await use(new AdminSettings(page))
   },
 
   applicantFileQuestion: async ({page}, use) => {

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -24,7 +24,6 @@ import {
 } from './config'
 import {AdminQuestions} from './admin_questions'
 import {AdminPrograms} from './admin_programs'
-import {AdminApiKeys} from './admin_api_keys'
 import {AdminProgramStatuses} from './admin_program_statuses'
 import {ApplicantFileQuestion} from './applicant_file_question'
 import {ApplicantQuestions} from './applicant_questions'
@@ -35,7 +34,6 @@ import {TIDashboard} from './ti_dashboard'
 import {AdminTIGroups} from './admin_ti_groups'
 import {BrowserErrorWatcher} from './browser_error_watcher'
 
-export {AdminApiKeys} from './admin_api_keys'
 export {AdminQuestions} from './admin_questions'
 export {AdminPredicates} from './admin_predicates'
 export {AdminPrograms} from './admin_programs'
@@ -155,7 +153,6 @@ export interface TestContext {
 
   adminQuestions: AdminQuestions
   adminPrograms: AdminPrograms
-  adminApiKeys: AdminApiKeys
   adminProgramStatuses: AdminProgramStatuses
   applicantFileQuestion: ApplicantFileQuestion
   applicantQuestions: ApplicantQuestions
@@ -258,7 +255,6 @@ export async function resetContext(ctx: TestContext) {
   ctx.page.setDefaultTimeout(8000)
   ctx.adminQuestions = new AdminQuestions(ctx.page)
   ctx.adminPrograms = new AdminPrograms(ctx.page)
-  ctx.adminApiKeys = new AdminApiKeys(ctx.page)
   ctx.adminProgramStatuses = new AdminProgramStatuses(ctx.page)
   ctx.applicantQuestions = new ApplicantQuestions(ctx.page)
   ctx.adminPredicates = new AdminPredicates(ctx.page)


### PR DESCRIPTION
### Description

Migrating more browser tests to use Playwright fixtures. Also removes obsolete references to `AdminApiKeys`.

Recommend you ignore whitespace when reviewing the diff

![image](https://github.com/civiform/civiform/assets/195162/fa0d063e-a979-447a-95fc-d2d59287548e)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
