### PR TITLE
Simplify help text typescript

### DIFF
--- a/server/app/assets/javascripts/admin_predicate_configuration.ts
+++ b/server/app/assets/javascripts/admin_predicate_configuration.ts
@@ -153,7 +153,7 @@ class AdminPredicateConfiguration {
       selectedScalarType,
       selectedScalarValue,
     )
-    this.configurePredicateValueInput(
+    this.configurePredicateValueInputs(
       selectedScalarType,
       selectedScalarValue,
       questionId,
@@ -206,44 +206,28 @@ class AdminPredicateConfiguration {
       operatorDropdownContainer.dataset.questionId,
     )
 
+    // Each value input has its own help text
     const csvHelpTexts = document.querySelectorAll(
       `#predicate-config-value-row-container [data-question-id="${questionId}"] .cf-predicate-value-comma-help-text`,
     )
-
-    // The help text div is present for inputs that allow specifying
-    // multiple values in a single text input. It won't be present
-    // for other input types e.g. multiselect inputs.
-    if (csvHelpTexts != null) {
-      const shouldShowCommaSeperatedHelpText =
+    csvHelpTexts.forEach((div: Element) =>
+      div.classList.toggle(
+        'hidden',
         selectedOperatorValue.toUpperCase() !== 'IN' &&
-        selectedOperatorValue.toUpperCase() !== 'NOT_IN'
-
-      for (const commaSeparatedHelpText of Array.from(csvHelpTexts)) {
-        commaSeparatedHelpText.classList.toggle(
-          'hidden',
-          shouldShowCommaSeperatedHelpText,
-        )
-      }
-    }
-
-    const betweenHelpText = document.querySelectorAll(
-      `#predicate-config-value-row-container [data-question-id="${questionId}"] .cf-predicate-value-between-help-text`,
+          selectedOperatorValue.toUpperCase() !== 'NOT_IN',
+      ),
     )
 
-    // The between help text div is present for inputs that allow specifying
-    // two number values in a single text input. It won't be present
-    // for other input types.
-    if (betweenHelpText != null) {
-      const shouldShowBetweenOperatorHelpText =
-        selectedOperatorValue.toUpperCase() !== 'AGE_BETWEEN'
-
-      for (const commaSeparatedHelpText of Array.from(betweenHelpText)) {
-        commaSeparatedHelpText.classList.toggle(
-          'hidden',
-          shouldShowBetweenOperatorHelpText,
-        )
-      }
-    }
+    // Each value input has its own help text
+    const betweenHelpTexts = document.querySelectorAll(
+      `#predicate-config-value-row-container [data-question-id="${questionId}"] .cf-predicate-value-between-help-text`,
+    )
+    betweenHelpTexts.forEach((div: Element) =>
+      div.classList.toggle(
+        'hidden',
+        selectedOperatorValue.toUpperCase() !== 'AGE_BETWEEN',
+      ),
+    )
 
     // Update the value field to reflect the new Operator selection.
     const scalarDropdown = this.getElementWithQuestionId(
@@ -256,7 +240,7 @@ class AdminPredicateConfiguration {
     )
     const selectedScalarValue =
       scalarDropdown.options[scalarDropdown.options.selectedIndex].value
-    this.configurePredicateValueInput(
+    this.configurePredicateValueInputs(
       selectedScalarType,
       selectedScalarValue,
       questionId,
@@ -270,7 +254,7 @@ class AdminPredicateConfiguration {
    *  @param {string} selectedScalarValue The value of the selected option.
    *  @param {number} questionId The ID of the question for this predicate value.
    */
-  configurePredicateValueInput(
+  configurePredicateValueInputs(
     selectedScalarType: string | null,
     selectedScalarValue: string | null,
     questionId: string,


### PR DESCRIPTION
### Description

Simplify help text logic:
* querySelectorAll never returns null so don't need to check for that
* Use NodeList.forEach instead of converting to Array
* Add a comment that each value input has its own help text, to explain why we need querySelectorAll in the first place
* Rename configurePredicateValueInput to configurePredicateValueInputs to also remind that there can be more than one value input
* Remove the comment about the help text maybe not being present, because it no longer matters for the logic
* Inline the hidden condition; it was named backwards anyway


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
