### PR TITLE
Move launch configuration to a separate file within devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,32 +63,6 @@
         "vscode-icons-team.vscode-icons",
         "Graphite.gti-vscode"
       ]
-    },
-    "launch": {
-      "version": "0.2.0",
-      "configurations": [
-        {
-          "type": "java",
-          "name": "Attach to Civiform Browser Tests",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "9457"
-        },
-        {
-          "type": "java",
-          "name": "Attach to Civiform Unit Tests",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "8459"
-        },
-        {
-          "type": "java",
-          "name": "Attach to Civiform Dev",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "8457"
-        }
-      ]
     }
   },
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,6 @@
         "bradlc.vscode-tailwindcss",
         "dbaeumer.vscode-eslint",
         "github.vscode-pull-request-github",
-        "hashicorp.terraform",
         "ms-azuretools.vscode-docker",
         "ms-ossdata.vscode-postgresql",
         "ms-playwright.playwright",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,6 +50,7 @@
         "bradlc.vscode-tailwindcss",
         "dbaeumer.vscode-eslint",
         "github.vscode-pull-request-github",
+        "hashicorp.terraform",
         "ms-azuretools.vscode-docker",
         "ms-ossdata.vscode-postgresql",
         "ms-playwright.playwright",

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,27 +1,27 @@
 {
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-          "type": "java",
-          "name": "Attach to Civiform Browser Tests",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "9457"
-        },
-        {
-          "type": "java",
-          "name": "Attach to Civiform Unit Tests",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "8459"
-        },
-        {
-          "type": "java",
-          "name": "Attach to Civiform Dev",
-          "request": "attach",
-          "hostName": "localhost",
-          "port": "8457"
-        }
-      ]
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Attach to Civiform Browser Tests",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": "9457"
+    },
+    {
+      "type": "java",
+      "name": "Attach to Civiform Unit Tests",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": "8459"
+    },
+    {
+      "type": "java",
+      "name": "Attach to Civiform Dev",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": "8457"
+    }
+  ]
 }

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,5 +1,5 @@
 {
-    # For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,7 +1,5 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    # For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+          "type": "java",
+          "name": "Attach to Civiform Browser Tests",
+          "request": "attach",
+          "hostName": "localhost",
+          "port": "9457"
+        },
+        {
+          "type": "java",
+          "name": "Attach to Civiform Unit Tests",
+          "request": "attach",
+          "hostName": "localhost",
+          "port": "8459"
+        },
+        {
+          "type": "java",
+          "name": "Attach to Civiform Dev",
+          "request": "attach",
+          "hostName": "localhost",
+          "port": "8457"
+        }
+      ]
+}


### PR DESCRIPTION
### Description

It didn't seem the "launch" section was doing anything in the devcontainer, but moving this over into launch.json allows the settings for the debug panel to work for any codespace
<img width="323" alt="Screenshot 2024-04-04 at 3 54 27 PM" src="https://github.com/civiform/civiform/assets/86739416/f13fc3a4-ef6c-4d99-9b64-b0d16ca964cd">


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6999