### PR TITLE
Send token when calling arcgis.com

### DIFF
--- a/server/test/services/geo/esri/RealEsriClientTest.java
+++ b/server/test/services/geo/esri/RealEsriClientTest.java
@@ -1,26 +1,39 @@
 package services.geo.esri;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import play.libs.Json;
+import play.libs.ws.WSClient;
 import services.geo.esri.EsriTestHelper.TestType;
+import services.settings.SettingsManifest;
 
+@RunWith(JUnitParamsRunner.class)
 public class RealEsriClientTest {
   private EsriTestHelper helper;
 
   @After
   public void tearDown() throws IOException {
-    helper.stopServer();
+    if (helper != null) {
+      helper.stopServer();
+    }
   }
 
   @Test
@@ -135,5 +148,146 @@ public class RealEsriClientTest {
             .toCompletableFuture()
             .join();
     assertThat(maybeResp.isPresent()).isFalse();
+  }
+
+  @Test
+  @Parameters(method = "getFetchAddressUrlsParams")
+  public void verifyFetchAddressUrlsConfigurationLoads(FetchAddressUrlsTestData testData) {
+    SettingsManifest mockSettingsManifest = mock();
+    EsriServiceAreaValidationConfig mockEsriServiceAreaValidationConfig = mock();
+    Clock mockClock = mock();
+    WSClient mockWsClient = mock();
+
+    when(mockSettingsManifest.getEsriFindAddressCandidatesUrls())
+        .thenReturn(testData.esriFindAddressCandidatesUrls());
+
+    when(mockSettingsManifest.getEsriFindAddressCandidatesUrl())
+        .thenReturn(testData.esriFindAddressCandidatesUrl());
+
+    when(mockSettingsManifest.getEsriArcgisApiToken()).thenReturn(testData.esriArcgisApiToken());
+
+    var client =
+        new RealEsriClient(
+            mockSettingsManifest, mockClock, mockEsriServiceAreaValidationConfig, mockWsClient);
+
+    assertThat(client.ESRI_FIND_ADDRESS_CANDIDATES_URLS.size())
+        .isEqualTo(testData.expectedUrlCount());
+  }
+
+  private static ImmutableList<Object[]> getFetchAddressUrlsParams() {
+    return ImmutableList.of(
+        // Expected one item in url list
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.of(
+                  ImmutableList.<String>builder()
+                      .add("http://subdomain.host1.tld/path/path/path")
+                      .build()),
+              Optional.empty(),
+              Optional.empty(),
+              1)
+        },
+        // Expect two in url list
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.of(
+                  ImmutableList.<String>builder()
+                      .add("http://subdomain.host1.tld/path/path/path")
+                      .add("http://subdomain.host2.tld/path/path/path")
+                      .build()),
+              Optional.empty(),
+              Optional.empty(),
+              2)
+        },
+        // Expect one in url list because arcgis.com is used without a token
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.of(
+                  ImmutableList.<String>builder()
+                      .add("http://subdomain.host1.tld/path/path/path")
+                      .add("http://api.arcgis.com/path/path/path")
+                      .build()),
+              Optional.empty(),
+              Optional.empty(),
+              1)
+        },
+        // Expect two in url list because arcgis.com is used with a token
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.of(
+                  ImmutableList.<String>builder()
+                      .add("http://subdomain.host1.tld/path/path/path")
+                      .add("http://api.arcgis.com/path/path/path")
+                      .build()),
+              Optional.empty(),
+              Optional.of("greetings-i-am-a-token"),
+              2)
+        },
+        // Expect two in url list because new url list is used which overrides anything set in the
+        // old url string
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.of(
+                  ImmutableList.<String>builder()
+                      .add("http://subdomain.host1.tld/path/path/path")
+                      .add("http://subdomain.host2.tld/path/path/path")
+                      .build()),
+              Optional.of("http://subdomain.host3.tld/path/path/path"),
+              Optional.empty(),
+              2)
+        },
+        // Expect one in url list because we use the old single value option
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.empty(),
+              Optional.of("http://subdomain.host1.tld/path/path/path"),
+              Optional.empty(),
+              1)
+        },
+        // Expect zero in url list because we use the old single value option and arcgis.com is used
+        // without a token
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.empty(),
+              Optional.of("http://api.arcgis.com/path/path/path"),
+              Optional.empty(),
+              0)
+        },
+        // Expect one in url list because we use the old single value option and arcgis.com is used
+        // with a token
+        new Object[] {
+          FetchAddressUrlsTestData.create(
+              Optional.empty(),
+              Optional.of("http://api.arcgis.com/path/path/path"),
+              Optional.of("greetings-i-am-a-token"),
+              1)
+        },
+        // Expect zero in url list because we have no urls configured
+        new Object[] {
+          FetchAddressUrlsTestData.create(Optional.empty(), Optional.empty(), Optional.empty(), 0)
+        });
+  }
+
+  @AutoValue
+  abstract static class FetchAddressUrlsTestData {
+    static FetchAddressUrlsTestData create(
+        Optional<ImmutableList<String>> esriFindAddressCandidatesUrls,
+        Optional<String> esriFindAddressCandidatesUrl,
+        Optional<String> esriArcgisApiToken,
+        int expectedUrlCount) {
+      return new AutoValue_RealEsriClientTest_FetchAddressUrlsTestData(
+          esriFindAddressCandidatesUrls,
+          esriFindAddressCandidatesUrl,
+          esriArcgisApiToken,
+          expectedUrlCount);
+    }
+
+    abstract Optional<ImmutableList<String>> esriFindAddressCandidatesUrls();
+
+    abstract Optional<String> esriFindAddressCandidatesUrl();
+
+    abstract Optional<String> esriArcgisApiToken();
+
+    abstract int expectedUrlCount();
   }
 }


### PR DESCRIPTION
### Description

Send api token when address correction calls to Arcgis Online (arcgis.com)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Related

Contributes to: #6800
