### PR TITLE
Set SBT_VERSION in script that pushes custom images

### DIFF
--- a/bin/build-and-push-image-for-testing
+++ b/bin/build-and-push-image-for-testing
@@ -40,4 +40,5 @@ docker buildx build --push \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg "git_commit_sha=${GIT_SHA}" \
   --build-arg "image_tag=${IMAGE_TAG}" \
+  --build-arg SBT_VERSION="${SBT_VERSION}" \
   .


### PR DESCRIPTION
### Description

Passes in the sbt version or building the image fails. This script rare is used and I missed adding it here when I updated the sbt version last month.

For the curious `SBT_VERSION` is defined when sourcing `bin/lib.sh`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
