### PR TITLE
Revert "Set playwright test timeout to 45 seconds (#7596)"

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -4,7 +4,7 @@ import {BASE_URL} from './src/support/config'
 // For details see: https://playwright.dev/docs/api/class-testconfig
 
 export default defineConfig({
-  timeout: 45000, // 45 seconds
+  timeout: 90000,
   testDir: './src',
   // Exit with error immediately if test.only() or test.describe.only()
   // was committed


### PR DESCRIPTION
This reverts commit 91fd5b8623c738e50f69dd8544442e224ed427d6.

Too many timeout against staging; not going to take the time to try to tag things as slow.
