### PR TITLE
Set retention days on artifacts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,6 +122,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: image diff output directory (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          retention-days: 3
           path: browser-test/diff_output
         if: failure()
 
@@ -129,6 +130,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: updated snapshots output directory (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          retention-days: 3
           path: browser-test/updated_snapshots
         if: failure()
 
@@ -136,10 +138,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tests videos (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          retention-days: 3
           path: |
             browser-test/tmp/html-output/
             browser-test/tmp/videos/
         if: failure()
+        
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs


### PR DESCRIPTION
### Description

Sets the retention of the PR artifacts to just 3 days down from the default of 90. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
