### PR TITLE
Refactor addValueRows in admin_predicates.ts

### DIFF
--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -18,13 +18,9 @@ export class AdminPredicates {
     this.page = page
   }
 
-  async addValueRows(predicateSpec: PredicateSpec) {
-    const values = predicateSpec.values
-
-    if (values && values.length > 1) {
-      for (let i = 1; i < values.length; i++) {
-        await this.page.click('#predicate-add-value-row')
-      }
+  async addValueRows(count: number) {
+    for (let i = 0; i < count; i++) {
+      await this.page.click('#predicate-add-value-row')
     }
   }
 
@@ -48,7 +44,8 @@ export class AdminPredicates {
     }
 
     await this.clickAddConditionButton()
-    await this.addValueRows(predicateSpecs[0])
+    const totalRowsNeeded = predicateSpecs[0]?.values?.length ?? 0
+    await this.addValueRows(Math.max(totalRowsNeeded - 1, 0))
 
     for (const predicateSpec of predicateSpecs) {
       await this.configurePredicate(predicateSpec)


### PR DESCRIPTION
### Description

It makes more sense for addValueRows to take a number to add, rather than a PredicateSpec. This way other users can add a specific number of rows if they don't have a PredicateSpec.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)