### PR TITLE
Moved to using fixtures

### DIFF
--- a/browser-test/src/admin/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin/admin_dropdown_create_and_edit.test.ts
@@ -1,125 +1,128 @@
-import {test, expect} from '@playwright/test'
-import {createTestContext, loginAsAdmin, waitForPageJsLoad} from '../support'
+import {test, expect} from '../support/civiform_fixtures'
+import {loginAsAdmin, waitForPageJsLoad} from '../support'
 
-test.describe('create dropdown question with options', () => {
-  const ctx = createTestContext()
+test.describe(
+  'create dropdown question with options',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test('add remove buttons work correctly', async ({
+      page,
+      adminQuestions,
+    }) => {
+      await loginAsAdmin(page)
 
-  test('add remove buttons work correctly', async () => {
-    const {page, adminQuestions} = ctx
+      await page.click('text=Questions')
+      await waitForPageJsLoad(page)
 
-    await loginAsAdmin(page)
+      await page.click('#create-question-button')
+      await page.click('#create-dropdown-question')
+      await waitForPageJsLoad(page)
 
-    await page.click('text=Questions')
-    await waitForPageJsLoad(page)
+      // Verify question preview has default text.
+      expect(await page.innerText('.cf-applicant-question-text')).toContain(
+        'Sample question text',
+      )
+      expect(
+        await page.innerText('.cf-applicant-question-help-text'),
+      ).toContain('')
 
-    await page.click('#create-question-button')
-    await page.click('#create-dropdown-question')
-    await waitForPageJsLoad(page)
+      // Fill in basic info
+      const questionName = 'favorite ice cream'
+      await page.fill('text=Question Text', 'questionText')
+      await page.fill('text=Question help text', 'helpText')
+      await page.fill('text=Administrative identifier', questionName)
+      await page.fill(
+        'text=Question note for administrative use only',
+        'description',
+      )
 
-    // Verify question preview has default text.
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      'Sample question text',
-    )
-    expect(await page.innerText('.cf-applicant-question-help-text')).toContain(
-      '',
-    )
+      // Add three options
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'chocolate',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+      })
 
-    // Fill in basic info
-    const questionName = 'favorite ice cream'
-    await page.fill('text=Question Text', 'questionText')
-    await page.fill('text=Question help text', 'helpText')
-    await page.fill('text=Administrative identifier', questionName)
-    await page.fill(
-      'text=Question note for administrative use only',
-      'description',
-    )
+      // Assert there are three options present
+      let questionSettingsDiv = await page.innerHTML('#question-settings')
+      // 2 inputs each for 3 options (option, optionAdminName) + hidden nextAvailableId
+      expect(questionSettingsDiv.match(/<input/g)).toHaveLength(7)
 
-    // Add three options
-    await page.click('#add-new-option')
-    await adminQuestions.fillMultiOptionAnswer(0, {
-      adminName: 'chocolate_admin',
-      text: 'chocolate',
+      // Remove first option - use :visible to not select the hidden template
+      // await page.click('button:has-text("Delete"):visible')
+      await adminQuestions.deleteMultiOptionAnswer(0)
+
+      // Assert there are only two options now
+      questionSettingsDiv = await page.innerHTML('#question-settings')
+      // 2 inputs each for 2 options (option, optionAdminName) + hidden nextAvailableId
+      expect(questionSettingsDiv.match(/<input/g)).toHaveLength(5)
+      // First option should now be vanilla
+      await adminQuestions.expectNewMultiOptionAnswer(0, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+      })
+
+      // Verify question preview text has changed based on user input.
+      expect(await page.innerText('.cf-applicant-question-text')).toContain(
+        'questionText',
+      )
+      expect(
+        await page.innerText('.cf-applicant-question-help-text'),
+      ).toContain('helpText')
+
+      // Submit the form, then edit that question again
+      await adminQuestions.clickSubmitButtonAndNavigate('Create')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+
+      // Edit the question
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      questionSettingsDiv = await page.innerHTML('#question-settings')
+      // 3 inputs each for 2 options (option, optionAdminName, and optionId) + hidden nextAvailableId
+      expect(questionSettingsDiv.match(/<input/g)).toHaveLength(7)
+      // Check that admin names were set correctly
+      await adminQuestions.expectExistingMultiOptionAnswer(0, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+      })
+
+      // Edit an option
+      await adminQuestions.changeMultiOptionAnswer(1, 'pistachio')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      // Expect that the option text has changed but the admin name has not
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'strawberry_admin',
+        text: 'pistachio',
+      })
+
+      // Remove the last option and add a new one, and assert the new option has the correct admin name
+      await adminQuestions.deleteMultiOptionAnswer(1)
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(1, {
+        adminName: 'mango_admin',
+        text: 'mango',
+      })
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      // Expect that the option text has changed but the admin name has not
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'mango_admin',
+        text: 'mango',
+      })
     })
-    await page.click('#add-new-option')
-    await adminQuestions.fillMultiOptionAnswer(1, {
-      adminName: 'vanilla_admin',
-      text: 'vanilla',
-    })
-    await page.click('#add-new-option')
-    await adminQuestions.fillMultiOptionAnswer(2, {
-      adminName: 'strawberry_admin',
-      text: 'strawberry',
-    })
-
-    // Assert there are three options present
-    let questionSettingsDiv = await page.innerHTML('#question-settings')
-    // 2 inputs each for 3 options (option, optionAdminName) + hidden nextAvailableId
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(7)
-
-    // Remove first option - use :visible to not select the hidden template
-    // await page.click('button:has-text("Delete"):visible')
-    await adminQuestions.deleteMultiOptionAnswer(0)
-
-    // Assert there are only two options now
-    questionSettingsDiv = await page.innerHTML('#question-settings')
-    // 2 inputs each for 2 options (option, optionAdminName) + hidden nextAvailableId
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(5)
-    // First option should now be vanilla
-    await adminQuestions.expectNewMultiOptionAnswer(0, {
-      adminName: 'vanilla_admin',
-      text: 'vanilla',
-    })
-
-    // Verify question preview text has changed based on user input.
-    expect(await page.innerText('.cf-applicant-question-text')).toContain(
-      'questionText',
-    )
-    expect(await page.innerText('.cf-applicant-question-help-text')).toContain(
-      'helpText',
-    )
-
-    // Submit the form, then edit that question again
-    await adminQuestions.clickSubmitButtonAndNavigate('Create')
-    await adminQuestions.expectDraftQuestionExist(questionName)
-
-    // Edit the question
-    await adminQuestions.gotoQuestionEditPage(questionName)
-    questionSettingsDiv = await page.innerHTML('#question-settings')
-    // 3 inputs each for 2 options (option, optionAdminName, and optionId) + hidden nextAvailableId
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(7)
-    // Check that admin names were set correctly
-    await adminQuestions.expectExistingMultiOptionAnswer(0, {
-      adminName: 'vanilla_admin',
-      text: 'vanilla',
-    })
-    await adminQuestions.expectExistingMultiOptionAnswer(1, {
-      adminName: 'strawberry_admin',
-      text: 'strawberry',
-    })
-
-    // Edit an option
-    await adminQuestions.changeMultiOptionAnswer(1, 'pistachio')
-    await adminQuestions.clickSubmitButtonAndNavigate('Update')
-    await adminQuestions.gotoQuestionEditPage(questionName)
-    // Expect that the option text has changed but the admin name has not
-    await adminQuestions.expectExistingMultiOptionAnswer(1, {
-      adminName: 'strawberry_admin',
-      text: 'pistachio',
-    })
-
-    // Remove the last option and add a new one, and assert the new option has the correct admin name
-    await adminQuestions.deleteMultiOptionAnswer(1)
-    await page.click('#add-new-option')
-    await adminQuestions.fillMultiOptionAnswer(1, {
-      adminName: 'mango_admin',
-      text: 'mango',
-    })
-    await adminQuestions.clickSubmitButtonAndNavigate('Update')
-    await adminQuestions.gotoQuestionEditPage(questionName)
-    // Expect that the option text has changed but the admin name has not
-    await adminQuestions.expectExistingMultiOptionAnswer(1, {
-      adminName: 'mango_admin',
-      text: 'mango',
-    })
-  })
-})
+  },
+)

--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -1,7 +1,6 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from '../support/civiform_fixtures'
 import {
   AdminPrograms,
-  createTestContext,
   enableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
@@ -9,11 +8,8 @@ import {
 } from '../support'
 import {ProgramVisibility} from '../support/admin_programs'
 
-test.describe('Program list page.', () => {
-  const ctx = createTestContext()
-
-  test('view draft program', async () => {
-    const {page, adminPrograms} = ctx
+test.describe('Program list page.', {tag: ['@uses-fixtures']}, () => {
+  test('view draft program', async ({page, adminPrograms}) => {
     await loginAsAdmin(page)
 
     const programName = 'Test program'
@@ -22,8 +18,7 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-one-draft-program')
   })
 
-  test('view active program', async () => {
-    const {page, adminPrograms} = ctx
+  test('view active program', async ({page, adminPrograms}) => {
     await loginAsAdmin(page)
 
     const programName = 'Test program'
@@ -33,8 +28,10 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-one-active-program')
   })
 
-  test('view program with active and draft versions', async () => {
-    const {page, adminPrograms} = ctx
+  test('view program with active and draft versions', async ({
+    page,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     const programName = 'Test program'
@@ -47,9 +44,10 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-active-and-draft-versions')
   })
 
-  test('sorts by last updated, preferring draft over active', async () => {
-    const {page, adminPrograms} = ctx
-
+  test('sorts by last updated, preferring draft over active', async ({
+    page,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     const programOne = 'List test program one'
@@ -79,9 +77,10 @@ test.describe('Program list page.', () => {
     ])
   })
 
-  test('shows which program is the common intake when enabled', async () => {
-    const {page, adminPrograms} = ctx
-
+  test('shows which program is the common intake when enabled', async ({
+    page,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'intake_form_enabled')
 
@@ -102,9 +101,11 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'intake-form-indicator')
   })
 
-  test('shows information about universal questions when the flag is enabled and at least one universal question is set', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
-
+  test('shows information about universal questions when the flag is enabled and at least one universal question is set', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     // Create a program and question that is not universal
@@ -155,9 +156,7 @@ test.describe('Program list page.', () => {
     expect(programListNames).toEqual(expectedPrograms)
   }
 
-  test('publishes a single program', async () => {
-    const {page, adminPrograms} = ctx
-
+  test('publishes a single program', async ({page, adminPrograms}) => {
     await loginAsAdmin(page)
 
     const programOne = 'list-test-program-one'
@@ -180,9 +179,11 @@ test.describe('Program list page.', () => {
     await adminPrograms.expectActiveProgram(programOne)
   })
 
-  test('publishing a single program shows a modal with conditional warning about universal questions', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
-
+  test('publishing a single program shows a modal with conditional warning about universal questions', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     // Create a program and question that is not universal
@@ -244,8 +245,11 @@ test.describe('Program list page.', () => {
     await adminPrograms.expectActiveProgram(programOne)
   })
 
-  test('program list has current image', async () => {
-    const {page, adminPrograms, adminProgramImage} = ctx
+  test('program list has current image', async ({
+    page,
+    adminPrograms,
+    adminProgramImage,
+  }) => {
     await loginAsAdmin(page)
 
     const programName = 'Images Flag On Program'
@@ -260,8 +264,7 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list')
   })
 
-  test('program list with no image', async () => {
-    const {page, adminPrograms} = ctx
+  test('program list with no image', async ({page, adminPrograms}) => {
     await loginAsAdmin(page)
 
     const programName = 'No Image Program'
@@ -272,8 +275,11 @@ test.describe('Program list page.', () => {
     await validateScreenshot(page, 'program-list-no-image')
   })
 
-  test('program list with new image in draft', async () => {
-    const {page, adminPrograms, adminProgramImage} = ctx
+  test('program list with new image in draft', async ({
+    page,
+    adminPrograms,
+    adminProgramImage,
+  }) => {
     await loginAsAdmin(page)
 
     // Start the program as having no image
@@ -297,8 +303,11 @@ test.describe('Program list page.', () => {
   // This test is flaky in staging prober tests, so only run it locally and on
   // GitHub actions. See issue #6624 for more details.
   if (isLocalDevEnvironment()) {
-    test('program list with different active and draft image', async () => {
-      const {page, adminPrograms, adminProgramImage} = ctx
+    test('program list with different active and draft image', async ({
+      page,
+      adminPrograms,
+      adminProgramImage,
+    }) => {
       await loginAsAdmin(page)
 
       const programName = 'Different Images Program'
@@ -324,8 +333,11 @@ test.describe('Program list page.', () => {
     })
   }
 
-  test('program list with same active and draft image', async () => {
-    const {page, adminPrograms, adminProgramImage} = ctx
+  test('program list with same active and draft image', async ({
+    page,
+    adminPrograms,
+    adminProgramImage,
+  }) => {
     await loginAsAdmin(page)
 
     const programName = 'Same Image Program'

--- a/browser-test/src/admin/admin_program_preview.test.ts
+++ b/browser-test/src/admin/admin_program_preview.test.ts
@@ -1,16 +1,13 @@
-import {expect, test} from '@playwright/test'
-import {
-  createTestContext,
-  loginAsAdmin,
-  validateScreenshot,
-  waitForPageJsLoad,
-} from '../support'
+import {expect, test} from '../support/civiform_fixtures'
+import {loginAsAdmin, validateScreenshot, waitForPageJsLoad} from '../support'
 
-test.describe('admin program preview', () => {
-  const ctx = createTestContext()
-
-  test('preview draft program and submit', async () => {
-    const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
+test.describe('admin program preview', {tag: ['@uses-fixtures']}, () => {
+  test('preview draft program and submit', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+    applicantQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.addEmailQuestion({questionName: 'email-q'})
@@ -34,8 +31,12 @@ test.describe('admin program preview', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  test('preview active program and submit', async () => {
-    const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
+  test('preview active program and submit', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+    applicantQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.addEmailQuestion({questionName: 'email-q'})
@@ -58,8 +59,12 @@ test.describe('admin program preview', () => {
     await adminPrograms.expectProgramBlockReadOnlyPage()
   })
 
-  test('preview program and use back button', async () => {
-    const {page, adminPrograms, adminQuestions, applicantQuestions} = ctx
+  test('preview program and use back button', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+    applicantQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.addEmailQuestion({questionName: 'email-q'})
@@ -80,8 +85,11 @@ test.describe('admin program preview', () => {
     await adminPrograms.expectProgramBlockEditPage(programName)
   })
 
-  test('download pdf preview of draft program', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
+  test('download pdf preview of draft program', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.addEmailQuestion({questionName: 'email-q'})
@@ -99,8 +107,11 @@ test.describe('admin program preview', () => {
     // This browser test just ensures a file is downloaded when the button is clicked.
   })
 
-  test('download pdf preview of active program', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
+  test('download pdf preview of active program', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.addEmailQuestion({questionName: 'email-q'})

--- a/browser-test/src/admin/admin_program_viewing.test.ts
+++ b/browser-test/src/admin/admin_program_viewing.test.ts
@@ -1,16 +1,11 @@
-import {test} from '@playwright/test'
-import {
-  createTestContext,
-  enableFeatureFlag,
-  loginAsAdmin,
-  validateScreenshot,
-} from '../support'
+import {test} from '../support/civiform_fixtures'
+import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 
-test.describe('admin program view page', () => {
-  const ctx = createTestContext()
-
-  test('view active program shows read only view', async () => {
-    const {page, adminPrograms} = ctx
+test.describe('admin program view page', {tag: ['@uses-fixtures']}, () => {
+  test('view active program shows read only view', async ({
+    page,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     const programName = 'Active Program'
@@ -20,8 +15,7 @@ test.describe('admin program view page', () => {
     await validateScreenshot(page, 'program-read-only-view')
   })
 
-  test('view draft program', async () => {
-    const {page, adminPrograms} = ctx
+  test('view draft program', async ({page, adminPrograms}) => {
     await loginAsAdmin(page)
 
     const programName = 'Draft Program'
@@ -31,8 +25,11 @@ test.describe('admin program view page', () => {
     await validateScreenshot(page, 'program-draft-view')
   })
 
-  test('view program with universal questions', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
+  test('view program with universal questions', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const programName = 'Program with universal questions'
@@ -75,8 +72,11 @@ test.describe('admin program view page', () => {
     await validateScreenshot(page, 'program-view-universal-questions')
   })
 
-  test('view program, view multiple blocks, then start editing with extra long screen name and description', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
+  test('view program, view multiple blocks, then start editing with extra long screen name and description', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'esri_address_correction_enabled')
 
@@ -125,8 +125,11 @@ test.describe('admin program view page', () => {
     )
   })
 
-  test('view program, view multiple blocks, then start editing', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
+  test('view program, view multiple blocks, then start editing', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
     await enableFeatureFlag(page, 'esri_address_correction_enabled')
 

--- a/browser-test/src/admin/admin_question_list.test.ts
+++ b/browser-test/src/admin/admin_question_list.test.ts
@@ -1,17 +1,17 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from '../support/civiform_fixtures'
 import {
   AdminPrograms,
   AdminQuestions,
-  createTestContext,
   loginAsAdmin,
   validateScreenshot,
   waitForPageJsLoad,
 } from '../support'
-test.describe('Admin question list', () => {
-  const ctx = createTestContext()
-  test('sorts by last updated, preferring draft over active', async () => {
-    const {page, adminPrograms, adminQuestions} = ctx
-
+test.describe('Admin question list', {tag: ['@uses-fixtures']}, () => {
+  test('sorts by last updated, preferring draft over active', async ({
+    page,
+    adminPrograms,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const questionOnePublishedText = 'question list test question one'
@@ -84,8 +84,10 @@ test.describe('Admin question list', () => {
     ])
   })
 
-  test('filters question list with search query', async () => {
-    const {page, adminQuestions} = ctx
+  test('filters question list with search query', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
     await adminQuestions.addTextQuestion({
       questionName: 'q-f',
@@ -111,8 +113,11 @@ test.describe('Admin question list', () => {
     ])
   })
 
-  test('sorts question list based on selection', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
+  test('sorts question list based on selection', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
     // Set the questionText to the same as questionName to make validation easier since questionBankNames()
     // returns the questionText. The questionText is not actually used to sort.
@@ -159,8 +164,11 @@ test.describe('Admin question list', () => {
     await validateScreenshot(page, 'questions-list-sort-dropdown-lastmodified')
   })
 
-  test('shows if questions are marked for archival', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
+  test('shows if questions are marked for archival', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     const questionOne = 'question list test question one'
@@ -191,8 +199,11 @@ test.describe('Admin question list', () => {
     await validateScreenshot(page, 'questions-list-with-archived-questions')
   })
 
-  test('does not sort archived questions', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
+  test('does not sort archived questions', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     const questionOne = 'question list test question one'
@@ -236,9 +247,10 @@ test.describe('Admin question list', () => {
     ])
   })
 
-  test('persists universal state and orders questions correctly', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('persists universal state and orders questions correctly', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     // Navigate to the new question page and ensure that the universal toggle is unset

--- a/browser-test/src/applicant/application_previous_version.test.ts
+++ b/browser-test/src/applicant/application_previous_version.test.ts
@@ -1,7 +1,6 @@
-import {test} from '@playwright/test'
+import {test} from '../support/civiform_fixtures'
 import {
   ApplicantQuestions,
-  createTestContext,
   loginAsAdmin,
   loginAsProgramAdmin,
   loginAsTestUser,
@@ -9,62 +8,67 @@ import {
   testUserDisplayName,
 } from '../support'
 
-test.describe('view an application in an older version', () => {
-  const ctx = createTestContext()
+test.describe(
+  'view an application in an older version',
+  {tag: ['@uses-fixtures']},
+  () => {
+    test('create an application, and create a new version of the program, and view the application in the old version of the program', async ({
+      page,
+      adminQuestions,
+      adminPrograms,
+    }) => {
+      await loginAsAdmin(page)
 
-  test('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
-    await loginAsAdmin(page)
+      // Create a program with one question
+      const questionName = 'text-to-be-obsolete-q'
+      await adminQuestions.addTextQuestion({questionName})
+      const programName = 'Program with previous applications'
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        [questionName],
+        programName,
+      )
 
-    // Create a program with one question
-    const questionName = 'text-to-be-obsolete-q'
-    await adminQuestions.addTextQuestion({questionName})
-    const programName = 'Program with previous applications'
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      [questionName],
-      programName,
-    )
+      await logout(page)
+      await loginAsTestUser(page)
+      const applicantQuestions = new ApplicantQuestions(page)
+      await applicantQuestions.validateHeader('en-US')
 
-    await logout(page)
-    await loginAsTestUser(page)
-    const applicantQuestions = new ApplicantQuestions(page)
-    await applicantQuestions.validateHeader('en-US')
+      // Submit an application to the program
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('some text')
+      await applicantQuestions.clickNext()
+      await applicantQuestions.submitFromReviewPage()
 
-    // Submit an application to the program
-    await applicantQuestions.applyProgram(programName)
-    await applicantQuestions.answerTextQuestion('some text')
-    await applicantQuestions.clickNext()
-    await applicantQuestions.submitFromReviewPage()
+      await logout(page)
+      await loginAsProgramAdmin(page)
 
-    await logout(page)
-    await loginAsProgramAdmin(page)
+      // See the application in admin page
+      await adminPrograms.viewApplications(programName)
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
+      await adminPrograms.expectApplicationAnswers(
+        'Screen 1',
+        questionName,
+        'some text',
+      )
 
-    // See the application in admin page
-    await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
-    await adminPrograms.expectApplicationAnswers(
-      'Screen 1',
-      questionName,
-      'some text',
-    )
+      await logout(page)
+      await loginAsAdmin(page)
 
-    await logout(page)
-    await loginAsAdmin(page)
+      // Create a new version of the question and program
+      await adminQuestions.createNewVersion(questionName)
+      await adminPrograms.publishProgram(programName)
 
-    // Create a new version of the question and program
-    await adminQuestions.createNewVersion(questionName)
-    await adminPrograms.publishProgram(programName)
+      await logout(page)
+      await loginAsProgramAdmin(page)
 
-    await logout(page)
-    await loginAsProgramAdmin(page)
-
-    // See the application in admin page in the old version
-    await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
-    await adminPrograms.expectApplicationAnswers(
-      'Screen 1',
-      questionName,
-      'some text',
-    )
-  })
-})
+      // See the application in admin page in the old version
+      await adminPrograms.viewApplications(programName)
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
+      await adminPrograms.expectApplicationAnswers(
+        'Screen 1',
+        questionName,
+        'some text',
+      )
+    })
+  },
+)

--- a/browser-test/src/pagination.test.ts
+++ b/browser-test/src/pagination.test.ts
@@ -1,16 +1,15 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from './support/civiform_fixtures'
 import {
-  createTestContext,
   loginAsTrustedIntermediary,
   waitForPageJsLoad,
   validateScreenshot,
 } from './support'
 
-test.describe('Pagination', () => {
-  const ctx = createTestContext()
-
-  test('shows 1 page and no previous or next buttons when there are 10 clients', async () => {
-    const {page, tiDashboard} = ctx
+test.describe('Pagination', {tag: ['@uses-fixtures']}, () => {
+  test('shows 1 page and no previous or next buttons when there are 10 clients', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)
@@ -44,8 +43,10 @@ test.describe('Pagination', () => {
     )
   })
 
-  test('shows 2 pages when there are 11 clients', async () => {
-    const {page, tiDashboard} = ctx
+  test('shows 2 pages when there are 11 clients', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)
@@ -97,8 +98,10 @@ test.describe('Pagination', () => {
     expect(await page.innerHTML('.usa-current')).toContain('2')
   })
 
-  test('shows 7 pages and no ellipses when there are 65 clients', async () => {
-    const {page, tiDashboard} = ctx
+  test('shows 7 pages and no ellipses when there are 65 clients', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)
@@ -133,8 +136,10 @@ test.describe('Pagination', () => {
     )
   })
 
-  test('shows one ellipses on the right when more than 7 pages and current page is < 5', async () => {
-    const {page, tiDashboard} = ctx
+  test('shows one ellipses on the right when more than 7 pages and current page is < 5', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)
@@ -173,8 +178,10 @@ test.describe('Pagination', () => {
     )
   })
 
-  test('shows two ellipses when there are 9 pages and there is overflow on both sides', async () => {
-    const {page, tiDashboard} = ctx
+  test('shows two ellipses when there are 9 pages and there is overflow on both sides', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)
@@ -208,8 +215,10 @@ test.describe('Pagination', () => {
     )
   })
 
-  test('shows one ellipses on the left when more than 7 pages and current page is one of the last 4 pages', async () => {
-    const {page, tiDashboard} = ctx
+  test('shows one ellipses on the left when more than 7 pages and current page is one of the last 4 pages', async ({
+    page,
+    tiDashboard,
+  }) => {
     await loginAsTrustedIntermediary(page)
     await tiDashboard.gotoTIDashboardPage(page)
     await waitForPageJsLoad(page)

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -1,8 +1,6 @@
-import {test, expect} from '@playwright/test'
+import {test, expect} from './support/civiform_fixtures'
 import {
   AdminQuestions,
-  createTestContext,
-  dropTables,
   loginAsAdmin,
   seedQuestions,
   validateScreenshot,
@@ -11,12 +9,8 @@ import {
 import {QuestionType} from './support/admin_questions'
 import {BASE_URL} from './support/config'
 
-test.describe('normal question lifecycle', () => {
-  const ctx = createTestContext()
-
-  test('sample question seeding works', async () => {
-    const {page, adminQuestions} = ctx
-    await dropTables(page)
+test.describe('normal question lifecycle', {tag: ['@uses-fixtures']}, () => {
+  test('sample question seeding works', async ({page, adminQuestions}) => {
     await seedQuestions(page)
 
     await page.goto(BASE_URL)
@@ -31,9 +25,11 @@ test.describe('normal question lifecycle', () => {
   // Run create-update-publish test for each question type individually to keep
   // test duration reasonable.
   for (const type of Object.values(QuestionType)) {
-    test(`${type} question: create, update, publish, create a new version, and update`, async () => {
-      const {page, adminQuestions, adminPrograms} = ctx
-
+    test(`${type} question: create, update, publish, create a new version, and update`, async ({
+      page,
+      adminQuestions,
+      adminPrograms,
+    }) => {
       await loginAsAdmin(page)
 
       const questionName = `qlc-${type}`
@@ -104,9 +100,10 @@ test.describe('normal question lifecycle', () => {
     })
   }
 
-  test('allows re-ordering options in dropdown question', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('allows re-ordering options in dropdown question', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -186,8 +183,10 @@ test.describe('normal question lifecycle', () => {
     expect(await adminNames[4].inputValue()).toContain('option4_admin')
   })
 
-  test('shows markdown format correctly in the preview when creating a new question', async () => {
-    const {page, adminQuestions} = ctx
+  test('shows markdown format correctly in the preview when creating a new question', async ({
+    page,
+    adminQuestions,
+  }) => {
     const questionName = 'markdown formatted question'
 
     await loginAsAdmin(page)
@@ -214,9 +213,10 @@ test.describe('normal question lifecycle', () => {
     await validateScreenshot(page, 'question-with-markdown-formatted-preview')
   })
 
-  test('shows error when creating a dropdown question and admin left an option field blank', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when creating a dropdown question and admin left an option field blank', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -245,9 +245,10 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithCreateSuccessToast()
   })
 
-  test('shows error when creating a radio question and admin left an option field blank', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when creating a radio question and admin left an option field blank', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -275,9 +276,10 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithCreateSuccessToast()
   })
 
-  test('shows error when updating a dropdown question and admin left an option field blank', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when updating a dropdown question and admin left an option field blank', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -301,9 +303,10 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  test('shows error when updating a radio question and admin left an option field blank', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when updating a radio question and admin left an option field blank', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -329,9 +332,10 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  test('shows error when updating a radio question and admin left an adminName field blank', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when updating a radio question and admin left an adminName field blank', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -360,9 +364,10 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectMultiOptionInvalidOptionAdminError(options, [2])
   })
 
-  test('shows error when updating a radio question and admin used invalid characters in the admin name', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows error when updating a radio question and admin used invalid characters in the admin name', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
 
     const options = [
@@ -403,9 +408,7 @@ test.describe('normal question lifecycle', () => {
     )
   })
 
-  test('persists export state', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('persists export state', async ({page, adminQuestions}) => {
     await loginAsAdmin(page)
 
     // Navigate to the new question page and ensure that "Don't allow answers to be exported"
@@ -459,9 +462,10 @@ test.describe('normal question lifecycle', () => {
     ).toBeTruthy()
   })
 
-  test('shows the "Remove from universal questions" confirmation modal in the right circumstances and navigation works', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows the "Remove from universal questions" confirmation modal in the right circumstances and navigation works', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
     const questionName = 'text question'
     await adminQuestions.addTextQuestion({questionName})
@@ -494,8 +498,11 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
   })
 
-  test('redirects to draft question when trying to edit original question', async () => {
-    const {page, adminQuestions, adminPrograms} = ctx
+  test('redirects to draft question when trying to edit original question', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+  }) => {
     await loginAsAdmin(page)
 
     await adminQuestions.gotoAdminQuestionsPage()
@@ -522,9 +529,10 @@ test.describe('normal question lifecycle', () => {
     )
   })
 
-  test('shows preview of formatted question name when creating a new question', async () => {
-    const {page, adminQuestions} = ctx
-
+  test('shows preview of formatted question name when creating a new question', async ({
+    page,
+    adminQuestions,
+  }) => {
     await loginAsAdmin(page)
     await adminQuestions.gotoAdminQuestionsPage()
     await page.click('#create-question-button')


### PR DESCRIPTION
### Description

Moves more tests over to using the playwright fixtures and not the custom createTestContext.

You'll want to ignore whitespace in the diff view.

![image](https://github.com/civiform/civiform/assets/195162/12ad26be-a1ad-4389-a5bd-e937eb3d1cfd)



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
