### PR TITLE
Better check for recording video

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   },
   use: {
     trace: 'on-first-retry',
-    video: process.env.RECORD_VIDEO ? 'on-first-retry' : 'off',
+    video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'
   },


### PR DESCRIPTION
### Description

The record video setting I had in the `playright.config.ts` was based on the presence of the `RECORD_VIDEO` environment variable. But it's possible we may use be passing in false in some places. This will handle both cases.
