### PR TITLE
Render markdown for question text 

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -10,7 +10,7 @@ enable=quote-safe-variables
 
 # Turn on warnings for unassigned uppercase variables
 enable=check-unassigned-uppercase
-
+# testing
 # Allow [ ! -z foo ] instead of suggesting -n
 disable=SC2236
 

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -10,6 +10,7 @@ enable=quote-safe-variables
 
 # Turn on warnings for unassigned uppercase variables
 enable=check-unassigned-uppercase
+
 # Allow [ ! -z foo ] instead of suggesting -n
 disable=SC2236
 

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -10,7 +10,6 @@ enable=quote-safe-variables
 
 # Turn on warnings for unassigned uppercase variables
 enable=check-unassigned-uppercase
-# testing
 # Allow [ ! -z foo ] instead of suggesting -n
 disable=SC2236
 

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -56,6 +56,7 @@ import views.components.Icons;
 import views.components.Modal;
 import views.components.ProgramQuestionBank;
 import views.components.SvgTag;
+import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
@@ -434,7 +435,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       ButtonTag blockDeleteModalButton,
       boolean isIntakeFormFeatureEnabled,
       Request request) {
-    // A block can only be deleted when it has no repeated blocks. Same is true for removing the
+    // A block can only be deleted when it has no repeated blocks. Same is true for
+    // removing the
     // enumerator question from the block.
     final boolean canDelete =
         !blockDefinitionIsEnumerator || hasNoRepeatedBlocks(program, blockDefinition.id());
@@ -566,8 +568,9 @@ public final class ProgramBlocksView extends ProgramBaseView {
             .withForm(CREATE_REPEATED_BLOCK_FORM_ID)
             .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON));
 
-    // TODO: Maybe add alpha variants to button color on hover over so we do not have
-    //  to hard-code what the color will be when button is in hover state?
+    // TODO: Maybe add alpha variants to button color on hover over so we do not
+    // have
+    // to hard-code what the color will be when button is in hover state?
 
     // Only add the delete button if there is more than one screen in the program
     if (program.blockDefinitions().size() > 1) {
@@ -727,8 +730,13 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 iff(
                     malformedQuestionDefinition,
                     p("Edit the program and try republishing").withClass("text-red-500")),
-                p(questionDefinition.getQuestionText().getDefault()),
-                p(questionHelpText).withClasses("mt-1", "text-sm"),
+                div()
+                    .with(
+                        TextFormatter.formatText(
+                            questionDefinition.getQuestionText().getDefault())),
+                div()
+                    .with(TextFormatter.formatText(questionHelpText))
+                    .withClasses("mt-1", "text-sm"),
                 p(String.format("Admin ID: %s", questionDefinition.getName()))
                     .withClasses("mt-1", "text-sm"));
 
@@ -998,7 +1006,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 StyleUtils.hover("bg-gray-400", "text-gray-300"))
             .withType("submit")
             .attr("hx-post", toggleAddressCorrectionAction)
-            // Replace entire Questions section so that the tooltips for all address questions get
+            // Replace entire Questions section so that the tooltips for all address
+            // questions get
             // updated.
             .attr("hx-select-oob", String.format("#%s", QUESTIONS_SECTION_ID))
             .with(p("Address correction").withClasses("hover-group:text-white"))
@@ -1125,7 +1134,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       itemsInBlock.add("visibility conditions");
     }
 
-    // If there are no questions, eligibilty conditions, or visibility conditions on this screen,
+    // If there are no questions, eligibilty conditions, or visibility conditions on
+    // this screen,
     // just print "Are you sure you want to delete this screen?"
     if (itemsInBlock.size() == 0) {
       deleteBlockForm
@@ -1138,7 +1148,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
                   .withId("delete-block-button")
                   .withClasses("my-1", "inline", "opacity-100", StyleUtils.disabled("opacity-50")));
     } else {
-      // If there are questions, eligibility conditions, or visibility conditions on this screen,
+      // If there are questions, eligibility conditions, or visibility conditions on
+      // this screen,
       // print the appropriate message.
       String listItemsInBlock = "";
       if (itemsInBlock.size() == 1) {

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -48,6 +48,7 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.ProgramCardFactory;
+import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
@@ -423,7 +424,7 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   private LiTag renderPublishModalQuestionItem(QuestionDefinition question) {
     return li().with(
-            span(question.getQuestionText().getDefault()).withClasses("font-medium"),
+            span(TextFormatter.formatText(question.getQuestionText().getDefault()).toString()),
             span(" - "),
             new LinkElement()
                 .setText("Edit")

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -52,6 +52,7 @@ import views.components.Modal;
 import views.components.Modal.Width;
 import views.components.QuestionBank;
 import views.components.QuestionSortOption;
+import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
@@ -124,7 +125,8 @@ public final class QuestionsListView extends BaseHtmlView {
   }
 
   private DivTag renderSummary(ActiveAndDraftQuestions activeAndDraftQuestions) {
-    // The total question count should be equivalent to the number of rows in the displayed table,
+    // The total question count should be equivalent to the number of rows in the
+    // displayed table,
     // where we have a single entry for a question that is active and has a draft.
     return div(String.format(
             "Total questions: %d", activeAndDraftQuestions.getQuestionNames().size()))
@@ -394,14 +396,15 @@ public final class QuestionsListView extends BaseHtmlView {
                 Icons.questionTypeSvg(definition.getQuestionType())
                     .withClasses("w-6", "h-6", "shrink-0"))
             .with(
-                div(definition.getQuestionText().getDefault())
+                div()
+                    .with(TextFormatter.formatText(definition.getQuestionText().getDefault()))
                     .withClasses(ReferenceClasses.ADMIN_QUESTION_TITLE, "pl-4", "text-xl"));
+    String questionDescriptionString =
+        definition.getQuestionHelpText().isEmpty()
+            ? ""
+            : definition.getQuestionHelpText().getDefault();
     DivTag questionDescription =
-        div(
-            div(definition.getQuestionHelpText().isEmpty()
-                    ? ""
-                    : definition.getQuestionHelpText().getDefault())
-                .withClasses("pl-10"));
+        div(div().with(TextFormatter.formatText(questionDescriptionString)).withClasses("pl-10"));
     return div()
         .withClasses("py-7", "w-1/4", "flex", "flex-col", "justify-between")
         .with(div().with(questionText).with(questionDescription));
@@ -684,9 +687,11 @@ public final class QuestionsListView extends BaseHtmlView {
         isActive ? cardData.activeQuestion().get() : cardData.draftQuestion().get();
     ImmutableList.Builder<DomContent> extraActions = ImmutableList.builder();
     ImmutableList.Builder<Modal> modals = ImmutableList.builder();
-    // some actions such as "edit" or "archive" need to be rendered only on one of two rows.
+    // some actions such as "edit" or "archive" need to be rendered only on one of
+    // two rows.
     // If there is only "draft" or only "active" rows - render these actions.
-    // If there are both "draft" and "active" versions - render edit actions only on "draft".
+    // If there are both "draft" and "active" versions - render edit actions only on
+    // "draft".
     boolean isEditable =
         !isActive
             || activeAndDraftQuestions.getDraftQuestionDefinition(question.getName()).isEmpty();
@@ -701,7 +706,8 @@ public final class QuestionsListView extends BaseHtmlView {
         modals.add(discardDraftButtonAndModal.getRight());
       }
     }
-    // Add Archive option only if current question is draft or it's active, but there is no
+    // Add Archive option only if current question is draft or it's active, but
+    // there is no
     // draft version of the question.
     if (isEditable) {
       Pair<DomContent, Optional<Modal>> archiveOptionsAndModal =

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -241,10 +241,13 @@ public final class ProgramQuestionBank {
         div()
             .withClasses("ml-4", "grow")
             .with(
-                p(definition.getQuestionText().getDefault())
+                div()
+                    .with(TextFormatter.formatText(definition.getQuestionText().getDefault()))
                     .withClasses(
                         ReferenceClasses.ADMIN_QUESTION_TITLE, "font-bold", "w-3/5", "break-all"),
-                p(questionHelpText).withClasses("mt-1", "text-sm", "line-clamp-2"),
+                div()
+                    .with(TextFormatter.formatText(questionHelpText))
+                    .withClasses("mt-1", "text-sm", "line-clamp-2"),
                 p(String.format("Admin ID: %s", definition.getName()))
                     .withClasses("mt-1", "text-sm"),
                 adminNote);

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -38,6 +38,11 @@ public final class TextFormatter {
     return builder.build();
   }
 
+  /** Passes provided text through Markdown formatter. */
+  public static ImmutableList<DomContent> formatText(String text) {
+    return formatText(text, false, false);
+  }
+
   /**
    * Passes provided text through Markdown formatter, returning a String with the sanitized HTML.
    * This is used by Thymeleaf to render Static Text questions.
@@ -98,7 +103,8 @@ public final class TextFormatter {
   }
 
   private static String addRequiredIndicator(String markdownText) {
-    // If the question ends with a list (UL or OL tag), we need to handle the required indicator
+    // If the question ends with a list (UL or OL tag), we need to handle the
+    // required indicator
     // differently
     if (endsWithListTag(markdownText, "</ul>\n")) {
       return handleRequiredQuestionsThatEndInAList(markdownText, "<ul");
@@ -106,7 +112,8 @@ public final class TextFormatter {
       return handleRequiredQuestionsThatEndInAList(markdownText, "<ol");
     }
 
-    // If the question doesn't end with a list, add the required indicator on to the end
+    // If the question doesn't end with a list, add the required indicator on to the
+    // end
     int indexOfClosingTag = markdownText.lastIndexOf("</");
     return buildStringWithRequiredIndicator(markdownText, indexOfClosingTag);
   }
@@ -120,7 +127,8 @@ public final class TextFormatter {
   private static String handleRequiredQuestionsThatEndInAList(
       String markdownText, String openingListTag) {
     int indexOfOpeningListTag = markdownText.indexOf(openingListTag);
-    // If the question has no text before the list, add the required indicator to the end
+    // If the question has no text before the list, add the required indicator to
+    // the end
     // of the list before the closing LI tag
     // Otherwise, add the required indicator to the paragraph that precedes the list
     return indexOfOpeningListTag == 0
@@ -157,7 +165,8 @@ public final class TextFormatter {
             // Per accessibility best practices, we want to disallow adding h1 headers to
             // ensure the page does not have more than one h1 header
             // https://www.a11yproject.com/posts/how-to-accessible-heading-structure/
-            // This logic changes h1 headers to h2 headers which are still larger than the default
+            // This logic changes h1 headers to h2 headers which are still larger than the
+            // default
             // text
             .allowElements(
                 (String elementName, List<String> attrs) -> {

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -22,13 +22,10 @@ import views.style.ApplicantStyles;
 import views.style.ReferenceClasses;
 
 /**
- * Superclass for all applicant question renderers with input field(s) for the
- * applicant to answer
- * the question. Question renderers should not subclass from
- * ApplicantQuestionRendererImpl directly;
+ * Superclass for all applicant question renderers with input field(s) for the applicant to answer
+ * the question. Question renderers should not subclass from ApplicantQuestionRendererImpl directly;
  * instead they should subclass from one of the child classes, either
- * ApplicantCompositeQuestionRenderer (for multiple input fields) or
- * ApplicantSingleQuestionRenderer
+ * ApplicantCompositeQuestionRenderer (for multiple input fields) or ApplicantSingleQuestionRenderer
  * (for single input field).
  */
 abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
@@ -61,25 +58,30 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
 
   @Override
   public final DivTag render(ApplicantQuestionRendererParams params) {
-    ImmutableList.Builder<String> ariaDescribedByBuilder = ImmutableList.<String>builder().add(descriptionId);
+    ImmutableList.Builder<String> ariaDescribedByBuilder =
+        ImmutableList.<String>builder().add(descriptionId);
     Messages messages = params.messages();
-    DivTag questionSecondaryTextDiv = div().condWith(!applicantQuestion.getQuestionHelpText().isEmpty(),
-        div().with(
-            div()
-                // Question help text
-                .withId(descriptionId)
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    ApplicantStyles.QUESTION_HELP_TEXT)
-                .with(
-                    TextFormatter.formatTextWithAriaLabel(
-                        applicantQuestion.getQuestionHelpText(),
-                        /* preserveEmptyLines= */ true,
-                        /* addRequiredIndicator= */ false,
-                        messages
-                            .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
-                            .toLowerCase(Locale.ROOT))))
-            .withClasses("mb-4"));
+    DivTag questionSecondaryTextDiv =
+        div()
+            .condWith(
+                !applicantQuestion.getQuestionHelpText().isEmpty(),
+                div()
+                    .with(
+                        div()
+                            // Question help text
+                            .withId(descriptionId)
+                            .withClasses(
+                                ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
+                                ApplicantStyles.QUESTION_HELP_TEXT)
+                            .with(
+                                TextFormatter.formatTextWithAriaLabel(
+                                    applicantQuestion.getQuestionHelpText(),
+                                    /* preserveEmptyLines= */ true,
+                                    /* addRequiredIndicator= */ false,
+                                    messages
+                                        .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
+                                        .toLowerCase(Locale.ROOT))))
+                    .withClasses("mb-4"));
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors;
     if (ApplicantQuestionRendererParams.ErrorDisplayMode.shouldShowErrors(
@@ -89,32 +91,34 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
       validationErrors = ImmutableMap.of();
     }
 
-    ImmutableSet<ValidationErrorMessage> questionErrors = validationErrors
-        .getOrDefault(applicantQuestion.getContextualizedPath(), ImmutableSet.of());
+    ImmutableSet<ValidationErrorMessage> questionErrors =
+        validationErrors.getOrDefault(applicantQuestion.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
       questionSecondaryTextDiv.with(
           BaseHtmlView.fieldErrors(
-              messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
+                  messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
               .withId(errorId));
       ariaDescribedByBuilder.add(errorId);
     }
 
-    ImmutableList<DomContent> questionTextDoms = TextFormatter.formatTextWithAriaLabel(
-        applicantQuestion.getQuestionText(),
-        /* preserveEmptyLines= */ true,
-        /* addRequiredIndicator= */ !applicantQuestion.isOptional(),
-        messages.at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName()).toLowerCase(Locale.ROOT));
+    ImmutableList<DomContent> questionTextDoms =
+        TextFormatter.formatTextWithAriaLabel(
+            applicantQuestion.getQuestionText(),
+            /* preserveEmptyLines= */ true,
+            /* addRequiredIndicator= */ !applicantQuestion.isOptional(),
+            messages.at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName()).toLowerCase(Locale.ROOT));
     // Reverse the list to have errors appear first.
     ImmutableList<String> ariaDescribedByIds = ariaDescribedByBuilder.build().reverse();
 
-    ContainerTag questionTag = renderQuestionTag(
-        params,
-        validationErrors,
-        ariaDescribedByIds,
-        questionTextDoms,
-        questionSecondaryTextDiv,
-        applicantQuestion.isOptional());
+    ContainerTag questionTag =
+        renderQuestionTag(
+            params,
+            validationErrors,
+            ariaDescribedByIds,
+            questionTextDoms,
+            questionSecondaryTextDiv,
+            applicantQuestion.isOptional());
 
     return div()
         .withId(questionId)

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -61,24 +61,23 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     ImmutableList.Builder<String> ariaDescribedByBuilder =
         ImmutableList.<String>builder().add(descriptionId);
     Messages messages = params.messages();
-    DivTag questionSecondaryTextDiv =
-        div()
-            .with(
-                div()
-                    // Question help text
-                    .withId(descriptionId)
-                    .withClasses(
-                        ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                        ApplicantStyles.QUESTION_HELP_TEXT)
-                    .with(
-                        TextFormatter.formatTextWithAriaLabel(
-                            applicantQuestion.getQuestionHelpText(),
-                            /* preserveEmptyLines= */ true,
-                            /* addRequiredIndicator= */ false,
-                            messages
-                                .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
+    DivTag questionSecondaryTextDiv = div().condWith(!applicantQuestion.getQuestionHelpText().isEmpty(),
+        div().with(
+            div()
+                // Question help text
+                .withId(descriptionId)
+                .withClasses(
+                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
+                    ApplicantStyles.QUESTION_HELP_TEXT)
+                .with(
+                    TextFormatter.formatTextWithAriaLabel(
+                        applicantQuestion.getQuestionHelpText(),
+                        /* preserveEmptyLines= */ true,
+                        /* addRequiredIndicator= */ false,
+                        messages
+                            .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
                                 .toLowerCase(Locale.ROOT))))
-            .withClasses("mb-4");
+            .withClasses("mb-4"));
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors;
     if (ApplicantQuestionRendererParams.ErrorDisplayMode.shouldShowErrors(

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -22,10 +22,13 @@ import views.style.ApplicantStyles;
 import views.style.ReferenceClasses;
 
 /**
- * Superclass for all applicant question renderers with input field(s) for the applicant to answer
- * the question. Question renderers should not subclass from ApplicantQuestionRendererImpl directly;
+ * Superclass for all applicant question renderers with input field(s) for the
+ * applicant to answer
+ * the question. Question renderers should not subclass from
+ * ApplicantQuestionRendererImpl directly;
  * instead they should subclass from one of the child classes, either
- * ApplicantCompositeQuestionRenderer (for multiple input fields) or ApplicantSingleQuestionRenderer
+ * ApplicantCompositeQuestionRenderer (for multiple input fields) or
+ * ApplicantSingleQuestionRenderer
  * (for single input field).
  */
 abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
@@ -58,8 +61,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
 
   @Override
   public final DivTag render(ApplicantQuestionRendererParams params) {
-    ImmutableList.Builder<String> ariaDescribedByBuilder =
-        ImmutableList.<String>builder().add(descriptionId);
+    ImmutableList.Builder<String> ariaDescribedByBuilder = ImmutableList.<String>builder().add(descriptionId);
     Messages messages = params.messages();
     DivTag questionSecondaryTextDiv = div().condWith(!applicantQuestion.getQuestionHelpText().isEmpty(),
         div().with(
@@ -76,7 +78,7 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
                         /* addRequiredIndicator= */ false,
                         messages
                             .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())
-                                .toLowerCase(Locale.ROOT))))
+                            .toLowerCase(Locale.ROOT))))
             .withClasses("mb-4"));
 
     ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors;
@@ -87,34 +89,32 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
       validationErrors = ImmutableMap.of();
     }
 
-    ImmutableSet<ValidationErrorMessage> questionErrors =
-        validationErrors.getOrDefault(applicantQuestion.getContextualizedPath(), ImmutableSet.of());
+    ImmutableSet<ValidationErrorMessage> questionErrors = validationErrors
+        .getOrDefault(applicantQuestion.getContextualizedPath(), ImmutableSet.of());
     if (!questionErrors.isEmpty()) {
       // Question error text
       questionSecondaryTextDiv.with(
           BaseHtmlView.fieldErrors(
-                  messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
+              messages, questionErrors, ReferenceClasses.APPLICANT_QUESTION_ERRORS)
               .withId(errorId));
       ariaDescribedByBuilder.add(errorId);
     }
 
-    ImmutableList<DomContent> questionTextDoms =
-        TextFormatter.formatTextWithAriaLabel(
-            applicantQuestion.getQuestionText(),
-            /* preserveEmptyLines= */ true,
-            /* addRequiredIndicator= */ !applicantQuestion.isOptional(),
-            messages.at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName()).toLowerCase(Locale.ROOT));
+    ImmutableList<DomContent> questionTextDoms = TextFormatter.formatTextWithAriaLabel(
+        applicantQuestion.getQuestionText(),
+        /* preserveEmptyLines= */ true,
+        /* addRequiredIndicator= */ !applicantQuestion.isOptional(),
+        messages.at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName()).toLowerCase(Locale.ROOT));
     // Reverse the list to have errors appear first.
     ImmutableList<String> ariaDescribedByIds = ariaDescribedByBuilder.build().reverse();
 
-    ContainerTag questionTag =
-        renderQuestionTag(
-            params,
-            validationErrors,
-            ariaDescribedByIds,
-            questionTextDoms,
-            questionSecondaryTextDiv,
-            applicantQuestion.isOptional());
+    ContainerTag questionTag = renderQuestionTag(
+        params,
+        validationErrors,
+        ariaDescribedByIds,
+        questionTextDoms,
+        questionSecondaryTextDiv,
+        applicantQuestion.isOptional());
 
     return div()
         .withId(questionId)

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -60,11 +60,34 @@ public class TextQuestionRendererTest extends ResetPostgres {
     renderer = new TextQuestionRenderer(question);
   }
 
+  @Test 
+  public void render_doNotRenderEmptyBlockIfNoHelpText() {
+     TextQuestionDefinition textQuestion = new TextQuestionDefinition(
+         QuestionDefinitionConfig.builder()
+             .setName("question name")
+             .setDescription("description")
+             .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+             .setLastModifiedTime(Optional.empty())
+             .setValidationPredicates(TextValidationPredicates.create(2, 3))
+             .setId(123L)
+             .build());
+     question = new ApplicantQuestion(
+         ProgramQuestionDefinition.create(textQuestion, Optional.empty())
+             .setOptional(true),
+         applicantData,
+         Optional.empty());
+    renderer = new TextQuestionRenderer(question);
+    DivTag result = renderer.render(params);
+
+    assertThat(result.render()).doesNotContain("cf-applicant-question-help-text");
+  }
+
   @Test
   public void render_withoutQuestionErrors() {
     DivTag result = renderer.render(params);
 
     assertThat(result.render()).doesNotContain("Must contain at");
+    assertThat(result.render()).contains("cf-applicant-question-help-text");
   }
 
   @Test

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -23,16 +23,17 @@ import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
 public class TextQuestionRendererTest extends ResetPostgres {
-  private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION = new TextQuestionDefinition(
-      QuestionDefinitionConfig.builder()
-          .setName("question name")
-          .setDescription("description")
-          .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
-          .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-          .setLastModifiedTime(Optional.empty())
-          .setValidationPredicates(TextValidationPredicates.create(2, 3))
-          .setId(123L)
-          .build());
+  private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
+      new TextQuestionDefinition(
+          QuestionDefinitionConfig.builder()
+              .setName("question name")
+              .setDescription("description")
+              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+              .setLastModifiedTime(Optional.empty())
+              .setValidationPredicates(TextValidationPredicates.create(2, 3))
+              .setId(123L)
+              .build());
 
   private final ApplicantData applicantData = new ApplicantData();
 
@@ -43,36 +44,39 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    question = new ApplicantQuestion(
-        ProgramQuestionDefinition.create(TEXT_QUESTION_DEFINITION, Optional.empty())
-            .setOptional(true),
-        applicantData,
-        Optional.empty());
+    question =
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(TEXT_QUESTION_DEFINITION, Optional.empty())
+                .setOptional(true),
+            applicantData,
+            Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+            .build();
     renderer = new TextQuestionRenderer(question);
   }
 
   @Test
   public void render_doNotRenderEmptyBlockIfNoHelpText() {
-    TextQuestionDefinition textQuestion = new TextQuestionDefinition(
-        QuestionDefinitionConfig.builder()
-            .setName("question name")
-            .setDescription("description")
-            .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
-            .setLastModifiedTime(Optional.empty())
-            .setValidationPredicates(TextValidationPredicates.create(2, 3))
-            .setId(123L)
-            .build());
-    question = new ApplicantQuestion(
-        ProgramQuestionDefinition.create(textQuestion, Optional.empty())
-            .setOptional(true),
-        applicantData,
-        Optional.empty());
+    TextQuestionDefinition textQuestion =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("question name")
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                .setLastModifiedTime(Optional.empty())
+                .setValidationPredicates(TextValidationPredicates.create(2, 3))
+                .setId(123L)
+                .build());
+    question =
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(textQuestion, Optional.empty()).setOptional(true),
+            applicantData,
+            Optional.empty());
     renderer = new TextQuestionRenderer(question);
     DivTag result = renderer.render(params);
 
@@ -112,19 +116,20 @@ public class TextQuestionRendererTest extends ResetPostgres {
     String cleanHtml = result.render().replace("\n", "");
 
     assertThat(
-        cleanHtml.matches(
-            ".*input type=\"text\" value=\"\""
-                + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
+            cleanHtml.matches(
+                ".*input type=\"text\" value=\"\""
+                    + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 
   @Test
   public void maybeFocusOnInputNameMatch_autofocusIsPresent() {
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD)
-        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+            .build();
 
     DivTag result = renderer.render(params);
 
@@ -133,11 +138,12 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Test
   public void maybeFocusOnInputNameMismatch_autofocusIsNotPresent() {
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+            .build();
 
     DivTag result = renderer.render(params);
 
@@ -146,11 +152,12 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Test
   public void maybeFocusOnInputNameIsBlank_autofocusIsNotPresent() {
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)
+            .build();
 
     DivTag result = renderer.render(params);
 

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -23,17 +23,16 @@ import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
 public class TextQuestionRendererTest extends ResetPostgres {
-  private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
-      new TextQuestionDefinition(
-          QuestionDefinitionConfig.builder()
-              .setName("question name")
-              .setDescription("description")
-              .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
-              .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
-              .setLastModifiedTime(Optional.empty())
-              .setValidationPredicates(TextValidationPredicates.create(2, 3))
-              .setId(123L)
-              .build());
+  private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION = new TextQuestionDefinition(
+      QuestionDefinitionConfig.builder()
+          .setName("question name")
+          .setDescription("description")
+          .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+          .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+          .setLastModifiedTime(Optional.empty())
+          .setValidationPredicates(TextValidationPredicates.create(2, 3))
+          .setId(123L)
+          .build());
 
   private final ApplicantData applicantData = new ApplicantData();
 
@@ -44,38 +43,36 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    question =
-        new ApplicantQuestion(
-            ProgramQuestionDefinition.create(TEXT_QUESTION_DEFINITION, Optional.empty())
-                .setOptional(true),
-            applicantData,
-            Optional.empty());
+    question = new ApplicantQuestion(
+        ProgramQuestionDefinition.create(TEXT_QUESTION_DEFINITION, Optional.empty())
+            .setOptional(true),
+        applicantData,
+        Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params =
-        ApplicantQuestionRendererParams.builder()
-            .setMessages(messages)
-            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-            .build();
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+        .build();
     renderer = new TextQuestionRenderer(question);
   }
 
-  @Test 
+  @Test
   public void render_doNotRenderEmptyBlockIfNoHelpText() {
-     TextQuestionDefinition textQuestion = new TextQuestionDefinition(
-         QuestionDefinitionConfig.builder()
-             .setName("question name")
-             .setDescription("description")
-             .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
-             .setLastModifiedTime(Optional.empty())
-             .setValidationPredicates(TextValidationPredicates.create(2, 3))
-             .setId(123L)
-             .build());
-     question = new ApplicantQuestion(
-         ProgramQuestionDefinition.create(textQuestion, Optional.empty())
-             .setOptional(true),
-         applicantData,
-         Optional.empty());
+    TextQuestionDefinition textQuestion = new TextQuestionDefinition(
+        QuestionDefinitionConfig.builder()
+            .setName("question name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+            .setLastModifiedTime(Optional.empty())
+            .setValidationPredicates(TextValidationPredicates.create(2, 3))
+            .setId(123L)
+            .build());
+    question = new ApplicantQuestion(
+        ProgramQuestionDefinition.create(textQuestion, Optional.empty())
+            .setOptional(true),
+        applicantData,
+        Optional.empty());
     renderer = new TextQuestionRenderer(question);
     DivTag result = renderer.render(params);
 
@@ -115,20 +112,19 @@ public class TextQuestionRendererTest extends ResetPostgres {
     String cleanHtml = result.render().replace("\n", "");
 
     assertThat(
-            cleanHtml.matches(
-                ".*input type=\"text\" value=\"\""
-                    + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
+        cleanHtml.matches(
+            ".*input type=\"text\" value=\"\""
+                + " aria-describedby=\"[A-Za-z]{8}-description\".*"))
         .isTrue();
   }
 
   @Test
   public void maybeFocusOnInputNameMatch_autofocusIsPresent() {
-    params =
-        ApplicantQuestionRendererParams.builder()
-            .setMessages(messages)
-            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD)
-            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-            .build();
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.FIRST_FIELD)
+        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+        .build();
 
     DivTag result = renderer.render(params);
 
@@ -137,12 +133,11 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Test
   public void maybeFocusOnInputNameMismatch_autofocusIsNotPresent() {
-    params =
-        ApplicantQuestionRendererParams.builder()
-            .setMessages(messages)
-            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
-            .build();
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
+        .build();
 
     DivTag result = renderer.render(params);
 
@@ -151,12 +146,11 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Test
   public void maybeFocusOnInputNameIsBlank_autofocusIsNotPresent() {
-    params =
-        ApplicantQuestionRendererParams.builder()
-            .setMessages(messages)
-            .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
-            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)
-            .build();
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setAutofocus(ApplicantQuestionRendererParams.AutoFocusTarget.NONE)
+        .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)
+        .build();
 
     DivTag result = renderer.render(params);
 


### PR DESCRIPTION
### Description

Render markdown for question text where previously we displayed the raw markdown format. 

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
  - [ ] Follow the workflow [here](<https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#workflow-for-adding-or-editing-translations>)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
