### PR TITLE
Migrate question type tests to use fixtures

### DIFF
--- a/browser-test/src/applicant/questions/address.test.ts
+++ b/browser-test/src/applicant/questions/address.test.ts
@@ -1,3 +1,4 @@
+import {Page} from '@playwright/test'
 import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminPrograms,
@@ -8,9 +9,8 @@ import {
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
-import {Page} from '@playwright/test'
 
-test.describe('address applicant flow', () => {
+test.describe('address applicant flow', {tag: ['@uses-fixtures']}, () => {
   test.describe('single required address question', () => {
     const programName = 'Test program for single address'
 

--- a/browser-test/src/applicant/questions/checkbox.test.ts
+++ b/browser-test/src/applicant/questions/checkbox.test.ts
@@ -11,126 +11,303 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Checkbox question for applicant flow', {tag: ['@uses-fixtures']}, () => {
-  test.describe('single checkbox question', () => {
-    const programName = 'Test program for single checkbox'
+test.describe(
+  'Checkbox question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single checkbox question', () => {
+      const programName = 'Test program for single checkbox'
 
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test('Updates options in preview', async ({page, adminQuestions}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.createCheckboxQuestion(
+          {
+            questionName: 'not-used-in-test',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [
+              {adminName: 'red_admin', text: 'red'},
+              {adminName: 'green_admin', text: 'green'},
+              {adminName: 'orange_admin', text: 'orange'},
+              {adminName: 'blue_admin', text: 'blue'},
+            ],
+          },
+          /* clickSubmit= */ false,
+        )
+
+        // Verify question preview has the default values.
+        await adminQuestions.expectCommonPreviewValues({
+          questionText: 'Sample question text',
+          questionHelpText: 'Sample question help text',
+        })
+        await adminQuestions.expectPreviewOptions([
+          'red',
+          'green',
+          'orange',
+          'blue',
+        ])
+
+        // Empty options renders default text.
+        await adminQuestions.createCheckboxQuestion(
+          {
+            questionName: '',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [],
+          },
+          /* clickSubmit= */ false,
+        )
+        await adminQuestions.expectPreviewOptions(['Sample question option'])
+      })
+
+      test('validate screenshot', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateScreenshot(page, 'checkbox')
+      })
+
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
+
+        await validateScreenshot(page, 'checkbox-errors')
+      })
+
+      test('with single checked box submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerCheckboxQuestion(['blue'])
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with no checked boxes does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        // No validation errors on first page load.
+        const checkBoxError = '.cf-applicant-question-errors'
+        await expect(page.locator(checkBoxError)).toBeHidden()
+
+        // Click next without selecting anything.
+        await applicantQuestions.clickNext()
+
+        // Check checkbox error and required error are present.
+        await expect(page.locator(checkBoxError)).toBeVisible()
+
+        const checkboxId = '.cf-question-checkbox'
+        expect(await page.innerText(checkboxId)).toContain(
+          'This question is required.',
+        )
+      })
+
+      test('with greater than max allowed checked boxes does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        const checkBoxError = '.cf-applicant-question-errors'
+        // No validation errors on first page load.
+        await expect(page.locator(checkBoxError)).toBeHidden()
+
+        // Max of two checked boxes are allowed, but we select three.
+        await applicantQuestions.answerCheckboxQuestion([
+          'blue',
+          'green',
+          'orange',
+        ])
+        await applicantQuestions.clickNext()
+
+        // Check error is shown.
+        await expect(page.locator(checkBoxError)).toBeVisible()
+      })
     })
 
+    test.describe('multiple checkbox questions', () => {
+      const programName = 'Test program for multiple checkboxes'
 
-    test('Updates options in preview', async ({page, adminQuestions}) => {
-      await loginAsAdmin(page)
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
 
-      await adminQuestions.createCheckboxQuestion(
-        {
-          questionName: 'not-used-in-test',
-          questionText: 'Sample question text',
-          helpText: 'Sample question help text',
+        await adminQuestions.addCheckboxQuestion({
+          questionName: 'checkbox-fave-color-q',
           options: [
             {adminName: 'red_admin', text: 'red'},
             {adminName: 'green_admin', text: 'green'},
             {adminName: 'orange_admin', text: 'orange'},
             {adminName: 'blue_admin', text: 'blue'},
           ],
-        },
-        /* clickSubmit= */ false,
-      )
+          minNum: 1,
+          maxNum: 2,
+        })
+        await adminQuestions.addCheckboxQuestion({
+          questionName: 'checkbox-vacation-q',
+          options: [
+            {adminName: 'beach_admin', text: 'beach'},
+            {adminName: 'mountains_admin', text: 'mountains'},
+            {adminName: 'city_admin', text: 'city'},
+            {adminName: 'cruise_admin', text: 'cruise'},
+          ],
+          minNum: 1,
+          maxNum: 2,
+        })
 
-      // Verify question preview has the default values.
-      await adminQuestions.expectCommonPreviewValues({
-        questionText: 'Sample question text',
-        questionHelpText: 'Sample question help text',
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['checkbox-fave-color-q'],
+          'checkbox-vacation-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
       })
-      await adminQuestions.expectPreviewOptions([
-        'red',
-        'green',
-        'orange',
-        'blue',
-      ])
 
-      // Empty options renders default text.
-      await adminQuestions.createCheckboxQuestion(
-        {
-          questionName: '',
-          questionText: 'Sample question text',
-          helpText: 'Sample question help text',
-          options: [],
+      test('with valid checkboxes submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerCheckboxQuestion(['blue'])
+        await applicantQuestions.answerCheckboxQuestion(['beach'])
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer required question.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerCheckboxQuestion(['red'])
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with first invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        const checkboxError = '.cf-applicant-question-errors'
+        // No validation errors on first page load.
+        await expect(page.locator(checkboxError)).toBeHidden()
+
+        // Max of 2 answers allowed.
+        await applicantQuestions.answerCheckboxQuestion([
+          'red',
+          'green',
+          'orange',
+        ])
+        await applicantQuestions.answerCheckboxQuestion(['beach'])
+        await applicantQuestions.clickNext()
+
+        await expect(page.locator(checkboxError)).toBeVisible()
+      })
+
+      test('with second invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        const checkboxError = '.cf-applicant-question-errors'
+        // No validation errors on first page load.
+        await expect(page.locator(checkboxError)).toBeHidden()
+
+        await applicantQuestions.answerCheckboxQuestion(['red'])
+        // Max of 2 answers allowed.
+        await applicantQuestions.answerCheckboxQuestion([
+          'beach',
+          'mountains',
+          'city',
+        ])
+        await applicantQuestions.clickNext()
+
+        await expect(page.locator(checkboxError)).toBeVisible()
+      })
+
+      test('has no accessibility violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe('single checkbox question with north star flag enabled', () => {
+      const programName = 'Test program for single checkbox'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test(
+        'validate screenshot',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'checkbox-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'checkbox-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
         },
-        /* clickSubmit= */ false,
-      )
-      await adminQuestions.expectPreviewOptions(['Sample question option'])
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'checkbox')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'checkbox-errors')
-    })
-
-    test('with single checked box submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerCheckboxQuestion(['blue'])
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with no checked boxes does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      // No validation errors on first page load.
-      const checkBoxError = '.cf-applicant-question-errors'
-      await expect(page.locator(checkBoxError)).toBeHidden()
-
-      // Click next without selecting anything.
-      await applicantQuestions.clickNext()
-
-      // Check checkbox error and required error are present.
-      await expect(page.locator(checkBoxError)).toBeVisible()
-
-      const checkboxId = '.cf-question-checkbox'
-      expect(await page.innerText(checkboxId)).toContain(
-        'This question is required.',
       )
     })
 
-    test('with greater than max allowed checked boxes does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      const checkBoxError = '.cf-applicant-question-errors'
-      // No validation errors on first page load.
-      await expect(page.locator(checkBoxError)).toBeHidden()
-
-      // Max of two checked boxes are allowed, but we select three.
-      await applicantQuestions.answerCheckboxQuestion([
-        'blue',
-        'green',
-        'orange',
-      ])
-      await applicantQuestions.clickNext()
-
-      // Check error is shown.
-      await expect(page.locator(checkBoxError)).toBeVisible()
-    })
-  })
-
-  test.describe('multiple checkbox questions', () => {
-    const programName = 'Test program for multiple checkboxes'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with single checkbox question.
       await loginAsAdmin(page)
 
       await adminQuestions.addCheckboxQuestion({
-        questionName: 'checkbox-fave-color-q',
+        questionName: 'checkbox-color-q',
         options: [
           {adminName: 'red_admin', text: 'red'},
           {adminName: 'green_admin', text: 'green'},
@@ -140,143 +317,12 @@ test.describe('Checkbox question for applicant flow', {tag: ['@uses-fixtures']},
         minNum: 1,
         maxNum: 2,
       })
-      await adminQuestions.addCheckboxQuestion({
-        questionName: 'checkbox-vacation-q',
-        options: [
-          {adminName: 'beach_admin', text: 'beach'},
-          {adminName: 'mountains_admin', text: 'mountains'},
-          {adminName: 'city_admin', text: 'city'},
-          {adminName: 'cruise_admin', text: 'cruise'},
-        ],
-        minNum: 1,
-        maxNum: 2,
-      })
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['checkbox-color-q'],
         programName,
-        'Optional question block',
-        ['checkbox-fave-color-q'],
-        'checkbox-vacation-q', // optional
       )
-      await adminPrograms.publishAllDrafts()
 
       await logout(page)
-    })
-
-    test('with valid checkboxes submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerCheckboxQuestion(['blue'])
-      await applicantQuestions.answerCheckboxQuestion(['beach'])
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer required question.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerCheckboxQuestion(['red'])
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      const checkboxError = '.cf-applicant-question-errors'
-      // No validation errors on first page load.
-      await expect(page.locator(checkboxError)).toBeHidden()
-
-      // Max of 2 answers allowed.
-      await applicantQuestions.answerCheckboxQuestion([
-        'red',
-        'green',
-        'orange',
-      ])
-      await applicantQuestions.answerCheckboxQuestion(['beach'])
-      await applicantQuestions.clickNext()
-
-      await expect(page.locator(checkboxError)).toBeVisible()
-    })
-
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      const checkboxError = '.cf-applicant-question-errors'
-      // No validation errors on first page load.
-      await expect(page.locator(checkboxError)).toBeHidden()
-
-      await applicantQuestions.answerCheckboxQuestion(['red'])
-      // Max of 2 answers allowed.
-      await applicantQuestions.answerCheckboxQuestion([
-        'beach',
-        'mountains',
-        'city',
-      ])
-      await applicantQuestions.clickNext()
-
-      await expect(page.locator(checkboxError)).toBeVisible()
-    })
-
-    test('has no accessibility violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe('single checkbox question with north star flag enabled', () => {
-    const programName = 'Test program for single checkbox'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', {tag: ['@northstar']}, async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await test.step('Screenshot without errors', async () => {
-        await validateScreenshot(
-          page,
-          'checkbox-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
-
-      await test.step('Screenshot with errors', async () => {
-        await applicantQuestions.clickContinue()
-        await validateScreenshot(
-          page,
-          'checkbox-errors-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
-    })
-  })
-
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with single checkbox question.
-    await loginAsAdmin(page)
-
-    await adminQuestions.addCheckboxQuestion({
-      questionName: 'checkbox-color-q',
-      options: [
-        {adminName: 'red_admin', text: 'red'},
-        {adminName: 'green_admin', text: 'green'},
-        {adminName: 'orange_admin', text: 'orange'},
-        {adminName: 'blue_admin', text: 'blue'},
-      ],
-      minNum: 1,
-      maxNum: 2,
-    })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['checkbox-color-q'],
-      programName,
-    )
-
-    await logout(page)
-  }
-})
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/checkbox.test.ts
+++ b/browser-test/src/applicant/questions/checkbox.test.ts
@@ -1,6 +1,8 @@
-import {test, expect} from '@playwright/test'
+import {Page} from '@playwright/test'
+import {test, expect} from '../../support/civiform_fixtures'
 import {
-  createTestContext,
+  AdminPrograms,
+  AdminQuestions,
   disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
@@ -9,23 +11,17 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Checkbox question for applicant flow', () => {
-  const ctx = createTestContext(/* clearDb= */ false)
-
+test.describe('Checkbox question for applicant flow', {tag: ['@uses-fixtures']}, () => {
   test.describe('single checkbox question', () => {
     const programName = 'Test program for single checkbox'
 
-    test.beforeAll(async () => {
-      await setUpForSingleQuestion(programName)
-    })
-
-    test.beforeEach(async () => {
-      const {page} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
       await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
-    test('Updates options in preview', async () => {
-      const {page, adminQuestions} = ctx
+
+    test('Updates options in preview', async ({page, adminQuestions}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.createCheckboxQuestion(
@@ -68,23 +64,20 @@ test.describe('Checkbox question for applicant flow', () => {
       await adminQuestions.expectPreviewOptions(['Sample question option'])
     })
 
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'checkbox')
     })
 
-    test('validate screenshot with errors', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'checkbox-errors')
     })
 
-    test('with single checked box submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with single checked box submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['blue'])
       await applicantQuestions.clickNext()
@@ -92,8 +85,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with no checked boxes does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with no checked boxes does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       // No validation errors on first page load.
@@ -112,8 +104,7 @@ test.describe('Checkbox question for applicant flow', () => {
       )
     })
 
-    test('with greater than max allowed checked boxes does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with greater than max allowed checked boxes does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       const checkBoxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
@@ -135,8 +126,7 @@ test.describe('Checkbox question for applicant flow', () => {
   test.describe('multiple checkbox questions', () => {
     const programName = 'Test program for multiple checkboxes'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addCheckboxQuestion({
@@ -174,8 +164,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await logout(page)
     })
 
-    test('with valid checkboxes submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid checkboxes submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['blue'])
       await applicantQuestions.answerCheckboxQuestion(['beach'])
@@ -184,8 +173,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with unanswered optional question submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
       // Only answer required question.
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['red'])
@@ -194,8 +182,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
@@ -213,8 +200,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await expect(page.locator(checkboxError)).toBeVisible()
     })
 
-    test('with second invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       const checkboxError = '.cf-applicant-question-errors'
       // No validation errors on first page load.
@@ -232,8 +218,7 @@ test.describe('Checkbox question for applicant flow', () => {
       await expect(page.locator(checkboxError)).toBeVisible()
     })
 
-    test('has no accessibility violations', async () => {
-      const {page, applicantQuestions} = ctx
+    test('has no accessibility violations', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -243,17 +228,12 @@ test.describe('Checkbox question for applicant flow', () => {
   test.describe('single checkbox question with north star flag enabled', () => {
     const programName = 'Test program for single checkbox'
 
-    test.beforeAll(async () => {
-      await setUpForSingleQuestion(programName)
-    })
-
-    test.beforeEach(async () => {
-      const {page} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
       await enableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
-    test('validate screenshot', {tag: ['@northstar']}, async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', {tag: ['@northstar']}, async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await test.step('Screenshot without errors', async () => {
@@ -277,8 +257,7 @@ test.describe('Checkbox question for applicant flow', () => {
     })
   })
 
-  async function setUpForSingleQuestion(programName: string) {
-    const {page, adminQuestions, adminPrograms} = ctx
+  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
     // As admin, create program with single checkbox question.
     await loginAsAdmin(page)
 

--- a/browser-test/src/applicant/questions/currency.test.ts
+++ b/browser-test/src/applicant/questions/currency.test.ts
@@ -19,7 +19,12 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
     const programName = 'Test program for single currency'
 
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleCurrencyQuestion(programName, page, adminQuestions, adminPrograms)
+      await setUpSingleCurrencyQuestion(
+        programName,
+        page,
+        adminQuestions,
+        adminPrograms,
+      )
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {
@@ -28,7 +33,10 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await validateScreenshot(page, 'currency')
     })
 
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
+    test('validate screenshot with errors', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
@@ -43,7 +51,10 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with invalid currency does not submit', async ({page, applicantQuestions}) => {
+    test('with invalid currency does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error'
       // When there are no validation errors, the div still exists but is hidden.
@@ -92,7 +103,9 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with unanswered optional question submits', async ({applicantQuestions}) => {
+    test('with unanswered optional question submits', async ({
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCurrencyQuestion(validCurrency, 1)
       await applicantQuestions.clickNext()
@@ -100,7 +113,10 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with first invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=0'
       // When there are no validation errors, the div still exists but is hidden.
@@ -113,7 +129,10 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await expect(page.locator(currencyError)).toBeVisible()
     })
 
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with second invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       const currencyError = '.cf-currency-value-error >> nth=1'
       // When there are no validation errors, the div still exists but is hidden.
@@ -126,7 +145,10 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
       await expect(page.locator(currencyError)).toBeVisible()
     })
 
-    test('has no accessibility violations', async ({page, applicantQuestions}) => {
+    test('has no accessibility violations', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -137,35 +159,49 @@ test.describe('currency applicant flow', {tag: ['@uses-fixtures']}, () => {
     const programName = 'Test program for single currency'
 
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleCurrencyQuestion(programName, page, adminQuestions, adminPrograms)
+      await setUpSingleCurrencyQuestion(
+        programName,
+        page,
+        adminQuestions,
+        adminPrograms,
+      )
       await enableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
-    test('validate screenshot', {tag: ['@northstar']}, async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
+    test(
+      'validate screenshot',
+      {tag: ['@northstar']},
+      async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
 
-      await test.step('Screenshot without errors', async () => {
-        await validateScreenshot(
-          page,
-          'currency-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
+        await test.step('Screenshot without errors', async () => {
+          await validateScreenshot(
+            page,
+            'currency-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
 
-      await test.step('Screenshot with errors', async () => {
-        await applicantQuestions.clickContinue()
-        await validateScreenshot(
-          page,
-          'currency-errors-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
-    })
+        await test.step('Screenshot with errors', async () => {
+          await applicantQuestions.clickContinue()
+          await validateScreenshot(
+            page,
+            'currency-errors-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
+      },
+    )
   })
 
-  async function setUpSingleCurrencyQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
+  async function setUpSingleCurrencyQuestion(
+    programName: string,
+    page: Page,
+    adminQuestions: AdminQuestions,
+    adminPrograms: AdminPrograms,
+  ) {
     await loginAsAdmin(page)
 
     await adminQuestions.addCurrencyQuestion({questionName: 'currency-q'})

--- a/browser-test/src/applicant/questions/dropdown.test.ts
+++ b/browser-test/src/applicant/questions/dropdown.test.ts
@@ -10,108 +10,227 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Dropdown question for applicant flow', {tag: ['@uses-fixtures']}, () => {
+test.describe(
+  'Dropdown question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single dropdown question', () => {
+      const programName = 'Test program for single dropdown'
 
-  test.describe('single dropdown question', () => {
-    const programName = 'Test program for single dropdown'
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpSingleDropdownQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+      })
 
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleDropdownQuestion(programName, page, adminQuestions, adminPrograms)
+      test('Updates options in preview', async ({page, adminQuestions}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.createDropdownQuestion(
+          {
+            questionName: 'not-used-in-test',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [
+              {adminName: 'red_admin', text: 'red'},
+              {adminName: 'green_admin', text: 'green'},
+              {adminName: 'orange_admin', text: 'orange'},
+              {adminName: 'blue_admin', text: 'blue'},
+            ],
+          },
+          /* clickSubmit= */ false,
+        )
+
+        // Verify question preview has the default values.
+        await adminQuestions.expectCommonPreviewValues({
+          questionText: 'Sample question text',
+          questionHelpText: 'Sample question help text',
+        })
+        await adminQuestions.expectPreviewOptions([
+          'red',
+          'green',
+          'orange',
+          'blue',
+        ])
+
+        // Empty options renders default text.
+        await adminQuestions.createDropdownQuestion(
+          {
+            questionName: '',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [],
+          },
+          /* clickSubmit= */ false,
+        )
+        await adminQuestions.expectPreviewOptions(['Sample question option'])
+      })
+
+      test('validate screenshot', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateScreenshot(page, 'dropdown')
+      })
+
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
+
+        await validateScreenshot(page, 'dropdown-errors')
+      })
+
+      test('with selected option submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerDropdownQuestion('green')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with no selection does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        // Click next without selecting anything.
+        await applicantQuestions.clickNext()
+
+        const dropdownId = '.cf-question-dropdown'
+        expect(await page.innerText(dropdownId)).toContain(
+          'This question is required.',
+        )
+      })
     })
 
-    test('Updates options in preview', async ({page, adminQuestions}) => {
-      await loginAsAdmin(page)
+    test.describe('multiple dropdown questions', () => {
+      const programName = 'Test program for multiple dropdowns'
 
-      await adminQuestions.createDropdownQuestion(
-        {
-          questionName: 'not-used-in-test',
-          questionText: 'Sample question text',
-          helpText: 'Sample question help text',
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addDropdownQuestion({
+          questionName: 'dropdown-fave-vacation-q',
+          options: [
+            {adminName: 'beach_admin', text: 'beach'},
+            {adminName: 'mountains_admin', text: 'mountains'},
+            {adminName: 'city_admin', text: 'city'},
+            {adminName: 'cruise_admin', text: 'cruise'},
+          ],
+        })
+        await adminQuestions.addDropdownQuestion({
+          questionName: 'dropdown-fave-color-q',
           options: [
             {adminName: 'red_admin', text: 'red'},
             {adminName: 'green_admin', text: 'green'},
             {adminName: 'orange_admin', text: 'orange'},
             {adminName: 'blue_admin', text: 'blue'},
           ],
-        },
-        /* clickSubmit= */ false,
-      )
+        })
 
-      // Verify question preview has the default values.
-      await adminQuestions.expectCommonPreviewValues({
-        questionText: 'Sample question text',
-        questionHelpText: 'Sample question help text',
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['dropdown-fave-color-q'],
+          'dropdown-fave-vacation-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
       })
-      await adminQuestions.expectPreviewOptions([
-        'red',
-        'green',
-        'orange',
-        'blue',
-      ])
 
-      // Empty options renders default text.
-      await adminQuestions.createDropdownQuestion(
-        {
-          questionName: '',
-          questionText: 'Sample question text',
-          helpText: 'Sample question help text',
-          options: [],
+      test('with selected options submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerDropdownQuestion('beach', 0)
+        await applicantQuestions.answerDropdownQuestion('blue', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerDropdownQuestion('red', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('has no accessibility violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe('single dropdown question with north star flag enabled', () => {
+      const programName = 'Test program for single dropdown'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpSingleDropdownQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test(
+        'validate screenshot',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'dropdown-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'dropdown-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
         },
-        /* clickSubmit= */ false,
-      )
-      await adminQuestions.expectPreviewOptions(['Sample question option'])
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'dropdown')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'dropdown-errors')
-    })
-
-    test('with selected option submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerDropdownQuestion('green')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with no selection does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      // Click next without selecting anything.
-      await applicantQuestions.clickNext()
-
-      const dropdownId = '.cf-question-dropdown'
-      expect(await page.innerText(dropdownId)).toContain(
-        'This question is required.',
       )
     })
-  })
 
-  test.describe('multiple dropdown questions', () => {
-    const programName = 'Test program for multiple dropdowns'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    async function setUpSingleDropdownQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with single dropdown question.
       await loginAsAdmin(page)
 
       await adminQuestions.addDropdownQuestion({
-        questionName: 'dropdown-fave-vacation-q',
-        options: [
-          {adminName: 'beach_admin', text: 'beach'},
-          {adminName: 'mountains_admin', text: 'mountains'},
-          {adminName: 'city_admin', text: 'city'},
-          {adminName: 'cruise_admin', text: 'cruise'},
-        ],
-      })
-      await adminQuestions.addDropdownQuestion({
-        questionName: 'dropdown-fave-color-q',
+        questionName: 'dropdown-color-q',
         options: [
           {adminName: 'red_admin', text: 'red'},
           {adminName: 'green_admin', text: 'green'},
@@ -119,94 +238,12 @@ test.describe('Dropdown question for applicant flow', {tag: ['@uses-fixtures']},
           {adminName: 'blue_admin', text: 'blue'},
         ],
       })
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['dropdown-color-q'],
         programName,
-        'Optional question block',
-        ['dropdown-fave-color-q'],
-        'dropdown-fave-vacation-q', // optional
       )
-      await adminPrograms.publishAllDrafts()
 
       await logout(page)
-    })
-
-    test('with selected options submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerDropdownQuestion('beach', 0)
-      await applicantQuestions.answerDropdownQuestion('blue', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerDropdownQuestion('red', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('has no accessibility violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe('single dropdown question with north star flag enabled', () => {
-    const programName = 'Test program for single dropdown'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleDropdownQuestion(programName, page, adminQuestions, adminPrograms)
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', {tag: ['@northstar']}, async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await test.step('Screenshot without errors', async () => {
-        await validateScreenshot(
-          page,
-          'dropdown-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
-
-      await test.step('Screenshot with errors', async () => {
-        await applicantQuestions.clickContinue()
-        await validateScreenshot(
-          page,
-          'dropdown-errors-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
-    })
-  })
-
-  async function setUpSingleDropdownQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with single dropdown question.
-    await loginAsAdmin(page)
-
-    await adminQuestions.addDropdownQuestion({
-      questionName: 'dropdown-color-q',
-      options: [
-        {adminName: 'red_admin', text: 'red'},
-        {adminName: 'green_admin', text: 'green'},
-        {adminName: 'orange_admin', text: 'orange'},
-        {adminName: 'blue_admin', text: 'blue'},
-      ],
-    })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['dropdown-color-q'],
-      programName,
-    )
-
-    await logout(page)
-  }
-})
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/email.test.ts
+++ b/browser-test/src/applicant/questions/email.test.ts
@@ -10,149 +10,187 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Email question for applicant flow', {tag: ['@uses-fixtures']}, () => {
-
-  test.describe('single email question', () => {
-    const programName = 'Test program for single email'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'email')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'email-errors')
-    })
-
-    test('with email input submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with no email input does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      // Click next without inputting anything.
-      await applicantQuestions.clickNext()
-
-      const emailId = '.cf-question-email'
-      expect(await page.innerText(emailId)).toContain(
-        'This question is required.',
-      )
-      expect(await page.innerHTML(emailId)).toContain('autofocus')
-    })
-  })
-
-  test.describe('multiple email questions', () => {
-    const programName = 'Test program for multiple emails'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await loginAsAdmin(page)
-
-      await adminQuestions.addEmailQuestion({questionName: 'my-email-q'})
-      await adminQuestions.addEmailQuestion({questionName: 'your-email-q'})
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
-        programName,
-        'Optional question block',
-        ['my-email-q'],
-        'your-email-q', // optional
-      )
-      await adminPrograms.publishAllDrafts()
-
-      await logout(page)
-    })
-
-    test('with email inputs submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerEmailQuestion('your_email@civiform.gov', 0)
-      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe(
-    'single email question with North Star flag enabled',
-    {tag: ['@northstar']},
-    () => {
+test.describe(
+  'Email question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single email question', () => {
       const programName = 'Test program for single email'
 
       test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-        await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
       })
 
       test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
-        await test.step('Screenshot without errors', async () => {
-          await validateScreenshot(
-            page,
-            'email-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-
-        await test.step('Screenshot with errors', async () => {
-          await applicantQuestions.clickContinue()
-          await validateScreenshot(
-            page,
-            'email-errors-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
+        await validateScreenshot(page, 'email')
       })
 
-      test('with email input submits successfully', async ({applicantQuestions}) => {
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
+
+        await validateScreenshot(page, 'email-errors')
+      })
+
+      test('with email input submits successfully', async ({
+        applicantQuestions,
+      }) => {
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerEmailQuestion('my_email@civiform.gov')
-        await applicantQuestions.clickContinue()
+        await applicantQuestions.clickNext()
 
         await applicantQuestions.submitFromReviewPage()
       })
-    },
-  )
 
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with single email question.
-    await loginAsAdmin(page)
+      test('with no email input does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        // Click next without inputting anything.
+        await applicantQuestions.clickNext()
 
-    await adminQuestions.addEmailQuestion({questionName: 'general-email-q'})
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['general-email-q'],
-      programName,
+        const emailId = '.cf-question-email'
+        expect(await page.innerText(emailId)).toContain(
+          'This question is required.',
+        )
+        expect(await page.innerHTML(emailId)).toContain('autofocus')
+      })
+    })
+
+    test.describe('multiple email questions', () => {
+      const programName = 'Test program for multiple emails'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addEmailQuestion({questionName: 'my-email-q'})
+        await adminQuestions.addEmailQuestion({questionName: 'your-email-q'})
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['my-email-q'],
+          'your-email-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with email inputs submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerEmailQuestion(
+          'your_email@civiform.gov',
+          0,
+        )
+        await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe(
+      'single email question with North Star flag enabled',
+      {tag: ['@northstar']},
+      () => {
+        const programName = 'Test program for single email'
+
+        test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+          await setUpForSingleQuestion(
+            programName,
+            page,
+            adminQuestions,
+            adminPrograms,
+          )
+          await enableFeatureFlag(page, 'north_star_applicant_ui')
+        })
+
+        test('validate screenshot', async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'email-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'email-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+        })
+
+        test('with email input submits successfully', async ({
+          applicantQuestions,
+        }) => {
+          await applicantQuestions.applyProgram(programName)
+          await applicantQuestions.answerEmailQuestion('my_email@civiform.gov')
+          await applicantQuestions.clickContinue()
+
+          await applicantQuestions.submitFromReviewPage()
+        })
+      },
     )
 
-    await logout(page)
-  }
-})
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with single email question.
+      await loginAsAdmin(page)
+
+      await adminQuestions.addEmailQuestion({questionName: 'general-email-q'})
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['general-email-q'],
+        programName,
+      )
+
+      await logout(page)
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/id.test.ts
+++ b/browser-test/src/applicant/questions/id.test.ts
@@ -11,204 +11,253 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Id question for applicant flow', {tag: ['@uses-fixtures']}, () => {
+test.describe(
+  'Id question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single id question', () => {
+      const programName = 'Test program for single id'
 
-  test.describe('single id question', () => {
-    const programName = 'Test program for single id'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpProgramWithSingleIdQuestion(programName, page, adminQuestions, adminPrograms)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'id')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'id-errors')
-    })
-
-    test('with id submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('12345')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with empty id does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      // Click next without inputting anything
-      await applicantQuestions.clickNext()
-
-      const identificationId = '.cf-question-id'
-      expect(await page.innerText(identificationId)).toContain(
-        'This question is required.',
-      )
-    })
-
-    test('with too short id does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('123')
-      await applicantQuestions.clickNext()
-
-      const identificationId = '.cf-question-id'
-      expect(await page.innerText(identificationId)).toContain(
-        'Must contain at least 5 characters.',
-      )
-    })
-
-    test('with too long id does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('123456')
-      await applicantQuestions.clickNext()
-
-      const identificationId = '.cf-question-id'
-      expect(await page.innerText(identificationId)).toContain(
-        'Must contain at most 5 characters.',
-      )
-    })
-
-    test('with non-numeric characters does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('abcde')
-      await applicantQuestions.clickNext()
-
-      const identificationId = '.cf-question-id'
-      expect(await page.innerText(identificationId)).toContain(
-        'Must contain only numbers.',
-      )
-    })
-  })
-
-  test.describe('multiple id questions', () => {
-    const programName = 'Test program for multiple ids'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-     await loginAsAdmin(page)
-
-      await adminQuestions.addIdQuestion({
-        questionName: 'my-id-q',
-      })
-      await adminQuestions.addIdQuestion({
-        questionName: 'your-id-q',
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpProgramWithSingleIdQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
-        programName,
-        'Optional question block',
-        ['my-id-q'],
-        'your-id-q', // optional
-      )
-      await adminPrograms.publishAllDrafts()
-
-      await logout(page)
-    })
-
-    test('with both id inputs submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('12345', 0)
-      await applicantQuestions.answerIdQuestion('67890', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('67890', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('abcde', 0)
-      await applicantQuestions.answerIdQuestion('67890', 1)
-      await applicantQuestions.clickNext()
-
-      const identificationId = '.cf-question-id'
-      expect(await page.innerText(identificationId)).toContain(
-        'Must contain only numbers.',
-      )
-    })
-
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerIdQuestion('67890', 0)
-      await applicantQuestions.answerIdQuestion('abcde', 1)
-      await applicantQuestions.clickNext()
-
-      const identificationId = `.cf-question-id >> nth=1`
-      expect(await page.innerText(identificationId)).toContain(
-        'Must contain only numbers.',
-      )
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe('single id question with north star flag enabled', () => {
-    const programName = 'Test program for single id'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpProgramWithSingleIdQuestion(programName, page, adminQuestions, adminPrograms)
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test(
-      'validate screenshot with north star flag enabled',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
+      test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
-        await test.step('Screenshot without errors', async () => {
-          await validateScreenshot(
-            page,
-            'id-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
+        await validateScreenshot(page, 'id')
+      })
 
-        await test.step('Screenshot with errors', async () => {
-          await applicantQuestions.clickContinue()
-          await validateScreenshot(
-            page,
-            'id-errors-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-      },
-    )
-  })
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
 
-  async function setUpProgramWithSingleIdQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with single id question.
-    await loginAsAdmin(page)
+        await validateScreenshot(page, 'id-errors')
+      })
 
-    await adminQuestions.addIdQuestion({
-      questionName: 'id-q',
-      minNum: 5,
-      maxNum: 5,
+      test('with id submits successfully', async ({applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('12345')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with empty id does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        // Click next without inputting anything
+        await applicantQuestions.clickNext()
+
+        const identificationId = '.cf-question-id'
+        expect(await page.innerText(identificationId)).toContain(
+          'This question is required.',
+        )
+      })
+
+      test('with too short id does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('123')
+        await applicantQuestions.clickNext()
+
+        const identificationId = '.cf-question-id'
+        expect(await page.innerText(identificationId)).toContain(
+          'Must contain at least 5 characters.',
+        )
+      })
+
+      test('with too long id does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('123456')
+        await applicantQuestions.clickNext()
+
+        const identificationId = '.cf-question-id'
+        expect(await page.innerText(identificationId)).toContain(
+          'Must contain at most 5 characters.',
+        )
+      })
+
+      test('with non-numeric characters does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('abcde')
+        await applicantQuestions.clickNext()
+
+        const identificationId = '.cf-question-id'
+        expect(await page.innerText(identificationId)).toContain(
+          'Must contain only numbers.',
+        )
+      })
     })
-    await adminPrograms.addAndPublishProgramWithQuestions(['id-q'], programName)
 
-    await logout(page)
-  }
-})
+    test.describe('multiple id questions', () => {
+      const programName = 'Test program for multiple ids'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addIdQuestion({
+          questionName: 'my-id-q',
+        })
+        await adminQuestions.addIdQuestion({
+          questionName: 'your-id-q',
+        })
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['my-id-q'],
+          'your-id-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with both id inputs submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('12345', 0)
+        await applicantQuestions.answerIdQuestion('67890', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('67890', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with first invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('abcde', 0)
+        await applicantQuestions.answerIdQuestion('67890', 1)
+        await applicantQuestions.clickNext()
+
+        const identificationId = '.cf-question-id'
+        expect(await page.innerText(identificationId)).toContain(
+          'Must contain only numbers.',
+        )
+      })
+
+      test('with second invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerIdQuestion('67890', 0)
+        await applicantQuestions.answerIdQuestion('abcde', 1)
+        await applicantQuestions.clickNext()
+
+        const identificationId = `.cf-question-id >> nth=1`
+        expect(await page.innerText(identificationId)).toContain(
+          'Must contain only numbers.',
+        )
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe('single id question with north star flag enabled', () => {
+      const programName = 'Test program for single id'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpProgramWithSingleIdQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test(
+        'validate screenshot with north star flag enabled',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'id-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'id-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+        },
+      )
+    })
+
+    async function setUpProgramWithSingleIdQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with single id question.
+      await loginAsAdmin(page)
+
+      await adminQuestions.addIdQuestion({
+        questionName: 'id-q',
+        minNum: 5,
+        maxNum: 5,
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['id-q'],
+        programName,
+      )
+
+      await logout(page)
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -15,12 +15,16 @@ const NAME_FIRST = '.cf-name-first'
 const NAME_LAST = '.cf-name-last'
 
 test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
-
   test.describe('single required name question', () => {
     const programName = 'Test program for single name'
 
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleRequiredQuestion(programName, page, adminQuestions, adminPrograms)
+      await setUpSingleRequiredQuestion(
+        programName,
+        page,
+        adminQuestions,
+        adminPrograms,
+      )
       await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
@@ -30,14 +34,20 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       await validateScreenshot(page, 'name')
     })
 
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
+    test('validate screenshot with errors', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'name-errors')
     })
 
-    test('does not show errors initially', async ({page, applicantQuestions}) => {
+    test('does not show errors initially', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '')
       let error = await page.$(`${NAME_FIRST}-error`)
@@ -54,7 +64,10 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with empty name does not submit', async ({page, applicantQuestions}) => {
+    test('with empty name does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '')
       await applicantQuestions.clickNext()
@@ -95,7 +108,10 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with first invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('', '', '', 0)
       await applicantQuestions.answerNameQuestion('Chuckie', 'Finster', '', 1)
@@ -114,7 +130,10 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       expect(await error?.isHidden()).toEqual(true)
     })
 
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
+    test('with second invalid does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 0)
       await applicantQuestions.answerNameQuestion('', '', '', 1)
@@ -133,7 +152,10 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       expect(await error?.isHidden()).toEqual(false)
     })
 
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
+    test('has no accessiblity violations', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -165,7 +187,9 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       await logout(page)
     })
 
-    test('with valid required name does submit', async ({applicantQuestions}) => {
+    test('with valid required name does submit', async ({
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 1)
       await applicantQuestions.clickNext()
@@ -173,7 +197,10 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with invalid optional name does not submit', async ({page, applicantQuestions}) => {
+    test('with invalid optional name does not submit', async ({
+      page,
+      applicantQuestions,
+    }) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNameQuestion('Tommy', '', '', 0)
       await applicantQuestions.answerNameQuestion('Tommy', 'Pickles', '', 1)
@@ -212,11 +239,15 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
   test.describe('single required name question with north star flag enabled', () => {
     const programName = 'Test program for single name'
 
-    test.beforeAll(async () => {
-    })
+    test.beforeAll(async () => {})
 
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpSingleRequiredQuestion(programName, page, adminQuestions, adminPrograms)
+      await setUpSingleRequiredQuestion(
+        programName,
+        page,
+        adminQuestions,
+        adminPrograms,
+      )
       await enableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
@@ -248,7 +279,12 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
     )
   })
 
-  async function setUpSingleRequiredQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
+  async function setUpSingleRequiredQuestion(
+    programName: string,
+    page: Page,
+    adminQuestions: AdminQuestions,
+    adminPrograms: AdminPrograms,
+  ) {
     await loginAsAdmin(page)
 
     await adminQuestions.addNameQuestion({

--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -239,8 +239,6 @@ test.describe('name applicant flow', {tag: ['@uses-fixtures']}, () => {
   test.describe('single required name question with north star flag enabled', () => {
     const programName = 'Test program for single name'
 
-    test.beforeAll(async () => {})
-
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await setUpSingleRequiredQuestion(
         programName,

--- a/browser-test/src/applicant/questions/number_input.test.ts
+++ b/browser-test/src/applicant/questions/number_input.test.ts
@@ -1,6 +1,8 @@
-import {test, expect} from '@playwright/test'
+import {Page} from '@playwright/test'
+import {test, expect} from '../../support/civiform_fixtures'
 import {
-  createTestContext,
+  AdminQuestions,
+  AdminPrograms,
   disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
@@ -9,39 +11,31 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Number question for applicant flow', () => {
-  const ctx = createTestContext(/* clearDb= */ false)
+test.describe('Number question for applicant flow', {tag: ['@uses-fixtures']}, () => {
   const numberInputError = 'div.cf-question-number-error'
 
   test.describe('single number question', () => {
     const programName = 'Test program for single number'
 
-    test.beforeAll(async () => {
-      await setUpForSingleQuestion(programName)
-    })
-
-    test.beforeEach(async () => {
-      const {page} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
       await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'number')
     })
 
-    test('validate screenshot with errors', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'number-errors')
     })
 
-    test('with valid number submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid number submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('8')
       await applicantQuestions.clickNext()
@@ -49,8 +43,7 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with no input does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with no input does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       // Leave field blank.
       await applicantQuestions.clickNext()
@@ -61,8 +54,7 @@ test.describe('Number question for applicant flow', () => {
       )
     })
 
-    test('with non-numeric inputs does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with non-numeric inputs does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       const testValues = ['12e3', '12E3', '-123', '1.23']
 
@@ -79,8 +71,7 @@ test.describe('Number question for applicant flow', () => {
   test.describe('multiple number questions', () => {
     const programName = 'Test program for multiple numbers'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addNumberQuestion({
@@ -102,8 +93,7 @@ test.describe('Number question for applicant flow', () => {
       await logout(page)
     })
 
-    test('with valid numbers submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with valid numbers submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('100', 0)
       await applicantQuestions.answerNumberQuestion('33', 1)
@@ -112,8 +102,7 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with unanswered optional question submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
       // Only answer required question.
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('33', 1)
@@ -122,8 +111,7 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('-10', 0)
       await applicantQuestions.answerNumberQuestion('33', 1)
@@ -139,8 +127,7 @@ test.describe('Number question for applicant flow', () => {
       expect(await page.isHidden(numberInputError)).toEqual(false)
     })
 
-    test('with second invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerNumberQuestion('10', 0)
       await applicantQuestions.answerNumberQuestion('-5', 1)
@@ -156,8 +143,7 @@ test.describe('Number question for applicant flow', () => {
       expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(false)
     })
 
-    test('has no accessiblity violations', async () => {
-      const {page, applicantQuestions} = ctx
+    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -170,17 +156,12 @@ test.describe('Number question for applicant flow', () => {
     () => {
       const programName = 'Test program for single number'
 
-      test.beforeAll(async () => {
-        await setUpForSingleQuestion(programName)
-      })
-
-      test.beforeEach(async () => {
-        const {page} = ctx
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
         await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
-      test('validate screenshot', async () => {
-        const {page, applicantQuestions} = ctx
+      test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
         await test.step('Screenshot without errors', async () => {
@@ -205,8 +186,7 @@ test.describe('Number question for applicant flow', () => {
     },
   )
 
-  async function setUpForSingleQuestion(programName: string) {
-    const {page, adminQuestions, adminPrograms} = ctx
+  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
     // As admin, create program with single number question.
     await loginAsAdmin(page)
 

--- a/browser-test/src/applicant/questions/number_input.test.ts
+++ b/browser-test/src/applicant/questions/number_input.test.ts
@@ -11,193 +11,238 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Number question for applicant flow', {tag: ['@uses-fixtures']}, () => {
-  const numberInputError = 'div.cf-question-number-error'
+test.describe(
+  'Number question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    const numberInputError = 'div.cf-question-number-error'
 
-  test.describe('single number question', () => {
-    const programName = 'Test program for single number'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'number')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'number-errors')
-    })
-
-    test('with valid number submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerNumberQuestion('8')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with no input does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      // Leave field blank.
-      await applicantQuestions.clickNext()
-
-      const numberId = '.cf-question-number'
-      expect(await page.innerText(numberId)).toContain(
-        'This question is required.',
-      )
-    })
-
-    test('with non-numeric inputs does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      const testValues = ['12e3', '12E3', '-123', '1.23']
-
-      for (const testValue of testValues) {
-        await applicantQuestions.answerNumberQuestion(testValue)
-        await applicantQuestions.clickNext()
-
-        await expect(page.locator(numberInputError)).toBeVisible()
-        await applicantQuestions.answerNumberQuestion('')
-      }
-    })
-  })
-
-  test.describe('multiple number questions', () => {
-    const programName = 'Test program for multiple numbers'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await loginAsAdmin(page)
-
-      await adminQuestions.addNumberQuestion({
-        questionName: 'my-number-q',
-      })
-      await adminQuestions.addNumberQuestion({
-        questionName: 'your-number-q',
-      })
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
-        programName,
-        'Optional question block',
-        ['my-number-q'],
-        'your-number-q', // optional
-      )
-      await adminPrograms.publishAllDrafts()
-
-      await logout(page)
-    })
-
-    test('with valid numbers submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerNumberQuestion('100', 0)
-      await applicantQuestions.answerNumberQuestion('33', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer required question.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerNumberQuestion('33', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerNumberQuestion('-10', 0)
-      await applicantQuestions.answerNumberQuestion('33', 1)
-      await applicantQuestions.clickNext()
-
-      // Fix me! ESLint: playwright/prefer-web-first-assertions
-      // Directly switching to the best practice method fails
-      // because of a locator stict mode violation. That is it
-      // returns multiple elements.
-      //
-      // Recommended prefer-web-first-assertions fix:
-      //   await expect(page.locator(numberInputError)).toBeVisible()
-      expect(await page.isHidden(numberInputError)).toEqual(false)
-    })
-
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerNumberQuestion('10', 0)
-      await applicantQuestions.answerNumberQuestion('-5', 1)
-      await applicantQuestions.clickNext()
-
-      // Fix me! ESLint: playwright/prefer-web-first-assertions
-      // Directly switching to the best practice method fails
-      // because of a locator stict mode violation. That is it
-      // returns multiple elements.
-      //
-      // Recommended prefer-web-first-assertions fix:
-      //   await expect(page.locator(numberInputError + ' >> nth=1')).toBeVisible()
-      expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(false)
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe(
-    'single number question with North Star flag enabled',
-    {tag: ['@northstar']},
-    () => {
+    test.describe('single number question', () => {
       const programName = 'Test program for single number'
 
       test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-        await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
       test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
-        await test.step('Screenshot without errors', async () => {
-          await validateScreenshot(
-            page,
-            'number-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-
-        await test.step('Screenshot with errors', async () => {
-          await applicantQuestions.clickContinue()
-          await validateScreenshot(
-            page,
-            'number-errors-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
+        await validateScreenshot(page, 'number')
       })
-    },
-  )
 
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with single number question.
-    await loginAsAdmin(page)
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
 
-    await adminQuestions.addNumberQuestion({
-      questionName: 'fave-number-q',
+        await validateScreenshot(page, 'number-errors')
+      })
+
+      test('with valid number submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNumberQuestion('8')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with no input does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        // Leave field blank.
+        await applicantQuestions.clickNext()
+
+        const numberId = '.cf-question-number'
+        expect(await page.innerText(numberId)).toContain(
+          'This question is required.',
+        )
+      })
+
+      test('with non-numeric inputs does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        const testValues = ['12e3', '12E3', '-123', '1.23']
+
+        for (const testValue of testValues) {
+          await applicantQuestions.answerNumberQuestion(testValue)
+          await applicantQuestions.clickNext()
+
+          await expect(page.locator(numberInputError)).toBeVisible()
+          await applicantQuestions.answerNumberQuestion('')
+        }
+      })
     })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['fave-number-q'],
-      programName,
+
+    test.describe('multiple number questions', () => {
+      const programName = 'Test program for multiple numbers'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addNumberQuestion({
+          questionName: 'my-number-q',
+        })
+        await adminQuestions.addNumberQuestion({
+          questionName: 'your-number-q',
+        })
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['my-number-q'],
+          'your-number-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with valid numbers submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNumberQuestion('100', 0)
+        await applicantQuestions.answerNumberQuestion('33', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer required question.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNumberQuestion('33', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with first invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNumberQuestion('-10', 0)
+        await applicantQuestions.answerNumberQuestion('33', 1)
+        await applicantQuestions.clickNext()
+
+        // Fix me! ESLint: playwright/prefer-web-first-assertions
+        // Directly switching to the best practice method fails
+        // because of a locator stict mode violation. That is it
+        // returns multiple elements.
+        //
+        // Recommended prefer-web-first-assertions fix:
+        //   await expect(page.locator(numberInputError)).toBeVisible()
+        expect(await page.isHidden(numberInputError)).toEqual(false)
+      })
+
+      test('with second invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNumberQuestion('10', 0)
+        await applicantQuestions.answerNumberQuestion('-5', 1)
+        await applicantQuestions.clickNext()
+
+        // Fix me! ESLint: playwright/prefer-web-first-assertions
+        // Directly switching to the best practice method fails
+        // because of a locator stict mode violation. That is it
+        // returns multiple elements.
+        //
+        // Recommended prefer-web-first-assertions fix:
+        //   await expect(page.locator(numberInputError + ' >> nth=1')).toBeVisible()
+        expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(
+          false,
+        )
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe(
+      'single number question with North Star flag enabled',
+      {tag: ['@northstar']},
+      () => {
+        const programName = 'Test program for single number'
+
+        test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+          await setUpForSingleQuestion(
+            programName,
+            page,
+            adminQuestions,
+            adminPrograms,
+          )
+          await enableFeatureFlag(page, 'north_star_applicant_ui')
+        })
+
+        test('validate screenshot', async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'number-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'number-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+        })
+      },
     )
 
-    await logout(page)
-  }
-})
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with single number question.
+      await loginAsAdmin(page)
+
+      await adminQuestions.addNumberQuestion({
+        questionName: 'fave-number-q',
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['fave-number-q'],
+        programName,
+      )
+
+      await logout(page)
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/phone.test.ts
+++ b/browser-test/src/applicant/questions/phone.test.ts
@@ -1,6 +1,8 @@
-import {test, expect} from '@playwright/test'
+import {Page} from '@playwright/test'
+import {test, expect} from '../../support/civiform_fixtures'
 import {
-  createTestContext,
+  AdminQuestions,
+  AdminPrograms,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -8,33 +10,29 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('phone question for applicant flow', () => {
-  const ctx = createTestContext(/* clearDb= */ false)
+test.describe('phone question for applicant flow', {tag: ['@uses-fixtures']}, () => {
 
   test.describe('single phone question', () => {
     const programName = 'Test program for single phone q'
 
-    test.beforeAll(async () => {
-      await setUpForSingleQuestion(programName)
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
     })
 
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'phone')
     })
 
-    test('validate screenshot with errors', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'phone-errors')
     })
 
-    test('with phone submits successfully', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with phone submits successfully', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('4256373270')
       await validateScreenshot(page, 'phone-format-usa')
@@ -43,8 +41,7 @@ test.describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with canada phone submits successfully', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with canada phone submits successfully', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212')
 
@@ -54,8 +51,7 @@ test.describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with empty phone does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with empty phone does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       // Click next without inputting anything
@@ -65,8 +61,7 @@ test.describe('phone question for applicant flow', () => {
       expect(await page.innerText(textId)).toContain('Phone number is required')
     })
 
-    test('invalid phone numbers', async () => {
-      const {page, applicantQuestions} = ctx
+    test('invalid phone numbers', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('1234567890')
 
@@ -78,8 +73,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('555 fake phone numbers', async () => {
-      const {page, applicantQuestions} = ctx
+    test('555 fake phone numbers', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('5553231234')
 
@@ -90,8 +84,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('invalid length of phone number when only valid characters are included', async () => {
-      const {page, applicantQuestions} = ctx
+    test('invalid length of phone number when only valid characters are included', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('123###1212')
 
@@ -102,8 +95,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('invalid characters in phone numbers', async () => {
-      const {page, applicantQuestions} = ctx
+    test('invalid characters in phone numbers', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('123###1212121')
 
@@ -114,8 +106,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('incorrect length of phone number', async () => {
-      const {page, applicantQuestions} = ctx
+    test('incorrect length of phone number', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('615974')
 
@@ -126,8 +117,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('hitting enter on phone does not trigger submission', async () => {
-      const {page, applicantQuestions} = ctx
+    test('hitting enter on phone does not trigger submission', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212.')
 
@@ -150,8 +140,7 @@ test.describe('phone question for applicant flow', () => {
       await applicantQuestions.expectReviewPage()
     })
 
-    test('has no accessiblity violations', async () => {
-      const {page, applicantQuestions} = ctx
+    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)
@@ -161,8 +150,7 @@ test.describe('phone question for applicant flow', () => {
   test.describe('multiple phone questions', () => {
     const programName = 'Test program for multiple phone qs'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addPhoneQuestion({
@@ -184,8 +172,7 @@ test.describe('phone question for applicant flow', () => {
       await logout(page)
     })
 
-    test('with both selections submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with both selections submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('2507274212', 0)
       await applicantQuestions.answerPhoneQuestion('4256373270', 1)
@@ -194,8 +181,7 @@ test.describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with unanswered optional question submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('4256373270', 1)
@@ -204,8 +190,7 @@ test.describe('phone question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('1234567320', 0)
       await applicantQuestions.answerPhoneQuestion('4256373270', 1)
@@ -219,8 +204,7 @@ test.describe('phone question for applicant flow', () => {
       )
     })
 
-    test('with second invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerPhoneQuestion('4256373270', 0)
       await applicantQuestions.answerPhoneQuestion('1234567320', 1)
@@ -240,16 +224,14 @@ test.describe('phone question for applicant flow', () => {
       const programName = 'Test program for single phone q'
 
       test.beforeAll(async () => {
-        await setUpForSingleQuestion(programName)
       })
 
-      test.beforeEach(async () => {
-        const {page} = ctx
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
         await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
-      test('validate screenshot', async () => {
-        const {page, applicantQuestions} = ctx
+      test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
         await test.step('Screenshot without errors', async () => {
@@ -274,8 +256,7 @@ test.describe('phone question for applicant flow', () => {
     },
   )
 
-  async function setUpForSingleQuestion(programName: string) {
-    const {page, adminQuestions, adminPrograms} = ctx
+  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
     // As admin, create program with a free form text question.
     await loginAsAdmin(page)
 

--- a/browser-test/src/applicant/questions/phone.test.ts
+++ b/browser-test/src/applicant/questions/phone.test.ts
@@ -10,264 +10,320 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('phone question for applicant flow', {tag: ['@uses-fixtures']}, () => {
-
-  test.describe('single phone question', () => {
-    const programName = 'Test program for single phone q'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'phone')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'phone-errors')
-    })
-
-    test('with phone submits successfully', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('4256373270')
-      await validateScreenshot(page, 'phone-format-usa')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with canada phone submits successfully', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('2507274212')
-
-      await validateScreenshot(page, 'phone-format-ca')
-
-      await applicantQuestions.clickNext()
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with empty phone does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      // Click next without inputting anything
-      await applicantQuestions.clickNext()
-
-      const textId = '.cf-question-phone'
-      expect(await page.innerText(textId)).toContain('Phone number is required')
-    })
-
-    test('invalid phone numbers', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('1234567890')
-
-      await applicantQuestions.clickNext()
-
-      const countryCodeId = '.cf-question-phone'
-      expect(await page.innerText(countryCodeId)).toContain(
-        'This phone number is invalid',
-      )
-    })
-
-    test('555 fake phone numbers', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('5553231234')
-
-      await applicantQuestions.clickNext()
-      const countryCodeId = '.cf-question-phone'
-      expect(await page.innerText(countryCodeId)).toContain(
-        'This phone number is invalid',
-      )
-    })
-
-    test('invalid length of phone number when only valid characters are included', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('123###1212')
-
-      await applicantQuestions.clickNext()
-      const countryCodeId = '.cf-question-phone'
-      expect(await page.innerText(countryCodeId)).toContain(
-        'This phone number is invalid',
-      )
-    })
-
-    test('invalid characters in phone numbers', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('123###1212121')
-
-      await applicantQuestions.clickNext()
-      const countryCodeId = '.cf-question-phone'
-      expect(await page.innerText(countryCodeId)).toContain(
-        'This phone number is invalid',
-      )
-    })
-
-    test('incorrect length of phone number', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('615974')
-
-      await applicantQuestions.clickNext()
-      const countryCodeId = '.cf-question-phone'
-      expect(await page.innerText(countryCodeId)).toContain(
-        'Phone number is required',
-      )
-    })
-
-    test('hitting enter on phone does not trigger submission', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('2507274212.')
-
-      // Ensure that clicking enter while on phone input doesn't trigger form
-      // submission.
-      await page.focus('input[type=text]')
-      await page.keyboard.press('Enter')
-      await expect(page.locator('input[type=text]')).toBeVisible()
-
-      // Check that pressing Enter on button works.
-      await page.focus('button:has-text("Save and next")')
-      await page.keyboard.press('Enter')
-      await applicantQuestions.expectReviewPage()
-
-      // Go back to question and ensure that "Review" button is also clickable
-      // via Enter.
-      await applicantQuestions.clickEdit()
-      await page.focus('text="Review"')
-      await page.keyboard.press('Enter')
-      await applicantQuestions.expectReviewPage()
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe('multiple phone questions', () => {
-    const programName = 'Test program for multiple phone qs'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await loginAsAdmin(page)
-
-      await adminQuestions.addPhoneQuestion({
-        questionName: 'firstphoneq',
-      })
-      await adminQuestions.addPhoneQuestion({
-        questionName: 'secondphoneq',
-      })
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
-        programName,
-        'Optional question block',
-        ['secondphoneq'],
-        'firstphoneq', // optional
-      )
-      await adminPrograms.publishAllDrafts()
-
-      await logout(page)
-    })
-
-    test('with both selections submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('2507274212', 0)
-      await applicantQuestions.answerPhoneQuestion('4256373270', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('4256373270', 1)
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('1234567320', 0)
-      await applicantQuestions.answerPhoneQuestion('4256373270', 1)
-      await applicantQuestions.clickNext()
-
-      const locatorId = '[name="applicant.firstphoneq.phone_number"]'
-      const parentElement = page.locator(locatorId).locator('..')
-
-      expect(await parentElement.innerText()).toContain(
-        'This phone number is invalid',
-      )
-    })
-
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerPhoneQuestion('4256373270', 0)
-      await applicantQuestions.answerPhoneQuestion('1234567320', 1)
-      await applicantQuestions.clickNext()
-
-      const textId = `.cf-question-phone >> nth=1`
-      expect(await page.innerText(textId)).toContain(
-        'This phone number is invalid',
-      )
-    })
-  })
-
-  test.describe(
-    'single phone question with North Star flag enabled',
-    {tag: ['@northstar']},
-    () => {
+test.describe(
+  'phone question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single phone question', () => {
       const programName = 'Test program for single phone q'
 
-      test.beforeAll(async () => {
-      })
-
       test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-        await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
       })
 
       test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
-        await test.step('Screenshot without errors', async () => {
-          await validateScreenshot(
-            page,
-            'phone-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-
-        await test.step('Screenshot with errors', async () => {
-          await applicantQuestions.clickContinue()
-          await validateScreenshot(
-            page,
-            'phone-errors-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
+        await validateScreenshot(page, 'phone')
       })
-    },
-  )
 
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with a free form text question.
-    await loginAsAdmin(page)
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
 
-    await adminQuestions.addPhoneQuestion({
-      questionName: 'phone-q',
+        await validateScreenshot(page, 'phone-errors')
+      })
+
+      test('with phone submits successfully', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('4256373270')
+        await validateScreenshot(page, 'phone-format-usa')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with canada phone submits successfully', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('2507274212')
+
+        await validateScreenshot(page, 'phone-format-ca')
+
+        await applicantQuestions.clickNext()
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with empty phone does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        // Click next without inputting anything
+        await applicantQuestions.clickNext()
+
+        const textId = '.cf-question-phone'
+        expect(await page.innerText(textId)).toContain(
+          'Phone number is required',
+        )
+      })
+
+      test('invalid phone numbers', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('1234567890')
+
+        await applicantQuestions.clickNext()
+
+        const countryCodeId = '.cf-question-phone'
+        expect(await page.innerText(countryCodeId)).toContain(
+          'This phone number is invalid',
+        )
+      })
+
+      test('555 fake phone numbers', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('5553231234')
+
+        await applicantQuestions.clickNext()
+        const countryCodeId = '.cf-question-phone'
+        expect(await page.innerText(countryCodeId)).toContain(
+          'This phone number is invalid',
+        )
+      })
+
+      test('invalid length of phone number when only valid characters are included', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('123###1212')
+
+        await applicantQuestions.clickNext()
+        const countryCodeId = '.cf-question-phone'
+        expect(await page.innerText(countryCodeId)).toContain(
+          'This phone number is invalid',
+        )
+      })
+
+      test('invalid characters in phone numbers', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('123###1212121')
+
+        await applicantQuestions.clickNext()
+        const countryCodeId = '.cf-question-phone'
+        expect(await page.innerText(countryCodeId)).toContain(
+          'This phone number is invalid',
+        )
+      })
+
+      test('incorrect length of phone number', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('615974')
+
+        await applicantQuestions.clickNext()
+        const countryCodeId = '.cf-question-phone'
+        expect(await page.innerText(countryCodeId)).toContain(
+          'Phone number is required',
+        )
+      })
+
+      test('hitting enter on phone does not trigger submission', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('2507274212.')
+
+        // Ensure that clicking enter while on phone input doesn't trigger form
+        // submission.
+        await page.focus('input[type=text]')
+        await page.keyboard.press('Enter')
+        await expect(page.locator('input[type=text]')).toBeVisible()
+
+        // Check that pressing Enter on button works.
+        await page.focus('button:has-text("Save and next")')
+        await page.keyboard.press('Enter')
+        await applicantQuestions.expectReviewPage()
+
+        // Go back to question and ensure that "Review" button is also clickable
+        // via Enter.
+        await applicantQuestions.clickEdit()
+        await page.focus('text="Review"')
+        await page.keyboard.press('Enter')
+        await applicantQuestions.expectReviewPage()
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
     })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['phone-q'],
-      programName,
+
+    test.describe('multiple phone questions', () => {
+      const programName = 'Test program for multiple phone qs'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addPhoneQuestion({
+          questionName: 'firstphoneq',
+        })
+        await adminQuestions.addPhoneQuestion({
+          questionName: 'secondphoneq',
+        })
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['secondphoneq'],
+          'firstphoneq', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with both selections submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('2507274212', 0)
+        await applicantQuestions.answerPhoneQuestion('4256373270', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('4256373270', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with first invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('1234567320', 0)
+        await applicantQuestions.answerPhoneQuestion('4256373270', 1)
+        await applicantQuestions.clickNext()
+
+        const locatorId = '[name="applicant.firstphoneq.phone_number"]'
+        const parentElement = page.locator(locatorId).locator('..')
+
+        expect(await parentElement.innerText()).toContain(
+          'This phone number is invalid',
+        )
+      })
+
+      test('with second invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerPhoneQuestion('4256373270', 0)
+        await applicantQuestions.answerPhoneQuestion('1234567320', 1)
+        await applicantQuestions.clickNext()
+
+        const textId = `.cf-question-phone >> nth=1`
+        expect(await page.innerText(textId)).toContain(
+          'This phone number is invalid',
+        )
+      })
+    })
+
+    test.describe(
+      'single phone question with North Star flag enabled',
+      {tag: ['@northstar']},
+      () => {
+        const programName = 'Test program for single phone q'
+
+        test.beforeAll(async () => {})
+
+        test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+          await setUpForSingleQuestion(
+            programName,
+            page,
+            adminQuestions,
+            adminPrograms,
+          )
+          await enableFeatureFlag(page, 'north_star_applicant_ui')
+        })
+
+        test('validate screenshot', async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'phone-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'phone-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+        })
+      },
     )
 
-    await logout(page)
-  }
-})
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with a free form text question.
+      await loginAsAdmin(page)
+
+      await adminQuestions.addPhoneQuestion({
+        questionName: 'phone-q',
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['phone-q'],
+        programName,
+      )
+
+      await logout(page)
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/radio_button.test.ts
+++ b/browser-test/src/applicant/questions/radio_button.test.ts
@@ -11,209 +11,242 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Radio button question for applicant flow', {tag: ['@uses-fixtures']}, () => {
+test.describe(
+  'Radio button question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single radio button question with north star flag disabled', () => {
+      const programName = 'Test program for single radio button'
 
-  test.describe('single radio button question with north star flag disabled', () => {
-    const programName = 'Test program for single radio button'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('Updates options in preview', async ({page, adminQuestions}) => {
-      await loginAsAdmin(page)
-
-      await adminQuestions.createRadioButtonQuestion(
-        {
-          questionName: 'not-used-in-test',
-          questionText: 'Sample question text',
-          helpText: 'Sample question help text',
-          options: [
-            {adminName: 'red_admin', text: 'red'},
-            {adminName: 'green_admin', text: 'green'},
-            {adminName: 'orange_admin', text: 'orange'},
-            {adminName: 'blue_admin', text: 'blue'},
-          ],
-        },
-        /* clickSubmit= */ false,
-      )
-
-      // Verify question preview has the default values.
-      await adminQuestions.expectCommonPreviewValues({
-        questionText: 'Sample question text',
-        questionHelpText: 'Sample question help text',
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
       })
-      await adminQuestions.expectPreviewOptions([
-        'red',
-        'green',
-        'orange',
-        'blue',
-      ])
 
-      // Empty options renders default text.
-      await adminQuestions.createRadioButtonQuestion(
-        {
-          questionName: '',
+      test('Updates options in preview', async ({page, adminQuestions}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.createRadioButtonQuestion(
+          {
+            questionName: 'not-used-in-test',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [
+              {adminName: 'red_admin', text: 'red'},
+              {adminName: 'green_admin', text: 'green'},
+              {adminName: 'orange_admin', text: 'orange'},
+              {adminName: 'blue_admin', text: 'blue'},
+            ],
+          },
+          /* clickSubmit= */ false,
+        )
+
+        // Verify question preview has the default values.
+        await adminQuestions.expectCommonPreviewValues({
           questionText: 'Sample question text',
-          helpText: 'Sample question help text',
-          options: [],
+          questionHelpText: 'Sample question help text',
+        })
+        await adminQuestions.expectPreviewOptions([
+          'red',
+          'green',
+          'orange',
+          'blue',
+        ])
+
+        // Empty options renders default text.
+        await adminQuestions.createRadioButtonQuestion(
+          {
+            questionName: '',
+            questionText: 'Sample question text',
+            helpText: 'Sample question help text',
+            options: [],
+          },
+          /* clickSubmit= */ false,
+        )
+        await adminQuestions.expectPreviewOptions(['Sample question option'])
+      })
+
+      test('validate screenshot', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateScreenshot(page, 'radio-button')
+      })
+
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickNext()
+
+        await validateScreenshot(page, 'radio-button-errors')
+      })
+
+      test('with selection submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerRadioButtonQuestion('matcha')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with empty selection does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        // Click next without inputting anything
+        await applicantQuestions.clickNext()
+
+        const radioButtonId = '.cf-question-radio'
+        expect(await page.innerText(radioButtonId)).toContain(
+          'This question is required.',
+        )
+        expect(await page.innerHTML(radioButtonId)).toContain('autofocus')
+      })
+    })
+
+    test.describe('multiple radio button questions', () => {
+      const programName = 'Test program for multiple radio button qs'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addRadioButtonQuestion({
+          questionName: 'fave-ice-cream-q',
+          options: [
+            {adminName: 'matcha_admin', text: 'matcha'},
+            {adminName: 'strawberry_admin', text: 'strawberry'},
+            {adminName: 'vanilla_admin', text: 'vanilla'},
+          ],
+        })
+
+        await adminQuestions.addCheckboxQuestion({
+          questionName: 'fave-vacation-q',
+          options: [
+            {adminName: 'beach_admin', text: 'beach'},
+            {adminName: 'mountains_admin', text: 'mountains'},
+            {adminName: 'city_admin', text: 'city'},
+            {adminName: 'cruise_admin', text: 'cruise'},
+          ],
+        })
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['fave-ice-cream-q'],
+          'fave-vacation-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with both selections submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerRadioButtonQuestion('matcha')
+        await applicantQuestions.answerRadioButtonQuestion('mountains')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerRadioButtonQuestion('matcha')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+    })
+
+    test.describe('single radio button question with north star flag enabled', () => {
+      const programName = 'Test program for single radio button'
+
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test(
+        'validate screenshot with north star flag enabled',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(programName)
+
+          await test.step('Screenshot without errors', async () => {
+            await validateScreenshot(
+              page,
+              'radio-button-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
+
+          await test.step('Screenshot with errors', async () => {
+            await applicantQuestions.clickContinue()
+            await validateScreenshot(
+              page,
+              'radio-button-errors-north-star',
+              /* fullPage= */ true,
+              /* mobileScreenshot= */ true,
+            )
+          })
         },
-        /* clickSubmit= */ false,
       )
-      await adminQuestions.expectPreviewOptions(['Sample question option'])
     })
 
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'radio-button')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'radio-button-errors')
-    })
-
-    test('with selection submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerRadioButtonQuestion('matcha')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with empty selection does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      // Click next without inputting anything
-      await applicantQuestions.clickNext()
-
-      const radioButtonId = '.cf-question-radio'
-      expect(await page.innerText(radioButtonId)).toContain(
-        'This question is required.',
-      )
-      expect(await page.innerHTML(radioButtonId)).toContain('autofocus')
-    })
-  })
-
-  test.describe('multiple radio button questions', () => {
-    const programName = 'Test program for multiple radio button qs'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with radio button question.
       await loginAsAdmin(page)
 
       await adminQuestions.addRadioButtonQuestion({
-        questionName: 'fave-ice-cream-q',
+        questionName: 'ice-cream-radio-q',
         options: [
           {adminName: 'matcha_admin', text: 'matcha'},
           {adminName: 'strawberry_admin', text: 'strawberry'},
           {adminName: 'vanilla_admin', text: 'vanilla'},
         ],
       })
-
-      await adminQuestions.addCheckboxQuestion({
-        questionName: 'fave-vacation-q',
-        options: [
-          {adminName: 'beach_admin', text: 'beach'},
-          {adminName: 'mountains_admin', text: 'mountains'},
-          {adminName: 'city_admin', text: 'city'},
-          {adminName: 'cruise_admin', text: 'cruise'},
-        ],
-      })
-
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['ice-cream-radio-q'],
         programName,
-        'Optional question block',
-        ['fave-ice-cream-q'],
-        'fave-vacation-q', // optional
       )
-      await adminPrograms.publishAllDrafts()
 
       await logout(page)
-    })
-
-    test('with both selections submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerRadioButtonQuestion('matcha')
-      await applicantQuestions.answerRadioButtonQuestion('mountains')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerRadioButtonQuestion('matcha')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-
-  test.describe('single radio button question with north star flag enabled', () => {
-    const programName = 'Test program for single radio button'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test(
-      'validate screenshot with north star flag enabled',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await applicantQuestions.applyProgram(programName)
-
-        await test.step('Screenshot without errors', async () => {
-          await validateScreenshot(
-            page,
-            'radio-button-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-
-        await test.step('Screenshot with errors', async () => {
-          await applicantQuestions.clickContinue()
-          await validateScreenshot(
-            page,
-            'radio-button-errors-north-star',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-      },
-    )
-  })
-
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with radio button question.
-    await loginAsAdmin(page)
-
-    await adminQuestions.addRadioButtonQuestion({
-      questionName: 'ice-cream-radio-q',
-      options: [
-        {adminName: 'matcha_admin', text: 'matcha'},
-        {adminName: 'strawberry_admin', text: 'strawberry'},
-        {adminName: 'vanilla_admin', text: 'vanilla'},
-      ],
-    })
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['ice-cream-radio-q'],
-      programName,
-    )
-
-    await logout(page)
-  }
-})
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -11,103 +11,124 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Static text question for applicant flow', {tag: ['@uses-fixtures']}, () => {
-  const staticText = 'Hello, I am some static text!'
-  const markdownText =
-    '\n[This is a link](https://www.example.com)\n' +
-    'This is a list:\n' +
-    '* Item 1\n' +
-    '* Item 2\n' +
-    '\n' +
-    'There are some empty lines below this that should be preserved\n' +
-    '\n' +
-    '\n' +
-    'This link should be autodetected: https://www.example.com\n' +
-    '__Last line of content should be bold__'
-  const programName = 'Test program for static text'
+test.describe(
+  'Static text question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    const staticText = 'Hello, I am some static text!'
+    const markdownText =
+      '\n[This is a link](https://www.example.com)\n' +
+      'This is a list:\n' +
+      '* Item 1\n' +
+      '* Item 2\n' +
+      '\n' +
+      'There are some empty lines below this that should be preserved\n' +
+      '\n' +
+      '\n' +
+      'This link should be autodetected: https://www.example.com\n' +
+      '__Last line of content should be bold__'
+    const programName = 'Test program for static text'
 
-  test.describe('With north star flag disabled', () => {
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
-    })
+    test.describe('With north star flag disabled', () => {
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
+      })
 
-    test('displays static text', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
+      test('displays static text', async ({applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
 
-      await applicantQuestions.seeStaticQuestion(staticText)
-    })
+        await applicantQuestions.seeStaticQuestion(staticText)
+      })
 
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-
-    test('parses markdown', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await validateScreenshot(page, 'markdown-text')
-
-      await verifyMarkdownHtml(page)
-    })
-  })
-
-  test.describe('With north star flag enabled', {tag: ['@northstar']} , () => {
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(programName, page, adminQuestions, adminPrograms)
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('parses markdown', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await validateScreenshot(
+      test('has no accessiblity violations', async ({
         page,
-        'markdown-text-north-star',
-        /* fullPage= */ true,
-        /* mobileScreenshot= */ true,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
+
+      test('parses markdown', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await validateScreenshot(page, 'markdown-text')
+
+        await verifyMarkdownHtml(page)
+      })
+    })
+
+    test.describe('With north star flag enabled', {tag: ['@northstar']}, () => {
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await setUpForSingleQuestion(
+          programName,
+          page,
+          adminQuestions,
+          adminPrograms,
+        )
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test('parses markdown', async ({page, applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await validateScreenshot(
+          page,
+          'markdown-text-north-star',
+          /* fullPage= */ true,
+          /* mobileScreenshot= */ true,
+        )
+
+        await verifyMarkdownHtml(page)
+      })
+    })
+
+    async function setUpForSingleQuestion(
+      programName: string,
+      page: Page,
+      adminQuestions: AdminQuestions,
+      adminPrograms: AdminPrograms,
+    ) {
+      // As admin, create program with static text question.
+      await loginAsAdmin(page)
+
+      await adminQuestions.addStaticQuestion({
+        questionName: 'static-text-q',
+        questionText: staticText,
+        markdownText: markdownText,
+      })
+      // Must add an answerable question for text to show.
+      await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['static-text-q', 'partner-email-q'],
+        programName,
       )
+      await logout(page)
+    }
 
-      await verifyMarkdownHtml(page)
-    })
-  })
-
-  async function setUpForSingleQuestion(programName: string, page: Page, adminQuestions: AdminQuestions, adminPrograms: AdminPrograms) {
-    // As admin, create program with static text question.
-    await loginAsAdmin(page)
-
-    await adminQuestions.addStaticQuestion({
-      questionName: 'static-text-q',
-      questionText: staticText,
-      markdownText: markdownText,
-    })
-    // Must add an answerable question for text to show.
-    await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['static-text-q', 'partner-email-q'],
-      programName,
-    )
-    await logout(page)
-  }
-
-
-  async function verifyMarkdownHtml(page: Page) {
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>Hello, I am some static text!<br>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<strong>Last line of content should be bold</strong>',
-    )
-  }
-})
+    async function verifyMarkdownHtml(page: Page) {
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<p>Hello, I am some static text!<br>',
+      )
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
+      )
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
+      )
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
+      )
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
+      )
+      expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+        '<strong>Last line of content should be bold</strong>',
+      )
+    }
+  },
+)

--- a/browser-test/src/applicant/questions/text.test.ts
+++ b/browser-test/src/applicant/questions/text.test.ts
@@ -1,6 +1,5 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from '../../support/civiform_fixtures'
 import {
-  createTestContext,
   disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
@@ -9,14 +8,12 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Text question for applicant flow', () => {
-  const ctx = createTestContext(/* clearDb= */ false)
+test.describe('Text question for applicant flow', {tag: ['@uses-fixtures']}, () => {
 
   test.describe('single text question', () => {
     const programName = 'Test program for single text q'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       // As admin, create program with a free form text question.
       await loginAsAdmin(page)
 
@@ -31,30 +28,23 @@ test.describe('Text question for applicant flow', () => {
       )
 
       await logout(page)
-    })
-
-    test.beforeEach(async () => {
-      const {page} = ctx
       await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
-    test('validate screenshot', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateScreenshot(page, 'text')
     })
 
-    test('validate screenshot with errors', async () => {
-      const {page, applicantQuestions} = ctx
+    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.clickNext()
 
       await validateScreenshot(page, 'text-errors')
     })
 
-    test('with text submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with text submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!')
       await applicantQuestions.clickNext()
@@ -65,8 +55,7 @@ test.describe('Text question for applicant flow', () => {
     test(
       'validate screenshot with north star flag enabled',
       {tag: ['@northstar']},
-      async () => {
-        const {page, applicantQuestions} = ctx
+      async ({page, applicantQuestions}) => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
         await applicantQuestions.applyProgram(programName)
 
@@ -82,8 +71,7 @@ test.describe('Text question for applicant flow', () => {
     test(
       'validate screenshot with errors with north star flag enabled',
       {tag: ['@northstar']},
-      async () => {
-        const {page, applicantQuestions} = ctx
+      async ({page, applicantQuestions}) => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.clickContinue()
@@ -97,8 +85,7 @@ test.describe('Text question for applicant flow', () => {
       },
     )
 
-    test('with empty text does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with empty text does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       // Click next without inputting anything
@@ -110,8 +97,7 @@ test.describe('Text question for applicant flow', () => {
       )
     })
 
-    test('with too short text does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with too short text does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('hi')
       await applicantQuestions.clickNext()
@@ -122,8 +108,7 @@ test.describe('Text question for applicant flow', () => {
       )
     })
 
-    test('with too long text does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with too long text does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion(
         'A long string that exceeds the character limit',
@@ -136,8 +121,7 @@ test.describe('Text question for applicant flow', () => {
       )
     })
 
-    test('hitting enter on text does not trigger submission', async () => {
-      const {page, applicantQuestions} = ctx
+    test('hitting enter on text does not trigger submission', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
 
@@ -164,8 +148,7 @@ test.describe('Text question for applicant flow', () => {
   test.describe('no max text question', () => {
     const programName = 'test-program-for-no-max-text-q'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       // As admin, create program with a free form text question.
       await loginAsAdmin(page)
 
@@ -182,8 +165,7 @@ test.describe('Text question for applicant flow', () => {
       await logout(page)
     })
 
-    test('text that is too long is cut off at 10k characters', async () => {
-      const {page, applicantQuestions} = ctx
+    test('text that is too long is cut off at 10k characters', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       let largeString = ''
       for (let i = 0; i < 1000; i++) {
@@ -209,8 +191,7 @@ test.describe('Text question for applicant flow', () => {
   test.describe('multiple text questions', () => {
     const programName = 'Test program for multiple text qs'
 
-    test.beforeAll(async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
+    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await loginAsAdmin(page)
 
       await adminQuestions.addTextQuestion({
@@ -236,8 +217,7 @@ test.describe('Text question for applicant flow', () => {
       await logout(page)
     })
 
-    test('with both selections submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with both selections submits successfully', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
       await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
@@ -246,8 +226,7 @@ test.describe('Text question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with unanswered optional question submits successfully', async () => {
-      const {applicantQuestions} = ctx
+    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
       // Only answer second question. First is optional.
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
@@ -256,8 +235,7 @@ test.describe('Text question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage()
     })
 
-    test('with first invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion(
         'A long string that exceeds the character limit',
@@ -272,8 +250,7 @@ test.describe('Text question for applicant flow', () => {
       )
     })
 
-    test('with second invalid does not submit', async () => {
-      const {page, applicantQuestions} = ctx
+    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
       await applicantQuestions.answerTextQuestion(
@@ -288,8 +265,7 @@ test.describe('Text question for applicant flow', () => {
       )
     })
 
-    test('has no accessiblity violations', async () => {
-      const {page, applicantQuestions} = ctx
+    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
 
       await validateAccessibility(page)

--- a/browser-test/src/applicant/questions/text.test.ts
+++ b/browser-test/src/applicant/questions/text.test.ts
@@ -8,267 +8,303 @@ import {
   validateScreenshot,
 } from '../../support'
 
-test.describe('Text question for applicant flow', {tag: ['@uses-fixtures']}, () => {
+test.describe(
+  'Text question for applicant flow',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test.describe('single text question', () => {
+      const programName = 'Test program for single text q'
 
-  test.describe('single text question', () => {
-    const programName = 'Test program for single text q'
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        // As admin, create program with a free form text question.
+        await loginAsAdmin(page)
 
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      // As admin, create program with a free form text question.
-      await loginAsAdmin(page)
+        await adminQuestions.addTextQuestion({
+          questionName: 'text-q',
+          minNum: 5,
+          maxNum: 20,
+        })
+        await adminPrograms.addAndPublishProgramWithQuestions(
+          ['text-q'],
+          programName,
+        )
 
-      await adminQuestions.addTextQuestion({
-        questionName: 'text-q',
-        minNum: 5,
-        maxNum: 20,
+        await logout(page)
+        await disableFeatureFlag(page, 'north_star_applicant_ui')
       })
-      await adminPrograms.addAndPublishProgramWithQuestions(
-        ['text-q'],
-        programName,
-      )
 
-      await logout(page)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('validate screenshot', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateScreenshot(page, 'text')
-    })
-
-    test('validate screenshot with errors', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.clickNext()
-
-      await validateScreenshot(page, 'text-errors')
-    })
-
-    test('with text submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('I love CiviForm!')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.submitFromReviewPage()
-    })
-
-    test(
-      'validate screenshot with north star flag enabled',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      test('validate screenshot', async ({page, applicantQuestions}) => {
         await applicantQuestions.applyProgram(programName)
 
-        await validateScreenshot(
-          page,
-          'text-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      },
-    )
+        await validateScreenshot(page, 'text')
+      })
 
-    test(
-      'validate screenshot with errors with north star flag enabled',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      test('validate screenshot with errors', async ({
+        page,
+        applicantQuestions,
+      }) => {
         await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.clickContinue()
+        await applicantQuestions.clickNext()
 
-        await validateScreenshot(
-          page,
-          'text-errors-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
+        await validateScreenshot(page, 'text-errors')
+      })
+
+      test('with text submits successfully', async ({applicantQuestions}) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('I love CiviForm!')
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test(
+        'validate screenshot with north star flag enabled',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await enableFeatureFlag(page, 'north_star_applicant_ui')
+          await applicantQuestions.applyProgram(programName)
+
+          await validateScreenshot(
+            page,
+            'text-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        },
+      )
+
+      test(
+        'validate screenshot with errors with north star flag enabled',
+        {tag: ['@northstar']},
+        async ({page, applicantQuestions}) => {
+          await enableFeatureFlag(page, 'north_star_applicant_ui')
+          await applicantQuestions.applyProgram(programName)
+          await applicantQuestions.clickContinue()
+
+          await validateScreenshot(
+            page,
+            'text-errors-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        },
+      )
+
+      test('with empty text does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        // Click next without inputting anything
+        await applicantQuestions.clickNext()
+
+        const textId = '.cf-question-text'
+        expect(await page.innerText(textId)).toContain(
+          'This question is required.',
         )
-      },
-    )
-
-    test('with empty text does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      // Click next without inputting anything
-      await applicantQuestions.clickNext()
-
-      const textId = '.cf-question-text'
-      expect(await page.innerText(textId)).toContain(
-        'This question is required.',
-      )
-    })
-
-    test('with too short text does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('hi')
-      await applicantQuestions.clickNext()
-
-      const textId = '.cf-question-text'
-      expect(await page.innerText(textId)).toContain(
-        'Must contain at least 5 characters.',
-      )
-    })
-
-    test('with too long text does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion(
-        'A long string that exceeds the character limit',
-      )
-      await applicantQuestions.clickNext()
-
-      const textId = '.cf-question-text'
-      expect(await page.innerText(textId)).toContain(
-        'Must contain at most 20 characters.',
-      )
-    })
-
-    test('hitting enter on text does not trigger submission', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
-
-      // Ensure that clicking enter while on text input doesn't trigger form
-      // submission.
-      await page.focus('input[type=text]')
-      await page.keyboard.press('Enter')
-      await expect(page.locator('input[type=text]')).toBeVisible()
-
-      // Check that pressing Enter on button works.
-      await page.focus('button:has-text("Save and next")')
-      await page.keyboard.press('Enter')
-      await applicantQuestions.expectReviewPage()
-
-      // Go back to question and ensure that "Review" button is also clickable
-      // via Enter.
-      await applicantQuestions.clickEdit()
-      await page.focus('text="Review"')
-      await page.keyboard.press('Enter')
-      await applicantQuestions.expectReviewPage()
-    })
-  })
-
-  test.describe('no max text question', () => {
-    const programName = 'test-program-for-no-max-text-q'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      // As admin, create program with a free form text question.
-      await loginAsAdmin(page)
-
-      await adminQuestions.addTextQuestion({
-        questionName: 'no-max-text-q',
-        minNum: 5,
       })
 
-      await adminPrograms.addAndPublishProgramWithQuestions(
-        ['no-max-text-q'],
-        programName,
-      )
+      test('with too short text does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('hi')
+        await applicantQuestions.clickNext()
 
-      await logout(page)
-    })
-
-    test('text that is too long is cut off at 10k characters', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      let largeString = ''
-      for (let i = 0; i < 1000; i++) {
-        largeString += '1234567890'
-      }
-      await applicantQuestions.answerTextQuestion(
-        // 10k characters + extra characters that should be trimmed
-        largeString + 'xxxxxxx',
-      )
-      await applicantQuestions.clickNext()
-
-      // Scroll to bottom so end of text is in view.
-      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
-
-      // Should display answered question with "x"s cut off from the end.
-      await validateScreenshot(page, 'text-max')
-
-      // Form should submit with partial text entry.
-      await applicantQuestions.submitFromReviewPage()
-    })
-  })
-
-  test.describe('multiple text questions', () => {
-    const programName = 'Test program for multiple text qs'
-
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await loginAsAdmin(page)
-
-      await adminQuestions.addTextQuestion({
-        questionName: 'first-text-q',
-        minNum: 5,
-        maxNum: 20,
-      })
-      await adminQuestions.addTextQuestion({
-        questionName: 'second-text-q',
-        minNum: 5,
-        maxNum: 20,
+        const textId = '.cf-question-text'
+        expect(await page.innerText(textId)).toContain(
+          'Must contain at least 5 characters.',
+        )
       })
 
-      await adminPrograms.addProgram(programName)
-      await adminPrograms.editProgramBlockWithOptional(
-        programName,
-        'Optional question block',
-        ['second-text-q'],
-        'first-text-q', // optional
-      )
-      await adminPrograms.publishAllDrafts()
+      test('with too long text does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion(
+          'A long string that exceeds the character limit',
+        )
+        await applicantQuestions.clickNext()
 
-      await logout(page)
+        const textId = '.cf-question-text'
+        expect(await page.innerText(textId)).toContain(
+          'Must contain at most 20 characters.',
+        )
+      })
+
+      test('hitting enter on text does not trigger submission', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+
+        // Ensure that clicking enter while on text input doesn't trigger form
+        // submission.
+        await page.focus('input[type=text]')
+        await page.keyboard.press('Enter')
+        await expect(page.locator('input[type=text]')).toBeVisible()
+
+        // Check that pressing Enter on button works.
+        await page.focus('button:has-text("Save and next")')
+        await page.keyboard.press('Enter')
+        await applicantQuestions.expectReviewPage()
+
+        // Go back to question and ensure that "Review" button is also clickable
+        // via Enter.
+        await applicantQuestions.clickEdit()
+        await page.focus('text="Review"')
+        await page.keyboard.press('Enter')
+        await applicantQuestions.expectReviewPage()
+      })
     })
 
-    test('with both selections submits successfully', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
-      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
-      await applicantQuestions.clickNext()
+    test.describe('no max text question', () => {
+      const programName = 'test-program-for-no-max-text-q'
 
-      await applicantQuestions.submitFromReviewPage()
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        // As admin, create program with a free form text question.
+        await loginAsAdmin(page)
+
+        await adminQuestions.addTextQuestion({
+          questionName: 'no-max-text-q',
+          minNum: 5,
+        })
+
+        await adminPrograms.addAndPublishProgramWithQuestions(
+          ['no-max-text-q'],
+          programName,
+        )
+
+        await logout(page)
+      })
+
+      test('text that is too long is cut off at 10k characters', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        let largeString = ''
+        for (let i = 0; i < 1000; i++) {
+          largeString += '1234567890'
+        }
+        await applicantQuestions.answerTextQuestion(
+          // 10k characters + extra characters that should be trimmed
+          largeString + 'xxxxxxx',
+        )
+        await applicantQuestions.clickNext()
+
+        // Scroll to bottom so end of text is in view.
+        await page.evaluate(() =>
+          window.scrollTo(0, document.body.scrollHeight),
+        )
+
+        // Should display answered question with "x"s cut off from the end.
+        await validateScreenshot(page, 'text-max')
+
+        // Form should submit with partial text entry.
+        await applicantQuestions.submitFromReviewPage()
+      })
     })
 
-    test('with unanswered optional question submits successfully', async ({applicantQuestions}) => {
-      // Only answer second question. First is optional.
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
-      await applicantQuestions.clickNext()
+    test.describe('multiple text questions', () => {
+      const programName = 'Test program for multiple text qs'
 
-      await applicantQuestions.submitFromReviewPage()
+      test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+        await loginAsAdmin(page)
+
+        await adminQuestions.addTextQuestion({
+          questionName: 'first-text-q',
+          minNum: 5,
+          maxNum: 20,
+        })
+        await adminQuestions.addTextQuestion({
+          questionName: 'second-text-q',
+          minNum: 5,
+          maxNum: 20,
+        })
+
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['second-text-q'],
+          'first-text-q', // optional
+        )
+        await adminPrograms.publishAllDrafts()
+
+        await logout(page)
+      })
+
+      test('with both selections submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+        await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with unanswered optional question submits successfully', async ({
+        applicantQuestions,
+      }) => {
+        // Only answer second question. First is optional.
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+        await applicantQuestions.clickNext()
+
+        await applicantQuestions.submitFromReviewPage()
+      })
+
+      test('with first invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion(
+          'A long string that exceeds the character limit',
+          0,
+        )
+        await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+        await applicantQuestions.clickNext()
+
+        const textId = '.cf-question-text'
+        expect(await page.innerText(textId)).toContain(
+          'Must contain at most 20 characters.',
+        )
+      })
+
+      test('with second invalid does not submit', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+        await applicantQuestions.answerTextQuestion(
+          'A long string that exceeds the character limit',
+          1,
+        )
+        await applicantQuestions.clickNext()
+
+        const textId = `.cf-question-text >> nth=1`
+        expect(await page.innerText(textId)).toContain(
+          'Must contain at most 20 characters.',
+        )
+      })
+
+      test('has no accessiblity violations', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(programName)
+
+        await validateAccessibility(page)
+      })
     })
-
-    test('with first invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion(
-        'A long string that exceeds the character limit',
-        0,
-      )
-      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
-      await applicantQuestions.clickNext()
-
-      const textId = '.cf-question-text'
-      expect(await page.innerText(textId)).toContain(
-        'Must contain at most 20 characters.',
-      )
-    })
-
-    test('with second invalid does not submit', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
-      await applicantQuestions.answerTextQuestion(
-        'A long string that exceeds the character limit',
-        1,
-      )
-      await applicantQuestions.clickNext()
-
-      const textId = `.cf-question-text >> nth=1`
-      expect(await page.innerText(textId)).toContain(
-        'Must contain at most 20 characters.',
-      )
-    })
-
-    test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-
-      await validateAccessibility(page)
-    })
-  })
-})
+  },
+)


### PR DESCRIPTION
### Description

Migrate question type tests to use fixtures. This prevents the North Star screenshot tests from flaking because the DB is being reset after each test.

I haven't done Date and File Upload yet, since I'll update those tests when I add Thymeleaf implementations for those question types.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
