### PR TITLE
Remove unnecessary qualifiers in QuestionDefinitions

### DIFF
--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -13,7 +13,7 @@ public final class DateQuestionDefinition extends QuestionDefinition {
   @AutoValue
   public abstract static class DateValidationPredicates extends ValidationPredicates {
 
-    public static DateQuestionDefinition.DateValidationPredicates parse(String jsonString) {
+    public static DateValidationPredicates parse(String jsonString) {
       try {
         return mapper.readValue(
             jsonString, AutoValue_DateQuestionDefinition_DateValidationPredicates.class);
@@ -27,8 +27,8 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     }
   }
 
-  public DateQuestionDefinition.DateValidationPredicates getDateValidationPredicates() {
-    return (DateQuestionDefinition.DateValidationPredicates) getValidationPredicates();
+  public DateValidationPredicates getDateValidationPredicates() {
+    return (DateValidationPredicates) getValidationPredicates();
   }
 
   @Override

--- a/server/app/services/question/types/EmailQuestionDefinition.java
+++ b/server/app/services/question/types/EmailQuestionDefinition.java
@@ -13,7 +13,7 @@ public final class EmailQuestionDefinition extends QuestionDefinition {
   @AutoValue
   public abstract static class EmailValidationPredicates extends ValidationPredicates {
 
-    public static EmailQuestionDefinition.EmailValidationPredicates parse(String jsonString) {
+    public static EmailValidationPredicates parse(String jsonString) {
       try {
         return mapper.readValue(
             jsonString, AutoValue_EmailQuestionDefinition_EmailValidationPredicates.class);
@@ -22,13 +22,13 @@ public final class EmailQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    public static EmailQuestionDefinition.EmailValidationPredicates create() {
+    public static EmailValidationPredicates create() {
       return new AutoValue_EmailQuestionDefinition_EmailValidationPredicates();
     }
   }
 
-  public EmailQuestionDefinition.EmailValidationPredicates getEmailValidationPredicates() {
-    return (EmailQuestionDefinition.EmailValidationPredicates) getValidationPredicates();
+  public EmailValidationPredicates getEmailValidationPredicates() {
+    return (EmailValidationPredicates) getValidationPredicates();
   }
 
   @Override

--- a/server/app/services/question/types/NullQuestionDefinition.java
+++ b/server/app/services/question/types/NullQuestionDefinition.java
@@ -47,6 +47,6 @@ public class NullQuestionDefinition extends QuestionDefinition {
   /** Get the default validation predicates for this question type. */
   @Override
   ValidationPredicates getDefaultValidationPredicates() {
-    return new NullQuestionDefinition.NullValidationPredicates();
+    return new NullValidationPredicates();
   }
 }

--- a/server/app/services/question/types/NumberQuestionDefinition.java
+++ b/server/app/services/question/types/NumberQuestionDefinition.java
@@ -18,7 +18,7 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
   @AutoValue
   public abstract static class NumberValidationPredicates extends ValidationPredicates {
 
-    public static NumberQuestionDefinition.NumberValidationPredicates parse(String jsonString) {
+    public static NumberValidationPredicates parse(String jsonString) {
       try {
         return mapper.readValue(
             jsonString, AutoValue_NumberQuestionDefinition_NumberValidationPredicates.class);
@@ -27,11 +27,11 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    public static NumberQuestionDefinition.NumberValidationPredicates create() {
+    public static NumberValidationPredicates create() {
       return builder().build();
     }
 
-    public static NumberQuestionDefinition.NumberValidationPredicates create(long min, long max) {
+    public static NumberValidationPredicates create(long min, long max) {
       return builder().setMin(min).setMax(max).build();
     }
 
@@ -41,7 +41,7 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
     @JsonProperty("max")
     public abstract OptionalLong max();
 
-    public static NumberQuestionDefinition.NumberValidationPredicates.Builder builder() {
+    public static Builder builder() {
       return new AutoValue_NumberQuestionDefinition_NumberValidationPredicates.Builder();
     }
 
@@ -49,23 +49,21 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
     public abstract static class Builder {
 
       @JsonProperty("min")
-      public abstract NumberQuestionDefinition.NumberValidationPredicates.Builder setMin(
-          OptionalLong min);
+      public abstract Builder setMin(OptionalLong min);
 
-      public abstract NumberQuestionDefinition.NumberValidationPredicates.Builder setMin(long min);
+      public abstract Builder setMin(long min);
 
       @JsonProperty("max")
-      public abstract NumberQuestionDefinition.NumberValidationPredicates.Builder setMax(
-          OptionalLong max);
+      public abstract Builder setMax(OptionalLong max);
 
-      public abstract NumberQuestionDefinition.NumberValidationPredicates.Builder setMax(long max);
+      public abstract Builder setMax(long max);
 
-      public abstract NumberQuestionDefinition.NumberValidationPredicates build();
+      public abstract NumberValidationPredicates build();
     }
   }
 
-  public NumberQuestionDefinition.NumberValidationPredicates getNumberValidationPredicates() {
-    return (NumberQuestionDefinition.NumberValidationPredicates) getValidationPredicates();
+  public NumberValidationPredicates getNumberValidationPredicates() {
+    return (NumberValidationPredicates) getValidationPredicates();
   }
 
   @Override

--- a/server/app/services/question/types/PhoneQuestionDefinition.java
+++ b/server/app/services/question/types/PhoneQuestionDefinition.java
@@ -10,10 +10,9 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
   }
 
   @AutoValue
-  public abstract static class PhoneValidationPredicates
-      extends QuestionDefinition.ValidationPredicates {
+  public abstract static class PhoneValidationPredicates extends ValidationPredicates {
 
-    public static PhoneQuestionDefinition.PhoneValidationPredicates parse(String jsonString) {
+    public static PhoneValidationPredicates parse(String jsonString) {
       try {
         return mapper.readValue(
             jsonString, AutoValue_PhoneQuestionDefinition_PhoneValidationPredicates.class);
@@ -22,13 +21,13 @@ public final class PhoneQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    public static PhoneQuestionDefinition.PhoneValidationPredicates create() {
+    public static PhoneValidationPredicates create() {
       return new AutoValue_PhoneQuestionDefinition_PhoneValidationPredicates();
     }
   }
 
-  public PhoneQuestionDefinition.PhoneValidationPredicates getPhoneValidationPredicates() {
-    return (PhoneQuestionDefinition.PhoneValidationPredicates) getValidationPredicates();
+  public PhoneValidationPredicates getPhoneValidationPredicates() {
+    return (PhoneValidationPredicates) getValidationPredicates();
   }
 
   @Override

--- a/server/app/services/question/types/StaticContentQuestionDefinition.java
+++ b/server/app/services/question/types/StaticContentQuestionDefinition.java
@@ -16,8 +16,7 @@ public final class StaticContentQuestionDefinition extends QuestionDefinition {
   @AutoValue
   public abstract static class StaticContentValidationPredicates extends ValidationPredicates {
 
-    public static StaticContentQuestionDefinition.StaticContentValidationPredicates parse(
-        String jsonString) {
+    public static StaticContentValidationPredicates parse(String jsonString) {
       try {
         return mapper.readValue(
             jsonString,
@@ -27,15 +26,13 @@ public final class StaticContentQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    public static StaticContentQuestionDefinition.StaticContentValidationPredicates create() {
+    public static StaticContentValidationPredicates create() {
       return new AutoValue_StaticContentQuestionDefinition_StaticContentValidationPredicates();
     }
   }
 
-  public StaticContentQuestionDefinition.StaticContentValidationPredicates
-      getStaticContentValidationPredicates() {
-    return (StaticContentQuestionDefinition.StaticContentValidationPredicates)
-        getValidationPredicates();
+  public StaticContentValidationPredicates getStaticContentValidationPredicates() {
+    return (StaticContentValidationPredicates) getValidationPredicates();
   }
 
   @Override


### PR DESCRIPTION
### Description

Remove unnecessary qualifiers in QuestionDefinitions. They make the code harder to read.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)