### PR TITLE
Fix bug where filtering applications by date excluded applications submitted on the "until" date

### DIFF
--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -626,7 +626,7 @@ test.describe(
   },
 )
 
-// Returns today's date with the format of "yyyy-mm-dd". Ignores time zones.
+/** Returns today's date with the format of "yyyy-mm-dd". Ignores time zones. */
 function formattedToday() {
   const today = new Date()
   const year = today.getFullYear()

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -611,6 +611,27 @@ test.describe(
         expect(csvContentPhoneSearch).toContain('twoFirst')
         expect(csvContentPhoneSearch).not.toContain('threeFirst')
       })
+
+      await test.step('Search by date and validate expected applications are returned', async () => {
+        await adminPrograms.filterProgramApplications({
+          fromDate: formattedToday(),
+          untilDate: formattedToday(),
+        })
+        const csvContentPhoneSearch = await adminPrograms.getCsv(applyFilters)
+        expect(csvContentPhoneSearch).toContain('oneFirst')
+        expect(csvContentPhoneSearch).toContain('twoFirst')
+        expect(csvContentPhoneSearch).toContain('threeFirst')
+      })
     })
   },
 )
+
+// Returns today's date with the format of "yyyy-mm-dd". Ignores time zones.
+function formattedToday() {
+  const today = new Date()
+  const year = today.getFullYear()
+  const month = String(today.getMonth() + 1).padStart(2, '0') // Month is 0-indexed
+  const day = String(today.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -977,12 +977,18 @@ export class AdminPrograms {
     'Only applications without a status'
 
   async filterProgramApplications({
+    fromDate = '',
+    untilDate = '',
     searchFragment = '',
     applicationStatusOption = '',
   }: {
+    fromDate?: string
+    untilDate?: string
     searchFragment?: string
     applicationStatusOption?: string
   }) {
+    await this.page.fill(`input[type="date"] >> nth=${0}`, fromDate)
+    await this.page.fill(`input[type="date"] >> nth=${1}`, untilDate)
     await this.page.fill('input[name="search"]', searchFragment)
     if (applicationStatusOption) {
       await this.page.selectOption('label:has-text("Application status")', {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -987,8 +987,8 @@ export class AdminPrograms {
     searchFragment?: string
     applicationStatusOption?: string
   }) {
-    await this.page.getByRole('textbox', {name: "from"}).fill(fromDate)
-    await this.page.getByRole('textbox', {name: "until"}).fill(untilDate)
+    await this.page.getByRole('textbox', {name: 'from'}).fill(fromDate)
+    await this.page.getByRole('textbox', {name: 'until'}).fill(untilDate)
     await this.page.fill('input[name="search"]', searchFragment)
     if (applicationStatusOption) {
       await this.page.selectOption('label:has-text("Application status")', {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -987,8 +987,8 @@ export class AdminPrograms {
     searchFragment?: string
     applicationStatusOption?: string
   }) {
-    await this.page.fill(`input[type="date"] >> nth=${0}`, fromDate)
-    await this.page.fill(`input[type="date"] >> nth=${1}`, untilDate)
+    await this.page.getByRole('textbox', {name: "from"}).fill(fromDate)
+    await this.page.getByRole('textbox', {name: "until"}).fill(untilDate)
     await this.page.fill('input[name="search"]', searchFragment)
     if (applicationStatusOption) {
       await this.page.selectOption('label:has-text("Application status")', {

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -79,6 +79,12 @@ public final class AdminApplicationController extends CiviFormController {
   private final MessagesApi messagesApi;
   private final DateConverter dateConverter;
 
+  public enum RelativeTimeOfDay {
+    UNKNOWN,
+    START, // The start of the day, like 12:00:00 am
+    END // The end of the day, like 11:59:59 pm
+  }
+
   @Inject
   public AdminApplicationController(
       ProgramService programService,
@@ -138,8 +144,10 @@ public final class AdminApplicationController extends CiviFormController {
               .setSearchNameFragment(search)
               .setSubmitTimeFilter(
                   TimeFilter.builder()
-                      .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-                      .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                      .setFromTime(
+                          parseDateTimeFromQuery(dateConverter, fromDate, RelativeTimeOfDay.START))
+                      .setUntilTime(
+                          parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                       .build())
               .setApplicationStatus(applicationStatus)
               .build();
@@ -174,8 +182,11 @@ public final class AdminApplicationController extends CiviFormController {
                 .setSearchNameFragment(search)
                 .setSubmitTimeFilter(
                     TimeFilter.builder()
-                        .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-                        .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                        .setFromTime(
+                            parseDateTimeFromQuery(
+                                dateConverter, fromDate, RelativeTimeOfDay.START))
+                        .setUntilTime(
+                            parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                         .build())
                 .setApplicationStatus(applicationStatus)
                 .build();
@@ -215,17 +226,26 @@ public final class AdminApplicationController extends CiviFormController {
   }
 
   /**
-   * Parses a date from a raw query string (e.g. 2022-01-02) and returns an instant representing the
-   * start of that date in the UTC time zone.
+   * Parses a date from a raw query string (e.g. 2022-01-02) and returns an instant representing
+   * that date in the UTC time zone.
    */
-  private Optional<Instant> parseDateFromQuery(
-      DateConverter dateConverter, Optional<String> maybeQueryParam) {
+  private Optional<Instant> parseDateTimeFromQuery(
+      DateConverter dateConverter,
+      Optional<String> maybeQueryParam,
+      RelativeTimeOfDay relativeTimeOfDay) {
     return maybeQueryParam
         .filter(s -> !s.isBlank())
         .map(
             s -> {
               try {
-                return dateConverter.parseIso8601DateToStartOfLocalDateInstant(s);
+                switch (relativeTimeOfDay) {
+                  case START:
+                    return dateConverter.parseIso8601DateToStartOfLocalDateInstant(s);
+                  case END:
+                    return dateConverter.parseIso8601DateToEndOfLocalDateInstant(s);
+                  default:
+                    return dateConverter.parseIso8601DateToStartOfLocalDateInstant(s);
+                }
               } catch (DateTimeParseException e) {
                 throw new BadRequestException("Malformed query param");
               }
@@ -242,8 +262,8 @@ public final class AdminApplicationController extends CiviFormController {
       Http.Request request, Optional<String> fromDate, Optional<String> untilDate) {
     TimeFilter submitTimeFilter =
         TimeFilter.builder()
-            .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-            .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+            .setFromTime(parseDateTimeFromQuery(dateConverter, fromDate, RelativeTimeOfDay.START))
+            .setUntilTime(parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
             .build();
     String filename = String.format("demographics-%s.csv", nowProvider.get());
     String csv = exporterService.getDemographicsCsv(submitTimeFilter);
@@ -453,6 +473,7 @@ public final class AdminApplicationController extends CiviFormController {
     return redirect(redirectUrl).flashing("success", "Application note updated");
   }
 
+  // TODO(ssandbekkhaug): test this
   /** Return a paginated HTML page displaying (part of) all applications to the program. */
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result index(
@@ -482,8 +503,10 @@ public final class AdminApplicationController extends CiviFormController {
             .setSearchNameFragment(search)
             .setSubmitTimeFilter(
                 TimeFilter.builder()
-                    .setFromTime(parseDateFromQuery(dateConverter, fromDate))
-                    .setUntilTime(parseDateFromQuery(dateConverter, untilDate))
+                    .setFromTime(
+                        parseDateTimeFromQuery(dateConverter, fromDate, RelativeTimeOfDay.START))
+                    .setUntilTime(
+                        parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                     .build())
             .setApplicationStatus(applicationStatus)
             .build();

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -81,13 +81,9 @@ public final class AdminApplicationController extends CiviFormController {
 
   public enum RelativeTimeOfDay {
     UNKNOWN,
-    /**
-     * The start of the day, like 12:00:00 am
-     */
+    /** The start of the day, like 12:00:00 am */
     START,
-    /**
-     * The end of the day, like 11:59:59 pm
-     */
+    /** The end of the day, like 11:59:59 pm */
     END
   }
 
@@ -479,7 +475,6 @@ public final class AdminApplicationController extends CiviFormController {
     return redirect(redirectUrl).flashing("success", "Application note updated");
   }
 
-  // TODO(ssandbekkhaug): test this
   /** Return a paginated HTML page displaying (part of) all applications to the program. */
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result index(

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -81,8 +81,14 @@ public final class AdminApplicationController extends CiviFormController {
 
   public enum RelativeTimeOfDay {
     UNKNOWN,
-    START, // The start of the day, like 12:00:00 am
-    END // The end of the day, like 11:59:59 pm
+    /**
+     * The start of the day, like 12:00:00 am
+     */
+    START,
+    /**
+     * The end of the day, like 11:59:59 pm
+     */
+    END
   }
 
   @Inject

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -74,6 +75,16 @@ public final class DateConverter {
    */
   public Instant parseIso8601DateToStartOfLocalDateInstant(String dateString) {
     return parseIso8601DateToLocalDate(dateString).atStartOfDay(zoneId).toInstant();
+  }
+
+  /**
+   * Parses a string containing a ISO-8601 date (i.e. "YYYY-MM-DD") and converts it to an {@link
+   * Instant} at the end of the day in Local time zone.
+   *
+   * @throws DateTimeParseException if dateString is not well-formed.
+   */
+  public Instant parseIso8601DateToEndOfLocalDateInstant(String dateString) {
+    return parseIso8601DateToLocalDate(dateString).atTime(LocalTime.MAX).atZone(zoneId).toInstant();
   }
 
   /** Formats an {@link Instant} to a human-readable date and time in the local time zone. */

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -22,12 +22,40 @@ public class DateConverterTest {
   private DateConverter dateConverterPT = new DateConverter(clockPT);
 
   @Test
-  public void parseIso8601DateToLocalDateInstant_isSuccessful() {
+  public void parseIso8601DateToStartOfLocalDateInstant_isSuccessful() {
     String original = "2021-01-01Z";
     Instant parsed = dateConverterUTC.parseIso8601DateToStartOfLocalDateInstant(original);
     String formatted = dateConverterUTC.formatIso8601Date(parsed);
 
     assertThat(formatted).isEqualTo(original);
+  }
+
+  @Test
+  public void parseIso8601DateToStartOfLocalDateInstant_DateTimeParseExceptionIsGenerated() {
+    String inputDate = "abcd";
+    assertThatThrownBy(() -> dateConverterUTC.parseIso8601DateToStartOfLocalDateInstant(inputDate))
+        .isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  public void parseIso8601DateToEndOfLocalDateInstant_isSuccessful() {
+    // Construct the expected Instant
+    LocalDate targetDate = LocalDate.of(2024, 5, 20);
+    ZonedDateTime zonedDateTime = targetDate.atStartOfDay(ZoneId.of("UTC"));
+    zonedDateTime = zonedDateTime.plusDays(1).minusNanos(1);
+    Instant expected = zonedDateTime.toInstant();
+
+    String inputDate = "2024-05-20";
+    Instant actual = dateConverterUTC.parseIso8601DateToEndOfLocalDateInstant(inputDate);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void parseIso8601DateToEndOfLocalDateInstant_DateTimeParseExceptionIsGenerated() {
+    String inputDate = "abcd";
+    assertThatThrownBy(() -> dateConverterUTC.parseIso8601DateToEndOfLocalDateInstant(inputDate))
+        .isInstanceOf(DateTimeParseException.class);
   }
 
   @Test


### PR DESCRIPTION
Fixes #6629

### Description

Fix bug where filtering applications by date excluded applications submitted on the "until" date

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method (not required for admin pages?)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/) (Looks bad, but do admin pages need mobile support?)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

n/a

### Issue(s) this completes

Fixes #6629
