### PR TITLE
Isolate more admin_predicates tests

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -1337,78 +1337,82 @@ test.describe('create and edit predicates', () => {
       await validateToastMessage(page, '')
       await applicantQuestions.submitFromReviewPage()
     })
+  })
 
-    test('multiple questions ineligible', async ({
-      page,
-      adminPrograms,
-      adminPredicates,
-      applicantQuestions,
-    }) => {
-      test.slow()
+  test('multiple questions ineligible', async ({
+    page,
+    adminPrograms,
+    adminPredicates,
+    adminQuestions,
+    applicantQuestions,
+  }) => {
+    test.slow()
 
-      await loginAsAdmin(page)
-      const programName = 'Multiple ineligible program'
-      await adminPrograms.addProgram(programName)
+    await loginAsAdmin(page)
 
-      // Name predicate
-      await adminPrograms.editProgramBlockUsingSpec(programName, {
-        name: 'Screen 1',
-        questions: [{name: 'single-string'}],
-      })
-      await adminPrograms.goToEditBlockEligibilityPredicatePage(
-        programName,
-        'Screen 1',
-      )
-      await adminPredicates.addPredicates({
-        questionName: 'single-string',
-        scalar: 'first name',
-        operator: 'is not equal to',
-        value: 'hidden',
-      })
-
-      // Currency predicate
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 2',
-        questions: [{name: 'predicate-currency'}],
-      })
-      await adminPrograms.goToEditBlockEligibilityPredicatePage(
-        programName,
-        'Screen 2',
-      )
-      await adminPredicates.addPredicates({
-        questionName: 'predicate-currency',
-        scalar: 'currency',
-        operator: 'is greater than',
-        value: '100.01',
-      })
-
-      await adminPrograms.publishProgram(programName)
-      await logout(page)
-
-      await loginAsTestUser(page)
-      await applicantQuestions.applyProgram(programName)
-
-      // 'Hidden' name is ineligible
-      await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
-      await applicantQuestions.clickNext()
-      await applicantQuestions.expectIneligiblePage()
-      await applicantQuestions.expectIneligibleQuestionsCount(1)
-      await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
-
-      // Less than or equal to 100.01 is ineligible
-      await applicantQuestions.answerQuestionFromReviewPage(
-        'currency question text',
-      )
-      await applicantQuestions.answerCurrencyQuestion('100.01')
-      await applicantQuestions.clickNext()
-
-      await applicantQuestions.expectIneligiblePage()
-      await applicantQuestions.expectIneligibleQuestionsCount(2)
-      await validateAccessibility(page)
-      await validateScreenshot(
-        page,
-        'ineligible-multiple-eligibility-questions',
-      )
+    await adminQuestions.addNameQuestion({questionName: 'name-question'})
+    await adminQuestions.addCurrencyQuestion({
+      questionName: 'currency-question',
     })
+
+    const programName = 'Multiple ineligible program'
+    await adminPrograms.addProgram(programName)
+
+    // Name predicate
+    await adminPrograms.editProgramBlockUsingSpec(programName, {
+      name: 'Screen 1',
+      questions: [{name: 'name-question'}],
+    })
+    await adminPrograms.goToEditBlockEligibilityPredicatePage(
+      programName,
+      'Screen 1',
+    )
+    await adminPredicates.addPredicates({
+      questionName: 'name-question',
+      scalar: 'first name',
+      operator: 'is not equal to',
+      value: 'hidden',
+    })
+
+    // Currency predicate
+    await adminPrograms.addProgramBlockUsingSpec(programName, {
+      name: 'Screen 2',
+      questions: [{name: 'currency-question'}],
+    })
+    await adminPrograms.goToEditBlockEligibilityPredicatePage(
+      programName,
+      'Screen 2',
+    )
+    await adminPredicates.addPredicates({
+      questionName: 'currency-question',
+      scalar: 'currency',
+      operator: 'is greater than',
+      value: '100.01',
+    })
+
+    await adminPrograms.publishProgram(programName)
+    await logout(page)
+
+    await loginAsTestUser(page)
+    await applicantQuestions.applyProgram(programName)
+
+    // 'Hidden' name is ineligible
+    await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
+    await applicantQuestions.clickNext()
+    await applicantQuestions.expectIneligiblePage()
+    await applicantQuestions.expectIneligibleQuestionsCount(1)
+    await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
+
+    // Less than or equal to 100.01 is ineligible
+    await applicantQuestions.answerQuestionFromReviewPage(
+      'currency question text',
+    )
+    await applicantQuestions.answerCurrencyQuestion('100.01')
+    await applicantQuestions.clickNext()
+
+    await applicantQuestions.expectIneligiblePage()
+    await applicantQuestions.expectIneligibleQuestionsCount(2)
+    await validateAccessibility(page)
+    await validateScreenshot(page, 'ineligible-multiple-eligibility-questions')
   })
 })


### PR DESCRIPTION
### Description

I missed this one in #7609. The 'test predicates' test.describe group is unnecessary shared setup because it just defines some questions, which are used unevenly across the tests within the group.

* Move the 'multiple questions ineligible' outside the group and define the two questions it actually needs in the test.
* Update the question names to reflect the question type

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)