### PR TITLE
Set schedule for renovatebot to run at

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,23 @@
 {
-  "extends": ["config:recommended"],
-  "labels": ["dependencies"],
+  "extends": [
+    "config:recommended"
+  ],
+  // Default timezone is UTC. Not running during the "work day" will free up github
+  // actions to run and lessen calls to docker hub.
+  //
+  // This will allow the schedule to run within this time range:
+  //   PST/PDT -> 9pm - 3am
+  //   EST/EDT -> Midnight - 6am 
+  "schedule": [
+    "after 4am",
+    "before 10am"
+  ],
+  // Github label(s) applied to the generated pull request, unless overridden below
+  "labels": [
+    "dependencies"
+  ],
+  // These files deviate from standard compose naming convention. 
+  // This makes sure renovate finds them.
   "docker-compose": {
     "fileMatch": [
       "browser-test/browser-test-compose.yml",
@@ -14,11 +31,15 @@
   "packageRules": [
     {
       "groupName": "autovalue",
-      "matchPackagePrefixes": ["com.google.auto.value:"]
+      "matchPackagePrefixes": [
+        "com.google.auto.value:"
+      ]
     },
     {
       "groupName": "jackson",
-      "matchPackagePrefixes": ["com.fasterxml.jackson"]
+      "matchPackagePrefixes": [
+        "com.fasterxml.jackson"
+      ]
     },
     {
       "groupName": "jdk and jre",
@@ -30,11 +51,15 @@
     },
     {
       "groupName": "jupiter",
-      "matchPackagePrefixes": ["org.junit.jupiter:"]
+      "matchPackagePrefixes": [
+        "org.junit.jupiter:"
+      ]
     },
     {
       "groupName": "pac4j",
-      "matchPackagePrefixes": ["org.pac4j:pac4j"]
+      "matchPackagePrefixes": [
+        "org.pac4j:pac4j"
+      ]
     },
     {
       "groupName": "playwright",
@@ -51,10 +76,15 @@
         "env-var-docs/**",
         "formatter/**"
       ],
-      "labels": ["dependencies", "ignore-for-release"]
+      "labels": [
+        "dependencies",
+        "ignore-for-release"
+      ]
     },
     {
-      "matchPackageNames": ["postgres"],
+      "matchPackageNames": [
+        "postgres"
+      ],
       "allowedVersions": "<13.0.0"
     }
   ]


### PR DESCRIPTION
### Description

#### Behaviorial changes 

Renovatebot runs frequently throughout the day. This can cause the github actions to get backed up as well as make numerous calls to docker hub making hitting the http 503 more frequent.

This sets renovate to run only after hours which I'm defining as 9pm-3am Pacific.

#### File changes

- Moved the file to be under the .github folder
- Renamed the file extension from json to json5 so I could leave comments.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
