### PR TITLE
Tagging slows tests with test.slow()

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -938,7 +938,7 @@ test.describe('create and edit predicates', () => {
       adminPredicates,
     }) => {
       test.slow()
-      
+
       await loginAsAdmin(page)
 
       const programName = 'Test all eligibility predicate types'
@@ -1304,7 +1304,7 @@ test.describe('create and edit predicates', () => {
       applicantQuestions,
     }) => {
       test.slow()
-      
+
       await loginAsAdmin(page)
       const programName = 'Multiple ineligible program'
       await adminPrograms.addProgram(programName)

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -518,6 +518,8 @@ test.describe('create and edit predicates', () => {
       adminPrograms,
       adminPredicates,
     }) => {
+      test.slow()
+
       await loginAsAdmin(page)
 
       const programName = 'Test multiple question and value predicate config'
@@ -704,6 +706,8 @@ test.describe('create and edit predicates', () => {
       applicantQuestions,
       adminPredicates,
     }) => {
+      test.slow()
+
       await loginAsAdmin(page)
 
       const programName = 'Test all visibility predicate types'
@@ -933,6 +937,8 @@ test.describe('create and edit predicates', () => {
       applicantQuestions,
       adminPredicates,
     }) => {
+      test.slow()
+      
       await loginAsAdmin(page)
 
       const programName = 'Test all eligibility predicate types'
@@ -1297,6 +1303,8 @@ test.describe('create and edit predicates', () => {
       adminPredicates,
       applicantQuestions,
     }) => {
+      test.slow()
+      
       await loginAsAdmin(page)
       const programName = 'Multiple ineligible program'
       await adminPrograms.addProgram(programName)

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -456,6 +456,8 @@ test.describe('applicant program index page with images', () => {
     adminQuestions,
     applicantQuestions,
   }) => {
+    test.slow()
+    
     await enableFeatureFlag(page, 'intake_form_enabled')
 
     // Common Intake: Basic (no image or status)

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -457,7 +457,7 @@ test.describe('applicant program index page with images', () => {
     applicantQuestions,
   }) => {
     test.slow()
-    
+
     await enableFeatureFlag(page, 'intake_form_enabled')
 
     // Common Intake: Basic (no image or status)

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -362,7 +362,7 @@ test.describe('address correction', () => {
     applicantQuestions,
   }) => {
     test.slow()
-    
+
     await disableFeatureFlag(page, 'esri_address_correction_enabled')
     await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
 

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -361,6 +361,8 @@ test.describe('address correction', () => {
     page,
     applicantQuestions,
   }) => {
+    test.slow()
+    
     await disableFeatureFlag(page, 'esri_address_correction_enabled')
     await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
 

--- a/browser-test/src/applicant/application_download.test.ts
+++ b/browser-test/src/applicant/application_download.test.ts
@@ -119,6 +119,8 @@ test.describe('normal application flow', () => {
     adminPrograms,
     applicantQuestions,
   }) => {
+    test.slow()
+    
     const noApplyFilters = false
     const applyFilters = true
 

--- a/browser-test/src/applicant/application_download.test.ts
+++ b/browser-test/src/applicant/application_download.test.ts
@@ -120,7 +120,7 @@ test.describe('normal application flow', () => {
     applicantQuestions,
   }) => {
     test.slow()
-    
+
     const noApplyFilters = false
     const applyFilters = true
 

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -20,7 +20,7 @@ test.describe('Program admin review of submitted applications', () => {
     applicantQuestions,
   }) => {
     test.slow()
-    
+
     const programName = 'A shiny new program'
 
     await loginAsAdmin(page)

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -19,6 +19,8 @@ test.describe('Program admin review of submitted applications', () => {
     adminPrograms,
     applicantQuestions,
   }) => {
+    test.slow()
+    
     const programName = 'A shiny new program'
 
     await loginAsAdmin(page)

--- a/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
@@ -95,6 +95,8 @@ test.describe('Applicant navigation flow', () => {
 
     test.describe('next button', () => {
       test('next block progression', async ({page, applicantQuestions}) => {
+        test.slow()
+
         await applicantQuestions.clickApplyProgramButton(programName)
 
         await validateAccessibility(page)
@@ -231,6 +233,8 @@ test.describe('Applicant navigation flow', () => {
       })
 
       test('can skip optional questions', async ({applicantQuestions}) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
 
         await test.step('screen 1', async () => {
@@ -284,6 +288,8 @@ test.describe('Applicant navigation flow', () => {
         page,
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.clickApplyProgramButton(programName)
 
         await test.step('answer screen 4', async () => {
@@ -387,6 +393,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking previous on first block goes to summary page', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
 
         await applicantQuestions.clickPrevious()
@@ -398,6 +406,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking previous on later blocks goes to previous blocks', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
 
         // Fill out the first block and click next
@@ -445,6 +455,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking previous with correct form shows previous page and saves answers', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('2021-11-01')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -478,6 +490,8 @@ test.describe('Applicant navigation flow', () => {
         page,
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -492,6 +506,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking previous with no answers does not show error modal', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
 
         // If the applicant has never answered this block before and doesn't fill in any
@@ -506,6 +522,8 @@ test.describe('Applicant navigation flow', () => {
       test('error on previous modal > click stay and fix > shows block', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -540,6 +558,8 @@ test.describe('Applicant navigation flow', () => {
       test('error on previous modal > click previous without saving > answers not saved', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('2021-11-01')
         await applicantQuestions.answerEmailQuestion('')
@@ -563,6 +583,8 @@ test.describe('Applicant navigation flow', () => {
       test('error on previous modal > click previous without saving > shows previous block', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('2021-11-01')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -593,6 +615,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking previous after deleting answers to required questions shows error modal', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await test.step('answer questions on first block', async () => {
           await applicantQuestions.applyProgram(programName)
           await applicantQuestions.answerDateQuestion('2021-11-01')
@@ -619,6 +643,8 @@ test.describe('Applicant navigation flow', () => {
       test('previous saves blank optional answers', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await test.step('answer blocks with all required questions', async () => {
           await applicantQuestions.applyProgram(programName)
           await applicantQuestions.answerDateQuestion('2021-11-01')
@@ -671,6 +697,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking review with correct form shows review page with saved answers', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('2021-11-01')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -692,6 +720,8 @@ test.describe('Applicant navigation flow', () => {
         page,
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -706,6 +736,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking review with no answers does not show error modal', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
 
         // If the applicant has never answered this block before and doesn't fill in any
@@ -719,6 +751,8 @@ test.describe('Applicant navigation flow', () => {
       test('error on review modal > click stay and fix > shows block', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('')
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
@@ -751,6 +785,8 @@ test.describe('Applicant navigation flow', () => {
       test('error on review modal > click review without saving > shows review page without saved answers', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await applicantQuestions.applyProgram(programName)
         await applicantQuestions.answerDateQuestion('2021-11-01')
         await applicantQuestions.answerEmailQuestion('')
@@ -773,6 +809,8 @@ test.describe('Applicant navigation flow', () => {
       test('clicking review after deleting answers to required questions shows error modal', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await test.step('answer questions on first block', async () => {
           await applicantQuestions.applyProgram(programName)
           await applicantQuestions.answerDateQuestion('2021-11-01')
@@ -799,6 +837,8 @@ test.describe('Applicant navigation flow', () => {
       test('review saves blank optional answers', async ({
         applicantQuestions,
       }) => {
+        test.slow()
+
         await test.step('answer blocks with all required questions', async () => {
           await applicantQuestions.applyProgram(programName)
           await applicantQuestions.answerDateQuestion('2021-11-01')

--- a/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
@@ -114,6 +114,8 @@ test.describe('Applicant navigation flow', () => {
     )
 
     test('verify program details page', async ({page}) => {
+      test.slow()
+
       // Begin waiting for the popup before clicking the link, otherwise
       // the popup may fire before the wait is registered, causing the test to flake.
       const popupPromise = page.waitForEvent('popup')
@@ -128,6 +130,8 @@ test.describe('Applicant navigation flow', () => {
     })
 
     test('verify program list page', async ({page, adminPrograms}) => {
+      test.slow()
+      
       await loginAsAdmin(page)
       // create second program that has an external link and markdown in the program description.
       const programWithExternalLink = 'Program with external link'
@@ -185,6 +189,8 @@ test.describe('Applicant navigation flow', () => {
       page,
       applicantQuestions,
     }) => {
+      test.slow()
+      
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.
@@ -236,6 +242,8 @@ test.describe('Applicant navigation flow', () => {
       page,
       applicantQuestions,
     }) => {
+      test.slow()
+      
       await loginAsTestUser(page)
       await applicantQuestions.applyProgram(programName)
 
@@ -277,6 +285,8 @@ test.describe('Applicant navigation flow', () => {
       applicantQuestions,
       adminPrograms,
     }) => {
+      test.slow()
+      
       // Login as an admin and add a bunch of programs
       await loginAsAdmin(page)
       await adminPrograms.addProgram('program 1')
@@ -321,6 +331,8 @@ test.describe('Applicant navigation flow', () => {
       page,
       applicantQuestions,
     }) => {
+      test.slow()
+      
       await applicantQuestions.clickApplyProgramButton(programName)
 
       // The UI correctly won't let us submit because the application isn't complete.
@@ -353,6 +365,8 @@ test.describe('Applicant navigation flow', () => {
       page,
       applicantQuestions,
     }) => {
+      test.slow()
+      
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.

--- a/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
@@ -131,7 +131,7 @@ test.describe('Applicant navigation flow', () => {
 
     test('verify program list page', async ({page, adminPrograms}) => {
       test.slow()
-      
+
       await loginAsAdmin(page)
       // create second program that has an external link and markdown in the program description.
       const programWithExternalLink = 'Program with external link'
@@ -190,7 +190,7 @@ test.describe('Applicant navigation flow', () => {
       applicantQuestions,
     }) => {
       test.slow()
-      
+
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.
@@ -243,7 +243,7 @@ test.describe('Applicant navigation flow', () => {
       applicantQuestions,
     }) => {
       test.slow()
-      
+
       await loginAsTestUser(page)
       await applicantQuestions.applyProgram(programName)
 
@@ -286,7 +286,7 @@ test.describe('Applicant navigation flow', () => {
       adminPrograms,
     }) => {
       test.slow()
-      
+
       // Login as an admin and add a bunch of programs
       await loginAsAdmin(page)
       await adminPrograms.addProgram('program 1')
@@ -332,7 +332,7 @@ test.describe('Applicant navigation flow', () => {
       applicantQuestions,
     }) => {
       test.slow()
-      
+
       await applicantQuestions.clickApplyProgramButton(programName)
 
       // The UI correctly won't let us submit because the application isn't complete.
@@ -366,7 +366,7 @@ test.describe('Applicant navigation flow', () => {
       applicantQuestions,
     }) => {
       test.slow()
-      
+
       await applicantQuestions.applyProgram(programName)
 
       // Fill out application and submit.


### PR DESCRIPTION
### Description

Tagging slow tests with `test.slow()`. This is a step toward lowering the Playwright test timeout a bit more.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
