### PR TITLE
Rename tailwind color seattle-blue to civiform-blue

### DIFF
--- a/server/app/assets/javascripts/radio.ts
+++ b/server/app/assets/javascripts/radio.ts
@@ -5,7 +5,7 @@ class RadioController {
   static radioDefaultClass = '.cf-radio-default'
   static radioInputClass = '.cf-radio-input'
   static radioOptionClass = '.cf-radio-option'
-  static selectedRadioClasses = ['border-seattle-blue', 'bg-blue-200']
+  static selectedRadioClasses = ['border-civiform-blue', 'bg-blue-200']
   static unselectedRadioClasses = ['border-gray-500', 'bg-white']
 
   constructor() {

--- a/server/app/views/style/BaseStyles.java
+++ b/server/app/views/style/BaseStyles.java
@@ -14,9 +14,9 @@ public final class BaseStyles {
 
   public static final String BG_CIVIFORM_WHITE = "bg-civiform-white";
 
-  public static final String BG_CIVIFORM_BLUE = "bg-seattle-blue";
-  public static final String TEXT_CIVIFORM_BLUE = "text-seattle-blue";
-  public static final String BORDER_CIVIFORM_BLUE = "border-seattle-blue";
+  public static final String BG_CIVIFORM_BLUE = "bg-civiform-blue";
+  public static final String TEXT_CIVIFORM_BLUE = "text-civiform-blue";
+  public static final String BORDER_CIVIFORM_BLUE = "border-civiform-blue";
 
   public static final String TEXT_CIVIFORM_GREEN = "text-civiform-green";
   public static final String BG_CIVIFORM_GREEN_LIGHT = "bg-civiform-green-light";

--- a/server/tailwind.config.js
+++ b/server/tailwind.config.js
@@ -40,7 +40,7 @@ module.exports = {
         'civiform-white': {
           DEFAULT: '#f8f9fa',
         },
-        'seattle-blue': {
+        'civiform-blue': {
           DEFAULT: '#113f9f',
         },
         'civiform-green': {


### PR DESCRIPTION
### Description

Renames the tailwind color "seattle-blue" to "civiform-blue"

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
