### PR TITLE
Add FIX_APPLICANT_DOB_DATA_PATH back into enum

### DIFF
--- a/server/app/durablejobs/DurableJobName.java
+++ b/server/app/durablejobs/DurableJobName.java
@@ -15,6 +15,9 @@ public enum DurableJobName {
   UNUSED_PROGRAM_IMAGES_CLEANUP("UNUSED_PROGRAM_IMAGES_CLEANUP"),
   MIGRATE_PRIMARY_APPLICANT_INFO("MIGRATE_PRIMARY_APPLICANT_INFO"),
 
+  // deprecated jobs (must be kept around so that durableJobRegistry.get does not throw an IllegalArgumentException error
+  FIX_APPLICANT_DOB_DATA_PATH("FIX_APPLICANT_DOB_DATA_PATH"),
+
   // job names used for tests
   TEST("TEST");
 

--- a/server/app/durablejobs/DurableJobName.java
+++ b/server/app/durablejobs/DurableJobName.java
@@ -15,7 +15,8 @@ public enum DurableJobName {
   UNUSED_PROGRAM_IMAGES_CLEANUP("UNUSED_PROGRAM_IMAGES_CLEANUP"),
   MIGRATE_PRIMARY_APPLICANT_INFO("MIGRATE_PRIMARY_APPLICANT_INFO"),
 
-  // deprecated jobs (must be kept around so that durableJobRegistry.get does not throw an IllegalArgumentException error
+  // deprecated jobs (must be kept around so that durableJobRegistry.get does not throw an
+  // IllegalArgumentException error
   FIX_APPLICANT_DOB_DATA_PATH("FIX_APPLICANT_DOB_DATA_PATH"),
 
   // job names used for tests

--- a/server/app/durablejobs/DurableJobName.java
+++ b/server/app/durablejobs/DurableJobName.java
@@ -15,8 +15,10 @@ public enum DurableJobName {
   UNUSED_PROGRAM_IMAGES_CLEANUP("UNUSED_PROGRAM_IMAGES_CLEANUP"),
   MIGRATE_PRIMARY_APPLICANT_INFO("MIGRATE_PRIMARY_APPLICANT_INFO"),
 
-  // deprecated jobs (must be kept around so that durableJobRegistry.get does not throw an
-  // IllegalArgumentException error
+  // Jobs below this line are deprecated, but must be kept around so that durableJobRegistry.get
+  // does not throw an IllegalArgumentException error
+  // TODO(#7347): remove the deprecated job names once we have logic in place to remove them from
+  // the db when not found
   FIX_APPLICANT_DOB_DATA_PATH("FIX_APPLICANT_DOB_DATA_PATH"),
 
   // job names used for tests

--- a/server/app/durablejobs/DurableJobRunner.java
+++ b/server/app/durablejobs/DurableJobRunner.java
@@ -164,12 +164,12 @@ public final class DurableJobRunner {
         String msg =
             String.format(
                 "Job was not found in the registry and there was an error deleting the job. Error:"
-                    + " %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d, duration_s=%f",
+                    + " %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d, duration_s=%f," + " message: %s",
                 e.getClass().getSimpleName(),
                 persistedDurableJob.getJobName(),
                 persistedDurableJob.id,
                 persistedDurableJob.getRemainingAttempts(),
-                getJobDurationInSeconds(startTime));
+                getJobDurationInSeconds(startTime), e.getMessage());
         LOGGER.error(msg);
         persistedDurableJob.appendErrorMessage(msg).save();
       }
@@ -177,12 +177,12 @@ public final class DurableJobRunner {
       String msg =
           String.format(
               "JobRunner_JobFailed %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d,"
-                  + " duration_s=%f",
+                  + " duration_s=%f," + " message: %s",
               e.getClass().getSimpleName(),
               persistedDurableJob.getJobName(),
               persistedDurableJob.id,
               persistedDurableJob.getRemainingAttempts(),
-              getJobDurationInSeconds(startTime));
+              getJobDurationInSeconds(startTime), e.getMessage());
       LOGGER.error(msg);
       persistedDurableJob.appendErrorMessage(msg).save();
     } catch (TimeoutException e) {

--- a/server/app/durablejobs/DurableJobRunner.java
+++ b/server/app/durablejobs/DurableJobRunner.java
@@ -164,12 +164,14 @@ public final class DurableJobRunner {
         String msg =
             String.format(
                 "Job was not found in the registry and there was an error deleting the job. Error:"
-                    + " %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d, duration_s=%f," + " message: %s",
+                    + " %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d, duration_s=%f,"
+                    + " message: %s",
                 e.getClass().getSimpleName(),
                 persistedDurableJob.getJobName(),
                 persistedDurableJob.id,
                 persistedDurableJob.getRemainingAttempts(),
-                getJobDurationInSeconds(startTime), e.getMessage());
+                getJobDurationInSeconds(startTime),
+                e.getMessage());
         LOGGER.error(msg);
         persistedDurableJob.appendErrorMessage(msg).save();
       }
@@ -177,12 +179,14 @@ public final class DurableJobRunner {
       String msg =
           String.format(
               "JobRunner_JobFailed %s job_name=\"%s\", job_ID=%d, attempts_remaining=%d,"
-                  + " duration_s=%f," + " message: %s",
+                  + " duration_s=%f,"
+                  + " message: %s",
               e.getClass().getSimpleName(),
               persistedDurableJob.getJobName(),
               persistedDurableJob.id,
               persistedDurableJob.getRemainingAttempts(),
-              getJobDurationInSeconds(startTime), e.getMessage());
+              getJobDurationInSeconds(startTime),
+              e.getMessage());
       LOGGER.error(msg);
       persistedDurableJob.appendErrorMessage(msg).save();
     } catch (TimeoutException e) {


### PR DESCRIPTION
### Description

Removing `FIX_APPLICANT_DOB_DATA_PATH` from the `DurableJobName` enum in https://github.com/civiform/civiform/pull/7302 resulted in an `IllegalArgumentException` error being thrown when the job attempted to run because the logic expects all job names found in the db to also be found in the enum.

This is a quick fix to get rid of those errors. I created https://github.com/civiform/civiform/issues/7347 to track a more permanent solution.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Extended the README / documentation, if necessary -- updated the wiki: https://github.com/civiform/civiform/wiki/Durable-Jobs/_compare/4ded0233e3a97c55123214c32af7ebc5fda32401...dee21b0526ea9ae94efaad59c9cc4853626a9dd7

### Instructions for manual testing

1. Set one of the jobs to schedule recurring jobs a minute out from now.
2. Start the server and check that the jobs get scheduled.
3. Remove the code to run the job and remove the job from where it gets registered in `DurableJobModule`, but leave it in the enum
4. Restart the server and see that jobs that have not been run yet should be removed from the db without error

### Issue(s) this completes

Fixes #7348 