### PR TITLE
Refresh enumerator entity add button status on page load

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -354,6 +354,19 @@ test.describe('End to end enumerator test', () => {
           page.locator('#enumerator-field-add-button'),
         ).toHaveAttribute('disabled')
       })
+
+      await test.step('Add button is still disabled after trying to save', async () => {
+        await applicantQuestions.clickNext()
+
+        // Error shows because of the empty entity
+        await expect(
+          page.locator('.cf-applicant-question-errors'),
+        ).toBeVisible()
+
+        await expect(
+          page.locator('#enumerator-field-add-button'),
+        ).toHaveAttribute('disabled')
+      })
     })
 
     test('Applicant can navigate to previous blocks', async ({

--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -4,6 +4,8 @@
 import {addEventListenerToElements, assertNotNull} from './util'
 
 export function init() {
+  refreshAddButtonStatus()
+
   addEventListenerToElements(
     '.cf-question-enumerator input[data-entity-input]',
     'input',
@@ -169,21 +171,19 @@ function setFocusAfterEnumeratorRemoval() {
  * inputs).
  */
 function refreshAddButtonStatus() {
-  const enumeratorQuestion = assertNotNull(
-    document.querySelector('.cf-question-enumerator'),
-  )
-  if (enumeratorQuestion) {
-    const enumeratorInputValues = Array.from(
-      enumeratorQuestion.querySelectorAll('input[data-entity-input]'),
-    ).map((item) => (item as HTMLInputElement).value)
+  const enumeratorInputValues = Array.from(
+    document.querySelectorAll(
+      '.cf-question-enumerator input[data-entity-input]',
+    ),
+  ).map((item) => (item as HTMLInputElement).value)
 
-    // validate that there are no empty inputs.
-    const addButton = <HTMLInputElement>(
-      document.getElementById('enumerator-field-add-button')
-    )
-    if (addButton) {
-      addButton.disabled = enumeratorInputValues.includes('')
-    }
+  // validate that there are no empty inputs.
+  const addButton = document.getElementById(
+    'enumerator-field-add-button',
+  ) as HTMLInputElement
+
+  if (addButton) {
+    addButton.disabled = enumeratorInputValues.includes('')
   }
 }
 


### PR DESCRIPTION
### Description

Refresh enumerator entity add button status on page load

Also refactor refreshAddButtonStatus so that it works when run on a page without an enumerator, and combines the two selector calls into one.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #7733
