### PR TITLE
In webassetbundler, don't log stdout to the error method

### DIFF
--- a/server/project/WebAssetsBundler.scala
+++ b/server/project/WebAssetsBundler.scala
@@ -128,8 +128,8 @@ object WebAssetsBundler extends AutoPlugin {
     val compilationCommand =
       "npx webpack --config webpack.config.js --output-path " + targetDir
     val res = Process(compilationCommand) ! ProcessLogger(
-      line => log.error(line),
-      line => log.error(line)
+      stdout => log.info(stdout),
+      stderr => log.error(stderr)
     )
     if (res != 0) {
       log.info(


### PR DESCRIPTION
### Description

Both stdout and stderr were being sent to the logger error method. Some recent dependency update seems to be having something come from stdout now. Not sure which :woman_shrugging: 

But both css/sass and js/ts still look to be compiling fine.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
