### PR TITLE
Fix typescript error "expected 0 arguments, but got 1"

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -1212,7 +1212,7 @@ test.describe('create and edit predicates', {tag: ['@uses-fixtures']}, () => {
       )
       await applicantQuestions.expectIneligibleQuestionsCount(1)
 
-      await applicantQuestions.clickGoBackAndEditOnIneligiblePage(page)
+      await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
       await validateScreenshot(page, 'review-page-has-ineligible-banner')
       await validateToastMessage(page, 'may not qualify')
 
@@ -1284,7 +1284,7 @@ test.describe('create and edit predicates', {tag: ['@uses-fixtures']}, () => {
       await applicantQuestions.clickNext()
       await applicantQuestions.expectIneligiblePage()
       await applicantQuestions.expectIneligibleQuestionsCount(1)
-      await applicantQuestions.clickGoBackAndEditOnIneligiblePage(page)
+      await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
 
       // Less than or equal to 100.01 is ineligible
       await applicantQuestions.answerQuestionFromReviewPage(


### PR DESCRIPTION
### Description

clickGoBackAndEditOnIneligiblePage doesn't take any arguments but the callers were passing one.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)