### PR TITLE
DEMO PR: Showing adding a button to Thymeleaf and J2HTML

### DIFF
--- a/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
@@ -45,6 +45,7 @@
           class="usa-button usa-button--outline"
           th:text="#{button.review}"
         ></button>
+        <button th:text="${randomButtonText}" class="usa-button"></button>
       </form>
     </div>
     <div th:replace="~{applicant/ModalFragment:: modalContainer}"></div>

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -1,6 +1,7 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
@@ -251,12 +252,17 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
         .withClasses(ApplicantStyles.APPLICATION_NAV_BAR)
         .with(renderReviewButton(settingsManifest, params))
         .with(renderPreviousButton(settingsManifest, params))
-        .with(renderNextButton(params));
+        .with(renderNextButton(params))
+        .with(renderRandomButton());
   }
 
   private ButtonTag renderNextButton(ApplicationBaseViewParams params) {
     return submitButton(params.messages().at(MessageKey.BUTTON_NEXT_SCREEN.getKeyName()))
         .withClasses(ButtonStyles.SOLID_BLUE)
         .withId("cf-block-submit");
+  }
+
+  private ButtonTag renderRandomButton() {
+    return button("Hello world this is not a real PR").withClasses("usa-button");
   }
 }

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -76,6 +76,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarAppli
           getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
+      context.setVariable("randomButtonText", "Hello world this is not a real PR");
       return templateEngine.process("applicant/ApplicantProgramBlockEditTemplate", context);
     }
   }


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

The title of the pull request will be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups

#### User visible changes

- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
  - [ ] Follow the workflow [here](<https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#workflow-for-adding-or-editing-translations>)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
