### PR TITLE
Refactor configurePredicate in admin_predicates.ts

### DIFF
--- a/browser-test/src/applicant/navigation/application_navigation_address_visibility_condition.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_address_visibility_condition.test.ts
@@ -85,7 +85,7 @@ test.describe('Applicant navigation flow', () => {
             questionName: questionAddress,
             scalar: 'service_area',
             operator: 'in service area',
-            values: ['Seattle'],
+            value: 'Seattle',
           })
 
           // Add the address visibility predicate
@@ -101,7 +101,7 @@ test.describe('Applicant navigation flow', () => {
             action: 'shown if',
             scalar: 'service_area',
             operator: 'in service area',
-            values: ['Seattle'],
+            value: 'Seattle',
           })
 
           // Publish Program


### PR DESCRIPTION
### Description

The increment of groupNum should happen exactly once per loop iteration, but is executed in various places, which is flimsy because it could result in 0 or 2+ increments. This code will get more complicated in the future (for #6109), so I pulled out the value filling logic to a separate method to isolate it from the increment logic. Also moved the value calculation logic down to where the values are filled since that's where it's used, and gave it a new name instead of overwriting the parameter.

Also update application_navigation_address_visibility_condition.test.ts to use value instead of values for its single value.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)