### PR TITLE
Forward oidc port and fix java version to 11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/java:1.4.1": {
       "version": "11",
-      "jdkDistro": "tem",
+      "jdkDistro": "tem", // Eclipse Adoptium Temurin per https://sdkman.io/jdks#tem See also: whichjdk.com
       "installMaven": "true",
       "installGradle": "false"
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,14 +16,14 @@
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/java:1.4.1": {
-			"version": "11",
-			"jdkDistro": "tem",
+      "version": "11",
+      "jdkDistro": "tem",
       "installMaven": "true",
       "installGradle": "false"
     },
     "ghcr.io/devcontainers-contrib/features/ant-sdkman:2": {
-			"jdkVersion": "11",
-			"jdkDistro": "tem"
+      "jdkVersion": "11",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,15 @@
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/java:1.4.1": {
-      "version": "none",
+			"version": "11",
+			"jdkDistro": "tem",
       "installMaven": "true",
       "installGradle": "false"
     },
-    "ghcr.io/devcontainers-contrib/features/ant-sdkman:2": {},
+    "ghcr.io/devcontainers-contrib/features/ant-sdkman:2": {
+			"jdkVersion": "11",
+			"jdkDistro": "tem"
+    },
     "ghcr.io/devcontainers/features/node:1": {}
   },
 
@@ -88,8 +92,8 @@
     }
   },
 
-  "onCreateCommand": "bin/vscode-setup",
+  "updateContentCommand": "bin/vscode-setup",
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [9000, 5432]
+  "forwardPorts": [9000, 5432, 3390]
 }


### PR DESCRIPTION
### Description

- Forward the port needed for oidc from the dev container
- Fix the java version to 11 to avoid issues with Play
- Change `onCreateCommand` to `updateContentCommand`, so it will re-run when pre-caching containers when the source tree updates ([details](https://containers.dev/implementors/json_reference/))

Part of #6999 
