### PR TITLE
Play 3 Upgrade

### DIFF
--- a/server/app/controllers/dev/DevToolsController.java
+++ b/server/app/controllers/dev/DevToolsController.java
@@ -120,7 +120,7 @@ public class DevToolsController extends Controller {
             .minus(1, ChronoUnit.DAYS)
             .toInstant(clock.getZone().getRules().getOffset(Instant.now()));
 
-    // Job types run on demand should be set to recurring in order to be picked up by akka
+    // Job types run on demand should be set to recurring in order to be picked up by pekko
     // and run dynamically.
     PersistedDurableJobModel job =
         new PersistedDurableJobModel(jobName, JobType.RECURRING, runTime);

--- a/server/app/durablejobs/DurableJob.java
+++ b/server/app/durablejobs/DurableJob.java
@@ -3,11 +3,11 @@ package durablejobs;
 import models.PersistedDurableJobModel;
 
 /**
- * Represents code that runs in a background thread. In contrast to Akka tasks, they are backed by
- * {@link PersistedDurableJobModel} records in the database, making them durable to server failures
- * and allowing automated retry logic. The behavior of a {@code DurableJob} is determined by its
- * implementing class, which is identified by its associated {@link PersistedDurableJobModel} record
- * via the {@code jobName} attribute.
+ * Represents code that runs in a background thread. In contrast to org.apache.pekko tasks, they are
+ * backed by {@link PersistedDurableJobModel} records in the database, making them durable to server
+ * failures and allowing automated retry logic. The behavior of a {@code DurableJob} is determined
+ * by its implementing class, which is identified by its associated {@link PersistedDurableJobModel}
+ * record via the {@code jobName} attribute.
  */
 public abstract class DurableJob {
 

--- a/server/app/durablejobs/DurableJobExecutionContext.java
+++ b/server/app/durablejobs/DurableJobExecutionContext.java
@@ -2,9 +2,9 @@ package durablejobs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import akka.actor.ActorSystem;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.pekko.actor.ActorSystem;
 import play.libs.concurrent.CustomExecutionContext;
 
 /** Thread pool for executing durable jobs. */

--- a/server/app/durablejobs/DurableJobRegistry.java
+++ b/server/app/durablejobs/DurableJobRegistry.java
@@ -91,7 +91,7 @@ public final class DurableJobRegistry {
 
     // Resolver to provide an immediate time for non-recurring jobs. This is here to keep it
     // contained and not accidentally used by recurring jobs as it will cause problems because of
-    // job the akka scheduler repeats.
+    // job the pekko scheduler repeats.
     class ImmediateJobExecutionTimeResolver implements JobExecutionTimeResolver {
       @Override
       public Instant resolveExecutionTime(Clock clock) {

--- a/server/app/filters/ApiKeyUsageFilter.java
+++ b/server/app/filters/ApiKeyUsageFilter.java
@@ -11,7 +11,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import play.api.libs.concurrent.AkkaSchedulerProvider;
+import play.api.libs.concurrent.PekkoSchedulerProvider;
 import play.mvc.EssentialAction;
 import play.mvc.EssentialFilter;
 import play.mvc.Http;
@@ -28,7 +28,7 @@ import services.apikey.ApiKeyService;
  */
 public class ApiKeyUsageFilter extends EssentialFilter {
 
-  private final AkkaSchedulerProvider akkaSchedulerProvider;
+  private final PekkoSchedulerProvider pekkoSchedulerProvider;
   private final Provider<ApiKeyService> apiKeyServiceProvider;
   private final Executor exec;
   private final Provider<ProfileUtils> profileUtilsProvider;
@@ -37,12 +37,12 @@ public class ApiKeyUsageFilter extends EssentialFilter {
 
   @Inject
   public ApiKeyUsageFilter(
-      AkkaSchedulerProvider akkaSchedulerProvider,
+      PekkoSchedulerProvider pekkoSchedulerProvider,
       Provider<ApiKeyService> apiKeyServiceProvider,
       Executor exec,
       Provider<ProfileUtils> profileUtilsProvider,
       ClientIpResolver clientIpResolver) {
-    this.akkaSchedulerProvider = checkNotNull(akkaSchedulerProvider);
+    this.pekkoSchedulerProvider = checkNotNull(pekkoSchedulerProvider);
     this.apiKeyServiceProvider = checkNotNull(apiKeyServiceProvider);
     this.exec = checkNotNull(exec);
     this.profileUtilsProvider = checkNotNull(profileUtilsProvider);
@@ -67,7 +67,7 @@ public class ApiKeyUsageFilter extends EssentialFilter {
                           if (maybeApiKeyId.isPresent()) {
                             String remoteAddress = clientIpResolver.resolveClientIp(request);
 
-                            akkaSchedulerProvider
+                            pekkoSchedulerProvider
                                 .get()
                                 .scheduleOnce(
                                     Duration.ZERO,

--- a/server/app/filters/CiviFormProfileFilter.java
+++ b/server/app/filters/CiviFormProfileFilter.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static play.mvc.Results.redirect;
 
-import akka.stream.Materializer;
 import auth.GuestClient;
 import auth.ProfileUtils;
 import com.google.inject.Inject;
@@ -12,6 +11,7 @@ import controllers.routes;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.apache.pekko.stream.Materializer;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;

--- a/server/app/filters/SettingsFilter.java
+++ b/server/app/filters/SettingsFilter.java
@@ -2,10 +2,10 @@ package filters;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import akka.stream.Materializer;
 import com.google.common.collect.ImmutableList;
 import javax.inject.Inject;
 import javax.inject.Provider;
+import org.apache.pekko.stream.Materializer;
 import play.libs.streams.Accumulator;
 import play.mvc.EssentialAction;
 import play.mvc.EssentialFilter;

--- a/server/app/models/JobType.java
+++ b/server/app/models/JobType.java
@@ -5,7 +5,7 @@ import io.ebean.annotation.DbEnumValue;
 
 /** Represents the job type for the durable jobs. */
 public enum JobType {
-  /** Runs via Akka scheduler. */
+  /** Runs via Pekko scheduler. */
   RECURRING,
   /**
    * Runs a job once each time the application is started, prior to the site being accessible to

--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -1,6 +1,5 @@
 package modules;
 
-import akka.actor.ActorSystem;
 import annotations.BindingAnnotations;
 import annotations.BindingAnnotations.RecurringJobsProviderName;
 import annotations.BindingAnnotations.StartupJobsProviderName;
@@ -29,6 +28,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Random;
 import models.JobType;
+import org.apache.pekko.actor.ActorSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Environment;
@@ -64,7 +64,7 @@ public final class DurableJobModule extends AbstractModule {
    * <p>See <a href="https://github.com/civiform/civiform/pull/8253">PR 8253</a> for more extensive
    * details.
    *
-   * <p>Additionally this uses The Akka scheduling system to schedules the job runner to run on an
+   * <p>Additionally this uses The Pekko scheduling system to schedules the job runner to run on an
    * interval.
    */
   public static final class DurableJobRunnerScheduler {

--- a/server/app/repository/DatabaseExecutionContext.java
+++ b/server/app/repository/DatabaseExecutionContext.java
@@ -2,9 +2,9 @@ package repository;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import akka.actor.ActorSystem;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.pekko.actor.ActorSystem;
 import play.libs.concurrent.CustomExecutionContext;
 
 /** Custom execution context wired to "database.dispatcher" thread pool */

--- a/server/app/services/program/ActiveAndDraftPrograms.java
+++ b/server/app/services/program/ActiveAndDraftPrograms.java
@@ -2,7 +2,6 @@ package services.program;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import akka.japi.Pair;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -14,6 +13,7 @@ import java.util.Set;
 import java.util.function.Function;
 import models.DisplayMode;
 import models.VersionModel;
+import org.apache.pekko.japi.Pair;
 import repository.VersionRepository;
 
 /**

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -1,6 +1,5 @@
 package services.question;
 
-import akka.japi.Pair;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -9,6 +8,7 @@ import com.google.common.collect.Sets;
 import java.util.Optional;
 import java.util.function.Function;
 import models.VersionModel;
+import org.apache.pekko.japi.Pair;
 import repository.VersionRepository;
 import services.DeletionStatus;
 import services.program.ProgramDefinition;

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -13,7 +13,8 @@ lazy val root = (project in file("."))
   .settings(
     name := """civiform-server""",
     version := "0.0.1",
-    scalaVersion := "2.13.15",
+    crossScalaVersions := Seq("2.13.15", "3.3.3"),
+    scalaVersion := crossScalaVersions.value.head,
     maintainer := "uat-public-contact@google.com",
     libraryDependencies ++= Seq(
       // Provides in-memory caching via the Play cache interface.
@@ -54,7 +55,7 @@ lazy val root = (project in file("."))
       "com.h2database" % "h2" % "2.3.232" % Test,
 
       // Metrics collection and export for Prometheus
-      "io.github.jyllands-posten" %% "play-prometheus-filters" % "0.6.1",
+      "io.github.jyllands-posten" %% "play-prometheus-filters" % "1.0.2",
 
       // Parameterized testing
       "pl.pragmatists" % "JUnitParams" % "1.1.1" % Test,
@@ -74,7 +75,7 @@ lazy val root = (project in file("."))
 
       // Security libraries
       // pac4j core (https://github.com/pac4j/play-pac4j)
-      "org.pac4j" %% "play-pac4j" % "12.0.0-PLAY2.9",
+      "org.pac4j" %% "play-pac4j" % "12.0.0-PLAY3.0",
       "org.pac4j" % "pac4j-core" % "6.1.0",
       // basic http authentication (for the anonymous client)
       "org.pac4j" % "pac4j-http" % "6.1.0",

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -28,20 +28,20 @@ include "helper/whitelabel.conf"
 ## filters/LoggingFilter configuration. Overrided in application.dev.conf.
 filters.LoggingFilter.enable_request_session_logging = false
 
-## Akka
-# https://www.playframework.com/documentation/latest/ScalaAkka#Configuration
-# https://www.playframework.com/documentation/latest/JavaAkka#Configuration
+## Pekko
+# https://www.playframework.com/documentation/latest/ScalaPekko#Configuration
+# https://www.playframework.com/documentation/latest/JavaPekko#Configuration
 # ~~~~~
-# Play uses Akka internally and exposes Akka Streams and actors in Websockets and
+# Play uses Pekko internally and exposes Pekko Streams and actors in Websockets and
 # other streaming HTTP responses.
-akka {
-  # "akka.log-config-on-start" is extraordinarly useful because it log the complete
+pekko {
+  # "pekko.log-config-on-start" is extraordinarly useful because it log the complete
   # configuration at INFO level, including defaults and overrides, so it s worth
   # putting at the very top.
   #
   # Put the following in your conf/logback.xml file:
   #
-  # <logger name="akka.actor" level="INFO" />
+  # <logger name="org.apache.pekko.actor" level="INFO" />
   #
   # And then uncomment this line to debug the configuration.
   #

--- a/server/project/plugins.sbt
+++ b/server/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Play plugins
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.5")
-addSbtPlugin("com.typesafe.play" % "sbt-play-ebean" % "7.3.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
+addSbtPlugin("org.playframework" % "sbt-play-ebean" % "8.3.0")
 
 // Dependency tree plugin. To use, open an sbt shell and run dependencyBrowseTree
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/server/test/controllers/applicant/ApplicantRoutesTest.java
+++ b/server/test/controllers/applicant/ApplicantRoutesTest.java
@@ -40,6 +40,10 @@ public class ApplicantRoutesTest extends ResetPostgres {
     for (MetricFamilySamples mfs : Collections.list(registry.metricFamilySamples())) {
       if (mfs.name.equals("applicant_id_in_profile")) {
         for (MetricFamilySamples.Sample sample : mfs.samples) {
+          if (!sample.name.equals("applicant_id_in_profile_total")) {
+            continue;
+          }
+
           if (sample.labelValues.contains("present")) {
             counts.present = sample.value;
           } else if (sample.labelValues.contains("absent")) {

--- a/server/test/filters/RecordCookieSizeFilterTest.java
+++ b/server/test/filters/RecordCookieSizeFilterTest.java
@@ -3,11 +3,11 @@ package filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
-import akka.stream.testkit.NoMaterializer$;
 import com.google.common.collect.ImmutableList;
 import io.prometheus.client.CollectorRegistry;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.pekko.stream.testkit.NoMaterializer$;
 import org.junit.Before;
 import org.junit.Test;
 import play.libs.streams.Accumulator;

--- a/server/test/filters/UnsupportedBrowserFilterTest.java
+++ b/server/test/filters/UnsupportedBrowserFilterTest.java
@@ -3,10 +3,10 @@ package filters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
-import akka.stream.testkit.NoMaterializer$;
 import com.google.common.collect.ImmutableList;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.apache.pekko.stream.testkit.NoMaterializer$;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import play.libs.streams.Accumulator;

--- a/server/test/repository/ResetPostgres.java
+++ b/server/test/repository/ResetPostgres.java
@@ -2,7 +2,6 @@ package repository;
 
 import static play.test.Helpers.fakeApplication;
 
-import akka.stream.Materializer;
 import io.ebean.DB;
 import io.ebean.Database;
 import java.time.Clock;
@@ -11,6 +10,7 @@ import java.time.ZoneId;
 import models.LifecycleStage;
 import models.Models;
 import models.VersionModel;
+import org.apache.pekko.stream.Materializer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;


### PR DESCRIPTION
## Docs

[Play 2.9 -> 3.x Migration Guide](https://www.playframework.com/documentation/3.0.x/Migration30)
[Play Scala 3 Migration](https://www.playframework.com/documentation/3.0.x/Scala3Migration)

## Akka -> Pekko

The primary change in Play 3 is that switch from Akka to the Apache fork named Pekko. 

There are some environment variables that have `Akka` in their name. It would be nice to rename them, but then we're having to verify all deployment config files are changed. There is no real downside in keeping the environment variables named as they are.

## Prometheus change 

Prior version of the Prometheus library only had `applicant_id_in_profile_total`. With the new version there is an additionally generated option named `applicant_id_in_profile_created`. The tests were written assuming only the `applicant_id_in_profile_total` was there.

mfs.name == "applicant_id_in_profile"
and includes "applicant_id_in_profile_total" and "applicant_id_in_profile_created"

![image](https://github.com/civiform/civiform/assets/195162/648f7b8c-1908-4d97-bfaa-4209dc4d2a5c)


Related to: #7466

Fixes: #7032, #7394