### PR TITLE
Remove vacuous beforeAll references

### DIFF
--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -76,7 +76,7 @@ test.describe('view program statuses', () => {
       adminPrograms,
       applicantQuestions,
     }) => {
-      // There is already 1 application from the beforeAll, so apply to 10 more programs.
+      // There is already 1 application from the beforeEach, so apply to 10 more programs.
       for (let i = 0; i < 10; i++) {
         await logout(page)
 

--- a/browser-test/src/admin/admin_publish.test.ts
+++ b/browser-test/src/admin/admin_publish.test.ts
@@ -11,7 +11,6 @@ test.describe('publishing all draft questions and programs', () => {
   const draftQuestionText = `${questionText} new version`
 
   test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
-    // beforeAll
     await loginAsAdmin(page)
 
     // Create a hidden program with no questions
@@ -41,7 +40,6 @@ test.describe('publishing all draft questions and programs', () => {
     await adminQuestions.createNewVersion(questionName)
 
     await adminPrograms.gotoAdminProgramsPage()
-    // beforeEach
   })
 
   test('shows programs and questions that will be published in the modal', async ({

--- a/browser-test/src/applicant/questions/phone.test.ts
+++ b/browser-test/src/applicant/questions/phone.test.ts
@@ -264,8 +264,6 @@ test.describe('phone question for applicant flow', () => {
     () => {
       const programName = 'Test program for single phone q'
 
-      test.beforeAll(async () => {})
-
       test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
         await setUpForSingleQuestion(
           programName,


### PR DESCRIPTION
### Description

Remove vacuous beforeAll references:
* Remove empty test.beforeAll
* Remove nonsense comments in admin_publish.test.test
* Fix comment that refers to beforeAll to refer correctly to beforeEach

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)