### PR TITLE
Set playwright test timeout to 45 seconds

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -4,7 +4,7 @@ import {BASE_URL} from './src/support/config'
 // For details see: https://playwright.dev/docs/api/class-testconfig
 
 export default defineConfig({
-  timeout: 90000,
+  timeout: 45000, // 45 seconds
   testDir: './src',
   // Exit with error immediately if test.only() or test.describe.only()
   // was committed


### PR DESCRIPTION
### Description

Lower playwright test timeout to 45 seconds. Any tests that took more than 30 seconds against staging have already been annotated with `test.slow()` which gives them 3x bump in the timeout. We can tag more where needed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
