### PR TITLE
Make PredicateGenerator.parsePredicateValue package protected

### DIFF
--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -278,9 +278,7 @@ public final class PredicateGenerator {
    *
    * <p>If value is the empty string, then parses the list of values instead.
    */
-  // TODO: make this private once the old predicate logic is removed from
-  // AdminProgramBlockPredicatesController
-  public static PredicateValue parsePredicateValue(
+  static PredicateValue parsePredicateValue(
       Scalar scalar, Operator operator, String value, List<String> values) {
 
     // TODO: if scalar is not SELECTION or SELECTIONS and there values then throw an exception.

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -7,7 +7,6 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.fakeRequest;
 
-import com.google.common.collect.ImmutableList;
 import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,10 +14,6 @@ import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.ResetPostgres;
-import services.applicant.question.Scalar;
-import services.program.predicate.Operator;
-import services.program.predicate.PredicateGenerator;
-import services.program.predicate.PredicateValue;
 import support.ProgramBuilder;
 
 public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
@@ -181,16 +176,5 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(() -> controller.destroyEligibility(programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
-  }
-
-  @Test
-  public void testParsePredicateValue_currency() {
-    PredicateValue got =
-        PredicateGenerator.parsePredicateValue(
-            Scalar.CURRENCY_CENTS, Operator.EQUAL_TO, "100.01", ImmutableList.of());
-
-    assertThat(
-            got.toDisplayString(testQuestionBank.applicantMonthlyIncome().getQuestionDefinition()))
-        .isEqualTo("$100.01");
   }
 }

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -49,6 +49,17 @@ public class PredicateGeneratorTest extends ResetPostgres {
   }
 
   @Test
+  public void testParsePredicateValue_currency() {
+    PredicateValue got =
+        PredicateGenerator.parsePredicateValue(
+            Scalar.CURRENCY_CENTS, Operator.EQUAL_TO, "100.01", ImmutableList.of());
+
+    assertThat(
+            got.toDisplayString(testQuestionBank.applicantMonthlyIncome().getQuestionDefinition()))
+        .isEqualTo("$100.01");
+  }
+
+  @Test
   public void generatePredicateDefinition_singleQuestion_singleValue_ageRange() throws Exception {
     DynamicForm form =
         buildForm(


### PR DESCRIPTION
### Description

Make PredicateGenerator.parsePredicateValue package protected

* Move a unit test from AdminProgramBlockPredicatesControllerTest to PredicateGeneratorTest because it's testing PredicateGenerator
* Reduce visibility of PredicateGenerator.parsePredicateValue to package protected because it's now just used privately and in the unit tests

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)