### PR TITLE
Refactor ProgramPredicateConfigureView.renderValueRow

### DIFF
--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -441,32 +441,19 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
     DivTag row = div(innerRow).withClasses("flex", "mb-6", "predicate-config-value-row");
     DivTag andText = div("and").withClasses("object-center", "w-16", "p-4", "leading-10");
 
-    if (maybeAndNode.isPresent()) {
-      int columnNumber = 1;
+    ImmutableMap<Long, LeafExpressionNode> questionIdLeafNodeMap =
+        maybeAndNode.map(AndNode::children).orElse(ImmutableList.of()).stream()
+            .map(PredicateExpressionNode::getLeafNode)
+            .collect(
+                ImmutableMap.toImmutableMap(LeafExpressionNode::questionId, Function.identity()));
 
-      ImmutableMap<Long, LeafExpressionNode> questionIdLeafNodeMap =
-          maybeAndNode.get().children().stream()
-              .map(PredicateExpressionNode::getLeafNode)
-              .collect(
-                  ImmutableMap.toImmutableMap(LeafExpressionNode::questionId, Function.identity()));
-
-      for (var qd : questionDefinitions) {
-        var leafNode = questionIdLeafNodeMap.get(qd.getId());
-
-        innerRow
-            .condWith(columnNumber++ != 1, andText)
-            .with(createValueField(qd, groupId, Optional.of(leafNode)));
-      }
-    } else {
-      int columnNumber = 1;
-
-      for (var questionDefinition : questionDefinitions) {
-        innerRow
-            .condWith(columnNumber++ != 1, andText)
-            .with(
-                createValueField(
-                    questionDefinition, groupId, /* maybeLeafNode= */ Optional.empty()));
-      }
+    int columnNumber = 1;
+    for (QuestionDefinition questionDefinition : questionDefinitions) {
+      Optional<LeafExpressionNode> maybeLeafNode =
+          Optional.ofNullable(questionIdLeafNodeMap.get(questionDefinition.getId()));
+      innerRow
+          .condWith(columnNumber++ != 1, andText)
+          .with(createValueField(questionDefinition, groupId, maybeLeafNode));
     }
 
     DivTag delete =


### PR DESCRIPTION
### Description

The ProgramPredicateConfigureView.renderValueRow method had forked logic based on maybeAndNode.isPresent. Instead of duplicating the logic, we can just create an empty map if maybeAndNode is not present, and handle both cases inline, so the logic is only happening once and it's easier to see how the two cases differ.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
