### PR TITLE
Fix links to uploaded files to use correct routes

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -270,7 +270,10 @@ public final class AdminApplicationController extends CiviFormController {
     ApplicationModel application = applicationMaybe.get();
     PdfExporter.InMemoryPdf pdf =
         pdfExporterService.generateApplicationPdf(
-            application, /* showEligibilityText= */ true, /* includeHiddenBlocks= */ true);
+            application,
+            /* showEligibilityText= */ true,
+            /* includeHiddenBlocks= */ true,
+            /* isAdmin= */ true);
     return ok(pdf.getByteArray())
         .as("application/pdf")
         .withHeader(

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -269,11 +269,7 @@ public final class AdminApplicationController extends CiviFormController {
     }
     ApplicationModel application = applicationMaybe.get();
     PdfExporter.InMemoryPdf pdf =
-        pdfExporterService.generateApplicationPdf(
-            application,
-            /* showEligibilityText= */ true,
-            /* includeHiddenBlocks= */ true,
-            /* isAdmin= */ true);
+        pdfExporterService.generateApplicationPdf(application, /* isAdmin= */ true);
     return ok(pdf.getByteArray())
         .as("application/pdf")
         .withHeader(

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -213,7 +213,8 @@ public final class UpsellController extends CiviFormController {
                   pdfExporterService.generateApplicationPdf(
                       applicationMaybe.join().get(),
                       /* showEligibilityText= */ false,
-                      /* includeHiddenBlocks= */ false);
+                      /* includeHiddenBlocks= */ false,
+                      /* isAdmin= */ false);
 
               return ok(pdf.getByteArray())
                   .as("application/pdf")

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -211,10 +211,7 @@ public final class UpsellController extends CiviFormController {
             check -> {
               PdfExporter.InMemoryPdf pdf =
                   pdfExporterService.generateApplicationPdf(
-                      applicationMaybe.join().get(),
-                      /* showEligibilityText= */ false,
-                      /* includeHiddenBlocks= */ false,
-                      /* isAdmin= */ false);
+                      applicationMaybe.join().get(), /* isAdmin= */ false);
 
               return ok(pdf.getByteArray())
                   .as("application/pdf")

--- a/server/app/services/applications/PdfExporterService.java
+++ b/server/app/services/applications/PdfExporterService.java
@@ -28,15 +28,10 @@ public final class PdfExporterService {
    * to review applications.
    */
   public PdfExporter.InMemoryPdf generateApplicationPdf(
-      ApplicationModel application,
-      boolean showEligibilityText,
-      boolean includeHiddenBlocks,
-      boolean isAdmin) {
+      ApplicationModel application, boolean isAdmin) {
     PdfExporter.InMemoryPdf pdf;
     try {
-      pdf =
-          pdfExporter.exportApplication(
-              application, showEligibilityText, includeHiddenBlocks, isAdmin);
+      pdf = pdfExporter.exportApplication(application, isAdmin);
     } catch (DocumentException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/applications/PdfExporterService.java
+++ b/server/app/services/applications/PdfExporterService.java
@@ -28,10 +28,15 @@ public final class PdfExporterService {
    * to review applications.
    */
   public PdfExporter.InMemoryPdf generateApplicationPdf(
-      ApplicationModel application, boolean showEligibilityText, boolean includeHiddenBlocks) {
+      ApplicationModel application,
+      boolean showEligibilityText,
+      boolean includeHiddenBlocks,
+      boolean isAdmin) {
     PdfExporter.InMemoryPdf pdf;
     try {
-      pdf = pdfExporter.exportApplication(application, showEligibilityText, includeHiddenBlocks);
+      pdf =
+          pdfExporter.exportApplication(
+              application, showEligibilityText, includeHiddenBlocks, isAdmin);
     } catch (DocumentException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -89,11 +89,7 @@ public final class PdfExporter {
    * inMemoryPDF object. The InMemoryPdf object is passed back to the AdminController Class to
    * generate the required PDF.
    */
-  public InMemoryPdf exportApplication(
-      ApplicationModel application,
-      boolean showEligibilityText,
-      boolean includeHiddenBlocks,
-      boolean isAdmin)
+  public InMemoryPdf exportApplication(ApplicationModel application, boolean isAdmin)
       throws DocumentException, IOException {
     ReadOnlyApplicantProgramService roApplicantService =
         applicantService
@@ -103,7 +99,7 @@ public final class PdfExporter {
 
     ImmutableList<AnswerData> answersOnlyActive = roApplicantService.getSummaryDataOnlyActive();
     ImmutableList<AnswerData> answersOnlyHidden = ImmutableList.<AnswerData>of();
-    if (includeHiddenBlocks) {
+    if (isAdmin) {
       answersOnlyHidden = roApplicantService.getSummaryDataOnlyHidden();
     }
 
@@ -122,7 +118,6 @@ public final class PdfExporter {
             application.getProgram().getProgramDefinition(),
             application.getLatestStatus(),
             getSubmitTime(application.getSubmitTime()),
-            showEligibilityText,
             isAdmin);
     return new InMemoryPdf(bytes, filename);
   }
@@ -141,7 +136,6 @@ public final class PdfExporter {
       ProgramDefinition programDefinition,
       Optional<String> statusValue,
       String submitTime,
-      boolean showEligibilityText,
       boolean isAdmin)
       throws DocumentException, IOException {
     ByteArrayOutputStream byteArrayOutputStream = null;
@@ -204,7 +198,7 @@ public final class PdfExporter {
             new Paragraph("Answered on : " + date, FontFactory.getFont(FontFactory.HELVETICA, 10));
         time.setAlignment(Paragraph.ALIGN_RIGHT);
         Paragraph eligibility = new Paragraph();
-        if (showEligibilityText && isEligibilityEnabledInProgram) {
+        if (isAdmin && isEligibilityEnabledInProgram) {
           try {
             Optional<EligibilityDefinition> eligibilityDef =
                 programDefinition.getBlockDefinition(answerData.blockId()).eligibilityDefinition();

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -90,7 +90,10 @@ public final class PdfExporter {
    * generate the required PDF.
    */
   public InMemoryPdf exportApplication(
-      ApplicationModel application, boolean showEligibilityText, boolean includeHiddenBlocks)
+      ApplicationModel application,
+      boolean showEligibilityText,
+      boolean includeHiddenBlocks,
+      boolean isAdmin)
       throws DocumentException, IOException {
     ReadOnlyApplicantProgramService roApplicantService =
         applicantService
@@ -115,10 +118,12 @@ public final class PdfExporter {
             answersOnlyActive,
             answersOnlyHidden,
             applicantNameWithApplicationId,
+            application.getApplicantData().getApplicant().id,
             application.getProgram().getProgramDefinition(),
             application.getLatestStatus(),
             getSubmitTime(application.getSubmitTime()),
-            showEligibilityText);
+            showEligibilityText,
+            isAdmin);
     return new InMemoryPdf(bytes, filename);
   }
 
@@ -132,10 +137,12 @@ public final class PdfExporter {
       ImmutableList<AnswerData> answersOnlyActive,
       ImmutableList<AnswerData> answersOnlyHidden,
       String applicantNameWithApplicationId,
+      Long applicantId,
       ProgramDefinition programDefinition,
       Optional<String> statusValue,
       String submitTime,
-      boolean showEligibilityText)
+      boolean showEligibilityText,
+      boolean isAdmin)
       throws DocumentException, IOException {
     ByteArrayOutputStream byteArrayOutputStream = null;
     PdfWriter writer = null;
@@ -176,7 +183,9 @@ public final class PdfExporter {
         if (answerData.encodedFileKey().isPresent()) {
           String encodedFileKey = answerData.encodedFileKey().get();
           String fileLink =
-              controllers.routes.FileController.adminShow(programDefinition.id(), encodedFileKey)
+              (isAdmin
+                      ? controllers.routes.FileController.acledAdminShow(encodedFileKey)
+                      : controllers.routes.FileController.show(applicantId, encodedFileKey))
                   .url();
           Anchor anchor = new Anchor(answerData.answerText());
           anchor.setReference(baseUrl + fileLink);

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -151,7 +151,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     blocks,
                     block ->
                         renderApplicationBlock(
-                            programId, block, blockToAnswers.get(block), hasEligibilityEnabled)))
+                            block, blockToAnswers.get(block), hasEligibilityEnabled)))
             .with(each(statusUpdateConfirmationModals, Modal::getButton));
 
     HtmlBundle htmlBundle =
@@ -184,7 +184,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
   }
 
   private DivTag renderApplicationBlock(
-      long programId, Block block, Collection<AnswerData> answers, boolean hasEligibilityEnabled) {
+      Block block, Collection<AnswerData> answers, boolean hasEligibilityEnabled) {
     DivTag topContent =
         div()
             .withClasses("flex")
@@ -203,7 +203,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
                     answers,
                     answer ->
                         renderAnswer(
-                            programId,
                             answer,
                             // If an eligibility predicate is defined for the block, check if
                             // the question is part of the predicate to determine whether to
@@ -227,13 +226,12 @@ public final class ProgramApplicationView extends BaseHtmlView {
         .withClasses(ReferenceClasses.ADMIN_APPLICATION_BLOCK_CARD, "w-full", "shadow-lg", "mb-4");
   }
 
-  private DivTag renderAnswer(long programId, AnswerData answerData, boolean showEligibilityText) {
+  private DivTag renderAnswer(AnswerData answerData, boolean showEligibilityText) {
     String date = dateConverter.renderDate(Instant.ofEpochMilli(answerData.timestamp()));
     DivTag answerContent;
     if (answerData.encodedFileKey().isPresent()) {
       String encodedFileKey = answerData.encodedFileKey().get();
-      String fileLink =
-          controllers.routes.FileController.adminShow(programId, encodedFileKey).url();
+      String fileLink = controllers.routes.FileController.acledAdminShow(encodedFileKey).url();
       answerContent = div(a(answerData.answerText()).withHref(fileLink));
     } else {
       answerContent = div(answerData.answerText().replace("\n", "; "));

--- a/server/test/services/applications/PdfExporterServiceTest.java
+++ b/server/test/services/applications/PdfExporterServiceTest.java
@@ -36,11 +36,7 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        service.generateApplicationPdf(
-            applicationOne,
-            /* showEligibilityText= */ true,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ true);
+        service.generateApplicationPdf(applicationOne, /* isAdmin= */ true);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 

--- a/server/test/services/applications/PdfExporterServiceTest.java
+++ b/server/test/services/applications/PdfExporterServiceTest.java
@@ -36,7 +36,11 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        service.generateApplicationPdf(applicationOne, /* showEligibilityText= */ true, false);
+        service.generateApplicationPdf(
+            applicationOne,
+            /* showEligibilityText= */ true,
+            /* includeHiddenBlocks= */ false,
+            /* isAdmin= */ true);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -53,10 +57,7 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
       assertThat(AnnotationAction.get(PdfName.S)).isEqualTo(PdfName.URI);
       PdfString link = AnnotationAction.getAsString(PdfName.URI);
       assertThat(link.toString())
-          .isEqualTo(
-              "http://localhost:9000/admin/programs/"
-                  + applicationOne.getProgram().id
-                  + "/files/my-file-key");
+          .isEqualTo("http://localhost:9000/admin/applicant-files/my-file-key");
     }
 
     pdfReader.close();

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -36,11 +36,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationOne,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationOne, /* isAdmin= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -90,11 +86,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationFive,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ true);
+        exporter.exportApplication(applicationFive, /* isAdmin= */ true);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -133,11 +125,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationFive,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationFive, /* isAdmin= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -178,11 +166,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationSix.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationSix,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationSix, /* isAdmin= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
@@ -207,7 +191,8 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void exportApplication_hiddenQuestionIncluded() throws IOException, DocumentException {
+  public void exportApplication_hiddenQuestionIncludedForAdmins()
+      throws IOException, DocumentException {
     createFakeProgramWithVisibilityPredicate();
 
     PdfExporter exporter = instanceOf(PdfExporter.class);
@@ -215,11 +200,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationSeven.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationSeven,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ true,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationSeven, /* isAdmin= */ true);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     String programName = applicationSeven.getProgram().getProgramDefinition().adminName();
@@ -234,7 +215,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void exportApplication_eligibility() throws IOException, DocumentException {
+  public void exportApplication_eligibilityShowsForAdmins() throws IOException, DocumentException {
     createFakeProgramWithEligibilityPredicate();
 
     PdfExporter exporter = instanceOf(PdfExporter.class);
@@ -243,11 +224,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationTwo.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(
-            applicationTwo,
-            /* showEligibilityText= */ false,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationTwo, /* isAdmin= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
@@ -259,11 +236,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
     assertThat(textFromPDF).doesNotContain("Meets eligibility");
     PdfExporter.InMemoryPdf resultWithEligibility =
-        exporter.exportApplication(
-            applicationTwo,
-            /* showEligibilityText= */ true,
-            /* includeHiddenBlocks= */ false,
-            /* isAdmin= */ false);
+        exporter.exportApplication(applicationTwo, /* isAdmin= */ true);
     PdfReader pdfReaderTwo = new PdfReader(resultWithEligibility.getByteArray());
     StringBuilder textFromPDFTwo = new StringBuilder();
     textFromPDFTwo.append(PdfTextExtractor.getTextFromPage(pdfReaderTwo, 1));


### PR DESCRIPTION
### Description

This makes two main changes:

1) Change any links we expose to download files from the deprecated adminShow to acledAdminShow. This is no-op change since adminShow just redirects to acledAdminShow.
2) For PDF exports, if an applicant is exporting, use the applicant "show" route, rather than the admin show route. I think this was the primary cause of issue #7205.

Note if the applicant isn't logged in, the link will still fail. So there are probably more improvements we could do, but they're larger in scope. (Either prompting users for login for acl'd routes, or downloading all uploaded files along with the application, which is difficult because they'd need to be in a zip or some other package, which may be confusing for applicants.)

## Release notes

Fixed issue where applicant's could not download uploaded files from the PDF export of their application.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing



### Issue(s) this completes

Fixes #7205
