### PR TITLE
Java 17

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/java:1.5.0": {
-      "version": "11",
+      "version": "17",
       "jdkDistro": "tem", // Eclipse Adoptium Temurin per https://sdkman.io/jdks#tem See also: whichjdk.com
       "installMaven": "true",
       "installGradle": "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # workaround uses an aarch64 (arm64) image instead when an optional platform argument is set to arm64.
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
-FROM eclipse-temurin:11.0.23_9-jdk-alpine as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.22-12 as arm64
+FROM eclipse-temurin:17.0.11_9-jdk-alpine as amd64
+FROM bellsoft/liberica-openjdk-alpine:17.0.11-10 as arm64
 
 FROM ${TARGETARCH}
 

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # For production images, use the adoptium.net official JRE & JDK docker images.
-FROM --platform=linux/amd64 eclipse-temurin:11.0.23_9-jdk-alpine AS stage1
+FROM --platform=linux/amd64 eclipse-temurin:17.0.11_9-jdk-alpine AS stage1
 
 ARG SBT_VERSION
 ENV SBT_VERSION "${SBT_VERSION}"
@@ -33,7 +33,7 @@ RUN cd "${PROJECT_LOC}" && \
 
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
-FROM --platform=linux/amd64 eclipse-temurin:11.0.23_9-jre-alpine AS stage2
+FROM --platform=linux/amd64 eclipse-temurin:17.0.11_9-jre-alpine AS stage2
 COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.

--- a/server/.sbtopts
+++ b/server/.sbtopts
@@ -1,0 +1,10 @@
+-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -92,6 +92,7 @@ lazy val root = (project in file("."))
 
       // Errorprone
       "com.google.errorprone" % "error_prone_core" % "2.28.0",
+      "org.checkerframework" % "dataflow-errorprone" % "3.44.0",
 
       // Apache libraries for export
       "org.apache.commons" % "commons-csv" % "1.11.0",


### PR DESCRIPTION
Branch configured for Java 17 instead of Java 11

Details at #6427

> [!WARNING]
> Make sure to run `bin/build-dev` or your container will continue to run Java 11

- [x] Errorprone working

### Running

Use `bin/run-dev` to get the error. I have not filed a bug as the error requests, I am not certain it's a bug or misconfiguration.

