### PR TITLE
Redirect to home page if unauthorized (except for API requests)

### DIFF
--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -5,9 +5,11 @@ test.describe(
   'applicant security',
   {tag: ['@uses-fixtures', '@parallel-candidate']},
   () => {
-    test('applicant cannot access admin pages', async ({page}) => {
-      const response = await page.goto('/admin/programs')
-      expect(response!.status()).toBe(403)
+    test('applicant cannot access admin pages', async ({request}) => {
+      const response = await request.get('/admin/programs')
+      await expect(response).toBeOK()
+      // Redirected to a non-admin page
+      expect(response.url()).not.toContain('/admin')
     })
 
     test('redirects to program index page when not logged in (guest)', async ({

--- a/server/test/auth/CiviFormHttpActionAdapterTest.java
+++ b/server/test/auth/CiviFormHttpActionAdapterTest.java
@@ -1,0 +1,61 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.test.Helpers.fakeRequest;
+
+import org.junit.Test;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.exception.http.StatusAction;
+import org.pac4j.play.PlayWebContext;
+import play.mvc.Result;
+
+public class CiviFormHttpActionAdapterTest {
+
+  // An UNAUTHORIZED response to an API route should remain UNAUTHORIZED.
+  @Test
+  public void testApiUnauthorizedAction() {
+    CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
+    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/api/v1/checkAuth").build());
+
+    Result result = adapter.adapt(new StatusAction(HttpConstants.UNAUTHORIZED), context);
+
+    assertThat(result.status()).isEqualTo(HttpConstants.UNAUTHORIZED);
+  }
+
+  // A FORBIDDEN response to a non-API route should redirect to the home page.
+  @Test
+  public void testNonApiForbiddenAction() {
+    CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
+    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/non-api").build());
+
+    Result result = adapter.adapt(new StatusAction(HttpConstants.FORBIDDEN), context);
+
+    assertThat(result.status()).isEqualTo(HttpConstants.SEE_OTHER);
+    assertThat(result.redirectLocation()).isNotEmpty();
+    assertThat(result.redirectLocation().get()).isEqualTo("/");
+  }
+
+  // An UNAUTHORIZED response to a non-API route should redirect to the home page.
+  @Test
+  public void testNonApiUnauthorizedAction() {
+    CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
+    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/non-api").build());
+
+    Result result = adapter.adapt(new StatusAction(HttpConstants.UNAUTHORIZED), context);
+
+    assertThat(result.status()).isEqualTo(HttpConstants.SEE_OTHER);
+    assertThat(result.redirectLocation()).isNotEmpty();
+    assertThat(result.redirectLocation().get()).isEqualTo("/");
+  }
+
+  // An OK response should just ... be OK.
+  @Test
+  public void testOkAction() {
+    CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
+    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/arbitrary").build());
+
+    Result result = adapter.adapt(new StatusAction(HttpConstants.OK), context);
+
+    assertThat(result.status()).isEqualTo(HttpConstants.OK);
+  }
+}


### PR DESCRIPTION
### Description

Redirect to home page if the request is not authorized.

This can be useful if (1) the server secret is rotated and (2) an admin user with an active session tries to access an admin page. Before this change, they would just be presented with a page with `403 Forbidden` and no hint about how to recover.

Note there is existing handling for API requests that is untouched.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Run a local instance of the server.
2. Authenticate as admin and load an admin page.
3. Modify `play.http.secret.key` in `server/conf/application.conf`.
4. Reload the admin page in the browser.
5. Verify that you are redirected to the home page.
6. Verify that the page says, "You're a guest user" in the top-right corner.

### Issue(s) this completes

Relates to #6197 