### PR TITLE
Refactor ValidationErrorMessage assertions in question tests

### DIFF
--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.LocalizedStrings;
 import services.MessageKey;
-import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.geo.ServiceAreaState;
@@ -233,13 +232,12 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        addressQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(ValidationErrorMessage.create(MessageKey.ADDRESS_VALIDATION_NO_PO_BOX));
+    assertThat(addressQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(MessageKey.ADDRESS_VALIDATION_NO_PO_BOX))));
   }
 
   @Test

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -91,14 +91,13 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly(value);
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        enumeratorQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(
-            ValidationErrorMessage.create(MessageKey.ENUMERATOR_VALIDATION_ENTITY_REQUIRED));
+    assertThat(enumeratorQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(
+                        MessageKey.ENUMERATOR_VALIDATION_ENTITY_REQUIRED))));
   }
 
   @Test
@@ -114,14 +113,13 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly("hello", "hello");
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        enumeratorQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(
-            ValidationErrorMessage.create(MessageKey.ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME));
+    assertThat(enumeratorQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(
+                        MessageKey.ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME))));
   }
 
   @Test

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.MessageKey;
-import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
 import services.program.ProgramQuestionDefinition;
@@ -81,13 +80,12 @@ public class MultiSelectQuestionTest extends ResetPostgres {
 
     MultiSelectQuestion multiSelectQuestion = new MultiSelectQuestion(applicantQuestion);
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        multiSelectQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_FEW, 2));
+    assertThat(multiSelectQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_FEW, 2))));
   }
 
   @Test
@@ -115,13 +113,12 @@ public class MultiSelectQuestionTest extends ResetPostgres {
 
     MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        multiSelectQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_FEW, 2));
+    assertThat(multiSelectQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_FEW, 2))));
   }
 
   @Test
@@ -140,14 +137,13 @@ public class MultiSelectQuestionTest extends ResetPostgres {
 
     MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        multiSelectQuestion.getValidationErrors();
-    assertThat(validationErrors.size()).isEqualTo(1);
-    assertThat(
-            validationErrors.getOrDefault(
-                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
-        .containsOnly(
-            ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_MANY, 4));
+    assertThat(multiSelectQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                applicantQuestion.getContextualizedPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(
+                        MessageKey.MULTI_SELECT_VALIDATION_TOO_MANY, 4))));
   }
 
   @Test


### PR DESCRIPTION
### Description

Refactor ValidationErrorMessage assertions in question tests:
* containsOnly allows duplicates, which is not desirable
* getOrDefault is kind of kludgy when the value should always exist
* It's clearer to assert on the whole validation errors object, rather than certain attributes like its size and a value for a specific key. Most similar tests already used this approach.
* For parameterized tests, switch from inputs as strings to fully typed ValidationErrorMessage, so it matches non-parameterized versions and validates the underlying object rather than just its string representation (e.g. several MessageKeys have the same string "Must contain at most {0} characters."

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
