### PR TITLE
Add ability to update localized name/description for blocks (not added in UI yet)

### DIFF
--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -132,12 +132,14 @@ public class AdminProgramTranslationsController extends CiviFormController {
             request,
             formFactory,
             program.statusDefinitions().getStatuses().size(),
-            program.localizedSummaryImageDescription().isPresent());
+            program.localizedSummaryImageDescription().isPresent(),
+            program.blockDefinitions());
 
     final ErrorAnd<ProgramDefinition, CiviFormError> result;
     try {
       result =
-          service.updateLocalization(program.id(), localeToUpdate, translationForm.getUpdateData());
+          service.updateLocalization(
+              program.id(), localeToUpdate, translationForm.getUpdateData(program));
     } catch (OutOfDateStatusesException e) {
       return redirect(routes.AdminProgramTranslationsController.edit(programName, locale))
           .flashing("error", e.userFacingMessage());
@@ -150,6 +152,6 @@ public class AdminProgramTranslationsController extends CiviFormController {
     }
     return ok(
         translationView.render(
-            request, localeToUpdate, program, translationForm, /*message=*/ Optional.empty()));
+            request, localeToUpdate, program, translationForm, /* message= */ Optional.empty()));
   }
 }

--- a/server/app/forms/BlockForm.java
+++ b/server/app/forms/BlockForm.java
@@ -4,16 +4,6 @@ package forms;
 public final class BlockForm {
   private String name;
   private String description;
-  private String localizedName;
-  private String localizedDescription;
-
-  public BlockForm(
-      String name, String description, String localizedName, String localizedDescription) {
-    this.name = name;
-    this.description = description;
-    this.localizedName = localizedName;
-    this.localizedDescription = localizedDescription;
-  }
 
   public BlockForm(String name, String description) {
     this.name = name;
@@ -23,8 +13,6 @@ public final class BlockForm {
   public BlockForm() {
     name = "";
     description = "";
-    localizedName = "";
-    localizedDescription = "";
   }
 
   public String getName() {
@@ -41,21 +29,5 @@ public final class BlockForm {
 
   public void setDescription(String description) {
     this.description = description;
-  }
-
-  public String getLocalizedName() {
-    return localizedName;
-  }
-
-  public void setLocalizedName(String localizedName) {
-    this.localizedName = localizedName;
-  }
-
-  public String getLocalizedDescription() {
-    return localizedDescription;
-  }
-
-  public void setLocalizedDescription(String localizedDescription) {
-    this.localizedDescription = localizedDescription;
   }
 }

--- a/server/app/forms/BlockForm.java
+++ b/server/app/forms/BlockForm.java
@@ -4,6 +4,16 @@ package forms;
 public final class BlockForm {
   private String name;
   private String description;
+  private String localizedName;
+  private String localizedDescription;
+
+  public BlockForm(
+      String name, String description, String localizedName, String localizedDescription) {
+    this.name = name;
+    this.description = description;
+    this.localizedName = localizedName;
+    this.localizedDescription = localizedDescription;
+  }
 
   public BlockForm(String name, String description) {
     this.name = name;
@@ -13,6 +23,8 @@ public final class BlockForm {
   public BlockForm() {
     name = "";
     description = "";
+    localizedName = "";
+    localizedDescription = "";
   }
 
   public String getName() {
@@ -29,5 +41,21 @@ public final class BlockForm {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  public String getLocalizedName() {
+    return localizedName;
+  }
+
+  public void setLocalizedName(String localizedName) {
+    this.localizedName = localizedName;
+  }
+
+  public String getLocalizedDescription() {
+    return localizedDescription;
+  }
+
+  public void setLocalizedDescription(String localizedDescription) {
+    this.localizedDescription = localizedDescription;
   }
 }

--- a/server/app/forms/translation/ProgramTranslationForm.java
+++ b/server/app/forms/translation/ProgramTranslationForm.java
@@ -87,23 +87,11 @@ public final class ProgramTranslationForm {
       BlockDefinition blockDefinition = program.blockDefinitions().get(i);
       formValuesBuilder.put(
           localizedScreenName(blockDefinition.id()),
-          new String[] {
-            blockDefinition
-                .localizedName()
-                .orElse(LocalizedStrings.empty())
-                .maybeGet(locale)
-                .orElse("")
-          });
+          new String[] {blockDefinition.localizedName().maybeGet(locale).orElse("")});
 
       formValuesBuilder.put(
           localizedScreenDescription(blockDefinition.id()),
-          new String[] {
-            blockDefinition
-                .localizedDescription()
-                .orElse(LocalizedStrings.empty())
-                .maybeGet(locale)
-                .orElse("")
-          });
+          new String[] {blockDefinition.localizedDescription().maybeGet(locale).orElse("")});
     }
 
     ImmutableList<Long> blockIds =
@@ -236,10 +224,10 @@ public final class ProgramTranslationForm {
               LocalizationUpdate.ScreenUpdate.Builder resultBuilder =
                   LocalizationUpdate.ScreenUpdate.builder().setBlockIdToUpdate(blockId);
               if (!maybeBlockName.get().isEmpty()) {
-                resultBuilder.setLocalizedName(maybeBlockName);
+                resultBuilder.setLocalizedName(maybeBlockName.get());
               }
               if (!maybeBlockDescription.get().isEmpty()) {
-                resultBuilder.setLocalizedDescription(maybeBlockDescription);
+                resultBuilder.setLocalizedDescription(maybeBlockDescription.get());
               }
               return Optional.of(resultBuilder.build());
             })

--- a/server/app/forms/translation/ProgramTranslationForm.java
+++ b/server/app/forms/translation/ProgramTranslationForm.java
@@ -223,12 +223,8 @@ public final class ProgramTranslationForm {
 
               LocalizationUpdate.ScreenUpdate.Builder resultBuilder =
                   LocalizationUpdate.ScreenUpdate.builder().setBlockIdToUpdate(blockId);
-              if (!maybeBlockName.get().isEmpty()) {
-                resultBuilder.setLocalizedName(maybeBlockName.get());
-              }
-              if (!maybeBlockDescription.get().isEmpty()) {
-                resultBuilder.setLocalizedDescription(maybeBlockDescription.get());
-              }
+              resultBuilder.setLocalizedName(maybeBlockName.orElse(""));
+              resultBuilder.setLocalizedDescription(maybeBlockDescription.orElse(""));
               return Optional.of(resultBuilder.build());
             })
         .filter(Optional::isPresent)

--- a/server/app/forms/translation/ProgramTranslationForm.java
+++ b/server/app/forms/translation/ProgramTranslationForm.java
@@ -214,17 +214,17 @@ public final class ProgramTranslationForm {
     return blockIds.stream()
         .map(
             blockId -> {
-              Optional<String> maybeBlockName = getStringFormField(localizedScreenName(blockId));
-              Optional<String> maybeBlockDescription =
+              Optional<String> optionalBlockName = getStringFormField(localizedScreenName(blockId));
+              Optional<String> optionalBlockDescription =
                   getStringFormField(localizedScreenDescription(blockId));
-              if (maybeBlockName.isEmpty() || maybeBlockDescription.isEmpty()) {
+              if (optionalBlockName.isEmpty() || optionalBlockDescription.isEmpty()) {
                 return Optional.<LocalizationUpdate.ScreenUpdate>empty();
               }
 
               LocalizationUpdate.ScreenUpdate.Builder resultBuilder =
                   LocalizationUpdate.ScreenUpdate.builder().setBlockIdToUpdate(blockId);
-              resultBuilder.setLocalizedName(maybeBlockName.orElse(""));
-              resultBuilder.setLocalizedDescription(maybeBlockDescription.orElse(""));
+              resultBuilder.setLocalizedName(optionalBlockName.orElse(""));
+              resultBuilder.setLocalizedDescription(optionalBlockDescription.orElse(""));
               return Optional.of(resultBuilder.build());
             })
         .filter(Optional::isPresent)

--- a/server/app/services/program/LocalizationUpdate.java
+++ b/server/app/services/program/LocalizationUpdate.java
@@ -21,6 +21,8 @@ public abstract class LocalizationUpdate {
 
   public abstract ImmutableList<StatusUpdate> statuses();
 
+  public abstract ImmutableList<ScreenUpdate> screens();
+
   public static Builder builder() {
     return new AutoValue_LocalizationUpdate.Builder();
   }
@@ -36,6 +38,8 @@ public abstract class LocalizationUpdate {
     public abstract Builder setLocalizedSummaryImageDescription(String v);
 
     public abstract Builder setStatuses(ImmutableList<StatusUpdate> v);
+
+    public abstract Builder setScreens(ImmutableList<ScreenUpdate> v);
 
     public abstract LocalizationUpdate build();
   }
@@ -71,6 +75,34 @@ public abstract class LocalizationUpdate {
       public abstract Builder setLocalizedEmailBody(Optional<String> v);
 
       public abstract StatusUpdate build();
+    }
+  }
+
+  /** Captures updates to the translations for a given block/screen name and description. */
+  @AutoValue
+  public abstract static class ScreenUpdate {
+    /** The block that is being updated */
+    public abstract Long blockIdToUpdate();
+
+    /** The new block name to update for a locale. */
+    public abstract Optional<String> localizedName();
+
+    /** The new block description to update for a locale. */
+    public abstract Optional<String> localizedDescription();
+
+    public static Builder builder() {
+      return new AutoValue_LocalizationUpdate_ScreenUpdate.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setBlockIdToUpdate(Long v);
+
+      public abstract Builder setLocalizedName(Optional<String> v);
+
+      public abstract Builder setLocalizedDescription(Optional<String> v);
+
+      public abstract ScreenUpdate build();
     }
   }
 }

--- a/server/app/services/program/LocalizationUpdate.java
+++ b/server/app/services/program/LocalizationUpdate.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 /**
  * Captures an update to the localized text associated with a program and its associated application
- * statuses.
+ * statuses and blocks.
  */
 @AutoValue
 public abstract class LocalizationUpdate {

--- a/server/app/services/program/LocalizationUpdate.java
+++ b/server/app/services/program/LocalizationUpdate.java
@@ -85,10 +85,10 @@ public abstract class LocalizationUpdate {
     public abstract Long blockIdToUpdate();
 
     /** The new block name to update for a locale. */
-    public abstract Optional<String> localizedName();
+    public abstract String localizedName();
 
     /** The new block description to update for a locale. */
-    public abstract Optional<String> localizedDescription();
+    public abstract String localizedDescription();
 
     public static Builder builder() {
       return new AutoValue_LocalizationUpdate_ScreenUpdate.Builder();
@@ -98,9 +98,9 @@ public abstract class LocalizationUpdate {
     public abstract static class Builder {
       public abstract Builder setBlockIdToUpdate(Long v);
 
-      public abstract Builder setLocalizedName(Optional<String> v);
+      public abstract Builder setLocalizedName(String v);
 
-      public abstract Builder setLocalizedDescription(Optional<String> v);
+      public abstract Builder setLocalizedDescription(String v);
 
       public abstract ScreenUpdate build();
     }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -662,7 +662,7 @@ public final class ProgramService {
     validateProgramText(
         errorsBuilder, "display description", localizationUpdate.localizedDisplayDescription());
     validateLocalizationStatuses(localizationUpdate, programDefinition);
-    validateBlockLocalizations(errorsBuilder, localizationUpdate);
+    validateBlockLocalizations(errorsBuilder, localizationUpdate, programDefinition);
 
     // We iterate the existing statuses along with the provided statuses since they were verified
     // to be consistently ordered above.
@@ -788,10 +788,19 @@ public final class ProgramService {
   }
 
   private void validateBlockLocalizations(
-      ImmutableSet.Builder<CiviFormError> errorsBuilder, LocalizationUpdate localizationUpdate) {
+      ImmutableSet.Builder<CiviFormError> errorsBuilder,
+      LocalizationUpdate localizationUpdate,
+      ProgramDefinition program) {
     localizationUpdate.screens().stream()
         .forEach(
             screenUpdate -> {
+              if (program.blockDefinitions().stream()
+                  .filter(blockDefinition -> blockDefinition.id() == screenUpdate.blockIdToUpdate())
+                  .findAny()
+                  .isEmpty()) {
+                errorsBuilder.add(
+                    CiviFormError.of("Found invalid block id " + screenUpdate.blockIdToUpdate()));
+              }
               validateProgramText(
                   errorsBuilder,
                   ProgramTranslationForm.localizedScreenName(screenUpdate.blockIdToUpdate()),

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -1194,11 +1194,6 @@ public final class ProgramService {
                     .localizedDescription()
                     .updateDefaultTranslation(blockForm.getDescription()))
             .build();
-    // blockDefinition = blockDefinition.toBuilder()
-    //         .setLocalizedName(blockDefinition.localizedName().updateTranslation(locale,
-    // displayName))
-    //         .setLocalizedDescription(null)
-    //         .build();
     ImmutableSet<CiviFormError> errors = validateBlockDefinition(blockDefinition);
     if (!errors.isEmpty()) {
       return ErrorAnd.errorAnd(errors, programDefinition);

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -709,23 +709,16 @@ public final class ProgramService {
         toUpdateBlockBuilder.add(block);
         continue;
       }
-      BlockDefinition.Builder blockBuilder = block.toBuilder();
-      if (screenUpdate.get().localizedName().isPresent()) {
-        blockBuilder.setLocalizedName(
-            Optional.of(
-                block
-                    .localizedName()
-                    .get()
-                    .updateTranslation(locale, screenUpdate.get().localizedName())));
-      }
-      if (screenUpdate.get().localizedDescription().isPresent()) {
-        blockBuilder.setLocalizedDescription(
-            Optional.of(
-                block
-                    .localizedDescription()
-                    .get()
-                    .updateTranslation(locale, screenUpdate.get().localizedDescription())));
-      }
+      BlockDefinition.Builder blockBuilder =
+          block.toBuilder()
+              .setLocalizedName(
+                  block
+                      .localizedName()
+                      .updateTranslation(locale, screenUpdate.get().localizedName()))
+              .setLocalizedDescription(
+                  block
+                      .localizedDescription()
+                      .updateTranslation(locale, screenUpdate.get().localizedDescription()));
       toUpdateBlockBuilder.add(blockBuilder.build());
     }
 
@@ -802,11 +795,11 @@ public final class ProgramService {
               validateProgramText(
                   errorsBuilder,
                   ProgramTranslationForm.localizedScreenName(screenUpdate.blockIdToUpdate()),
-                  screenUpdate.localizedName().orElse(""));
+                  screenUpdate.localizedName());
               validateProgramText(
                   errorsBuilder,
                   ProgramTranslationForm.localizedScreenDescription(screenUpdate.blockIdToUpdate()),
-                  screenUpdate.localizedDescription().orElse(""));
+                  screenUpdate.localizedDescription());
             });
   }
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -81,7 +81,11 @@ public final class ProgramTranslationView extends TranslationFormView {
 
   private ImmutableList<DomContent> formFields(
       ProgramDefinition program, ProgramTranslationForm translationForm) {
-    LocalizationUpdate updateData = translationForm.getUpdateData(program);
+    ImmutableList<Long> blockIds =
+        program.blockDefinitions().stream()
+            .map(block -> block.id())
+            .collect(ImmutableList.toImmutableList());
+    LocalizationUpdate updateData = translationForm.getUpdateData(blockIds);
     String programDetailsLink =
         controllers.admin.routes.AdminProgramController.edit(
                 program.id(), ProgramEditStatus.EDIT.name())

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -81,7 +81,7 @@ public final class ProgramTranslationView extends TranslationFormView {
 
   private ImmutableList<DomContent> formFields(
       ProgramDefinition program, ProgramTranslationForm translationForm) {
-    LocalizationUpdate updateData = translationForm.getUpdateData();
+    LocalizationUpdate updateData = translationForm.getUpdateData(program);
     String programDetailsLink =
         controllers.admin.routes.AdminProgramController.edit(
                 program.id(), ProgramEditStatus.EDIT.name())

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -331,7 +331,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
     ProgramTranslationForm form =
         ProgramTranslationForm.fromProgram(
             program.getProgramDefinition(), Locale.FRENCH, instanceOf(FormFactory.class));
-    assertThat(form.getUpdateData())
+    assertThat(form.getUpdateData(program.getProgramDefinition()))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("french-name")
@@ -360,6 +360,6 @@ public class ProgramTranslationFormTest extends ResetPostgres {
         ProgramTranslationForm.fromProgram(
             program.getProgramDefinition(), Locale.FRENCH, instanceOf(FormFactory.class));
 
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isFalse();
+    assertThat(form.getUpdateData(program.getProgramDefinition()).localizedSummaryImageDescription().isPresent()).isFalse();
   }
 }

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -67,13 +67,16 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   public void bindFromRequest_extraStatusesInFormBodyBeyondSpecifiedAreIgnored() throws Exception {
     Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
+    ImmutableList<Long> blockIds = ImmutableList.of();
+
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 1,
-            /* hasSummaryImageDescription= */ false);
-    assertThat(form.getUpdateData())
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
+    assertThat(form.getUpdateData(blockIds))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("display name")
@@ -93,6 +96,8 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   public void bindFromRequest_missingStatusesInFormBodyAreOmmitted() throws Exception {
     Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
+    ImmutableList<Long> blockIds = ImmutableList.of();
+
     // While parsing the form, it's expected for there to be 3 distinct statuses. When there are
     // only 2 statuses provided in the request body, attempting to parse a 3rd should not throw
     // an error and just return a list of 2 updates.
@@ -101,8 +106,9 @@ public class ProgramTranslationFormTest extends ResetPostgres {
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 3,
-            /* hasSummaryImageDescription= */ false);
-    assertThat(form.getUpdateData())
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
+    assertThat(form.getUpdateData(blockIds))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("display name")
@@ -147,13 +153,16 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                     .build())
             .build();
 
+    ImmutableList<Long> blockIds = ImmutableList.of();
+
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 2,
-            /* hasSummaryImageDescription= */ false);
-    assertThat(form.getUpdateData())
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
+    assertThat(form.getUpdateData(blockIds))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("display name")
@@ -181,15 +190,18 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                         ProgramTranslationForm.DISPLAY_DESCRIPTION_FORM_NAME, "display description")
                     .build())
             .build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 0,
-            /* hasSummaryImageDescription= */ false);
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
 
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isFalse();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isFalse();
   }
 
   @Test
@@ -208,16 +220,20 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                     .build())
             .build();
 
+    ImmutableList<Long> blockIds = ImmutableList.of();
+
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 0,
             // ... But the form is set up to not have a description...
-            /* hasSummaryImageDescription= */ false);
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
 
     // ... Then the localization update doesn't contain the image description from the form.
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isFalse();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isFalse();
   }
 
   @Test
@@ -234,16 +250,19 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                         "fake image description")
                     .build())
             .build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 0,
-            /* hasSummaryImageDescription= */ true);
+            /* hasSummaryImageDescription= */ true,
+            blockIds);
 
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isTrue();
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().get())
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isTrue();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().get())
         .isEqualTo("fake image description");
   }
 
@@ -259,6 +278,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                         ProgramTranslationForm.DISPLAY_DESCRIPTION_FORM_NAME, "display description")
                     .build())
             .build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     // ...even though the form says there is an image description...
     ProgramTranslationForm form =
@@ -266,12 +286,14 @@ public class ProgramTranslationFormTest extends ResetPostgres {
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 0,
-            /* hasSummaryImageDescription= */ true);
+            /* hasSummaryImageDescription= */ true,
+            blockIds);
 
     // ... Then the form should still parse successfully.
-    assertThat(form.getUpdateData().localizedDisplayName()).isEqualTo("display name");
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isTrue();
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().get()).isEqualTo("");
+    assertThat(form.getUpdateData(blockIds).localizedDisplayName()).isEqualTo("display name");
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isTrue();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().get()).isEqualTo("");
   }
 
   @Test
@@ -286,16 +308,19 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                     .put(ProgramTranslationForm.IMAGE_DESCRIPTION_FORM_NAME, "")
                     .build())
             .build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 0,
-            /* hasSummaryImageDescription= */ true);
+            /* hasSummaryImageDescription= */ true,
+            blockIds);
 
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().isPresent()).isTrue();
-    assertThat(form.getUpdateData().localizedSummaryImageDescription().get()).isEqualTo("");
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isTrue();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().get()).isEqualTo("");
   }
 
   @Test
@@ -327,11 +352,12 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                                     .updateTranslation(Locale.FRENCH, "second-status-french"))
                             .build())))
             .build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     ProgramTranslationForm form =
         ProgramTranslationForm.fromProgram(
             program.getProgramDefinition(), Locale.FRENCH, instanceOf(FormFactory.class));
-    assertThat(form.getUpdateData(program.getProgramDefinition()))
+    assertThat(form.getUpdateData(blockIds))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("french-name")
@@ -355,11 +381,13 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   public void fromProgram_noSummaryImageDescription_fieldNotIncluded() {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("english-name", "english-description").build();
+    ImmutableList<Long> blockIds = ImmutableList.of();
 
     ProgramTranslationForm form =
         ProgramTranslationForm.fromProgram(
             program.getProgramDefinition(), Locale.FRENCH, instanceOf(FormFactory.class));
 
-    assertThat(form.getUpdateData(program.getProgramDefinition()).localizedSummaryImageDescription().isPresent()).isFalse();
+    assertThat(form.getUpdateData(blockIds).localizedSummaryImageDescription().isPresent())
+        .isFalse();
   }
 }

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -36,13 +36,16 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   public void bindFromRequest() throws Exception {
     Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
+    ImmutableList<Long> blockIds = ImmutableList.of();
+
     ProgramTranslationForm form =
         ProgramTranslationForm.bindFromRequest(
             request,
             instanceOf(FormFactory.class),
             /* maxStatusTranslations= */ 2,
-            /* hasSummaryImageDescription= */ false);
-    assertThat(form.getUpdateData())
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
+    assertThat(form.getUpdateData(blockIds))
         .isEqualTo(
             LocalizationUpdate.builder()
                 .setLocalizedDisplayName("display name")

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -32,6 +32,16 @@ public class ProgramTranslationFormTest extends ResetPostgres {
           .put(ProgramTranslationForm.localizedEmailFieldName(1), "second status email")
           .build();
 
+  private static final ImmutableMap<String, String> REQUEST_DATA_WITH_TWO_BLOCKS_TRANSLATED =
+      ImmutableMap.<String, String>builder()
+          .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
+          .put(ProgramTranslationForm.DISPLAY_DESCRIPTION_FORM_NAME, "display description")
+          .put(ProgramTranslationForm.localizedScreenName(0), "first block name")
+          .put(ProgramTranslationForm.localizedScreenDescription(0), "first block description")
+          .put(ProgramTranslationForm.localizedScreenName(1), "second block name")
+          .put(ProgramTranslationForm.localizedScreenDescription(1), "second block description")
+          .build();
+
   @Test
   public void bindFromRequest() throws Exception {
     Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
@@ -132,6 +142,41 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                             .setLocalizedEmailBody(Optional.of("second status email"))
                             .build()))
                 .setScreens(ImmutableList.of())
+                .build());
+  }
+
+  @Test
+  public void bindFromRequest_includesScreenNameAndDescription() throws Exception {
+    Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_BLOCKS_TRANSLATED).build();
+
+    ImmutableList<Long> blockIds = ImmutableList.of(0l, 1l);
+
+    ProgramTranslationForm form =
+        ProgramTranslationForm.bindFromRequest(
+            request,
+            instanceOf(FormFactory.class),
+            /* maxStatusTranslations= */ 3,
+            /* hasSummaryImageDescription= */ false,
+            blockIds);
+    assertThat(form.getUpdateData(blockIds))
+        .isEqualTo(
+            LocalizationUpdate.builder()
+                .setLocalizedDisplayName("display name")
+                .setLocalizedDisplayDescription("display description")
+                .setLocalizedConfirmationMessage("")
+                .setStatuses(ImmutableList.of())
+                .setScreens(
+                    ImmutableList.of(
+                        LocalizationUpdate.ScreenUpdate.builder()
+                            .setBlockIdToUpdate(0l)
+                            .setLocalizedName("first block name")
+                            .setLocalizedDescription("first block description")
+                            .build(),
+                        LocalizationUpdate.ScreenUpdate.builder()
+                            .setBlockIdToUpdate(1l)
+                            .setLocalizedName("second block name")
+                            .setLocalizedDescription("second block description")
+                            .build()))
                 .build());
   }
 

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -63,6 +63,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                             .setLocalizedStatusText(Optional.of("second status text"))
                             .setLocalizedEmailBody(Optional.of("second status email"))
                             .build()))
+                .setScreens(ImmutableList.of())
                 .build());
   }
 
@@ -92,6 +93,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                             .setLocalizedStatusText(Optional.of("first status text"))
                             .setLocalizedEmailBody(Optional.of("first status email"))
                             .build()))
+                .setScreens(ImmutableList.of())
                 .build());
   }
 
@@ -129,6 +131,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                             .setLocalizedStatusText(Optional.of("second status text"))
                             .setLocalizedEmailBody(Optional.of("second status email"))
                             .build()))
+                .setScreens(ImmutableList.of())
                 .build());
   }
 
@@ -179,6 +182,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                         LocalizationUpdate.StatusUpdate.builder()
                             .setStatusKeyToUpdate("second configured status text")
                             .build()))
+                .setScreens(ImmutableList.of())
                 .build());
   }
 
@@ -377,6 +381,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
                             .setStatusKeyToUpdate("second-status-english")
                             .setLocalizedStatusText(Optional.of("second-status-french"))
                             .build()))
+                .setScreens(ImmutableList.of())
                 .build());
   }
 

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2239,6 +2239,7 @@ public class ProgramServiceTest extends ResetPostgres {
                         .setStatusKeyToUpdate(STATUS_WITH_NO_EMAIL_ENGLISH_NAME)
                         .setLocalizedStatusText(Optional.of("german-status-with-no-email"))
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateLocalization(program.id, Locale.GERMAN, updateData);
@@ -2313,6 +2314,7 @@ public class ProgramServiceTest extends ResetPostgres {
                         .setLocalizedStatusText(
                             Optional.of(STATUS_WITH_NO_EMAIL_FRENCH_NAME + "-updated"))
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateLocalization(program.id, Locale.FRENCH, updateData);
@@ -2363,6 +2365,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .setLocalizedDisplayDescription("")
             .setLocalizedConfirmationMessage("")
             .setStatuses(ImmutableList.of())
+            .setScreens(ImmutableList.of())
             .build();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateLocalization(program.id, Locale.FRENCH, updateData);
@@ -2382,6 +2385,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .setLocalizedDisplayDescription("a description")
             .setLocalizedConfirmationMessage("")
             .setStatuses(ImmutableList.of())
+            .setScreens(ImmutableList.of())
             .build();
     assertThatThrownBy(() -> ps.updateLocalization(1000L, Locale.FRENCH, updateData))
         .isInstanceOf(ProgramNotFoundException.class)
@@ -2412,6 +2416,7 @@ public class ProgramServiceTest extends ResetPostgres {
                     LocalizationUpdate.StatusUpdate.builder()
                         .setStatusKeyToUpdate(STATUS_WITH_NO_EMAIL_ENGLISH_NAME)
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateLocalization(program.id, Locale.FRENCH, updateData);
@@ -2475,6 +2480,7 @@ public class ProgramServiceTest extends ResetPostgres {
                         .setStatusKeyToUpdate(STATUS_WITH_NO_EMAIL_ENGLISH_NAME)
                         .setLocalizedStatusText(Optional.of("german-status-with-no-email"))
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
 
     assertThatThrownBy(() -> ps.updateLocalization(program.id, Locale.FRENCH, updateData))
@@ -2501,6 +2507,7 @@ public class ProgramServiceTest extends ResetPostgres {
                         .setLocalizedStatusText(Optional.of("german-status-with-email"))
                         .setLocalizedEmailBody(Optional.of("german email body"))
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
 
     assertThatThrownBy(() -> ps.updateLocalization(program.id, Locale.FRENCH, updateData))
@@ -2538,6 +2545,7 @@ public class ProgramServiceTest extends ResetPostgres {
                             Optional.of(STATUS_WITH_NO_EMAIL_FRENCH_NAME + "-updated"))
                         .setLocalizedEmailBody(Optional.of("a localized email"))
                         .build()))
+            .setScreens(ImmutableList.of())
             .build();
 
     assertThatThrownBy(() -> ps.updateLocalization(program.id, Locale.FRENCH, updateData))
@@ -2557,6 +2565,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .setLocalizedConfirmationMessage("")
             .setLocalizedSummaryImageDescription("invalid French image description")
             .setStatuses(ImmutableList.of())
+            .setScreens(ImmutableList.of())
             .build();
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2358,21 +2358,21 @@ public class ProgramServiceTest extends ResetPostgres {
   @Test
   public void updateLocalizations_blockTranslationsProvided() throws Exception {
     ProgramModel program =
-    ProgramBuilder.newDraftProgram("English name", "English description")
-        .withLocalizedName(Locale.FRENCH, "existing French name")
-        .withLocalizedDescription(Locale.FRENCH, "existing French description")
-        .withLocalizedConfirmationMessage(Locale.FRENCH, "")
-        .setLocalizedSummaryImageDescription(
-            LocalizedStrings.of(
-                Locale.US,
-                "English image description",
-                Locale.FRENCH,
-                "existing French image description"))
-        .withBlock("first block", "a description")
-        .withBlock("second block", "another description")
-        .build();
+        ProgramBuilder.newDraftProgram("English name", "English description")
+            .withLocalizedName(Locale.FRENCH, "existing French name")
+            .withLocalizedDescription(Locale.FRENCH, "existing French description")
+            .withLocalizedConfirmationMessage(Locale.FRENCH, "")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(
+                    Locale.US,
+                    "English image description",
+                    Locale.FRENCH,
+                    "existing French image description"))
+            .withBlock("first block", "a description")
+            .withBlock("second block", "another description")
+            .build();
 
-        LocalizationUpdate updateData =
+    LocalizationUpdate updateData =
         LocalizationUpdate.builder()
             .setLocalizedDisplayName("new French name")
             .setLocalizedDisplayDescription("new French description")
@@ -2386,7 +2386,7 @@ public class ProgramServiceTest extends ResetPostgres {
                         .setLocalizedName("a french screen name")
                         .setLocalizedDescription("a french description")
                         .build(),
-                        LocalizationUpdate.ScreenUpdate.builder()
+                    LocalizationUpdate.ScreenUpdate.builder()
                         .setBlockIdToUpdate(2L)
                         .setLocalizedName("a second french screen name")
                         .setLocalizedDescription("another french description")
@@ -2399,10 +2399,13 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramDefinition definition = result.getResult();
     BlockDefinition firstBlock = definition.getBlockDefinition(1L);
     assertThat(firstBlock.localizedName().get(Locale.FRENCH)).isEqualTo("a french screen name");
-    assertThat(firstBlock.localizedDescription().get(Locale.FRENCH)).isEqualTo("a french description");
+    assertThat(firstBlock.localizedDescription().get(Locale.FRENCH))
+        .isEqualTo("a french description");
     BlockDefinition secondBlock = definition.getBlockDefinition(2L);
-    assertThat(secondBlock.localizedName().get(Locale.FRENCH)).isEqualTo("a second french screen name");
-    assertThat(secondBlock.localizedDescription().get(Locale.FRENCH)).isEqualTo("another french description");
+    assertThat(secondBlock.localizedName().get(Locale.FRENCH))
+        .isEqualTo("a second french screen name");
+    assertThat(secondBlock.localizedDescription().get(Locale.FRENCH))
+        .isEqualTo("another french description");
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2409,6 +2409,85 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void updateLocalizations_blockTranslationsForNonexistantBlock() throws Exception {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("English name", "English description")
+            .withLocalizedName(Locale.FRENCH, "existing French name")
+            .withLocalizedDescription(Locale.FRENCH, "existing French description")
+            .withLocalizedConfirmationMessage(Locale.FRENCH, "")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(
+                    Locale.US,
+                    "English image description",
+                    Locale.FRENCH,
+                    "existing French image description"))
+            .withBlock("first block", "a description")
+            .build();
+
+    LocalizationUpdate updateData =
+        LocalizationUpdate.builder()
+            .setLocalizedDisplayName("new French name")
+            .setLocalizedDisplayDescription("new French description")
+            .setLocalizedSummaryImageDescription("new French image description")
+            .setLocalizedConfirmationMessage("")
+            .setStatuses(ImmutableList.of())
+            .setScreens(
+                ImmutableList.of(
+                    LocalizationUpdate.ScreenUpdate.builder()
+                        .setBlockIdToUpdate(3L)
+                        .setLocalizedName("a second french screen name")
+                        .setLocalizedDescription("another french description")
+                        .build()))
+            .build();
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.updateLocalization(program.id, Locale.FRENCH, updateData);
+
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors()).containsExactly(CiviFormError.of("Found invalid block id 3"));
+  }
+
+  @Test
+  public void updateLocalizations_blockTranslationsEmpty() throws Exception {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("English name", "English description")
+            .withLocalizedName(Locale.FRENCH, "existing French name")
+            .withLocalizedDescription(Locale.FRENCH, "existing French description")
+            .withLocalizedConfirmationMessage(Locale.FRENCH, "")
+            .setLocalizedSummaryImageDescription(
+                LocalizedStrings.of(
+                    Locale.US,
+                    "English image description",
+                    Locale.FRENCH,
+                    "existing French image description"))
+            .withBlock("first block", "a description")
+            .build();
+
+    LocalizationUpdate updateData =
+        LocalizationUpdate.builder()
+            .setLocalizedDisplayName("new French name")
+            .setLocalizedDisplayDescription("new French description")
+            .setLocalizedSummaryImageDescription("new French image description")
+            .setLocalizedConfirmationMessage("")
+            .setStatuses(ImmutableList.of())
+            .setScreens(
+                ImmutableList.of(
+                    LocalizationUpdate.ScreenUpdate.builder()
+                        .setBlockIdToUpdate(1L)
+                        .setLocalizedName("")
+                        .setLocalizedDescription("")
+                        .build()))
+            .build();
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.updateLocalization(program.id, Locale.FRENCH, updateData);
+
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .containsExactly(
+            CiviFormError.of("program screen-name-1 cannot be blank"),
+            CiviFormError.of("program screen-description-1 cannot be blank"));
+  }
+
+  @Test
   public void updateLocalizations_returnsErrorMessages() throws Exception {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
 


### PR DESCRIPTION
### Description

Adds the plumbing to allow translations to be specified for block names/descriptions. A follow up PR will add the form inputs required for admins to specify those values

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Progress towards #7606