### PR TITLE
Add tmux to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers-contrib/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers/features/java:1.4.1": {
       "version": "11",
       "jdkDistro": "tem", // Eclipse Adoptium Temurin per https://sdkman.io/jdks#tem See also: whichjdk.com


### PR DESCRIPTION
### Description

Added tmux to the devcontainer. This allows a tmux terminal window to be created. In order to save the tmux configuration setup, I also added the following to ~/.tmux.conf

```
# Plugins
set -g @plugin 'tmux-plugins/tpm'
set -g @plugin 'tmux-plugins/tmux-resurrect'
set -g @plugin 'tmux-plugins/tmux-continuum'

set -g @resurrect-capture-pane-contents 'on'
set -g @continuum-restore 'on'

# Initialize 
run '~/.tmux/plugins/tpm/tpm'
```

This allows your pane contents to appear when you stop and restart the codespaces, but the bash history isn't there. I also tried adding the following to my .bashrc to get the history:

```
# Append history to a file in the persistent storage volume
export HISTFILE="$HOME/.bash_history"
# Ensure unlimited history size
export HISTSIZE=-1 
export HISTFILESIZE=-1 
```

And I tried some versions of what's described [here](https://github.com/tmux-plugins/tmux-resurrect/blob/cff343cf9e81983d3da0c8562b01616f12e8d548/docs/restoring_bash_history.md?plain=1).

Documenting in case someone else wants to try getting the history piece working - I'll probably come back to this at some other point in time if not. Note that normal bash history (non-tmux) seems to work


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)


### Issue(s) this completes

https://github.com/civiform/civiform/issues/6999
