### PR TITLE
Alert if merge to main has failured tests

### DIFF
--- a/.github/workflows/push_tests.yaml
+++ b/.github/workflows/push_tests.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id:  ${{ env.SLACK_CI_CHANNEL }}
-          slack-message: "${{ env.STATUS_ICON }} AWS Staging Deploy for ${{ env.LATEST_SNAPSHOT_TAG }}: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+          slack-message: "${{ env.STATUS_ICON }} Merging PR to Main had failed test(s). See: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           STATUS_ICON: ${{fromJSON('[":no_entry:", ":white_check_mark:"]')[job.status == 'success']}}

--- a/.github/workflows/push_tests.yaml
+++ b/.github/workflows/push_tests.yaml
@@ -14,3 +14,18 @@ jobs:
   run_all_tests:
     uses: ./.github/workflows/tests.yaml
     secrets: inherit
+
+  on_failure:
+    needs: [ run_all_tests ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send alert
+        if: needs.run_parent.result == 'failure'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id:  ${{ env.SLACK_CI_CHANNEL }}
+          slack-message: "${{ env.STATUS_ICON }} AWS Staging Deploy for ${{ env.LATEST_SNAPSHOT_TAG }}: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          STATUS_ICON: ${{fromJSON('[":no_entry:", ":white_check_mark:"]')[job.status == 'success']}}


### PR DESCRIPTION
### Description

The `On Push to Main` github action, which runs when a PR is merged into the main branch, can have tests fail. The only way to know is if you watch the actions or see the badge on the main github page for the `civiform/civiform` repository. Just adding Slack message to the eng-ci channel to raise awareness of potential problems.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
