### PR TITLE
Removing version from docker compose files

### DIFF
--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -1,6 +1,5 @@
 # Builds on browser-test-compose.yml
 # Mount code for hot reloading and cache for faster compile in dev mode.
-version: '3.4'
 services:
   civiform:
     volumes:

--- a/browser-test/browser-test-compose.dev_local.yml
+++ b/browser-test/browser-test-compose.dev_local.yml
@@ -1,6 +1,5 @@
 # Builds on browser-test-compose.dev.yml
 # Expose port 3390 for OIDC container. May conflict with other stacks.
-version: '3.4'
 services:
   dev-oidc:
     ports:

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -1,6 +1,4 @@
 # Builds on docker-compose.yml
-version: '3.4'
-
 services:
   # Load custom postgres config that disables durability for performance
   # Not for use in a production environment

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,5 @@
 # Builds on docker-compose.yml
 # Mount code for hot reloading and cache for faster compile in dev mode.
-version: '3.4'
 
 # Shared yaml extensions (https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields)
 # Volume mapping shared between containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 # Use postgres/example user/password credentials
-version: '3.4'
-
 services:
   localstack:
     image: localstack/localstack:3.3.0

--- a/test-support/prod-simulator-compose.yml
+++ b/test-support/prod-simulator-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:12.18


### PR DESCRIPTION
### Description

The Version property in docker compose files has been optional for a while and now generates warnings when running. 

[Compose spec says](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md) it's only been used for informational purposes anyway.


```shell
docker compose version
Docker Compose version v2.25.0

docker --version
Docker version 26.0.0, build 2ae903e
```

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
