### PR TITLE
Rearrange predicate tests

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -689,115 +689,36 @@ test.describe('create and edit predicates', () => {
     )
   })
 
-  test.describe('test predicates', () => {
-    test.beforeEach(async ({page, adminQuestions}) => {
-      await loginAsAdmin(page)
+  test('every visibility right hand type evaluates correctly', async ({
+    page,
+    adminPrograms,
+    applicantQuestions,
+    adminPredicates,
+    adminQuestions,
+  }) => {
+    test.slow()
 
+    await loginAsAdmin(page)
+
+    const programName = 'Test all visibility predicate types'
+    await adminPrograms.addProgram(programName)
+
+    // Configure each screen so that it is not shown until the question on
+    // the screen before it is answered a certain way
+    await test.step('Configure screen 1 - question only', async () => {
       await adminQuestions.addNameQuestion({questionName: 'name-question'})
-      await adminQuestions.addTextQuestion({questionName: 'text-question'})
-      await adminQuestions.addNumberQuestion({
-        questionName: 'number-question-equal-to',
-      })
-      await adminQuestions.addNumberQuestion({
-        questionName: 'number-question-one-of',
-      })
-      await adminQuestions.addCurrencyQuestion({
-        questionName: 'currency-question',
-      })
-      await adminQuestions.addDateQuestion({
-        questionName: 'date-question-is-earlier-than',
-      })
-      await adminQuestions.addDateQuestion({
-        questionName: 'date-question-on-or-after',
-      })
-      await adminQuestions.addDateQuestion({
-        questionName: 'date-question-age-older-than',
-      })
-      await adminQuestions.addDateQuestion({
-        questionName: 'date-question-age-younger-than',
-      })
-      await adminQuestions.addDateQuestion({
-        questionName: 'date-question-age-between',
-      })
-      await adminQuestions.addCheckboxQuestion({
-        questionName: 'checkbox-question',
-        options: [
-          {adminName: 'dog_admin', text: 'dog'},
-          {adminName: 'rabbit_admin', text: 'rabbit'},
-          {adminName: 'cat_admin', text: 'cat'},
-        ],
-      })
-
-      await logout(page)
-    })
-
-    test('every visibility right hand type evaluates correctly', async ({
-      page,
-      adminPrograms,
-      applicantQuestions,
-      adminPredicates,
-      adminQuestions,
-    }) => {
-      test.slow()
-
-      await loginAsAdmin(page)
-
-      await adminQuestions.addTextQuestion({
-        questionName: 'text-question-last-page',
-      })
-
-      const programName = 'Test all visibility predicate types'
-      await adminPrograms.addProgram(programName)
       await adminPrograms.editProgramBlockUsingSpec(programName, {
         name: 'Screen 1',
         questions: [{name: 'name-question'}],
       })
+    })
+
+    await test.step('Configure screen 2', async () => {
+      await adminQuestions.addTextQuestion({questionName: 'text-question'})
       await adminPrograms.addProgramBlockUsingSpec(programName, {
         name: 'Screen 2',
         questions: [{name: 'text-question'}],
       })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 3',
-        questions: [{name: 'number-question-equal-to'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 4',
-        questions: [{name: 'number-question-one-of'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 5',
-        questions: [{name: 'currency-question'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 6',
-        questions: [{name: 'date-question-is-earlier-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 7',
-        questions: [{name: 'date-question-on-or-after'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 8',
-        questions: [{name: 'date-question-age-older-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 9',
-        questions: [{name: 'date-question-age-younger-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 10',
-        questions: [{name: 'date-question-age-between'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 11',
-        questions: [{name: 'checkbox-question'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 12',
-        questions: [{name: 'text-question-last-page'}],
-      })
-
-      // Simple string predicate
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 2',
@@ -809,8 +730,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is not equal to',
         value: 'hidden',
       })
+    })
 
-      // Single string one of a list of strings
+    await test.step('Configure screen 3', async () => {
+      await adminQuestions.addNumberQuestion({
+        questionName: 'number-question-equal-to',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 3',
+        questions: [{name: 'number-question-equal-to'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 3',
@@ -822,8 +751,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is one of',
         value: 'blue, green',
       })
+    })
 
-      // Simple long predicate
+    await test.step('Configure screen 4', async () => {
+      await adminQuestions.addNumberQuestion({
+        questionName: 'number-question-one-of',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 4',
+        questions: [{name: 'number-question-one-of'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 4',
@@ -835,8 +772,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is equal to',
         value: '42',
       })
+    })
 
-      // Single long one of a list of longs
+    await test.step('Configure screen 5', async () => {
+      await adminQuestions.addCurrencyQuestion({
+        questionName: 'currency-question',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 5',
+        questions: [{name: 'currency-question'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 5',
@@ -848,8 +793,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is one of',
         value: '123, 456',
       })
+    })
 
-      // Currency predicate
+    await test.step('Configure screen 6', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-is-earlier-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 6',
+        questions: [{name: 'date-question-is-earlier-than'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 6',
@@ -861,8 +814,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is greater than',
         value: '100.01',
       })
+    })
 
-      // Date predicate is before
+    await test.step('Configure screen 7', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-on-or-after',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 7',
+        questions: [{name: 'date-question-on-or-after'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 7',
@@ -874,8 +835,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is earlier than',
         value: '2021-01-01',
       })
+    })
 
-      // Date predicate is on or after
+    await test.step('Configure screen 8', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-older-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 8',
+        questions: [{name: 'date-question-age-older-than'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 8',
@@ -887,8 +856,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is on or later than',
         value: '2023-01-01',
       })
+    })
 
-      // Date predicate age is greater than
+    await test.step('Configure screen 9', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-younger-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 9',
+        questions: [{name: 'date-question-age-younger-than'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 9',
@@ -900,8 +877,16 @@ test.describe('create and edit predicates', () => {
         operator: 'age is older than',
         value: '90',
       })
+    })
 
-      // Date predicate age is less than
+    await test.step('Configure screen 10', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-between',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 10',
+        questions: [{name: 'date-question-age-between'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 10',
@@ -913,8 +898,21 @@ test.describe('create and edit predicates', () => {
         operator: 'age is younger than',
         value: '50.5',
       })
+    })
 
-      // Date predicate age is between
+    await test.step('Configure screen 11', async () => {
+      await adminQuestions.addCheckboxQuestion({
+        questionName: 'checkbox-question',
+        options: [
+          {adminName: 'dog_admin', text: 'dog'},
+          {adminName: 'rabbit_admin', text: 'rabbit'},
+          {adminName: 'cat_admin', text: 'cat'},
+        ],
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 11',
+        questions: [{name: 'checkbox-question'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 11',
@@ -926,8 +924,16 @@ test.describe('create and edit predicates', () => {
         operator: 'age is between',
         value: '1,90',
       })
+    })
 
-      // Lists of strings on both sides (multi-option question checkbox)
+    await test.step('Configure screen 12', async () => {
+      await adminQuestions.addTextQuestion({
+        questionName: 'text-question-last-page',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 12',
+        questions: [{name: 'text-question-last-page'}],
+      })
       await adminPrograms.goToEditBlockVisibilityPredicatePage(
         programName,
         'Screen 12',
@@ -939,21 +945,23 @@ test.describe('create and edit predicates', () => {
         operator: 'contains any of',
         value: 'dog,cat',
       })
+    })
 
-      await adminPrograms.publishProgram(programName)
+    await adminPrograms.publishProgram(programName)
 
-      // Switch to applicantQuestions.view - if they answer each question according to the predicate,
-      // the next screen will be shown.
-      await logout(page)
-      await loginAsTestUser(page)
-      await applicantQuestions.applyProgram(programName)
+    // Switch to applicantQuestions.view - if they answer each question according to the predicate,
+    // the next screen will be shown.
+    await logout(page)
+    await loginAsTestUser(page)
+    await applicantQuestions.applyProgram(programName)
 
-      // For each condition:
-      // - submit an invalid option
-      // - verify the other screens aren't show and the review page is shown
-      // - go back
-      // - enter an allowed value
+    // For each condition:
+    // - submit an invalid option
+    // - verify the other screens aren't show and the review page is shown
+    // - go back
+    // - enter an allowed value
 
+    await test.step('Apply screen 1', async () => {
       // "hidden" first name is not allowed.
       await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
       await applicantQuestions.clickNext()
@@ -961,7 +969,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerNameQuestion('show', 'next', 'screen')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 2', async () => {
       // "blue" or "green" are allowed.
       await applicantQuestions.answerTextQuestion('red')
       await applicantQuestions.clickNext()
@@ -969,7 +979,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerTextQuestion('blue')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 3', async () => {
       // 42 is allowed.
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickNext()
@@ -977,7 +989,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerNumberQuestion('42')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 4', async () => {
       // 123 or 456 are allowed.
       await applicantQuestions.answerNumberQuestion('11111')
       await applicantQuestions.clickNext()
@@ -985,7 +999,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerNumberQuestion('123')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 5', async () => {
       // Greater than 100.01 is allowed
       await applicantQuestions.answerCurrencyQuestion('100.01')
       await applicantQuestions.clickNext()
@@ -993,7 +1009,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerCurrencyQuestion('100.02')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 6', async () => {
       // Earlier than 2021-01-01 is allowed
       await applicantQuestions.answerDateQuestion('2021-01-01')
       await applicantQuestions.clickNext()
@@ -1001,7 +1019,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2020-12-31')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 7', async () => {
       // On or later than 2023-01-01 is allowed
       await applicantQuestions.answerDateQuestion('2022-12-31')
       await applicantQuestions.clickNext()
@@ -1009,7 +1029,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2023-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 8', async () => {
       // Age greater than 90 is allowed
       await applicantQuestions.answerDateQuestion('2022-12-31')
       await applicantQuestions.clickNext()
@@ -1017,7 +1039,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('1930-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 9', async () => {
       // Age less than 50.5 is allowed
       await applicantQuestions.answerDateQuestion('1930-12-31')
       await applicantQuestions.clickNext()
@@ -1025,7 +1049,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2022-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 10', async () => {
       // Age between 1 and 90 is allowed
       await applicantQuestions.answerDateQuestion('1920-12-31')
       await applicantQuestions.clickNext()
@@ -1033,7 +1059,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2000-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 11', async () => {
       // "dog" or "cat" are allowed.
       await applicantQuestions.answerCheckboxQuestion(['rabbit'])
       await applicantQuestions.clickNext()
@@ -1041,71 +1069,36 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerCheckboxQuestion(['cat'])
       await applicantQuestions.clickNext()
-
-      await applicantQuestions.answerTextQuestion('last one!')
-      await applicantQuestions.clickNext()
-
-      // We should now be on the summary page
-      await applicantQuestions.submitFromReviewPage()
     })
 
-    test('every eligibility right hand type evaluates correctly', async ({
-      page,
-      adminPrograms,
-      applicantQuestions,
-      adminPredicates,
-    }) => {
-      test.slow()
+    await test.step('Apply screen 12', async () => {
+      await applicantQuestions.answerTextQuestion('last one!')
+      await applicantQuestions.clickNext()
+    })
 
-      await loginAsAdmin(page)
+    // We should now be on the summary page
+    await applicantQuestions.submitFromReviewPage()
+  })
 
-      const programName = 'Test all eligibility predicate types'
-      await adminPrograms.addProgram(programName)
+  test('every eligibility right hand type evaluates correctly', async ({
+    page,
+    adminPrograms,
+    applicantQuestions,
+    adminPredicates,
+    adminQuestions,
+  }) => {
+    test.slow()
+
+    await loginAsAdmin(page)
+    const programName = 'Test all eligibility predicate types'
+    await adminPrograms.addProgram(programName)
+
+    await test.step('Configure screen 1', async () => {
+      await adminQuestions.addNameQuestion({questionName: 'name-question'})
       await adminPrograms.editProgramBlockUsingSpec(programName, {
         name: 'Screen 1',
         questions: [{name: 'name-question'}],
       })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 2',
-        questions: [{name: 'text-question'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 3',
-        questions: [{name: 'number-question-equal-to'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 4',
-        questions: [{name: 'number-question-one-of'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 5',
-        questions: [{name: 'currency-question'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 6',
-        questions: [{name: 'date-question-is-earlier-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 7',
-        questions: [{name: 'date-question-on-or-after'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 8',
-        questions: [{name: 'date-question-age-older-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 9',
-        questions: [{name: 'date-question-age-younger-than'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 10',
-        questions: [{name: 'date-question-age-between'}],
-      })
-      await adminPrograms.addProgramBlockUsingSpec(programName, {
-        name: 'Screen 11',
-        questions: [{name: 'checkbox-question'}],
-      })
-
       // Simple string predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1117,7 +1110,14 @@ test.describe('create and edit predicates', () => {
         operator: 'is not equal to',
         value: 'hidden',
       })
+    })
 
+    await test.step('Configure screen 2', async () => {
+      await adminQuestions.addTextQuestion({questionName: 'text-question'})
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 2',
+        questions: [{name: 'text-question'}],
+      })
       // Single string one of a list of strings
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1129,7 +1129,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is one of',
         value: 'blue, green',
       })
+    })
 
+    await test.step('Configure screen 3', async () => {
+      await adminQuestions.addNumberQuestion({
+        questionName: 'number-question-equal-to',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 3',
+        questions: [{name: 'number-question-equal-to'}],
+      })
       // Simple long predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1141,7 +1150,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is equal to',
         value: '42',
       })
+    })
 
+    await test.step('Configure screen 4', async () => {
+      await adminQuestions.addNumberQuestion({
+        questionName: 'number-question-one-of',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 4',
+        questions: [{name: 'number-question-one-of'}],
+      })
       // Single long one of a list of longs
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1153,7 +1171,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is one of',
         value: '123, 456',
       })
+    })
 
+    await test.step('Configure screen 5', async () => {
+      await adminQuestions.addCurrencyQuestion({
+        questionName: 'currency-question',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 5',
+        questions: [{name: 'currency-question'}],
+      })
       // Currency predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1165,7 +1192,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is greater than',
         value: '100.01',
       })
+    })
 
+    await test.step('Configure screen 6', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-is-earlier-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 6',
+        questions: [{name: 'date-question-is-earlier-than'}],
+      })
       // Date predicate
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1177,7 +1213,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is earlier than',
         value: '2021-01-01',
       })
+    })
 
+    await test.step('Configure screen 7', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-on-or-after',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 7',
+        questions: [{name: 'date-question-on-or-after'}],
+      })
       // Date predicate is on or after
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1189,7 +1234,16 @@ test.describe('create and edit predicates', () => {
         operator: 'is on or later than',
         value: '2023-01-01',
       })
+    })
 
+    await test.step('Configure screen 8', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-older-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 8',
+        questions: [{name: 'date-question-age-older-than'}],
+      })
       // Date predicate age is greater than
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1201,7 +1255,6 @@ test.describe('create and edit predicates', () => {
         operator: 'age is older than',
         value: '90',
       })
-
       // ensure the edit page renders without errors
       await adminPredicates.clickEditPredicateButton('eligibility')
       expect(await page.innerText('h1')).toContain(
@@ -1209,7 +1262,16 @@ test.describe('create and edit predicates', () => {
       )
       await validateScreenshot(page, 'predicate-age-greater-than-edit')
       await adminPredicates.clickSaveConditionButton()
+    })
 
+    await test.step('Configure screen 9', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-younger-than',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 9',
+        questions: [{name: 'date-question-age-younger-than'}],
+      })
       // Date predicate age is less than
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1228,7 +1290,16 @@ test.describe('create and edit predicates', () => {
         'Configure eligibility conditions',
       )
       await adminPredicates.clickSaveConditionButton()
+    })
 
+    await test.step('Configure screen 10', async () => {
+      await adminQuestions.addDateQuestion({
+        questionName: 'date-question-age-between',
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 10',
+        questions: [{name: 'date-question-age-between'}],
+      })
       // Date predicate age is between
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1248,7 +1319,21 @@ test.describe('create and edit predicates', () => {
       )
       await validateScreenshot(page, 'predicate-age-between-edit')
       await adminPredicates.clickSaveConditionButton()
+    })
 
+    await test.step('Configure screen 11', async () => {
+      await adminQuestions.addCheckboxQuestion({
+        questionName: 'checkbox-question',
+        options: [
+          {adminName: 'dog_admin', text: 'dog'},
+          {adminName: 'rabbit_admin', text: 'rabbit'},
+          {adminName: 'cat_admin', text: 'cat'},
+        ],
+      })
+      await adminPrograms.addProgramBlockUsingSpec(programName, {
+        name: 'Screen 11',
+        questions: [{name: 'checkbox-question'}],
+      })
       // Lists of strings on both sides (multi-option question checkbox)
       await adminPrograms.goToEditBlockEligibilityPredicatePage(
         programName,
@@ -1260,21 +1345,23 @@ test.describe('create and edit predicates', () => {
         operator: 'contains any of',
         value: 'dog,cat',
       })
+    })
 
-      await adminPrograms.publishProgram(programName)
+    await adminPrograms.publishProgram(programName)
 
-      // Switch to applicantQuestions.view - if they answer each question according to the predicate,
-      // the next screen will be shown.
-      await logout(page)
-      await loginAsTestUser(page)
-      await applicantQuestions.applyProgram(programName)
+    // Switch to applicantQuestions.view - if they answer each question according to the predicate,
+    // the next screen will be shown.
+    await logout(page)
+    await loginAsTestUser(page)
+    await applicantQuestions.applyProgram(programName)
 
-      // For each condition:
-      // - submit an invalid option
-      // - verify the ineligible page is shown
-      // - go back
-      // - enter an allowed value
+    // For each condition:
+    // - submit an invalid option
+    // - verify the ineligible page is shown
+    // - go back
+    // - enter an allowed value
 
+    await test.step('Apply screen 1', async () => {
       // "hidden" first name is not allowed.
       await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
       await applicantQuestions.clickNext()
@@ -1286,7 +1373,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.clickNext()
       await validateScreenshot(page, 'toast-message-may-qualify')
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 2', async () => {
       // "blue" or "green" are allowed.
       await applicantQuestions.answerTextQuestion('red')
       await applicantQuestions.clickNext()
@@ -1297,7 +1386,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerTextQuestion('blue')
       await applicantQuestions.clickNext()
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 3', async () => {
       // 42 is allowed.
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickNext()
@@ -1308,7 +1399,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerNumberQuestion('42')
       await applicantQuestions.clickNext()
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 4', async () => {
       // 123 or 456 are allowed.
       await applicantQuestions.answerNumberQuestion('11111')
       await applicantQuestions.clickNext()
@@ -1324,7 +1417,9 @@ test.describe('create and edit predicates', () => {
       await validateScreenshot(page, 'review-page-no-ineligible-banner')
       await validateToastMessage(page, '')
       await applicantQuestions.clickContinue()
+    })
 
+    await test.step('Apply screen 5', async () => {
       // Greater than 100.01 is allowed
       await applicantQuestions.answerCurrencyQuestion('100.01')
       await applicantQuestions.clickNext()
@@ -1337,7 +1432,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerCurrencyQuestion('100.02')
       await applicantQuestions.clickNext()
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 6', async () => {
       // Earlier than 2021-01-01 is allowed
       await applicantQuestions.answerDateQuestion('2021-01-01')
       await applicantQuestions.clickNext()
@@ -1348,7 +1445,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerDateQuestion('2020-12-31')
       await applicantQuestions.clickNext()
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 7', async () => {
       // On or later than 2023-01-01 is allowed
       await applicantQuestions.answerDateQuestion('2022-12-31')
       await applicantQuestions.clickNext()
@@ -1359,7 +1458,9 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.answerDateQuestion('2023-01-01')
       await applicantQuestions.clickNext()
       await validateToastMessage(page, 'may qualify')
+    })
 
+    await test.step('Apply screen 8', async () => {
       // Age greater than 90 is allowed
       await applicantQuestions.answerDateQuestion('2022-12-31')
       await applicantQuestions.clickNext()
@@ -1369,7 +1470,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('1930-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 9', async () => {
       // Age less than 50.5 is allowed
       await applicantQuestions.answerDateQuestion('1930-12-31')
       await applicantQuestions.clickNext()
@@ -1379,7 +1482,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2022-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 10', async () => {
       // Age between 1 and 90 is allowed
       await applicantQuestions.answerDateQuestion('1920-12-31')
       await applicantQuestions.clickNext()
@@ -1389,7 +1494,9 @@ test.describe('create and edit predicates', () => {
       await page.goBack()
       await applicantQuestions.answerDateQuestion('2000-01-01')
       await applicantQuestions.clickNext()
+    })
 
+    await test.step('Apply screen 11', async () => {
       // "dog" or "cat" are allowed.
       await applicantQuestions.answerCheckboxQuestion(['rabbit'])
       await applicantQuestions.clickNext()
@@ -1415,8 +1522,9 @@ test.describe('create and edit predicates', () => {
         'review-page-no-ineligible-banner-completed',
       )
       await validateToastMessage(page, '')
-      await applicantQuestions.submitFromReviewPage()
     })
+
+    await applicantQuestions.submitFromReviewPage()
   })
 
   test('multiple questions ineligible', async ({


### PR DESCRIPTION
### Description

Rearrange predicate tests:
* Group the three program configuration steps (add question, add screen, configure eligibility/visibility predicate) into one section per screen
* Add test.steps for the configuration and application sections with screen numbers so it's easier to match up the two sections
* Remove the test.describe('test predicates') group now that there is no shared state between the tests

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)