### PR TITLE
Improve PredicateGeneratorTest with best practices and more cases

### DIFF
--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -268,7 +268,7 @@ public final class PredicateGenerator {
    *
    * <p>If value is the empty string, then parses the list of values instead.
    */
-  static PredicateValue parsePredicateValue(
+  private static PredicateValue parsePredicateValue(
       Scalar scalar, Operator operator, String value, List<String> values) {
 
     // TODO: if scalar is not SELECTION or SELECTIONS and there values then throw an exception.


### PR DESCRIPTION
### Description

Improve PredicateGeneratorTest with best practices and more cases

* Make PredicateGenerator.parsePredicateValue private because it's only used internally and shouldn't be tested directly
* Replace testParsePredicateValue_currency that tested parsePredicateValue with singleQuestion_singleValue_currency which tests the public generatePredicateDefinition method
* Replace usages of parsePredicateValue in the test class with PredicateValue create methods
* Remove "generatePredicateDefinition_" from all the test names since it's the only public method and they all test it

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)