### PR TITLE
Move "delete screen" test logic from helper to test

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -812,7 +812,10 @@ test.describe('program creation', () => {
   }) => {
     await loginAsAdmin(page)
 
-    await adminPrograms.launchDeleteScreenModal()
+    const programName = 'Test program 7'
+    await adminPrograms.addProgram(programName)
+    await adminPrograms.addProgramBlock(programName)
+    await adminPrograms.launchRemoveProgramBlockModal(programName, 'Screen 1')
     await validateScreenshot(
       page,
       'delete-screen-confirmation-modal',

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -657,17 +657,13 @@ export class AdminPrograms {
     }
   }
 
-  async launchDeleteScreenModal() {
-    const programName = 'Test program 7'
-    await this.addProgram(programName)
-    await this.addProgramBlock(programName)
-    await this.goToBlockInProgram(programName, 'Screen 1')
+  async launchRemoveProgramBlockModal(programName: string, blockName: string) {
+    await this.goToBlockInProgram(programName, blockName)
     await clickAndWaitForModal(this.page, 'block-delete-modal')
   }
 
   async removeProgramBlock(programName: string, blockName: string) {
-    await this.goToBlockInProgram(programName, blockName)
-    await clickAndWaitForModal(this.page, 'block-delete-modal')
+    await this.launchRemoveProgramBlockModal(programName, blockName)
     await this.page.click('#delete-block-button')
     await waitForPageJsLoad(this.page)
     await this.gotoAdminProgramsPage()


### PR DESCRIPTION
### Description

* Move test setup from the launchDeleteScreenModal helper to the test itself
* Rename launchDeleteScreenModal to launchRemoveProgramBlockModal so it matches the related removeProgramBlock method
* Use launchRemoveProgramBlockModal in removeProgramBlock

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)