### PR TITLE
Skip address correction if an optional question is not answered

### DIFF
--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -122,19 +122,19 @@ test.describe('address correction', () => {
     })
 
     await test.step('Create optional address program', async () => {
-    await adminPrograms.addProgram(optionalAddressProgram)
+      await adminPrograms.addProgram(optionalAddressProgram)
 
-    await adminPrograms.editProgramBlockWithOptional(
-      optionalAddressProgram,
-      'first block',
-      [],
-      addressWithCorrectionQuestionId,
-    )
+      await adminPrograms.editProgramBlockWithOptional(
+        optionalAddressProgram,
+        'first block',
+        [],
+        addressWithCorrectionQuestionId,
+      )
 
-    await adminPrograms.goToBlockInProgram(optionalAddressProgram, 'Screen 1')
-    await adminPrograms.clickAddressCorrectionToggleByName(
-      addressWithCorrectionQuestionId,
-    )
+      await adminPrograms.goToBlockInProgram(optionalAddressProgram, 'Screen 1')
+      await adminPrograms.clickAddressCorrectionToggleByName(
+        addressWithCorrectionQuestionId,
+      )
 
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.publishProgram(optionalAddressProgram)
@@ -256,8 +256,8 @@ test.describe('address correction', () => {
       await applicantQuestions.applyProgram(optionalAddressProgram)
 
       await applicantQuestions.clickNext()
-
       await applicantQuestions.expectReviewPage()
+
       await applicantQuestions.clickSubmit()
       await logout(page)
     })

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -20,6 +20,7 @@ test.describe('address correction', () => {
     'Address correction single-block, multi-address program'
   const singleBlockSingleAddressProgram =
     'Address correction single-block, single-address program'
+  const optionalAddressProgram = 'Address correction optional address program'
 
   const addressWithCorrectionQuestionId = 'address-with-correction-q'
   const addressWithoutCorrectionQuestionId = 'address-without-correction-q'
@@ -118,9 +119,28 @@ test.describe('address correction', () => {
 
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.publishProgram(singleBlockSingleAddressProgram)
-
-      await logout(page)
     })
+
+    await test.step('Create optional address program', async () => {
+    await adminPrograms.addProgram(optionalAddressProgram)
+
+    await adminPrograms.editProgramBlockWithOptional(
+      optionalAddressProgram,
+      'first block',
+      [],
+      addressWithCorrectionQuestionId,
+    )
+
+    await adminPrograms.goToBlockInProgram(optionalAddressProgram, 'Screen 1')
+    await adminPrograms.clickAddressCorrectionToggleByName(
+      addressWithCorrectionQuestionId,
+    )
+
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishProgram(optionalAddressProgram)
+    })
+
+    await logout(page)
   })
 
   if (isLocalDevEnvironment()) {
@@ -226,6 +246,18 @@ test.describe('address correction', () => {
         addressWithCorrectionText,
         'Address In Area',
       )
+      await applicantQuestions.clickSubmit()
+      await logout(page)
+    })
+
+    test('skips address correction if optional address question is not answered', async () => {
+      const {page, applicantQuestions} = ctx
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await applicantQuestions.applyProgram(optionalAddressProgram)
+
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.expectReviewPage()
       await applicantQuestions.clickSubmit()
       await logout(page)
     })

--- a/server/app/services/applicant/question/AddressQuestion.java
+++ b/server/app/services/applicant/question/AddressQuestion.java
@@ -277,11 +277,13 @@ public final class AddressQuestion extends Question {
   }
 
   /**
-   * Returns true if this question has address correction enabled, and it has not yet been through
-   * the correction process.
+   * Returns true if this question has address correction enabled, has been answered, and has not
+   * yet been through the correction process.
    */
   public Boolean needsAddressCorrection() {
-    return applicantQuestion.isAddressCorrectionEnabled() && getCorrectedValue().isEmpty();
+    return applicantQuestion.isAddressCorrectionEnabled()
+        && isAnswered()
+        && getCorrectedValue().isEmpty();
   }
 
   @Override


### PR DESCRIPTION
### Description

An address question can be optional and also have address correction enabled. Previously address correction would run even if the user didn't enter any data, which led to an error loop that prevented the user from proceeding. Now address correction will only run if the question is answered (i.e. any address data is filled in).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

Steps to reproduce are in issue #7138.

### Issue(s) this completes

Fixes #7138