### PR TITLE
Combine redundant addPredicate and addPredicates test helper methods

### DIFF
--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -680,13 +680,12 @@ test.describe('view program statuses', () => {
           eligibilityProgramName,
           'Screen 1',
         )
-        await adminPredicates.addPredicate(
-          eligibilityQuestionId,
-          /* action= */ null,
-          'number',
-          'is equal to',
-          '5',
-        )
+        await adminPredicates.addPredicates({
+          questionName: eligibilityQuestionId,
+          scalar: 'number',
+          operator: 'is equal to',
+          value: '5',
+        })
         await adminPrograms.gotoAdminProgramsPage()
         await adminPrograms.publishProgram(eligibilityProgramName)
         await logout(page)

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -48,13 +48,13 @@ test.describe('create and edit predicates', () => {
     await adminPredicates.clickAddConditionButton()
     await validateToastMessage(page, 'Please select a question')
 
-    await adminPredicates.addPredicate(
-      'hide-predicate-q',
-      'hidden if',
-      'text',
-      'is equal to',
-      'hide me',
-    )
+    await adminPredicates.addPredicates({
+      questionName: 'hide-predicate-q',
+      action: 'hidden if',
+      scalar: 'text',
+      operator: 'is equal to',
+      value: 'hide me',
+    })
     await adminPredicates.expectPredicateDisplayTextContains(
       'Screen 2 is hidden if "hide-predicate-q" text is equal to "hide me"',
     )
@@ -138,13 +138,13 @@ test.describe('create and edit predicates', () => {
       programName,
       'Screen 2',
     )
-    await adminPredicates.addPredicate(
-      'show-predicate-q',
-      'shown if',
-      'text',
-      'is equal to',
-      'show me',
-    )
+    await adminPredicates.addPredicates({
+      questionName: 'show-predicate-q',
+      action: 'shown if',
+      scalar: 'text',
+      operator: 'is equal to',
+      value: 'show me',
+    })
     await adminPredicates.expectPredicateDisplayTextContains(
       'Screen 2 is shown if "show-predicate-q" text is equal to "show me"',
     )
@@ -232,18 +232,16 @@ test.describe('create and edit predicates', () => {
     )
 
     // Add predicate with missing operator.
-    await adminPredicates.addPredicate(
-      'eligibility-predicate-q',
-      /* action= */ null,
-      'text',
-      '',
-      'eligible',
-    )
+    await adminPredicates.addPredicates({
+      questionName: 'eligibility-predicate-q',
+      scalar: 'text',
+      operator: '',
+      value: 'eligible',
+    })
     await adminPredicates.expectPredicateErrorToast('dropdowns')
 
     await adminPredicates.configurePredicate({
       questionName: 'eligibility-predicate-q',
-      action: null,
       scalar: 'text',
       operator: 'is equal to',
       value: 'eligible',
@@ -252,19 +250,17 @@ test.describe('create and edit predicates', () => {
     await adminPredicates.clickRemovePredicateButton('eligibility')
 
     // Add predicate with missing value.
-    await adminPredicates.addPredicate(
-      'eligibility-predicate-q',
-      /* action= */ null,
-      'text',
-      'is equal to',
-      '',
-    )
+    await adminPredicates.addPredicates({
+      questionName: 'eligibility-predicate-q',
+      scalar: 'text',
+      operator: 'is equal to',
+      value: '',
+    })
     await adminPredicates.expectPredicateErrorToast('form fields')
     await validateScreenshot(page, 'predicate-error')
 
     await adminPredicates.configurePredicate({
       questionName: 'eligibility-predicate-q',
-      action: null,
       scalar: 'text',
       operator: 'is equal to',
       value: 'eligible',
@@ -273,19 +269,17 @@ test.describe('create and edit predicates', () => {
     await adminPredicates.clickRemovePredicateButton('eligibility')
 
     // Add predicate with missing operator and value.
-    await adminPredicates.addPredicate(
-      'eligibility-predicate-q',
-      /* action= */ null,
-      'text',
-      '',
-      '',
-    )
+    await adminPredicates.addPredicates({
+      questionName: 'eligibility-predicate-q',
+      scalar: 'text',
+      operator: '',
+      value: '',
+    })
     await adminPredicates.clickSaveConditionButton()
     await adminPredicates.expectPredicateErrorToast('form fields or dropdowns')
 
     await adminPredicates.configurePredicate({
       questionName: 'eligibility-predicate-q',
-      action: null,
       scalar: 'text',
       operator: 'is equal to',
       value: 'eligible',
@@ -379,14 +373,12 @@ test.describe('create and edit predicates', () => {
       )
 
       // Add two to ensure the JS correctly handles multiple value rows
-      await adminPredicates.addPredicates([
-        {
-          questionName: 'eligibility-predicate-q',
-          scalar: 'service_area',
-          operator: 'in service area',
-          values: ['Seattle', 'Seattle'],
-        },
-      ])
+      await adminPredicates.addPredicates({
+        questionName: 'eligibility-predicate-q',
+        scalar: 'service_area',
+        operator: 'in service area',
+        values: ['Seattle', 'Seattle'],
+      })
 
       await adminPredicates.expectPredicateDisplayTextContains(
         '"eligibility-predicate-q" is in service area "Seattle"',
@@ -512,7 +504,7 @@ test.describe('create and edit predicates', () => {
         'Screen 1',
       )
 
-      await adminPredicates.addPredicates([
+      await adminPredicates.addPredicates(
         {
           questionName: 'predicate-date-is-earlier-than',
           scalar: 'date',
@@ -541,7 +533,7 @@ test.describe('create and edit predicates', () => {
           operator: 'is not one of',
           values: ['one,two', 'three,four'],
         },
-      ])
+      )
 
       let predicateDisplay = await page.innerText('.cf-display-predicate')
       await validateScreenshot(
@@ -611,7 +603,7 @@ test.describe('create and edit predicates', () => {
         'Screen 2',
       )
 
-      await adminPredicates.addPredicates([
+      await adminPredicates.addPredicates(
         {
           questionName: 'predicate-date-is-earlier-than',
           scalar: 'date',
@@ -624,7 +616,7 @@ test.describe('create and edit predicates', () => {
           operator: 'is less than',
           values: ['10', '20'],
         },
-      ])
+      )
 
       let predicateDisplay = await page.innerText('.cf-display-predicate')
       await validateScreenshot(
@@ -717,104 +709,104 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 2',
       )
-      await adminPredicates.addPredicate(
-        'single-string',
-        'shown if',
-        'first name',
-        'is not equal to',
-        'hidden',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'single-string',
+        action: 'shown if',
+        scalar: 'first name',
+        operator: 'is not equal to',
+        value: 'hidden',
+      })
 
       // Single string one of a list of strings
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 3',
       )
-      await adminPredicates.addPredicate(
-        'list of strings',
-        'shown if',
-        'text',
-        'is one of',
-        'blue, green',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'list of strings',
+        action: 'shown if',
+        scalar: 'text',
+        operator: 'is one of',
+        value: 'blue, green',
+      })
 
       // Simple long predicate
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 4',
       )
-      await adminPredicates.addPredicate(
-        'single-long',
-        'shown if',
-        'number',
-        'is equal to',
-        '42',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'single-long',
+        action: 'shown if',
+        scalar: 'number',
+        operator: 'is equal to',
+        value: '42',
+      })
 
       // Single long one of a list of longs
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 5',
       )
-      await adminPredicates.addPredicate(
-        'list of longs',
-        'shown if',
-        'number',
-        'is one of',
-        '123, 456',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'list of longs',
+        action: 'shown if',
+        scalar: 'number',
+        operator: 'is one of',
+        value: '123, 456',
+      })
 
       // Currency predicate
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 6',
       )
-      await adminPredicates.addPredicate(
-        'predicate-currency',
-        'shown if',
-        'currency',
-        'is greater than',
-        '100.01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-currency',
+        action: 'shown if',
+        scalar: 'currency',
+        operator: 'is greater than',
+        value: '100.01',
+      })
 
       // Date predicate is before
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 7',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-is-earlier-than',
-        'shown if',
-        'date',
-        'is earlier than',
-        '2021-01-01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-is-earlier-than',
+        action: 'shown if',
+        scalar: 'date',
+        operator: 'is earlier than',
+        value: '2021-01-01',
+      })
 
       // Date predicate is on or after
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 8',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-on-or-after',
-        'shown if',
-        'date',
-        'is on or later than',
-        '2023-01-01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-on-or-after',
+        action: 'shown if',
+        scalar: 'date',
+        operator: 'is on or later than',
+        value: '2023-01-01',
+      })
 
       // Lists of strings on both sides (multi-option question checkbox)
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 9',
       )
-      await adminPredicates.addPredicate(
-        'both sides are lists',
-        'shown if',
-        'selections',
-        'contains any of',
-        'dog,cat',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'both sides are lists',
+        action: 'shown if',
+        scalar: 'selections',
+        operator: 'contains any of',
+        value: 'dog,cat',
+      })
 
       await adminPrograms.publishProgram(programName)
 
@@ -958,104 +950,96 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 1',
       )
-      await adminPredicates.addPredicate(
-        'single-string',
-        /* action= */ null,
-        'first name',
-        'is not equal to',
-        'hidden',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'single-string',
+        scalar: 'first name',
+        operator: 'is not equal to',
+        value: 'hidden',
+      })
 
       // Single string one of a list of strings
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 2',
       )
-      await adminPredicates.addPredicate(
-        'list of strings',
-        /* action= */ null,
-        'text',
-        'is one of',
-        'blue, green',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'list of strings',
+        scalar: 'text',
+        operator: 'is one of',
+        value: 'blue, green',
+      })
 
       // Simple long predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 3',
       )
-      await adminPredicates.addPredicate(
-        'single-long',
-        /* action= */ null,
-        'number',
-        'is equal to',
-        '42',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'single-long',
+        scalar: 'number',
+        operator: 'is equal to',
+        value: '42',
+      })
 
       // Single long one of a list of longs
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 4',
       )
-      await adminPredicates.addPredicate(
-        'list of longs',
-        /* action= */ null,
-        'number',
-        'is one of',
-        '123, 456',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'list of longs',
+        scalar: 'number',
+        operator: 'is one of',
+        value: '123, 456',
+      })
 
       // Currency predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 5',
       )
-      await adminPredicates.addPredicate(
-        'predicate-currency',
-        /* action= */ null,
-        'currency',
-        'is greater than',
-        '100.01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-currency',
+        scalar: 'currency',
+        operator: 'is greater than',
+        value: '100.01',
+      })
 
       // Date predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 6',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-is-earlier-than',
-        /* action= */ null,
-        'date',
-        'is earlier than',
-        '2021-01-01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-is-earlier-than',
+        scalar: 'date',
+        operator: 'is earlier than',
+        value: '2021-01-01',
+      })
 
       // Date predicate is on or after
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 7',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-on-or-after',
-        /* action= */ null,
-        'date',
-        'is on or later than',
-        '2023-01-01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-on-or-after',
+        scalar: 'date',
+        operator: 'is on or later than',
+        value: '2023-01-01',
+      })
 
       // Date predicate age is greater than
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
         'Screen 8',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-age-older-than',
-        /* action= */ null,
-        'date',
-        'age is older than',
-        '90',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-age-older-than',
+        scalar: 'date',
+        operator: 'age is older than',
+        value: '90',
+      })
 
       // ensure the edit page renders without errors
       await adminPredicates.clickEditPredicateButton('eligibility')
@@ -1070,13 +1054,12 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 9',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-age-younger-than',
-        /* action= */ null,
-        'date',
-        'age is younger than',
-        '50.5',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-age-younger-than',
+        scalar: 'date',
+        operator: 'age is younger than',
+        value: '50.5',
+      })
 
       // ensure the edit page renders without errors
       await adminPredicates.clickEditPredicateButton('eligibility')
@@ -1090,13 +1073,12 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 10',
       )
-      await adminPredicates.addPredicate(
-        'predicate-date-age-between',
-        /* action= */ null,
-        'date',
-        'age is between',
-        '1,90',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-date-age-between',
+        scalar: 'date',
+        operator: 'age is between',
+        value: '1,90',
+      })
 
       // ensure the edit page renders without errors
       await adminPredicates.clickEditPredicateButton('eligibility')
@@ -1111,13 +1093,12 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 11',
       )
-      await adminPredicates.addPredicate(
-        'both sides are lists',
-        /* action= */ null,
-        'selections',
-        'contains any of',
-        'dog,cat',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'both sides are lists',
+        scalar: 'selections',
+        operator: 'contains any of',
+        value: 'dog,cat',
+      })
 
       await adminPrograms.publishProgram(programName)
 
@@ -1294,13 +1275,12 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 1',
       )
-      await adminPredicates.addPredicate(
-        'single-string',
-        /* action= */ null,
-        'first name',
-        'is not equal to',
-        'hidden',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'single-string',
+        scalar: 'first name',
+        operator: 'is not equal to',
+        value: 'hidden',
+      })
 
       // Currency predicate
       await adminPrograms.addProgramBlock(programName, 'currency', [
@@ -1310,13 +1290,12 @@ test.describe('create and edit predicates', () => {
         programName,
         'Screen 2',
       )
-      await adminPredicates.addPredicate(
-        'predicate-currency',
-        /* action= */ null,
-        'currency',
-        'is greater than',
-        '100.01',
-      )
+      await adminPredicates.addPredicates({
+        questionName: 'predicate-currency',
+        scalar: 'currency',
+        operator: 'is greater than',
+        value: '100.01',
+      })
 
       await adminPrograms.publishProgram(programName)
       await logout(page)

--- a/browser-test/src/applicant/navigation/application_navigation_address_visibility_condition.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_address_visibility_condition.test.ts
@@ -81,14 +81,12 @@ test.describe('Applicant navigation flow', () => {
             screen1,
           )
 
-          await adminPredicates.addPredicates([
-            {
-              questionName: questionAddress,
-              scalar: 'service_area',
-              operator: 'in service area',
-              values: ['Seattle'],
-            },
-          ])
+          await adminPredicates.addPredicates({
+            questionName: questionAddress,
+            scalar: 'service_area',
+            operator: 'in service area',
+            values: ['Seattle'],
+          })
 
           // Add the address visibility predicate
           await adminPrograms.goToBlockInProgram(programName, screen2)
@@ -98,15 +96,13 @@ test.describe('Applicant navigation flow', () => {
             screen2,
           )
 
-          await adminPredicates.addPredicates([
-            {
-              questionName: questionAddress,
-              action: 'shown if',
-              scalar: 'service_area',
-              operator: 'in service area',
-              values: ['Seattle'],
-            },
-          ])
+          await adminPredicates.addPredicates({
+            questionName: questionAddress,
+            action: 'shown if',
+            scalar: 'service_area',
+            operator: 'in service area',
+            values: ['Seattle'],
+          })
 
           // Publish Program
           await adminPrograms.gotoAdminProgramsPage()

--- a/browser-test/src/applicant/navigation/application_navigation_common_intake.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_common_intake.test.ts
@@ -59,13 +59,12 @@ test.describe('Applicant navigation flow', () => {
           secondProgramName,
           'Screen 1',
         )
-        await adminPredicates.addPredicate(
-          'nav-predicate-number-q',
-          /* action= */ null,
-          'number',
-          'is equal to',
-          secondProgramCorrectAnswer,
-        )
+        await adminPredicates.addPredicates({
+          questionName: 'nav-predicate-number-q',
+          scalar: 'number',
+          operator: 'is equal to',
+          value: secondProgramCorrectAnswer,
+        })
 
         await adminPrograms.publishAllDrafts()
         await logout(page)

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -39,13 +39,12 @@ test.describe('Applicant navigation flow', () => {
           fullProgramName,
           'Screen 1',
         )
-        await adminPredicates.addPredicate(
-          'nav-predicate-number-q',
-          /* action= */ null,
-          'number',
-          'is equal to',
-          '5',
-        )
+        await adminPredicates.addPredicates({
+          questionName: 'nav-predicate-number-q',
+          scalar: 'number',
+          operator: 'is equal to',
+          value: '5',
+        })
 
         await adminPrograms.addProgramBlock(
           fullProgramName,
@@ -369,13 +368,12 @@ test.describe('Applicant navigation flow', () => {
         programName,
         'Screen 1',
       )
-      await adminPredicates.addPredicate(
-        questionName,
-        /* action= */ null,
-        'text',
-        'is equal to',
-        'foo',
-      )
+      await adminPredicates.addPredicates({
+        questionName: questionName,
+        scalar: 'text',
+        operator: 'is equal to',
+        value: 'foo',
+      })
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.publishProgram(programName)
       await logout(page)

--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -1,6 +1,5 @@
 import {expect} from '@playwright/test'
 import {Page} from 'playwright'
-import {waitForPageJsLoad} from './wait'
 
 type PredicateSpec = {
   questionName: string
@@ -38,7 +37,7 @@ export class AdminPredicates {
     )
   }
 
-  async addPredicates(predicateSpecs: PredicateSpec[]) {
+  async addPredicates(...predicateSpecs: PredicateSpec[]) {
     for (const predicateSpec of predicateSpecs) {
       await this.selectQuestionForPredicate(predicateSpec.questionName)
     }
@@ -143,32 +142,6 @@ export class AdminPredicates {
         }
       }
     }
-  }
-
-  // For multi-option questions where the value is a checkbox of options, provide a comma-separated
-  // list of the options you would like to check as the value. Ex: blue,red,green
-  //
-  // If action is null the action selector will not be set.
-  async addPredicate(
-    questionName: string,
-    action: string | null,
-    scalar: string,
-    operator: string,
-    value: string,
-  ) {
-    await this.selectQuestionForPredicate(questionName)
-    await this.clickAddConditionButton()
-
-    await this.configurePredicate({
-      questionName,
-      action,
-      scalar,
-      operator,
-      value,
-    })
-
-    await this.clickSaveConditionButton()
-    await waitForPageJsLoad(this.page)
   }
 
   async expectPredicateDisplayTextContains(condition: string) {

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -746,13 +746,12 @@ test.describe('Trusted intermediaries', () => {
           fullProgramName,
           'Screen 1',
         )
-        await adminPredicates.addPredicate(
-          eligibilityQuestionId,
-          /* action= */ null,
-          'number',
-          'is equal to',
-          '5',
-        )
+        await adminPredicates.addPredicates({
+          questionName: eligibilityQuestionId,
+          scalar: 'number',
+          operator: 'is equal to',
+          value: '5',
+        })
 
         await adminPrograms.addProgramBlock(
           fullProgramName,


### PR DESCRIPTION
### Description

The addPredicate and addPredicates test support methods in admin_predicates.ts were redundant with each other. Combine them, and use a rest parameter (...) to make the caller syntax simple for either case. This also has the benefit of labeling all the params on all callers, which was previously not readable for addPredicate.

Also waitForPageJsLoad seems to have been unnecessary since addPredicate had it but addPredicates does not.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)