### PR TITLE
Cut browser test timeout to 90 seconds

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -4,7 +4,7 @@ import {BASE_URL} from './src/support/config'
 // For details see: https://playwright.dev/docs/api/class-testconfig
 
 export default defineConfig({
-  timeout: 180000,
+  timeout: 90000,
   testDir: './src',
   // Exit with error immediately if test.only() or test.describe.only()
   // was committed
@@ -13,7 +13,7 @@ export default defineConfig({
   globalSetup: './src/setup/global-setup.ts',
   fullyParallel: false,
   workers: 1,
-  retries: 1,
+  retries: process.env.CI === 'true' ? 1 : 0,
   outputDir: './tmp/test-output',
   expect: {
     toHaveScreenshot: {
@@ -25,7 +25,7 @@ export default defineConfig({
     },
   },
   use: {
-    trace: 'on-first-retry',
+    trace: process.env.CI === 'true' ? 'on-first-retry' : 'on',
     video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'


### PR DESCRIPTION
### Description

Change the browser test timeout from 3 minutes to 90 seconds.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
