### PR TITLE
Allow global admin with program privileges to download applicant files

### DIFF
--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -121,6 +121,8 @@ public class FileController extends CiviFormController {
     AccountModel adminAccount =
         profileUtils.currentUserProfile(request).orElseThrow().getAccount().join();
 
+    // An admin is eligible if they are a global admin with the program access flag turned on
+    // or if they have been explicitly given read permission to the program.
     return ((adminAccount.getGlobalAdmin()
                 && settingsManifest.getAllowCiviformAdminAccessPrograms(request))
             || maybeFile.get().getAcls().hasProgramReadPermission(adminAccount))

--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -22,6 +22,7 @@ import repository.StoredFileRepository;
 import repository.VersionRepository;
 import services.cloud.ApplicantFileNameFormatter;
 import services.cloud.ApplicantStorageClient;
+import services.settings.SettingsManifest;
 
 /** Controller for handling methods for admins and applicants accessing uploaded files. */
 public class FileController extends CiviFormController {
@@ -30,6 +31,7 @@ public class FileController extends CiviFormController {
   private final HttpExecutionContext classLoaderExecutionContext;
   private final ApplicantStorageClient applicantStorageClient;
   private final StoredFileRepository storedFileRepository;
+  private final SettingsManifest settingsManifest;
 
   @Inject
   public FileController(
@@ -37,11 +39,13 @@ public class FileController extends CiviFormController {
       StoredFileRepository storedFileRepository,
       ApplicantStorageClient applicantStorageClient,
       ProfileUtils profileUtils,
-      VersionRepository versionRepository) {
+      VersionRepository versionRepository,
+      SettingsManifest settingsManifest) {
     super(profileUtils, versionRepository);
     this.classLoaderExecutionContext = checkNotNull(classLoaderExecutionContext);
     this.applicantStorageClient = checkNotNull(applicantStorageClient);
     this.storedFileRepository = checkNotNull(storedFileRepository);
+    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   @Secure
@@ -117,7 +121,9 @@ public class FileController extends CiviFormController {
     AccountModel adminAccount =
         profileUtils.currentUserProfile(request).orElseThrow().getAccount().join();
 
-    return maybeFile.get().getAcls().hasProgramReadPermission(adminAccount)
+    return ((adminAccount.getGlobalAdmin()
+                && settingsManifest.getAllowCiviformAdminAccessPrograms(request))
+            || maybeFile.get().getAcls().hasProgramReadPermission(adminAccount))
         ? redirect(applicantStorageClient.getPresignedUrlString(decodedFileKey))
         : unauthorized();
   }

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -2,6 +2,7 @@ package controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
@@ -9,6 +10,7 @@ import static play.test.Helpers.fakeRequest;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import models.ApplicantModel;
 import models.ProgramModel;
 import models.StoredFileModel;
@@ -30,6 +32,9 @@ public class FileControllerTest extends WithMockedProfiles {
   public void setUp() {
     resetDatabase();
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(false);
+    setupInjectorWithExtraBinding(bind(SettingsManifest.class).toInstance(mockSettingsManifest));
     controller = instanceOf(FileController.class);
   }
 
@@ -61,7 +66,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void show_redirects() {
+  public void show_applicant_redirects() {
     ApplicantModel applicant = createApplicantWithMockedProfile();
     String fileKey = fakeFileKey(applicant.id, 1L);
     Result result = controller.show(request, applicant.id, fileKey).toCompletableFuture().join();
@@ -69,7 +74,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void adminShow_invalidProgram_returnsNotFound() {
+  public void adminShow_programAdmin_invalidProgram_returnsNotFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
     String fileKey = fakeFileKey(1L, program.id);
@@ -78,7 +83,16 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void adminShow_differentProgram_returnsUnauthorizedResult() {
+  public void adminShow_globalAdmin_invalidProgram_returnsNotFound() {
+    ProgramModel program = ProgramBuilder.newDraftProgram().build();
+    createGlobalAdminWithMockedProfile();
+    String fileKey = fakeFileKey(1L, program.id);
+    Result result = controller.adminShow(request, program.id + 1, fileKey);
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void adminShow_programAdmin_differentProgram_returnsUnauthorizedResult() {
     ProgramModel programOne = ProgramBuilder.newDraftProgram("one").build();
     ProgramModel programTwo = ProgramBuilder.newDraftProgram("two").build();
     createProgramAdminWithMockedProfile(programOne);
@@ -90,9 +104,21 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void adminShow_differentFileKey_returnsNotFound() {
+  public void adminShow_programAdmin_differentFileKey_returnsNotFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
+    String fileKey = fakeFileKey(1L, program.id + 1);
+    createStoredFileWithProgramAccess(fakeFileKey(1L, program.id), program);
+
+    Result result = controller.adminShow(request, program.id, fileKey);
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void adminShow_globalAdminWithPrivledges_differentFileKey_returnsNotFound() {
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
+    ProgramModel program = ProgramBuilder.newDraftProgram().build();
+    createGlobalAdminWithMockedProfile();
     String fileKey = fakeFileKey(1L, program.id + 1);
     createStoredFileWithProgramAccess(fakeFileKey(1L, program.id), program);
 
@@ -124,7 +150,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void adminShow_redirects() {
+  public void adminShow_programAdmin_redirects() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
     String fileKey = fakeFileKey(1L, program.id);
@@ -135,7 +161,19 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void acledAdminShow_differentProgram_returnsUnauthorizedResult() {
+  public void adminShow_globalAdminWithPrivledges_redirects() {
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
+    ProgramModel program = ProgramBuilder.newDraftProgram().build();
+    createGlobalAdminWithMockedProfile();
+    String fileKey = fakeFileKey(1L, program.id);
+    createStoredFileWithProgramAccess(fileKey, program);
+
+    Result result = controller.adminShow(request, program.id, fileKey);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+  }
+
+  @Test
+  public void acledAdminShow_programAdmin_differentProgram_returnsUnauthorizedResult() {
     ProgramModel programOne = ProgramBuilder.newDraftProgram("one").build();
     ProgramModel programTwo = ProgramBuilder.newDraftProgram("two").build();
     createProgramAdminWithMockedProfile(programOne);
@@ -148,7 +186,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void acledAdminShow_differentFileKey_returnsNotFound() {
+  public void acledAdminShow_programAdmin_differentFileKey_returnsNotFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
     createStoredFileWithProgramAccess(fakeFileKey(1L, program.id), program);
@@ -159,9 +197,20 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void acledAdminShow_globalAdminWithoutPrivledges_returnsUnauthorizedResult() {
+  public void acledAdminShow_globalAdminWithPrivledges_differentFileKey_returnsNotFound() {
     when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
+    createGlobalAdminWithMockedProfile();
+    ProgramModel program = ProgramBuilder.newDraftProgram().build();
+    createStoredFileWithProgramAccess(fakeFileKey(1L, program.id), program);
 
+    String fileKey = fakeFileKey(1L, program.id + 1);
+    Result result = controller.acledAdminShow(request, fileKey);
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void acledAdminShow_globalAdminWithoutPrivledges_returnsUnauthorizedResult() {
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(false);
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createGlobalAdminWithMockedProfile();
     String fileKey = fakeFileKey(1L, program.id);
@@ -174,9 +223,8 @@ public class FileControllerTest extends WithMockedProfiles {
   @Test
   public void acledAdminShow_globalAdminWithPrivledges_redirects() {
     when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
-
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
-    createProgramAdminWithMockedProfile(program);
+    createGlobalAdminWithMockedProfile();
     String fileKey = fakeFileKey(1L, program.id);
     createStoredFileWithProgramAccess(fileKey, program);
     String encodedFileKey = encodefakeFileKey(fileKey);
@@ -187,7 +235,7 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void acledAdminShow_redirects() {
+  public void acledAdminShow_programAdmin_redirects() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
     String fileKey = fakeFileKey(1L, program.id);

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -187,7 +187,7 @@ public class FileControllerTest extends WithMockedProfiles {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
-  
+
   @Test
   public void acledAdminShow_redirects() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -160,22 +160,20 @@ public class FileControllerTest extends WithMockedProfiles {
 
   @Test
   public void acledAdminShow_globalAdminWithoutPrivledges_returnsUnauthorizedResult() {
-    Request fakeRequest = fakeRequest().build();
-    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(fakeRequest)).thenReturn(true);
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
 
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createGlobalAdminWithMockedProfile();
     String fileKey = fakeFileKey(1L, program.id);
     createStoredFileWithProgramAccess(fileKey, program);
 
-    Result result = controller.acledAdminShow(fakeRequest, fileKey);
+    Result result = controller.acledAdminShow(request, fileKey);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void acledAdminShow_globalAdminWithPrivledges_redirects() {
-    Request fakeRequest = fakeRequest().build();
-    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(fakeRequest)).thenReturn(true);
+    when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(true);
 
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
@@ -183,7 +181,7 @@ public class FileControllerTest extends WithMockedProfiles {
     createStoredFileWithProgramAccess(fileKey, program);
     String encodedFileKey = encodefakeFileKey(fileKey);
 
-    Result result = controller.acledAdminShow(fakeRequest, encodedFileKey);
+    Result result = controller.acledAdminShow(request, encodedFileKey);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
@@ -196,7 +194,7 @@ public class FileControllerTest extends WithMockedProfiles {
     createStoredFileWithProgramAccess(fileKey, program);
     String encodedFileKey = encodefakeFileKey(fileKey);
 
-    Result result = controller.acledAdminShow(fakeRequest().build(), encodedFileKey);
+    Result result = controller.acledAdminShow(request, encodedFileKey);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -48,11 +48,7 @@ public class WithMockedProfiles {
         new GuiceApplicationBuilder()
             .overrides(bind(ProfileUtils.class).toInstance(MOCK_UTILS))
             .build();
-    injector = app.injector();
-    resourceCreator = new ResourceCreator(injector);
-    Helpers.start(app);
-    profileFactory = injector.instanceOf(ProfileFactory.class);
-    ProgramBuilder.setInjector(injector);
+    setupInjectorForApp(app);
   }
 
   @AfterClass
@@ -61,6 +57,15 @@ public class WithMockedProfiles {
       Helpers.stop(app);
       app = null;
     }
+  }
+
+  public static void setupInjectorWithExtraBinding(play.api.inject.Binding<?> additionalBinding) {
+    stopApp();
+    app =
+        new GuiceApplicationBuilder()
+            .overrides(bind(ProfileUtils.class).toInstance(MOCK_UTILS), additionalBinding)
+            .build();
+    setupInjectorForApp(app);
   }
 
   protected <T> T instanceOf(Class<T> clazz) {
@@ -138,6 +143,14 @@ public class WithMockedProfiles {
     applicant.save();
 
     return adminAccount;
+  }
+
+  private static void setupInjectorForApp(Application app) {
+    injector = app.injector();
+    resourceCreator = new ResourceCreator(injector);
+    Helpers.start(app);
+    profileFactory = injector.instanceOf(ProfileFactory.class);
+    ProgramBuilder.setInjector(injector);
   }
 
   private ArgumentMatcher<Http.Request> skipUserProfile() {


### PR DESCRIPTION
### Description

CiviForm admins that are allowed to review programs through the ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS flag should be able to access files

This also adds a method in WithMockedProfiles to allow for an additional mock to be bound.

## Release notes

Allow global admin with program privileges (through ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS) to download applicant files.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Create a program with a file upload question and fill it out as an applicant
2. Navigate to civiform admin view with ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS on
3. Able to download file from application view

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/7204
