### PR TITLE
Fix erroneous toBeVisible(true)

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -86,7 +86,7 @@ test.describe('End to end enumerator test', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.clickNext()
 
       // Check that we are on the enumerator page
-      await expect(page.locator('.cf-question-enumerator')).toBeVisible(true)
+      await expect(page.locator('.cf-question-enumerator')).toBeVisible()
 
       // Validate that enumerators are accessible
       await validateAccessibility(page)


### PR DESCRIPTION
### Description

Replace toBeVisible(true) with toBeVisible(). The argument is unnecessary and the correct syntax would be toBeVisible({visible: true}). This fixes a warning.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
