### PR TITLE
Change ESRI findAddressCandidiates url to a list or urls

### DIFF
--- a/server/app/modules/EsriModule.java
+++ b/server/app/modules/EsriModule.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.AbstractModule;
 import com.typesafe.config.Config;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Environment;
@@ -31,8 +30,10 @@ public final class EsriModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    List<String> urls = config.getStringList("esri_find_address_candidates_url");
-    String className = urls.isEmpty() ? FAKE_ESRI_CLIENT_CLASS_NAME : REAL_ESRI_CLIENT_CLASS_NAME;
+    String className =
+        config.getStringList("esri_find_address_candidates_url").isEmpty()
+            ? FAKE_ESRI_CLIENT_CLASS_NAME
+            : REAL_ESRI_CLIENT_CLASS_NAME;
 
     LOGGER.info(String.format("Using %s class for Esri client", className));
 

--- a/server/app/modules/EsriModule.java
+++ b/server/app/modules/EsriModule.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.AbstractModule;
 import com.typesafe.config.Config;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Environment;
@@ -30,8 +31,8 @@ public final class EsriModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    String url = config.getString("esri_find_address_candidates_url");
-    String className = url.isEmpty() ? FAKE_ESRI_CLIENT_CLASS_NAME : REAL_ESRI_CLIENT_CLASS_NAME;
+    List<String> urls = config.getStringList("esri_find_address_candidates_url");
+    String className = urls.isEmpty() ? FAKE_ESRI_CLIENT_CLASS_NAME : REAL_ESRI_CLIENT_CLASS_NAME;
 
     LOGGER.info(String.format("Using %s class for Esri client", className));
 

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -3,14 +3,17 @@ package services.geo.esri;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.prometheus.client.Counter;
 import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.StreamSupport;
 import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +41,9 @@ import services.settings.SettingsManifest;
 public final class RealEsriClient extends EsriClient implements WSBodyReadables, WSBodyWritables {
   private final WSClient ws;
 
+  private static final String CANDIDATES_NODE_NAME = "candidates";
+  private static final String SCORE_NODE_NAME = "score";
+
   private static final Counter ESRI_REQUEST_C0UNT =
       Counter.build()
           .name("esri_requests_total")
@@ -52,8 +58,14 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
   // The service supports responses in JSON or PJSON format. You can specify the response format
   // using the f parameter. This is a required parameter
   private static final String ESRI_RESPONSE_FORMAT = "json";
+  @VisibleForTesting ImmutableList<String> ESRI_FIND_ADDRESS_CANDIDATES_URLS;
 
-  @VisibleForTesting Optional<String> ESRI_FIND_ADDRESS_CANDIDATES_URL;
+  /**
+   * The lowest score value or of 100 that will preempt loading data from another endpoint. Anything
+   * below this will continue to gather data from the next available endpoint.
+   */
+  private static final double SCORE_THRESHOLD = 90.0;
+
   private int ESRI_EXTERNAL_CALL_TRIES;
   private final Optional<Integer> ESRI_WELLKNOWN_ID_OVERRIDE;
 
@@ -69,7 +81,8 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
     checkNotNull(settingsManifest);
     this.ws = checkNotNull(ws);
 
-    this.ESRI_FIND_ADDRESS_CANDIDATES_URL = settingsManifest.getEsriFindAddressCandidatesUrl();
+    this.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
+        settingsManifest.getEsriFindAddressCandidatesUrl().orElse(ImmutableList.of());
     this.ESRI_EXTERNAL_CALL_TRIES = settingsManifest.getEsriExternalCallTries().orElse(3);
     this.ESRI_WELLKNOWN_ID_OVERRIDE = settingsManifest.getEsriWellknownIdOverride();
   }
@@ -99,23 +112,119 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
   @Override
   @VisibleForTesting
   CompletionStage<Optional<JsonNode>> fetchAddressSuggestions(ObjectNode addressJson) {
-    if (this.ESRI_FIND_ADDRESS_CANDIDATES_URL.isEmpty()) {
+    // Check if the URL list is empty
+    if (ESRI_FIND_ADDRESS_CANDIDATES_URLS.isEmpty()) {
       return CompletableFuture.completedFuture(Optional.empty());
     }
-    WSRequest request = ws.url(this.ESRI_FIND_ADDRESS_CANDIDATES_URL.get());
+
+    var result =
+        processAddressSuggestionUrlsSequentially(
+            addressJson, ESRI_FIND_ADDRESS_CANDIDATES_URLS, Optional.empty());
+    return result;
+  }
+
+  /**
+   * Recursive method to get address correction data from one or more findAddressCandidates
+   * endpoints. This will stop when there are no urls in the list to process or we end early because
+   * we have results that are greater than the scoring threashold.
+   *
+   * @param addressJson Uncorrected address
+   * @param urls A list of urls that will be processed in order; may stop early if surpassing score
+   *     threshold. The first url in the list will be fetched. Recursive calls will always send in
+   *     all elements except the first one. Processing ends when there are no urls in the list.
+   * @param optionalPreviousRootNode The response from the previous findAddressCandidates call, if
+   *     any
+   * @return The CompletionStage for result of findAddressCandidates, if any. The `candidates` array
+   *     will be the merged results of multiple endpoints if more than one is called.
+   */
+  private CompletionStage<Optional<JsonNode>> processAddressSuggestionUrlsSequentially(
+      ObjectNode addressJson,
+      ImmutableList<String> urls,
+      Optional<JsonNode> optionalPreviousRootNode) {
+    // Base case: All URLs processed or no valid URLs left
+    if (urls.isEmpty()) {
+      return CompletableFuture.completedFuture(optionalPreviousRootNode);
+    }
+
+    // Urls will have at least one item in the list at this point
+    var request = createWebRequest(urls.stream().findFirst().get(), addressJson);
+
+    // Perform the request and handle response
+    return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)
+        .thenCompose(
+            response -> {
+              ESRI_REQUEST_C0UNT.labels(String.valueOf(response.getStatus())).inc();
+              // Skip the first url which we've just called, send the rest to the next recursive
+              // call
+              var nextSetOfUrls = urls.stream().skip(1).collect(ImmutableList.toImmutableList());
+
+              if (response.getStatus() != 200) {
+                // If request fails, proceed to the next URL
+                return processAddressSuggestionUrlsSequentially(
+                    addressJson, nextSetOfUrls, Optional.empty());
+              } else {
+                // Process the successful response
+                JsonNode rootNode = response.asJson();
+
+                // If we have data from a previous call we'll stitch the candidate records together
+                if (optionalPreviousRootNode.isPresent()
+                    && hasCandidatesArray(optionalPreviousRootNode.get())
+                    && hasCandidatesArray(rootNode)) {
+                  optionalPreviousRootNode
+                      .get()
+                      .get(CANDIDATES_NODE_NAME)
+                      .forEach(
+                          candidateNode ->
+                              ((ArrayNode) rootNode.get(CANDIDATES_NODE_NAME)).add(candidateNode));
+                }
+
+                // This will check that all results are under the score threshold. Meaning there
+                // are no result of a high even quality we want to expand to the next url to
+                // see if we can find better matches.
+                boolean hasAnyNodesUnderTheScoreThreshold =
+                    StreamSupport.stream(rootNode.get(CANDIDATES_NODE_NAME).spliterator(), false)
+                        .anyMatch(
+                            candidateNode ->
+                                candidateNode.path(SCORE_NODE_NAME).asDouble() < SCORE_THRESHOLD);
+
+                // If there are no results from this url we definitely want to check the next
+                // available url to see if there are any there.
+                boolean hasNoResults =
+                    hasCandidatesArray(rootNode) && rootNode.get(CANDIDATES_NODE_NAME).isEmpty();
+
+                boolean loadAnotherUrl = hasAnyNodesUnderTheScoreThreshold || hasNoResults;
+
+                if (loadAnotherUrl == true) {
+                  return processAddressSuggestionUrlsSequentially(
+                      addressJson, nextSetOfUrls, Optional.of(rootNode));
+                }
+
+                return CompletableFuture.completedFuture(Optional.of(rootNode));
+              }
+            });
+  }
+
+  /**
+   * Build the request payload to be sent to the Esri service
+   *
+   * @param url The full url to the fetchAddressSuggestions endpoint
+   * @param addressJson Uncorrected address
+   * @return Play WSRequest object ready to be sent to the target endpoint
+   */
+  private WSRequest createWebRequest(String url, ObjectNode addressJson) {
+    WSRequest request = ws.url(url);
     request.setContentType(ESRI_CONTENT_TYPE);
     request.addQueryParameter("outFields", ESRI_FIND_ADDRESS_CANDIDATES_OUT_FIELDS);
     // "f" stands for "format", options are json and pjson (PrettyJson)
     request.addQueryParameter("f", ESRI_RESPONSE_FORMAT);
 
     // Override the spatial reference if provided
-    if (ESRI_WELLKNOWN_ID_OVERRIDE.isPresent()) {
-      request.addQueryParameter("outSR", ESRI_WELLKNOWN_ID_OVERRIDE.get().toString());
-    }
+    ESRI_WELLKNOWN_ID_OVERRIDE.ifPresent(val -> request.addQueryParameter("outSR", val.toString()));
 
     // limit max locations to 3 to keep the size down, since CF stores the suggestions in the user
     // session
     request.addQueryParameter("maxLocations", "3");
+
     Optional<String> address =
         Optional.ofNullable(addressJson.findPath(AddressField.STREET.getValue()).textValue());
     Optional<String> address2 =
@@ -126,22 +235,21 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
         Optional.ofNullable(addressJson.findPath(AddressField.STATE.getValue()).textValue());
     Optional<String> postal =
         Optional.ofNullable(addressJson.findPath(AddressField.ZIP.getValue()).textValue());
+
     address.ifPresent(val -> request.addQueryParameter("address", val));
     address2.ifPresent(val -> request.addQueryParameter("address2", val));
     city.ifPresent(val -> request.addQueryParameter("city", val));
     region.ifPresent(val -> request.addQueryParameter("region", val));
     postal.ifPresent(val -> request.addQueryParameter("postal", val));
 
-    return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)
-        .thenApply(
-            res -> {
-              ESRI_REQUEST_C0UNT.labels(String.valueOf(res.getStatus())).inc();
-              // return empty if still failing after retries
-              if (res.getStatus() != 200) {
-                return Optional.empty();
-              }
-              return Optional.of(res.getBody(json()));
-            });
+    return request;
+  }
+
+  /** Determines if the node has a candidates property that is an array */
+  private static Boolean hasCandidatesArray(JsonNode rootNode) {
+    return rootNode != null
+        && rootNode.get(CANDIDATES_NODE_NAME) != null
+        && rootNode.get(CANDIDATES_NODE_NAME).isArray();
   }
 
   @Override

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -126,7 +126,7 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
   /**
    * Recursive method to get address correction data from one or more findAddressCandidates
    * endpoints. This will stop when there are no urls in the list to process or we end early because
-   * we have results that are greater than the scoring threashold.
+   * we have results that are greater than the scoring threshold.
    *
    * @param addressJson Uncorrected address
    * @param urls A list of urls that will be processed in order; may stop early if surpassing score

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -536,11 +536,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * The URL CiviForm will use to call Esri’s [findAddressCandidates
+   * The list of URLs CiviForm will use to call Esri’s [findAddressCandidates
    * service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).
+   * These are used sequentially and not all of them may need to be used for every correction. If
+   * any results have a scores of 90 or higher lower priority urls will not be called.
    */
-  public Optional<String> getEsriFindAddressCandidatesUrl() {
-    return getString("ESRI_FIND_ADDRESS_CANDIDATES_URL");
+  public Optional<ImmutableList<String>> getEsriFindAddressCandidatesUrl() {
+    return getListOfStrings("ESRI_FIND_ADDRESS_CANDIDATES_URL");
   }
 
   /**
@@ -1547,10 +1549,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       ImmutableList.of(
                           SettingDescription.create(
                               "ESRI_FIND_ADDRESS_CANDIDATES_URL",
-                              "The URL CiviForm will use to call Esri’s [findAddressCandidates"
-                                  + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
+                              "The list of URLs CiviForm will use to call Esri’s"
+                                  + " [findAddressCandidates"
+                                  + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm)."
+                                  + " These are used sequentially and not all of them may need to"
+                                  + " be used for every correction. If any results have a scores of"
+                                  + " 90 or higher lower priority urls will not be called.",
                               /* isRequired= */ false,
-                              SettingType.STRING,
+                              SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),
                           SettingDescription.create(
                               "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS",

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -539,7 +539,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    * The list of URLs CiviForm will use to call Esri’s [findAddressCandidates
    * service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).
    * These are used sequentially and not all of them may need to be used for every correction. If
-   * any results have a scores of 90 or higher lower priority urls will not be called.
+   * any results have a score of 90 or higher, lower priority urls will not be called.
    */
   public Optional<ImmutableList<String>> getEsriFindAddressCandidatesUrl() {
     return getListOfStrings("ESRI_FIND_ADDRESS_CANDIDATES_URL");
@@ -1553,8 +1553,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   + " [findAddressCandidates"
                                   + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm)."
                                   + " These are used sequentially and not all of them may need to"
-                                  + " be used for every correction. If any results have a scores of"
-                                  + " 90 or higher lower priority urls will not be called.",
+                                  + " be used for every correction. If any results have a score of"
+                                  + " 90 or higher, lower priority urls will not be called.",
                               /* isRequired= */ false,
                               SettingType.LIST_OF_STRINGS,
                               SettingMode.ADMIN_READABLE),

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -32,7 +32,7 @@ play.filters {
 # See sections 2.3.a.6, 2.5.b and 3.2.d
 # Esri Mock Service
 esri_address_correction_enabled=true
-esri_find_address_candidates_url = "http://mock-web-services:8000/esri/findAddressCandidates"
+esri_find_address_candidates_url = ["http://mock-web-services:8000/esri/findAddressCandidates"]
 esri_external_call_tries = 3
 esri_address_service_area_validation_enabled=true
 esri_address_service_area_validation_urls = ["http://mock-web-services:8000/esri/serviceAreaFeatures"]

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -19,8 +19,13 @@ azure.blob.account = "my awesome azure account name"
 civiform_applicant_idp = "disabled"
 
 # address service area validation relative path for testing
-esri_find_address_candidates_url = ""
+esri_find_address_candidates_url = []
 esri_address_service_area_validation_urls = ["/query"]
+esri_address_service_area_validation_labels = ["Seattle"]
+esri_address_service_area_validation_ids = ["Seattle"]
+esri_address_service_area_validation_attributes = ["CITYNAME"]
+
+
 
 question_cache_enabled=true
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -453,7 +453,7 @@
         "members": {
           "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
             "mode": "ADMIN_READABLE",
-            "description": "The list of URLs CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). These are used sequentially and not all of them may need to be used for every correction. If any results have a scores of 90 or higher lower priority urls will not be called.",
+            "description": "The list of URLs CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). These are used sequentially and not all of them may need to be used for every correction. If any results have a score of 90 or higher, lower priority urls will not be called.",
             "type": "index-list"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -453,8 +453,8 @@
         "members": {
           "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
             "mode": "ADMIN_READABLE",
-            "description": "The URL CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
-            "type": "string"
+            "description": "The list of URLs CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). These are used sequentially and not all of them may need to be used for every correction. If any results have a scores of 90 or higher lower priority urls will not be called.",
+            "type": "index-list"
           },
           "ESRI_ADDRESS_SERVICE_AREA_VALIDATION_LABELS": {
             "mode": "ADMIN_READABLE",

--- a/server/conf/helper/esri.conf
+++ b/server/conf/helper/esri.conf
@@ -3,7 +3,7 @@
 esri_address_correction_enabled = false
 esri_address_correction_enabled = ${?ESRI_ADDRESS_CORRECTION_ENABLED}
 
-esri_find_address_candidates_url = ""
+esri_find_address_candidates_url = []
 esri_find_address_candidates_url = ${?ESRI_FIND_ADDRESS_CANDIDATES_URL}
 # address service area validation
 esri_address_service_area_validation_enabled = false

--- a/server/test/resources/esri/findAddressCandidatesNo100PercentMatch.json
+++ b/server/test/resources/esri/findAddressCandidatesNo100PercentMatch.json
@@ -1,0 +1,38 @@
+{
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  },
+  "candidates": [
+    {
+      "address": "Redlands, California, 92373",
+      "location": {
+        "x": -100,
+        "y": 100
+      },
+      "score": 89,
+      "attributes": {
+        "SubAddr": "",
+        "Address": "",
+        "City": "Redlands",
+        "RegionAbbr": "CA",
+        "Postal": "92373"
+      }
+    },
+    {
+      "address": "Address Not In Area, Redlands, California, 92373",
+      "location": {
+        "x": -102,
+        "y": 102
+      },
+      "score": 70,
+      "attributes": {
+        "SubAddr": "",
+        "Address": "Address Not In Area",
+        "City": "Redlands",
+        "RegionAbbr": "CA",
+        "Postal": "92373"
+      }
+    }
+  ]
+}

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -4,7 +4,6 @@
  */
 package services.geo.esri;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.mvc.Results.internalServerError;
@@ -37,9 +36,9 @@ public class EsriTestHelper {
     private final EsriClient esriClient;
 
     public ServerSettings(Server server, WSClient wsClient, EsriClient esriClient) {
-      this.server = checkNotNull(server);
-      this.wsClient = checkNotNull(wsClient);
-      this.esriClient = checkNotNull(esriClient);
+      this.server = server;
+      this.wsClient = wsClient;
+      this.esriClient = esriClient;
     }
 
     public Server getServer() {

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -4,6 +4,7 @@
  */
 package services.geo.esri;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.mvc.Results.internalServerError;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.ZoneId;
 import java.util.Optional;
+import org.apache.commons.lang3.NotImplementedException;
 import play.libs.ws.WSClient;
 import play.routing.RoutingDsl;
 import play.server.Server;
@@ -23,7 +25,32 @@ import services.geo.AddressLocation;
 import services.settings.SettingsManifest;
 
 public class EsriTestHelper {
-  public static enum TestType {
+  // Basically here because java doesn't have built in tuples
+  private static class ServerSettings {
+    private final Server server;
+    private final WSClient wsClient;
+    private final EsriClient esriClient;
+
+    public ServerSettings(Server server, WSClient wsClient, EsriClient esriClient) {
+      this.server = checkNotNull(server);
+      this.wsClient = checkNotNull(wsClient);
+      this.esriClient = checkNotNull(esriClient);
+    }
+
+    public Server getServer() {
+      return server;
+    }
+
+    public WSClient getWsClient() {
+      return wsClient;
+    }
+
+    public EsriClient getEsriClient() {
+      return esriClient;
+    }
+  }
+
+  public enum TestType {
     STANDARD,
     STANDARD_WITH_LINE_2,
     NO_CANDIDATES,
@@ -61,148 +88,136 @@ public class EsriTestHelper {
   private final WSClient ws;
   private final EsriClient client;
 
-  public EsriTestHelper(TestType testType) throws Exception {
+  public EsriTestHelper(TestType testType) {
+    ServerSettings serverSettings;
+
     switch (testType) {
       case STANDARD:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/findAddressCandidates")
-                        .routingTo(request -> ok().sendResource("esri/findAddressCandidates.json"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk(
+                "/findAddressCandidates", "esri/findAddressCandidates.json");
         break;
       case STANDARD_WITH_LINE_2:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/findAddressCandidates")
-                        .routingTo(
-                            request ->
-                                ok().sendResource("esri/findAddressCandidatesWithLine2.json"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk(
+                "/findAddressCandidates", "esri/findAddressCandidatesWithLine2.json");
         break;
       case NO_CANDIDATES:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/findAddressCandidates")
-                        .routingTo(
-                            request ->
-                                ok().sendResource("esri/findAddressCandidatesNoCandidates.json"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk(
+                "/findAddressCandidates", "esri/findAddressCandidatesNoCandidates.json");
         break;
       case ERROR:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/findAddressCandidates")
-                        .routingTo(
-                            request ->
-                                internalServerError("{ \"Error\": \"An error has occurred\"}"))
-                        .build());
+        serverSettings = createServerSettingsThatReturnError("/findAddressCandidates");
         break;
       case SERVICE_AREA_VALIDATION:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/query")
-                        .routingTo(request -> ok().sendResource("esri/serviceAreaFeatures.json"))
-                        .build());
-        break;
-      case SERVICE_AREA_VALIDATION_ERROR:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/query")
-                        .routingTo(
-                            request ->
-                                internalServerError("{ \"Error\": \"An error has occurred\"}"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk("/query", "esri/serviceAreaFeatures.json");
         break;
       case SERVICE_AREA_VALIDATION_NOT_INCLUDED:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/query")
-                        .routingTo(
-                            request -> ok().sendResource("esri/serviceAreaFeaturesNotInArea.json"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk("/query", "esri/serviceAreaFeaturesNotInArea.json");
         break;
       case SERVICE_AREA_VALIDATION_NO_FEATURES:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/query")
-                        .routingTo(
-                            request -> ok().sendResource("esri/serviceAreaFeaturesNoFeatures.json"))
-                        .build());
+        serverSettings =
+            createServerSettingsThatReturnOk("/query", "esri/serviceAreaFeaturesNoFeatures.json");
+        break;
+      case SERVICE_AREA_VALIDATION_ERROR:
+        serverSettings = createServerSettingsThatReturnError("/query");
         break;
       case MULTIPLE_ENDPOINTS:
-        server =
-            Server.forRouter(
-                (components) ->
-                    RoutingDsl.fromComponents(components)
-                        .GET("/findAddressCandidates1")
-                        .routingTo(
-                            request ->
-                                ok().sendResource(
-                                        "esri/findAddressCandidatesNo100PercentMatch.json"))
-                        .GET("/findAddressCandidates2")
-                        .routingTo(
-                            request ->
-                                ok().sendResource("esri/findAddressCandidatesNoCandidates.json"))
-                        .GET("/findAddressCandidates3")
-                        .routingTo(
-                            request ->
-                                ok().sendResource("esri/findAddressCandidatesWithLine2.json"))
-                        .GET("/findAddressCandidates4")
-                        .routingTo(request -> ok().sendResource("esri/findAddressCandidates.json"))
-                        .build());
-
-        ws = play.test.WSTestClient.newClient(server.httpPort());
-
-        SettingsManifest mockSettingsManifest = mock();
-        when(mockSettingsManifest.getEsriFindAddressCandidatesUrl())
-            .thenReturn(
-                Optional.of(
-                    ImmutableList.<String>builder()
-                        .add("/findAddressCandidates1")
-                        .add("/findAddressCandidates2")
-                        .add("/findAddressCandidates3")
-                        .add("/findAddressCandidates4")
-                        .build()));
-
-        RealEsriClient realClient =
-            new RealEsriClient(
-                mockSettingsManifest, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, ws);
-
-        client = realClient;
-        return;
+        serverSettings = createServerSettingsThatReturnMultiEndpoints();
+        break;
       case FAKE:
-        server = null;
-        ws = null;
-        client = new FakeEsriClient(CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG);
-        return;
+        serverSettings = createServerSettingsThatReturnFakeClient();
+        break;
       default:
-        // Not really possible
-        throw new Exception("Unknown server type");
+        throw new NotImplementedException(
+            String.format("Could not create EsriTestHelper for TestType: %s", testType));
     }
-    ws = play.test.WSTestClient.newClient(server.httpPort());
 
-    RealEsriClient realClient =
-        new RealEsriClient(SETTINGS_MANIFEST, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, ws);
-    // overwrite to not include base URL so it uses the mock service
-    realClient.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
-        ImmutableList.<String>builder().add("/findAddressCandidates").build();
-    client = realClient;
+    server = serverSettings.getServer();
+    ws = serverSettings.getWsClient();
+    client = serverSettings.getEsriClient();
+  }
+
+  private static ServerSettings createServerSettingsThatReturnOk(String endpoint, String resource) {
+    Server server =
+        Server.forRouter(
+            (components) ->
+                RoutingDsl.fromComponents(components)
+                    .GET(endpoint)
+                    .routingTo(request -> ok().sendResource(resource))
+                    .build());
+
+    WSClient wsClient = play.test.WSTestClient.newClient(server.httpPort());
+
+    EsriClient esriClient =
+        new RealEsriClient(SETTINGS_MANIFEST, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, wsClient);
+
+    return new ServerSettings(server, wsClient, esriClient);
+  }
+
+  private static ServerSettings createServerSettingsThatReturnError(String endpoint) {
+    Server server =
+        Server.forRouter(
+            (components) ->
+                RoutingDsl.fromComponents(components)
+                    .GET(endpoint)
+                    .routingTo(
+                        request -> internalServerError("{ \"Error\": \"An error has occurred\"}"))
+                    .build());
+
+    WSClient wsClient = play.test.WSTestClient.newClient(server.httpPort());
+
+    EsriClient esriClient =
+        new RealEsriClient(SETTINGS_MANIFEST, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, wsClient);
+
+    return new ServerSettings(server, wsClient, esriClient);
+  }
+
+  private static ServerSettings createServerSettingsThatReturnMultiEndpoints() {
+    Server server =
+        Server.forRouter(
+            (components) ->
+                RoutingDsl.fromComponents(components)
+                    .GET("/findAddressCandidates1")
+                    .routingTo(
+                        request ->
+                            ok().sendResource("esri/findAddressCandidatesNo100PercentMatch.json"))
+                    .GET("/findAddressCandidates2")
+                    .routingTo(
+                        request -> ok().sendResource("esri/findAddressCandidatesNoCandidates.json"))
+                    .GET("/findAddressCandidates3")
+                    .routingTo(
+                        request -> ok().sendResource("esri/findAddressCandidatesWithLine2.json"))
+                    .GET("/findAddressCandidates4")
+                    .routingTo(request -> ok().sendResource("esri/findAddressCandidates.json"))
+                    .build());
+
+    WSClient wsClient = play.test.WSTestClient.newClient(server.httpPort());
+
+    SettingsManifest mockSettingsManifest = mock();
+    when(mockSettingsManifest.getEsriFindAddressCandidatesUrl())
+        .thenReturn(
+            Optional.of(
+                ImmutableList.<String>builder()
+                    .add("/findAddressCandidates1")
+                    .add("/findAddressCandidates2")
+                    .add("/findAddressCandidates3")
+                    .add("/findAddressCandidates4")
+                    .build()));
+
+    RealEsriClient esriClient =
+        new RealEsriClient(
+            mockSettingsManifest, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, wsClient);
+
+    return new ServerSettings(server, wsClient, esriClient);
+  }
+
+  private static ServerSettings createServerSettingsThatReturnFakeClient() {
+    return new ServerSettings(
+        null, null, new FakeEsriClient(CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG));
   }
 
   public EsriClient getClient() {
@@ -211,9 +226,13 @@ public class EsriTestHelper {
 
   public void stopServer() throws IOException {
     try {
-      ws.close();
+      if (ws != null) {
+        ws.close();
+      }
     } finally {
-      server.stop();
+      if (server != null) {
+        server.stop();
+      }
     }
   }
 }

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -156,8 +156,12 @@ public class EsriTestHelper {
 
     WSClient wsClient = play.test.WSTestClient.newClient(server.httpPort());
 
-    EsriClient esriClient =
+    RealEsriClient esriClient =
         new RealEsriClient(SETTINGS_MANIFEST, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, wsClient);
+
+    // overwrite to not include base URL so it uses the mock service
+    esriClient.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
+        ImmutableList.<String>builder().add("/findAddressCandidates").build();
 
     return new ServerSettings(server, wsClient, esriClient);
   }
@@ -174,8 +178,12 @@ public class EsriTestHelper {
 
     WSClient wsClient = play.test.WSTestClient.newClient(server.httpPort());
 
-    EsriClient esriClient =
+    RealEsriClient esriClient =
         new RealEsriClient(SETTINGS_MANIFEST, CLOCK, ESRI_SERVICE_AREA_VALIDATION_CONFIG, wsClient);
+
+    // overwrite to not include base URL so it uses the mock service
+    esriClient.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
+        ImmutableList.<String>builder().add("/findAddressCandidates").build();
 
     return new ServerSettings(server, wsClient, esriClient);
   }

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -24,6 +24,11 @@ import play.server.Server;
 import services.geo.AddressLocation;
 import services.settings.SettingsManifest;
 
+/**
+ * This class creates test Play webservers. Each option from the TestType enum corresponds to a
+ * specific setup for an endpoint for either address correction or service area validation, and
+ * returns specific results from files in the test resources directory.
+ */
 public class EsriTestHelper {
   // Basically here because java doesn't have built in tuples
   private static class ServerSettings {

--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -75,6 +75,8 @@ public class RealEsriClientTest {
 
   @Test
   public void fetchAddressSuggestionsMultipleUrls() throws Exception {
+    // TestType.MULTIPLE_ENDPOINTS configures the test web server with multi endpoints
+    // that each return different numbers of results
     helper = new EsriTestHelper(TestType.MULTIPLE_ENDPOINTS);
     ObjectNode addressJson = Json.newObject();
     addressJson.put("street", "380 New York St");
@@ -83,7 +85,11 @@ public class RealEsriClientTest {
     JsonNode resp = maybeResp.get();
     ArrayNode candidates = (ArrayNode) resp.get("candidates");
     assertThat(resp.get("spatialReference").get("wkid").asInt()).isEqualTo(4326);
-    assertThat(candidates).hasSize(8);
+
+    // For this test this value is the merged combination of candidate results
+    // from multiple endpoints.
+    int expectedNumberOfCandidates = 8;
+    assertThat(candidates).hasSize(expectedNumberOfCandidates);
   }
 
   @Test

--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -74,6 +74,19 @@ public class RealEsriClientTest {
   }
 
   @Test
+  public void fetchAddressSuggestionsMultipleUrls() throws Exception {
+    helper = new EsriTestHelper(TestType.MULTIPLE_ENDPOINTS);
+    ObjectNode addressJson = Json.newObject();
+    addressJson.put("street", "380 New York St");
+    Optional<JsonNode> maybeResp =
+        helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
+    JsonNode resp = maybeResp.get();
+    ArrayNode candidates = (ArrayNode) resp.get("candidates");
+    assertThat(resp.get("spatialReference").get("wkid").asInt()).isEqualTo(4326);
+    assertThat(candidates).hasSize(8);
+  }
+
+  @Test
   public void fetchServiceAreaFeatures() throws Exception {
     helper = new EsriTestHelper(TestType.SERVICE_AREA_VALIDATION);
     Optional<JsonNode> maybeResp =


### PR DESCRIPTION
### Description

This changes the env var `esri_find_address_candidates_url` from a string to a list and can now try to correct addresses from multiple sources. Each correction occurs sequentially and may not call all the options depending on the score in the correction results.

## Release notes

Address correction can now use multiple Esri sources. Each additional source is only checked if there either no results from the current source of if there are no results with a score 90 or higher. All results are combined and continue to show the top three options with the highest score to the applicant.


The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary


### Issue(s) this relates to

Related to: #6800