### PR TITLE
Remove year, month, and day from predicate view dropdown

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1886,11 +1886,11 @@ public final class ApplicantService {
                           monthValue == null ? "" : Strings.padStart(monthValue, 2, '0'),
                           dayValue == null ? "" : Strings.padStart(dayValue, 2, '0'));
                   newFormData.put(dateQuestion.getDatePath().toString(), dateString);
-                  // Remove the 3 individual paths, so they won't be stored.
-                  newFormData.remove(dateQuestion.getYearPath().toString());
-                  newFormData.remove(dateQuestion.getMonthPath().toString());
-                  newFormData.remove(dateQuestion.getDayPath().toString());
                 }
+                // Remove the 3 individual paths, so they won't be stored.
+                newFormData.remove(dateQuestion.getYearPath().toString());
+                newFormData.remove(dateQuestion.getMonthPath().toString());
+                newFormData.remove(dateQuestion.getDayPath().toString());
               }
 
               return CompletableFuture.completedFuture(ImmutableMap.copyOf(newFormData));

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -52,7 +52,8 @@ public enum Scalar {
   PHONE_NUMBER("phone_number", ScalarType.PHONE_NUMBER),
   COUNTRY_CODE("country_code", ScalarType.STRING),
 
-  // Scalars for Date Question using memorable date (3 different inputs)
+  // Scalars for Date Question using memorable date (3 different inputs). They are not used
+  // for storage or predicates, so they are not included in getScalars.
   DAY("day", ScalarType.LONG),
   MONTH("month", ScalarType.LONG),
   YEAR("year", ScalarType.LONG),
@@ -110,7 +111,7 @@ public enum Scalar {
       case CURRENCY:
         return ImmutableSet.of(CURRENCY_CENTS);
       case DATE:
-        return ImmutableSet.of(DATE, YEAR, MONTH, DAY);
+        return ImmutableSet.of(DATE);
       case EMAIL:
         return ImmutableSet.of(EMAIL);
       case FILEUPLOAD:


### PR DESCRIPTION
### Description

In https://github.com/civiform/civiform/pull/6703 , we accidentally added the year, month, and day scalars to the dropdown where we configure eligibility questions. This PR removes that part of the change, since those paths are only used on the frontend and not for storage

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
