### PR TITLE
Re-add old find address url setting value and making backward compatible

### DIFF
--- a/server/app/modules/EsriModule.java
+++ b/server/app/modules/EsriModule.java
@@ -31,9 +31,7 @@ public final class EsriModule extends AbstractModule {
   @Override
   protected void configure() {
     String className =
-        config.getStringList("esri_find_address_candidates_url").isEmpty()
-            ? FAKE_ESRI_CLIENT_CLASS_NAME
-            : REAL_ESRI_CLIENT_CLASS_NAME;
+        useRealEsriClient() ? REAL_ESRI_CLIENT_CLASS_NAME : FAKE_ESRI_CLIENT_CLASS_NAME;
 
     LOGGER.info(String.format("Using %s class for Esri client", className));
 
@@ -46,5 +44,27 @@ public final class EsriModule extends AbstractModule {
       throw new RuntimeException(
           String.format("Failed to load esri client class: %s", className), e);
     }
+  }
+
+  /**
+   * @return True if either esri_find_address_candidates_urls or esri_find_address_candidates_url
+   *     have a value, otherwise false
+   */
+  private Boolean useRealEsriClient() {
+    if (!config.getStringList("esri_find_address_candidates_urls").isEmpty()) {
+      return true;
+    }
+
+    if (!config.getString("esri_find_address_candidates_url").isEmpty()) {
+      LOGGER.warn(
+          "Address correction is enabled, but configured with the environment value"
+              + " `ESRI_FIND_ADDRESS_CANDIDATES_URL`. Please migrate to using the"
+              + " `ESRI_FIND_ADDRESS_CANDIDATES_URLS` See the latest server environment variable"
+              + " documentation for details."
+              + " https://docs.civiform.us/it-manual/sre-playbook/upgrading-to-a-new-release/server-environment-variables");
+      return true;
+    }
+
+    return false;
   }
 }

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -81,8 +81,19 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
     checkNotNull(settingsManifest);
     this.ws = checkNotNull(ws);
 
+    // Default to using the new setting which is a list
     this.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
-        settingsManifest.getEsriFindAddressCandidatesUrl().orElse(ImmutableList.of());
+        settingsManifest.getEsriFindAddressCandidatesUrls().orElse(ImmutableList.of());
+
+    // Fallback to using the old setting if the list is empty
+    if (this.ESRI_FIND_ADDRESS_CANDIDATES_URLS.isEmpty()
+        && !settingsManifest.getEsriFindAddressCandidatesUrl().orElse("").isEmpty()) {
+      this.ESRI_FIND_ADDRESS_CANDIDATES_URLS =
+          ImmutableList.<String>builder()
+              .add(settingsManifest.getEsriFindAddressCandidatesUrl().get())
+              .build();
+    }
+
     this.ESRI_EXTERNAL_CALL_TRIES = settingsManifest.getEsriExternalCallTries().orElse(3);
     this.ESRI_WELLKNOWN_ID_OVERRIDE = settingsManifest.getEsriWellknownIdOverride();
   }

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -536,13 +536,22 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * [Deprecated: Switch to `ESRI_FIND_ADDRESS_CANDIDATES_URLS`] The URL CiviForm will use to call
+   * Esri’s [findAddressCandidates
+   * service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).
+   */
+  public Optional<String> getEsriFindAddressCandidatesUrl() {
+    return getString("ESRI_FIND_ADDRESS_CANDIDATES_URL");
+  }
+
+  /**
    * The list of URLs CiviForm will use to call Esri’s [findAddressCandidates
    * service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).
    * These are used sequentially and not all of them may need to be used for every correction. If
    * any results have a score of 90 or higher, lower priority urls will not be called.
    */
-  public Optional<ImmutableList<String>> getEsriFindAddressCandidatesUrl() {
-    return getListOfStrings("ESRI_FIND_ADDRESS_CANDIDATES_URL");
+  public Optional<ImmutableList<String>> getEsriFindAddressCandidatesUrls() {
+    return getListOfStrings("ESRI_FIND_ADDRESS_CANDIDATES_URLS");
   }
 
   /**
@@ -1549,6 +1558,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       ImmutableList.of(
                           SettingDescription.create(
                               "ESRI_FIND_ADDRESS_CANDIDATES_URL",
+                              "[Deprecated: Switch to `ESRI_FIND_ADDRESS_CANDIDATES_URLS`] The URL"
+                                  + " CiviForm will use to call Esri’s [findAddressCandidates"
+                                  + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
+                              /* isRequired= */ false,
+                              SettingType.STRING,
+                              SettingMode.ADMIN_READABLE),
+                          SettingDescription.create(
+                              "ESRI_FIND_ADDRESS_CANDIDATES_URLS",
                               "The list of URLs CiviForm will use to call Esri’s"
                                   + " [findAddressCandidates"
                                   + " service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm)."

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -32,7 +32,7 @@ play.filters {
 # See sections 2.3.a.6, 2.5.b and 3.2.d
 # Esri Mock Service
 esri_address_correction_enabled=true
-esri_find_address_candidates_url = ["http://mock-web-services:8000/esri/findAddressCandidates"]
+esri_find_address_candidates_urls = ["http://mock-web-services:8000/esri/findAddressCandidates"]
 esri_external_call_tries = 3
 esri_address_service_area_validation_enabled=true
 esri_address_service_area_validation_urls = ["http://mock-web-services:8000/esri/serviceAreaFeatures"]

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -19,7 +19,8 @@ azure.blob.account = "my awesome azure account name"
 civiform_applicant_idp = "disabled"
 
 # address service area validation relative path for testing
-esri_find_address_candidates_url = []
+esri_find_address_candidates_url = ""
+esri_find_address_candidates_urls = []
 esri_address_service_area_validation_urls = ["/query"]
 esri_address_service_area_validation_labels = ["Seattle"]
 esri_address_service_area_validation_ids = ["Seattle"]

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -453,6 +453,11 @@
         "members": {
           "ESRI_FIND_ADDRESS_CANDIDATES_URL": {
             "mode": "ADMIN_READABLE",
+            "description": "[Deprecated: Switch to `ESRI_FIND_ADDRESS_CANDIDATES_URLS`] The URL CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm).",
+            "type": "string"
+          },
+          "ESRI_FIND_ADDRESS_CANDIDATES_URLS": {
+            "mode": "ADMIN_READABLE",
             "description": "The list of URLs CiviForm will use to call Esri’s [findAddressCandidates service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm). These are used sequentially and not all of them may need to be used for every correction. If any results have a score of 90 or higher, lower priority urls will not be called.",
             "type": "index-list"
           },

--- a/server/conf/helper/esri.conf
+++ b/server/conf/helper/esri.conf
@@ -3,8 +3,14 @@
 esri_address_correction_enabled = false
 esri_address_correction_enabled = ${?ESRI_ADDRESS_CORRECTION_ENABLED}
 
-esri_find_address_candidates_url = []
+# legacy single support url, to be phased out
+esri_find_address_candidates_url = ""
 esri_find_address_candidates_url = ${?ESRI_FIND_ADDRESS_CANDIDATES_URL}
+
+# list of urls for used to for address correction
+esri_find_address_candidates_urls = []
+esri_find_address_candidates_urls = ${?ESRI_FIND_ADDRESS_CANDIDATES_URLS}
+
 # address service area validation
 esri_address_service_area_validation_enabled = false
 esri_address_service_area_validation_enabled = ${?ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED}

--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -37,6 +37,22 @@ public class RealEsriClientTest {
   }
 
   @Test
+  public void fetchAddressSuggestionsWorksUsingOldLegacySingleUrlConfigValue() throws Exception {
+    // This is the same as the fetchAddressSuggestions test but forces use of the old config
+    // setting.
+    // Can do away after the removal of the old config setting.
+    helper = new EsriTestHelper(TestType.LEGACY_SINGLE_URL_CONFIG_SETTING);
+    ObjectNode addressJson = Json.newObject();
+    addressJson.put("street", "380 New York St");
+    Optional<JsonNode> maybeResp =
+        helper.getClient().fetchAddressSuggestions(addressJson).toCompletableFuture().get();
+    JsonNode resp = maybeResp.get();
+    ArrayNode candidates = (ArrayNode) resp.get("candidates");
+    assertThat(resp.get("spatialReference").get("wkid").asInt()).isEqualTo(4326);
+    assertThat(candidates).hasSize(5);
+  }
+
+  @Test
   public void fetchAddressSuggestionsHavingLine2Populated() throws Exception {
     helper = new EsriTestHelper(TestType.STANDARD_WITH_LINE_2);
     ObjectNode addressJson = Json.newObject();


### PR DESCRIPTION
### Description

Added a new environment variable for the find address list. Swapped the old one back to a string. Now will conditionally load for backward compatibility. Updating the release notes on the previous PR to they align.

Related: #7177

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
