### PR TITLE
Redirect home on unauthorized

### DIFF
--- a/server/app/controllers/ErrorHandler.java
+++ b/server/app/controllers/ErrorHandler.java
@@ -126,6 +126,20 @@ public class ErrorHandler extends DefaultHttpErrorHandler {
     return Optional.empty();
   }
 
+  /**
+   * Normally the application handles 403s before this and redirects home. This is a failsafe for
+   * edge cases that would leave the user on a grey 403 page that is just builtin to Play. To be
+   * consistent with the rest of the app we redirect home.
+   *
+   * <p>This only known way to hit this is to have an active session, change the application secret,
+   * and try using your existing session.
+   */
+  @Override
+  protected CompletionStage<Result> onForbidden(RequestHeader request, String message) {
+    return CompletableFuture.completedFuture(
+        Results.redirect(controllers.routes.HomeController.index().url()));
+  }
+
   @Override
   public CompletionStage<Result> onNotFound(RequestHeader request, String message) {
     return CompletableFuture.completedFuture(


### PR DESCRIPTION
### Description

Normally the application handles 403s before this and redirects home. This is a failsafe for edge cases that would leave the user on a grey 403 page that is just builtin to Play. To be consistent with the rest of the app we redirect home.

This only known way to hit this is to have an active session, change the application secret, and try using your existing session.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)



### Instructions for manual testing

#### In Dev Mode

- `bin/run-dev`
- start app as guest, fill out a page or two of data
- change secret
- reload
- wait for app to be fully loaded
- click save and next on open page
- get the 403 error, along with the warn/error in the console log

#### In Prod Mode

- runProd
- start app as guest, fill out a page or two of data
- stop app
- change secret
- runProd
- wait for app to be fully loaded
- click save and next on open page
- get the 403 error, along with the warn/error in the console log

 ### Issue(s) this completes

Fixes #7279
