### PR TITLE
Turn off new no-nested-step eslint playwright rule

### DIFF
--- a/browser-test/.eslintrc.json
+++ b/browser-test/.eslintrc.json
@@ -12,15 +12,19 @@
     "no-unsanitized/property": "off",
     // Playwright specific: off until we can clean it all up
     "playwright/expect-expect": "off",
-    "playwright/no-wait-for-selector": "off",
-    "playwright/no-element-handle": "off",
-    "playwright/no-conditional-in-test": "off",
     "playwright/no-conditional-expect": "off",
-    "playwright/no-wait-for-timeout": "off",
-    "playwright/no-networkidle": "off",
-    "playwright/no-skipped-test": "off",
-    "playwright/prefer-web-first-assertions": "off",
+    "playwright/no-conditional-in-test": "off",
+    "playwright/no-element-handle": "off",
     "playwright/no-eval": "off",
+    "playwright/no-networkidle": "off",
+    // We shouldn't go crazy with nesting test.step, but it's a hard no
+    // on enforcing it. There are times when it makes complex tests more
+    // easier to read.
+    "playwright/no-nested-step": "off",
+    "playwright/no-skipped-test": "off",
+    "playwright/no-wait-for-selector": "off",
+    "playwright/no-wait-for-timeout": "off",
+    "playwright/prefer-web-first-assertions": "off",
     "playwright/valid-expect": "off"
   },
   "parserOptions": {


### PR DESCRIPTION
### Description

New eslint playwright rule will complain if you have nested Playwright `test.step`. I'm disabling this. While we shouldn't go overboard it can be useful to be able to nest them. 

Also sorting the rules list.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
