### PR TITLE
[Disabled Programs] refactor ActiveAndDraftPrograms

### DIFF
--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -45,6 +45,20 @@ public final class ActiveAndDraftPrograms {
     return new ActiveAndDraftPrograms(repository, Optional.empty());
   }
 
+  public ImmutableMap<String, ProgramDefinition> nameToProgram(
+      VersionRepository repository, Optional<ProgramService> service, VersionModel versionModel) {
+    ImmutableMap<String, ProgramDefinition> result =
+        repository.getProgramsForVersion(checkNotNull(versionModel)).stream()
+            .map(
+                program ->
+                    service.isPresent()
+                        ? getFullProgramDefinition(service.get(), program.id)
+                        : program.getProgramDefinition())
+            .collect(
+                ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
+    return result;
+  }
+
   private ActiveAndDraftPrograms(VersionRepository repository, Optional<ProgramService> service) {
     VersionModel active = repository.getActiveVersion();
     VersionModel draft = repository.getDraftVersionOrCreate();
@@ -52,24 +66,10 @@ public final class ActiveAndDraftPrograms {
     // an additional database lookup in order to sync the set of questions associated with the
     // program.
     ImmutableMap<String, ProgramDefinition> activeNameToProgram =
-        repository.getProgramsForVersion(checkNotNull(active)).stream()
-            .map(
-                program ->
-                    service.isPresent()
-                        ? getFullProgramDefinition(service.get(), program.id)
-                        : program.getProgramDefinition())
-            .collect(
-                ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
+        nameToProgram(repository, service, active);
 
     ImmutableMap<String, ProgramDefinition> draftNameToProgram =
-        repository.getProgramsForVersion(checkNotNull(draft)).stream()
-            .map(
-                program ->
-                    service.isPresent()
-                        ? getFullProgramDefinition(service.get(), program.id)
-                        : program.getProgramDefinition())
-            .collect(
-                ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
+        nameToProgram(repository, service, draft);
 
     this.activePrograms = activeNameToProgram.values().asList();
     this.draftPrograms = draftNameToProgram.values().asList();

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import java.util.*;
 import java.util.Optional;
 import java.util.function.Function;
 import models.DisplayMode;

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.*;
 import java.util.Optional;
 import java.util.function.Function;
 import models.DisplayMode;
@@ -65,6 +66,11 @@ public final class ActiveAndDraftPrograms {
         .collect(ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
   }
 
+  private ImmutableMap<String, ProgramDefinition> mapNameToProgram(
+      VersionRepository repository, Optional<ProgramService> service, VersionModel versionModel) {
+    return mapNameToProgramWithFilter(repository, service, versionModel, Optional.empty());
+  }
+
   private ActiveAndDraftPrograms(VersionRepository repository, Optional<ProgramService> service) {
     VersionModel active = repository.getActiveVersion();
     VersionModel draft = repository.getDraftVersionOrCreate();
@@ -72,10 +78,10 @@ public final class ActiveAndDraftPrograms {
     // an additional database lookup in order to sync the set of questions associated with the
     // program.
     ImmutableMap<String, ProgramDefinition> activeNameToProgram =
-        mapNameToProgramWithFilter(repository, service, active, Optional.empty());
+        mapNameToProgram(repository, service, active);
 
     ImmutableMap<String, ProgramDefinition> draftNameToProgram =
-        mapNameToProgramWithFilter(repository, service, draft, Optional.empty());
+        mapNameToProgram(repository, service, draft);
 
     this.activePrograms = activeNameToProgram.values().asList();
     this.draftPrograms = draftNameToProgram.values().asList();

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -47,15 +47,19 @@ public final class ActiveAndDraftPrograms {
   }
 
   private ImmutableMap<String, ProgramDefinition> nameToProgram(
-    VersionRepository repository, Optional<ProgramService> service, VersionModel versionModel,
-    Predicate<ProgramDefinition> filter) {
+      VersionRepository repository,
+      Optional<ProgramService> service,
+      VersionModel versionModel,
+      Predicate<ProgramDefinition> filter) {
 
     return repository.getProgramsForVersion(checkNotNull(versionModel)).stream()
-      .map(program -> service.isPresent()
-        ? getFullProgramDefinition(service.get(), program.id)
-        : program.getProgramDefinition())
-      .filter(filter)
-      .collect(ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
+        .map(
+            program ->
+                service.isPresent()
+                    ? getFullProgramDefinition(service.get(), program.id)
+                    : program.getProgramDefinition())
+        .filter(filter)
+        .collect(ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
   }
 
   private ActiveAndDraftPrograms(VersionRepository repository, Optional<ProgramService> service) {

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -45,18 +45,15 @@ public final class ActiveAndDraftPrograms {
     return new ActiveAndDraftPrograms(repository, Optional.empty());
   }
 
-  public ImmutableMap<String, ProgramDefinition> nameToProgram(
+  private ImmutableMap<String, ProgramDefinition> nameToProgram(
       VersionRepository repository, Optional<ProgramService> service, VersionModel versionModel) {
-    ImmutableMap<String, ProgramDefinition> result =
-        repository.getProgramsForVersion(checkNotNull(versionModel)).stream()
-            .map(
-                program ->
-                    service.isPresent()
-                        ? getFullProgramDefinition(service.get(), program.id)
-                        : program.getProgramDefinition())
-            .collect(
-                ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
-    return result;
+    return repository.getProgramsForVersion(checkNotNull(versionModel)).stream()
+        .map(
+            program ->
+                service.isPresent()
+                    ? getFullProgramDefinition(service.get(), program.id)
+                    : program.getProgramDefinition())
+        .collect(ImmutableMap.toImmutableMap(ProgramDefinition::adminName, Function.identity()));
   }
 
   private ActiveAndDraftPrograms(VersionRepository repository, Optional<ProgramService> service) {


### PR DESCRIPTION
### Description

There are some duplicated code for activeNameToProgram and draftNameToProgram. For this PR, I took out a helper function to avoid them.

I also added a `Predicate<ProgramDefinition> filter` parameter for future use when we need a filter for non disabled active programs. It will be used as below.

```
ImmutableMap<String, ProgramDefinition> nonDisabledActiveNameToProgram = nameToProgram(repository, service, active, program -> program.displayMode() != DisplayMode.DISABLED);
```


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

#7195 