### PR TITLE
Fix bug where the eligibility condition trash icon is clickable even when hidden

### DIFF
--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -416,9 +416,7 @@ class AdminPredicateConfiguration {
     )
     // The first row which is being used as a template cannot be deleted
     // and is rendered with a hidden delete button.
-    assertNotNull(deleteButtonDiv.querySelector('svg')).classList.remove(
-      'hidden',
-    )
+    deleteButtonDiv.classList.remove('hidden')
 
     assertNotNull(
       document.getElementById('predicate-config-value-row-container'),

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -470,10 +470,15 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
     }
 
     DivTag delete =
-        div(Icons.svg(Icons.DELETE).withClasses("w-8", iff(groupId == 1, "hidden")))
+        div(Icons.svg(Icons.DELETE).withClasses("w-8"))
             .attr("role", "button")
             .withClasses(
-                "predicate-config-delete-value-row", "mx-6", "w-12", "pt-2", "cursor-pointer");
+                "predicate-config-delete-value-row",
+                "mx-6",
+                "w-12",
+                "pt-2",
+                "cursor-pointer",
+                iff(groupId == 1, "hidden"));
 
     return row.with(delete);
   }


### PR DESCRIPTION
### Description

The trash button for an eligibility condition value was still clickable even when it was supposed to be hidden for the first row.

The svg was marked hidden, rather than the parent button div, so the button was blank but still clickable. Fixed by moving the hidden class from the svg to the parent button.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #7272