### PR TITLE
Allow easy connect to psql prompt

### DIFF
--- a/bin/dev-psql
+++ b/bin/dev-psql
@@ -1,17 +1,54 @@
 #! /usr/bin/env bash
 
-# DOC: Connect to dev environment PostgreSQL database.
+# DOC: Open psql prompt to specified postgres database. Defaults to
+# DOC: connecting to the dev environment database.
+# DOC:
+# DOC: Optional Arguments:
+# DOC:   --help   Show help screen to display supported environments
+
+# Without this you can't resolve the local aliases defined below
+shopt -s expand_aliases
 
 source bin/lib.sh
-docker::set_project_name_dev
 
-docker::compose_dev \
+ENVIRONMENT="${1:---dev}"
+
+case "${ENVIRONMENT}" in
+  "--dev")
+    alias docker_set_project_name='docker::set_project_name_dev'
+    alias docker_compose='docker::compose_dev'
+    ;;
+
+  "--browser-tests")
+    alias docker_set_project_name='docker::set_project_name_browser_tests'
+    alias docker_compose='docker::compose_browser_test'
+    ;;
+
+  "--unit-tests")
+    alias docker_set_project_name='docker::set_project_name_unit_tests'
+    alias docker_compose='docker::compose_unit_test'
+    ;;
+
+  "--help")
+    echo "Open psql prompt to specified postgres database"
+    echo ""
+    echo "Available environments:"
+    echo "  --dev"
+    echo "  --browser-tests"
+    echo "  --unit-tests"
+    exit 0
+    ;;
+esac
+
+docker_set_project_name
+
+docker_compose \
   up db \
   --no-deps \
   --wait \
   -d
 
-docker::compose_dev exec \
+docker_compose exec \
   -e "PGPASSWORD=example" \
   db \
   /usr/bin/psql \


### PR DESCRIPTION
### Description

The `bin/dev-psql` script only connected to the dev environment. This maintains the default, but allows passing an argument to point at the unit test or browser test databases.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
