### PR TITLE
 Stop rendering empty paragraph when there is no question help text

### DIFF
--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -39,6 +39,7 @@ import views.components.Modal;
 import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.ApplicantStyles;
+import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -196,11 +197,11 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       if (data.encodedFileKey().isPresent()) {
         String encodedFileKey = data.encodedFileKey().get();
         String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
-        answerContent = a().withHref(fileLink);
+        answerContent = a().withHref(fileLink).withClasses(BaseStyles.LINK_TEXT, "font-light");
       } else {
         answerContent = div();
+        answerContent.withClasses("font-light", "text-sm");
       }
-      answerContent.withClasses("font-light", "text-sm");
       // Add answer text, converting newlines to <br/> tags.
       String[] texts = data.answerText().split("\n");
       texts = Arrays.stream(texts).filter(text -> text.length() > 0).toArray(String[]::new);
@@ -245,7 +246,6 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     LinkElement editElement =
         new LinkElement()
             .setStyles("bottom-0", "right-0", "text-blue-600", StyleUtils.hover("text-blue-700"));
-
     QuestionDefinition questionDefinition = data.questionDefinition();
     Optional<String> questionName = Optional.of(questionDefinition.getName());
     if (data.isAnswered() || haveAnswerText) {

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -39,7 +39,6 @@ import views.components.Modal;
 import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.ApplicantStyles;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -197,11 +196,11 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       if (data.encodedFileKey().isPresent()) {
         String encodedFileKey = data.encodedFileKey().get();
         String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
-        answerContent = a().withHref(fileLink).withClasses(BaseStyles.LINK_TEXT);
+        answerContent = a().withHref(fileLink);
       } else {
         answerContent = div();
-        answerContent.withClasses("font-light", "text-sm");
       }
+      answerContent.withClasses("font-light", "text-sm");
       // Add answer text, converting newlines to <br/> tags.
       String[] texts = data.answerText().split("\n");
       texts = Arrays.stream(texts).filter(text -> text.length() > 0).toArray(String[]::new);
@@ -246,6 +245,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     LinkElement editElement =
         new LinkElement()
             .setStyles("bottom-0", "right-0", "text-blue-600", StyleUtils.hover("text-blue-700"));
+
     QuestionDefinition questionDefinition = data.questionDefinition();
     Optional<String> questionName = Optional.of(questionDefinition.getName());
     if (data.isAnswered() || haveAnswerText) {

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -197,7 +197,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       if (data.encodedFileKey().isPresent()) {
         String encodedFileKey = data.encodedFileKey().get();
         String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
-        answerContent = a().withHref(fileLink).withClasses(BaseStyles.LINK_TEXT, "font-light");
+        answerContent = a().withHref(fileLink).withClasses(BaseStyles.LINK_TEXT);
       } else {
         answerContent = div();
         answerContent.withClasses("font-light", "text-sm");

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -61,24 +61,22 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     ImmutableList.Builder<String> ariaDescribedByBuilder =
         ImmutableList.<String>builder().add(descriptionId);
     Messages messages = params.messages();
-    DivTag questionSecondaryTextDiv =
+    DivTag questionSecondaryTextDiv = div().condWith(!applicantQuestion.getQuestionHelpText().isEmpty(), div().with(
         div()
+            // Question help text
+            .withId(descriptionId)
+            .withClasses(
+                ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
+                ApplicantStyles.QUESTION_HELP_TEXT)
             .with(
-                div()
-                    // Question help text
-                    .withId(descriptionId)
-                    .withClasses(
-                        ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                        ApplicantStyles.QUESTION_HELP_TEXT)
-                    .with(
-                        TextFormatter.formatTextWithAriaLabel(
-                            applicantQuestion.getQuestionHelpText(),
-                            /* preserveEmptyLines= */ true,
-                            /* addRequiredIndicator= */ false,
-                            messages
-                                .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
-                                .toLowerCase(Locale.ROOT))))
-            .withClasses("mb-4");
+                TextFormatter.formatTextWithAriaLabel(
+                    applicantQuestion.getQuestionHelpText(),
+                    /* preserveEmptyLines= */ true,
+                    /* addRequiredIndicator= */ false,
+                    messages
+                        .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
+                        .toLowerCase(Locale.ROOT))))
+        .withClasses("mb-4"));
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors;
     if (ApplicantQuestionRendererParams.ErrorDisplayMode.shouldShowErrors(

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -60,6 +60,28 @@ public class TextQuestionRendererTest extends ResetPostgres {
     renderer = new TextQuestionRenderer(question);
   }
 
+  @Test 
+  public void render_doNotRenderEmptyBlockIfNoHelpText() {
+     TextQuestionDefinition textQuestion = new TextQuestionDefinition(
+         QuestionDefinitionConfig.builder()
+             .setName("question name")
+             .setDescription("description")
+             .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+             .setLastModifiedTime(Optional.empty())
+             .setValidationPredicates(TextValidationPredicates.create(2, 3))
+             .setId(123L)
+             .build());
+     question = new ApplicantQuestion(
+         ProgramQuestionDefinition.create(textQuestion, Optional.empty())
+             .setOptional(true),
+         applicantData,
+         Optional.empty());
+    renderer = new TextQuestionRenderer(question);
+    DivTag result = renderer.render(params);
+
+    assertThat(result.render()).doesNotContain("cf-applicant-question-help-text");
+  }
+
   @Test
   public void render_withoutQuestionErrors() {
     DivTag result = renderer.render(params);


### PR DESCRIPTION
### Description

Preventing empty question help text block from rendering.


## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
  - [ ] Follow the workflow [here](<https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#workflow-for-adding-or-editing-translations>)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
