### PR TITLE
Fix add button enable/disable logic when answering enumerator questions

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -303,6 +303,59 @@ test.describe('End to end enumerator test', {tag: ['@uses-fixtures']}, () => {
       await logout(page)
     })
 
+    test('Enumerator add button is enabled/disabled correctly', async ({
+      page,
+      applicantQuestions,
+    }) => {
+      await test.step('Set up application', async () => {
+        await applicantQuestions.applyProgram(programName)
+
+        await applicantQuestions.answerNameQuestion('Porky', 'Pig')
+        await applicantQuestions.clickNext()
+      })
+
+      await test.step('Add button is enabled with a non-blank entity', async () => {
+        await applicantQuestions.addEnumeratorAnswer('Bugs')
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).not.toHaveAttribute('disabled')
+      })
+
+      await test.step('Add button is disabled if an entity is blank', async () => {
+        await applicantQuestions.addEnumeratorAnswer('')
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).toHaveAttribute('disabled')
+      })
+
+      await test.step('Add button is re-enabled when the blank item is removed', async () => {
+        await applicantQuestions.deleteEnumeratorEntityByIndex(2)
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).not.toHaveAttribute('disabled')
+      })
+
+      await test.step('Add button is still enabled after navigating away and back', async () => {
+        await applicantQuestions.clickNext()
+        await applicantQuestions.clickPrevious()
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).not.toHaveAttribute('disabled')
+      })
+
+      await test.step('Add button is disabled when an existing item is blanked', async () => {
+        await applicantQuestions.editEnumeratorAnswer('Bugs', '')
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).toHaveAttribute('disabled')
+      })
+    })
+
     test('Applicant can navigate to previous blocks', async ({
       page,
       applicantQuestions,

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -163,6 +163,16 @@ export class ApplicantQuestions {
     )
   }
 
+  async editEnumeratorAnswer(
+    existingEntityName: string,
+    newEntityName: string,
+  ) {
+    await this.page.fill(
+      `#enumerator-fields .cf-enumerator-field input[value="${existingEntityName}"]`,
+      newEntityName,
+    )
+  }
+
   async checkEnumeratorAnswerValue(entityName: string, index: number) {
     await this.page.waitForSelector(
       `#enumerator-fields .cf-enumerator-field:nth-of-type(${index}) input`,

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -119,6 +119,7 @@ function removeExistingEnumeratorField(event: Event) {
     enumeratorFieldDiv.querySelector('input'),
   )
   enumeratorInput.classList.add('hidden')
+  enumeratorInput.removeAttribute('data-entity-input')
 
   // Create a copy of the hidden deleted entity template. Set the value to this
   // button's ID, and set disabled to false so the data is submitted with the form.

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -163,6 +163,9 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
                         localizedEntityType)
                     + indexString)
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT);
+    if (!isDisabled) {
+      entityNameInputField.setAttribute("data-entity-input");
+    }
     if (elementId.isPresent()) {
       entityNameInputField.setId(elementId.get());
     }


### PR DESCRIPTION
### Description

When filling out an enumerator question in an application, the Add button is supposed to be disabled if any of the entries are blank. This only worked for entries that were created in the current page load. If entries were saved and then the page was reloaded, they would no longer participate in the enable/disable logic. This fixes that inconsistency so if an existing entry is blanked out the add button will be disabled.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Steps to reproduce are in #7317.

### Issue(s) this completes

Fixes #7317