### PR TITLE
Remove -contrib features and install packages in onCreateCommand.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,16 +17,11 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-contrib/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers/features/java:1.4.1": {
       "version": "11",
       "jdkDistro": "tem", // Eclipse Adoptium Temurin per https://sdkman.io/jdks#tem See also: whichjdk.com
       "installMaven": "true",
       "installGradle": "false"
-    },
-    "ghcr.io/devcontainers-contrib/features/ant-sdkman:2": {
-      "jdkVersion": "11",
-      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/python:1": {}
@@ -69,7 +64,7 @@
     }
   },
 
-  "onCreateCommand": "npm install -g @withgraphite/graphite-cli@stable && npm install --no-save @playwright/test",
+  "onCreateCommand": ".devcontainer/onCreateCommand.sh",
   "updateContentCommand": "bin/vscode-setup",
   "postCreateCommand": "pip install requests && echo 'source /usr/share/bash-completion/completions/git' >> ~/.bashrc",
 

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+# DOC: For installing additional packages and configuration in the devcontainer.
+# Runs before updateContentCommand and before user secrets are available in the container.
+
+echo "hello"
+
+# Install tmux
+sudo apt update
+sudo apt install -y tmux
+
+# Graphite
+npm install -g @withgraphite/graphite-cli@stable && npm install --no-save @playwright/test

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -7,5 +7,8 @@
 sudo apt update
 sudo apt install -y tmux
 
-# Graphite
-npm install -g @withgraphite/graphite-cli@stable && npm install --no-save @playwright/test
+# Install Graphite
+npm install -g @withgraphite/graphite-cli@stable
+
+# Install Playwright
+npm install --no-save @playwright/test

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -3,8 +3,6 @@
 # DOC: For installing additional packages and configuration in the devcontainer.
 # Runs before updateContentCommand and before user secrets are available in the container.
 
-echo "hello"
-
 # Install tmux
 sudo apt update
 sudo apt install -y tmux


### PR DESCRIPTION
### Description

- Remove -contrib codespace features that I couldn't find a public repository for
  - tmux we install manually
  - the sdkman feature was redudant since we're already installing java with ghcr.io/devcontainers/features/java:1.4.1
- Manually installs tmux and moves other package installation to `onCreateCommand.sh`

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary



### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #7412