### PR TITLE
Consolidate editProgramBlock methods

### DIFF
--- a/browser-test/src/admin/admin_program_viewing.test.ts
+++ b/browser-test/src/admin/admin_program_viewing.test.ts
@@ -85,19 +85,26 @@ test.describe('admin program view page', () => {
 
     await adminPrograms.addProgram(programName)
     await adminPrograms.addProgramBlock(programName, 'screen 2 description', [])
-    await adminPrograms.editProgramBlockWithBlockName(
-      programName,
-      'Screen 2 ooooooooooooooooooooooooooooooooooooooooooooooooooo' +
+
+    await adminPrograms.editProgramBlockUsingSpec(programName, {
+      name:
+        'Screen 2 ooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo',
-      'dummy description oooooooooooooooooooooooooooooooooooooo' +
+      description:
+        'dummy description oooooooooooooooooooooooooooooooooooooo' +
         'oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo' +
         'ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo',
-      ['address-q'],
-    )
+      questions: [
+        {
+          name: 'address-q',
+        },
+      ],
+    })
+
     await adminPrograms.publishAllDrafts()
 
     await adminPrograms.gotoViewActiveProgramPage(programName)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -576,16 +576,14 @@ export class AdminPrograms {
     blockDescription = 'screen description',
     questionNames: string[] = [],
   ) {
-    await this.gotoEditDraftProgramPage(programName)
-
-    await clickAndWaitForModal(this.page, 'block-description-modal')
-    await this.page.fill('textarea', blockDescription)
-    // Make sure input validation enables the button before clicking.
-    await this.page.click('#update-block-button:not([disabled])')
-
-    for (const questionName of questionNames) {
-      await this.addQuestionFromQuestionBank(questionName)
-    }
+    await this.editProgramBlockUsingSpec(programName, {
+      description: blockDescription,
+      questions: questionNames.map((questionName) => {
+        return {
+          name: questionName,
+        }
+      }),
+    })
   }
 
   /**
@@ -598,21 +596,21 @@ export class AdminPrograms {
     questionNames: string[],
     optionalQuestionName: string,
   ) {
-    await this.gotoEditDraftProgramPage(programName)
-
-    await clickAndWaitForModal(this.page, 'block-description-modal')
-    await this.page.fill('textarea', blockDescription)
-    await this.page.click('#update-block-button:not([disabled])')
-
-    // Add the optional question
-    await this.addQuestionFromQuestionBank(optionalQuestionName)
-    // Only allow one optional question per block; this selector will always toggle the first optional button.  It
-    // cannot tell the difference between multiple option buttons
-    await this.page.click(`:is(button:has-text("optional"))`)
-
-    for (const questionName of questionNames) {
-      await this.addQuestionFromQuestionBank(questionName)
+    const block: BlockSpec = {
+      description: blockDescription,
+      questions: questionNames.map((questionName) => {
+        return {
+          name: questionName,
+        }
+      }),
     }
+
+    block.questions.push({
+      name: optionalQuestionName,
+      isOptional: true,
+    })
+
+    await this.editProgramBlockUsingSpec(programName, block)
   }
 
   /**

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -588,7 +588,10 @@ export class AdminPrograms {
 
   /**
    * Edit basic block details and required and optional questions. Cannot handle more than one optional question.
-   * @deprecated prefer using {@link #editProgramBlockUsingSpec} instead.
+   * @deprecated prefer using {@link #editProgramBlockUsingSpec} instead. Be aware that the new method will place
+   * the optional question in the order as defined in the question array. The older method could only handle one
+   * optional question and forced it to be the first question on the list. Tests may need to be updated to handle
+   * a different question order.
    */
   async editProgramBlockWithOptional(
     programName: string,
@@ -598,16 +601,18 @@ export class AdminPrograms {
   ) {
     const block: BlockSpec = {
       description: blockDescription,
-      questions: questionNames.map((questionName) => {
-        return {
-          name: questionName,
-        }
-      }),
+      questions: [],
     }
 
     block.questions.push({
       name: optionalQuestionName,
       isOptional: true,
+    })
+
+    questionNames.forEach((questionName) => {
+      block.questions.push({
+        name: questionName,
+      })
     })
 
     await this.editProgramBlockUsingSpec(programName, block)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -49,7 +49,13 @@ export enum Eligibility {
 
 export interface QuestionSpec {
   name: string
-  isOptional: boolean
+  isOptional?: boolean
+}
+
+export interface BlockSpec {
+  name?: string
+  description?: string
+  questions: QuestionSpec[]
 }
 
 function slugify(value: string): string {
@@ -561,6 +567,10 @@ export class AdminPrograms {
     }
   }
 
+  /**
+   * Edit basic block details and required questions
+   * @deprecated prefer using {@link #editProgramBlockUsingSpec} instead.
+   */
   async editProgramBlock(
     programName: string,
     blockDescription = 'screen description',
@@ -577,22 +587,61 @@ export class AdminPrograms {
       await this.addQuestionFromQuestionBank(questionName)
     }
   }
-  async editProgramBlockWithBlockName(
+
+  /**
+   * Edit basic block details and required and optional questions. Cannot handle more than one optional question.
+   * @deprecated prefer using {@link #editProgramBlockUsingSpec} instead.
+   */
+  async editProgramBlockWithOptional(
     programName: string,
-    blockName: string,
     blockDescription = 'screen description',
-    questionNames: string[] = [],
+    questionNames: string[],
+    optionalQuestionName: string,
   ) {
     await this.gotoEditDraftProgramPage(programName)
 
     await clickAndWaitForModal(this.page, 'block-description-modal')
-    await this.page.fill('#block-name-input', blockName)
     await this.page.fill('textarea', blockDescription)
-    // Make sure input validation enables the button before clicking.
     await this.page.click('#update-block-button:not([disabled])')
+
+    // Add the optional question
+    await this.addQuestionFromQuestionBank(optionalQuestionName)
+    // Only allow one optional question per block; this selector will always toggle the first optional button.  It
+    // cannot tell the difference between multiple option buttons
+    await this.page.click(`:is(button:has-text("optional"))`)
 
     for (const questionName of questionNames) {
       await this.addQuestionFromQuestionBank(questionName)
+    }
+  }
+
+  /**
+   * Edit basic block details and questions
+   * @param programName Name of the program to edit
+   * @param block Block information
+   */
+  async editProgramBlockUsingSpec(programName: string, block: BlockSpec) {
+    await this.gotoEditDraftProgramPage(programName)
+
+    await clickAndWaitForModal(this.page, 'block-description-modal')
+
+    if (block.name !== undefined) {
+      await this.page.fill('#block-name-input', block.name)
+    }
+
+    await this.page.fill('textarea', block.description || 'screen description')
+
+    await this.page.click('#update-block-button:not([disabled])')
+
+    for (const question of block.questions) {
+      await this.addQuestionFromQuestionBank(question.name)
+
+      if (question.isOptional) {
+        await this.page
+          .getByTestId(`question-admin-name-${question.name}`)
+          .locator(':is(button:has-text("optional"))')
+          .click()
+      }
     }
   }
 
@@ -651,29 +700,6 @@ export class AdminPrograms {
         : '#question-bank-nonuniversal ' + loc,
     )
     return titles.allTextContents()
-  }
-
-  async editProgramBlockWithOptional(
-    programName: string,
-    blockDescription = 'screen description',
-    questionNames: string[],
-    optionalQuestionName: string,
-  ) {
-    await this.gotoEditDraftProgramPage(programName)
-
-    await clickAndWaitForModal(this.page, 'block-description-modal')
-    await this.page.fill('textarea', blockDescription)
-    await this.page.click('#update-block-button:not([disabled])')
-
-    // Add the optional question
-    await this.addQuestionFromQuestionBank(optionalQuestionName)
-    // Only allow one optional question per block; this selector will always toggle the first optional button.  It
-    // cannot tell the difference between multiple option buttons
-    await this.page.click(`:is(button:has-text("optional"))`)
-
-    for (const questionName of questionNames) {
-      await this.addQuestionFromQuestionBank(questionName)
-    }
   }
 
   /**

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -692,6 +692,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
       Request request) {
     DivTag ret =
         div()
+            .withData("testid", "question-admin-name-" + questionDefinition.getName())
             .withClasses(
                 ReferenceClasses.PROGRAM_QUESTION,
                 "my-2",


### PR DESCRIPTION
### Description

Adding new method `editProgramBlockUsingSpec` to serve as the consolidated way of editing the admin program question block.

Removes a method that was only used in one place.

Deprecates the others.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
