### PR TITLE
Remove jobs from the db that are not found in the job registry

### DIFF
--- a/server/app/durablejobs/DurableJobRunner.java
+++ b/server/app/durablejobs/DurableJobRunner.java
@@ -163,7 +163,9 @@ public final class DurableJobRunner {
               persistedDurableJob.id,
               persistedDurableJob.getRemainingAttempts(),
               getJobDurationInSeconds(startTime));
-      LOGGER.error(msg);
+      // change this to info?
+      // if a job is missing from the registry, it likely means it was intentionally removed
+      LOGGER.info(msg);
       persistedDurableJob.appendErrorMessage(msg).save();
     } catch (TimeoutException e) {
       String msg =

--- a/server/app/durablejobs/DurableJobRunner.java
+++ b/server/app/durablejobs/DurableJobRunner.java
@@ -150,26 +150,30 @@ public final class DurableJobRunner {
           persistedDurableJob.getJobName(),
           persistedDurableJob.id,
           getJobDurationInSeconds(startTime));
-    } catch(JobNotFoundException e) {
-      boolean deleted = persistedDurableJob.delete();
-      if (!deleted) {
-        // throw error
+    } catch (JobNotFoundException e) {
+      // If the job is not found in the registry, it was likely removed intentionally
+      // In this case, we want to delete the job from the database becuase it should not be run
+      // anymore
+      if (persistedDurableJob.delete()) {
+        LOGGER.info(
+            String.format(
+                "Job was not found in the registry and was deleted from the db. job_name=\"%s\"",
+                persistedDurableJob.getJobName()));
       } else {
+        // If the delete fails, handle it like the other errors
         String msg =
-        String.format(
-            "JobRunner_JobFailed %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d,"
-                + " duration_s=%f",
-            e.getClass().getSimpleName(),
-            persistedDurableJob.getJobName(),
-            persistedDurableJob.id,
-            persistedDurableJob.getRemainingAttempts(),
-            getJobDurationInSeconds(startTime));
-        LOGGER.info(msg);
+            String.format(
+                "Job was not found in the registry and there was an error deleting the job. Error:"
+                    + " %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d, duration_s=%f",
+                e.getClass().getSimpleName(),
+                persistedDurableJob.getJobName(),
+                persistedDurableJob.id,
+                persistedDurableJob.getRemainingAttempts(),
+                getJobDurationInSeconds(startTime));
+        LOGGER.error(msg);
+        persistedDurableJob.appendErrorMessage(msg).save();
       }
-    }
-    catch (IllegalArgumentException
-        | CancellationException
-        | InterruptedException e) {
+    } catch (IllegalArgumentException | CancellationException | InterruptedException e) {
       String msg =
           String.format(
               "JobRunner_JobFailed %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d,"

--- a/server/test/durablejobs/DurableJobRunnerTest.java
+++ b/server/test/durablejobs/DurableJobRunnerTest.java
@@ -1,7 +1,6 @@
 package durablejobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import annotations.BindingAnnotations;

--- a/server/test/durablejobs/DurableJobRunnerTest.java
+++ b/server/test/durablejobs/DurableJobRunnerTest.java
@@ -147,6 +147,8 @@ public class DurableJobRunnerTest extends ResetPostgres {
     PersistedDurableJobModel job = createPersistedJobToExecute();
     durableJobRunner.runJobs();
 
+    // The job should have been deleted since it does not exist in the registry.
+    // Calling job.refresh should throw an error since the job was deleted.
     Exception exception =
         assertThrows(
             EntityNotFoundException.class,


### PR DESCRIPTION
### Description

We need a way to easily remove Durable Jobs from our codebase, but currently an error is thrown when you remove a job from the registry because the db expects the code to be there to run the job. Both the job runner and the job scheduler reference the same registry, so it doesn't work to remove the job from just the scheduler to prevent future runs.

After talking it over with @nb1701 , we think it is safe to remove a job from the db if it is no longer in the registry. The only way a job can get into the db is through the registry, so it stands to reason if it is no longer in the registry it should no longer be in the db.

This PR deletes the job from the db when it is not also found in the registry and lowers the log level from error to info when it does so.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

1. Set the time resolver for the job to 5 minutes from now
2. Run the server to add the job(s) to db (it will schedule a bunch of them)
3. Remove the logic registering the job job from `provideDurableJobRegistry` in `DurableJobModule`
4. Restart the server
5. Wait 5 minutes then check the db to see that the scheduled jobs were deleted

### Issue(s) this completes

Fixes #6897 
