### PR TITLE
Remove PROGRAM_CARD_IMAGES flag

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -284,9 +284,8 @@ public final class AdminProgramController extends CiviFormController {
   /** Returns where admins should be taken to after saving program detail edits. */
   private Result getSaveProgramDetailsRedirect(
       long programId, ProgramEditStatus programEditStatus) {
-    if (settingsManifest.getProgramCardImages()
-        && (programEditStatus == ProgramEditStatus.CREATION
-            || programEditStatus == ProgramEditStatus.CREATION_EDIT)) {
+    if (programEditStatus == ProgramEditStatus.CREATION
+        || programEditStatus == ProgramEditStatus.CREATION_EDIT) {
       // While creating a new program, we want to direct admins to also add a program image.
       return redirect(
           routes.AdminProgramImageController.index(programId, programEditStatus.name()).url());

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -898,14 +898,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * Enables images on program cards, both for admins to upload them and for applicants to view
-   * them.
-   */
-  public boolean getProgramCardImages() {
-    return getBool("PROGRAM_CARD_IMAGES");
-  }
-
-  /**
    * Add programs cards to the confirmation screen that an applicant sees after finishing an
    * application.
    */
@@ -1895,13 +1887,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
-                  SettingDescription.create(
-                      "PROGRAM_CARD_IMAGES",
-                      "Enables images on program cards, both for admins to upload them and for"
-                          + " applicants to view them.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
-                      SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE",
                       "Add programs cards to the confirmation screen that an applicant sees after"

--- a/server/app/views/ProgramImageUtils.java
+++ b/server/app/views/ProgramImageUtils.java
@@ -10,20 +10,15 @@ import java.util.Optional;
 import services.cloud.PublicFileNameFormatter;
 import services.cloud.PublicStorageClient;
 import services.program.ProgramDefinition;
-import services.settings.SettingsManifest;
 import views.style.StyleUtils;
 
 /** Utility class for rendering program images. */
 public final class ProgramImageUtils {
   private final PublicStorageClient publicStorageClient;
 
-  private final SettingsManifest settingsManifest;
-
   @Inject
-  public ProgramImageUtils(
-      PublicStorageClient publicStorageClient, SettingsManifest settingsManifest) {
+  public ProgramImageUtils(PublicStorageClient publicStorageClient) {
     this.publicStorageClient = checkNotNull(publicStorageClient);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   /**
@@ -35,9 +30,6 @@ public final class ProgramImageUtils {
    */
   public Optional<ImgTag> createProgramImage(
       ProgramDefinition program, Locale preferredLocale, boolean isWithinProgramCard) {
-    if (!settingsManifest.getProgramCardImages()) {
-      return Optional.empty();
-    }
     if (program.summaryImageFileKey().isEmpty()) {
       return Optional.empty();
     }

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -157,9 +157,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
             .anyMatch(BlockDefinition::hasNullQuestion);
 
     ArrayList<ProgramHeaderButton> headerButtons =
-        new ArrayList<>(
-            getEditHeaderButtons(
-                settingsManifest, /* isEditingAllowed= */ viewAllowsEditingProgram()));
+        new ArrayList<>(getEditHeaderButtons(/* isEditingAllowed= */ viewAllowsEditingProgram()));
     headerButtons.add(ProgramHeaderButton.PREVIEW_AS_APPLICANT);
     headerButtons.add(ProgramHeaderButton.DOWNLOAD_PDF_PREVIEW);
 
@@ -237,8 +235,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
    * @param isEditingAllowed true if the view allows editing and false otherwise. (Typically, a view
    *     only allows editing if a program is in draft mode.)
    */
-  private ImmutableList<ProgramHeaderButton> getEditHeaderButtons(
-      SettingsManifest settingsManifest, boolean isEditingAllowed) {
+  private ImmutableList<ProgramHeaderButton> getEditHeaderButtons(boolean isEditingAllowed) {
     if (isEditingAllowed) {
       return ImmutableList.of(
           ProgramHeaderButton.EDIT_PROGRAM_DETAILS, ProgramHeaderButton.EDIT_PROGRAM_IMAGE);

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -240,12 +240,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
   private ImmutableList<ProgramHeaderButton> getEditHeaderButtons(
       SettingsManifest settingsManifest, boolean isEditingAllowed) {
     if (isEditingAllowed) {
-      if (settingsManifest.getProgramCardImages()) {
-        return ImmutableList.of(
-            ProgramHeaderButton.EDIT_PROGRAM_DETAILS, ProgramHeaderButton.EDIT_PROGRAM_IMAGE);
-      } else {
-        return ImmutableList.of(ProgramHeaderButton.EDIT_PROGRAM_DETAILS);
-      }
+      return ImmutableList.of(
+          ProgramHeaderButton.EDIT_PROGRAM_DETAILS, ProgramHeaderButton.EDIT_PROGRAM_IMAGE);
     } else {
       return ImmutableList.of(ProgramHeaderButton.EDIT_PROGRAM);
     }

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -372,9 +372,8 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
 
   private ButtonTag createSubmitButton(ProgramEditStatus programEditStatus) {
     String saveProgramDetailsText;
-    if (settingsManifest.getProgramCardImages()
-        && (programEditStatus == ProgramEditStatus.CREATION
-            || programEditStatus == ProgramEditStatus.CREATION_EDIT)) {
+    if (programEditStatus == ProgramEditStatus.CREATION
+        || programEditStatus == ProgramEditStatus.CREATION_EDIT) {
       // If the admin is in the middle of creating a new program, they'll be redirected to the next
       // step of adding a program image, so we want the save button text to reflect that.
       saveProgramDetailsText = "Save and continue to next step";

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -206,10 +206,6 @@ public final class ProgramCardFactory {
   }
 
   private DivTag createImageIcon(ProgramDefinition program, Optional<CiviFormProfile> profile) {
-    if (!settingsManifest.getProgramCardImages()) {
-      // If the program card images feature isn't enabled, don't make any changes to the admin page.
-      return div();
-    }
     boolean isCiviFormAdmin = profile.isPresent() && profile.get().isCiviFormAdmin();
     if (!isCiviFormAdmin) {
       // Only CiviForm admins need the program image preview since they're the only ones that can

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -44,5 +44,4 @@ intake_form_enabled = false
 api_generated_docs_enabled = true
 application_exportable = true
 primary_applicant_info_questions_enabled = true
-program_card_images = true
 save_on_all_actions = true

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -753,11 +753,6 @@
         "description": "Enables setting a universal question as a question representing information about the applicant. The system can then take certain actions based on the answer to this question.",
         "type": "bool"
       },
-      "PROGRAM_CARD_IMAGES": {
-        "mode": "ADMIN_READABLE",
-        "description": "Enables images on program cards, both for admins to upload them and for applicants to view them.",
-        "type": "bool"
-      },
       "SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE": {
         "mode": "ADMIN_WRITEABLE",
         "description": "Add programs cards to the confirmation screen that an applicant sees after finishing an application.",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -53,10 +53,6 @@ application_exportable = ${?APPLICATION_EXPORTABLE}
 primary_applicant_info_questions_enabled = false
 primary_applicant_info_questions_enabled = ${?PRIMARY_APPLICANT_INFO_QUESTIONS_ENABLED}
 
-# Program card images
-program_card_images = true
-program_card_images = ${?PROGRAM_CARD_IMAGES}
-
 # Upsell programs
 suggest_programs_on_application_confirmation_page = false
 suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE}

--- a/server/test/views/ProgramImageUtilsTest.java
+++ b/server/test/views/ProgramImageUtilsTest.java
@@ -1,49 +1,21 @@
 package views;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 import j2html.tags.specialized.ImgTag;
 import java.util.Locale;
 import java.util.Optional;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.cloud.PublicStorageClient;
 import services.program.ProgramDefinition;
-import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 import support.cloud.FakePublicStorageClient;
 
 public class ProgramImageUtilsTest extends ResetPostgres {
   private final PublicStorageClient publicStorageClient = new FakePublicStorageClient();
-  private final SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-  private final ProgramImageUtils programImageUtils =
-      new ProgramImageUtils(publicStorageClient, mockSettingsManifest);
-
-  @Before
-  public void setUp() {
-    when(mockSettingsManifest.getProgramCardImages()).thenReturn(true);
-  }
-
-  @Test
-  public void createProgramImage_featureNotEnabled_returnsEmpty() {
-    when(mockSettingsManifest.getProgramCardImages()).thenReturn(false);
-
-    ProgramDefinition program =
-        ProgramBuilder.newDraftProgram("Test Program Name")
-            .setSummaryImageFileKey(Optional.of("program-summary-image/program-10/myFile.jpg"))
-            .build()
-            .getProgramDefinition();
-
-    Optional<ImgTag> result =
-        programImageUtils.createProgramImage(
-            program, Locale.getDefault(), /* isWithinProgramCard= */ true);
-
-    assertThat(result).isEmpty();
-  }
+  private final ProgramImageUtils programImageUtils = new ProgramImageUtils(publicStorageClient);
 
   @Test
   public void createProgramImage_noImageFileKey_returnsEmpty() {


### PR DESCRIPTION
### Description

The PROGRAM_CARD_IMAGES flag has been enabled in production for a month with no issues, so we can remove it! 🎉 

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Fixes #5919