### PR TITLE
Add toasts to summary/review page

### DIFF
--- a/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
@@ -110,7 +110,7 @@ test.describe('Applicant navigation flow', () => {
           )
         })
 
-        test('shows error with incomplete submission', async ({
+        test('shows error toast with incomplete submission', async ({
           page,
           applicantQuestions,
         }) => {

--- a/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
@@ -95,8 +95,11 @@ test.describe('Applicant navigation flow', () => {
       'review page with North Star enabled',
       {tag: ['@northstar']},
       () => {
-        test('validate screenshot', async ({page, applicantQuestions}) => {
+        test.beforeEach(async ({page}) => {
           await enableFeatureFlag(page, 'north_star_applicant_ui')
+        })
+
+        test('validate screenshot', async ({page, applicantQuestions}) => {
           await applicantQuestions.clickApplyProgramButton(programName)
 
           await validateScreenshot(
@@ -104,6 +107,34 @@ test.describe('Applicant navigation flow', () => {
             'north-star-program-preview',
             /* fullPage= */ true,
             /* mobileScreenshot= */ true,
+          )
+        })
+
+        test('shows error with incomplete submission', async ({
+          page,
+          applicantQuestions,
+        }) => {
+          test.slow()
+
+          await applicantQuestions.clickApplyProgramButton(programName)
+
+          // The UI correctly won't let us submit because the application isn't complete.
+          // To fake submitting an incomplete application add a submit button and click it.
+          // Note the form already triggers for the submit action.
+          // A clearer way to set this up would be to have two browser contexts but that isn't doable in our setup.
+          await page.evaluate(() => {
+            const buttonEl = document.createElement('button')
+            buttonEl.id = 'test-form-submit'
+            buttonEl.type = 'submit'
+            const formEl = document.querySelector('.cf-debounced-form')!
+            formEl.appendChild(buttonEl)
+          })
+          const submitButton = page.locator('#test-form-submit')
+          await submitButton.click()
+
+          await validateToastMessage(
+            page,
+            "Error: There's been an update to the application",
           )
         })
       },

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -100,67 +100,6 @@ test.describe('Applicant navigation flow', () => {
       await validateAccessibility(page)
     })
 
-    test(
-      'North Star shows ineligible on home page',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
-        await applicantQuestions.applyProgram(fullProgramName)
-
-        await test.step('fill out application and submit', async () => {
-          await applicantQuestions.answerNumberQuestion('1')
-          await applicantQuestions.clickContinue()
-          await applicantQuestions.expectIneligiblePage()
-        })
-
-        await test.step('verify question is marked ineligible', async () => {
-          await applicantQuestions.gotoApplicantHomePage()
-          await applicantQuestions.seeEligibilityTag(
-            fullProgramName,
-            /* isEligible= */ false,
-          )
-
-          await validateScreenshot(
-            page,
-            'ineligible-home-page-program-tagnorthstar',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-        await disableFeatureFlag(page, 'north_star_applicant_ui')
-      },
-    )
-
-    test(
-      'North Star shows eligible on home page',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
-        await applicantQuestions.applyProgram(fullProgramName)
-
-        await test.step('fill out application and submit', async () => {
-          await applicantQuestions.answerNumberQuestion('5')
-          await applicantQuestions.clickContinue()
-        })
-
-        await test.step('verify question is marked eligible', async () => {
-          await applicantQuestions.gotoApplicantHomePage()
-          await applicantQuestions.seeEligibilityTag(
-            fullProgramName,
-            /* isEligible= */ true,
-          )
-
-          await validateScreenshot(
-            page,
-            'eligible-home-page-program-tagnorthstar',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        })
-        await disableFeatureFlag(page, 'north_star_applicant_ui')
-      },
-    )
-
     test('shows may be eligible with an eligible answer', async ({
       page,
       applicantQuestions,
@@ -203,27 +142,6 @@ test.describe('Applicant navigation flow', () => {
         /* isEligible= */ true,
       )
     })
-
-    test(
-      'North Star shows may be eligible toast with an eligible answer',
-      {tag: ['@northstar']},
-      async ({page, applicantQuestions}) => {
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
-        await applicantQuestions.applyProgram(fullProgramName)
-
-        // Fill out application and without submitting.
-        await applicantQuestions.answerNumberQuestion('5')
-        await applicantQuestions.clickContinue()
-        await validateToastMessage(page, 'may qualify')
-        await validateScreenshot(
-          page,
-          'north-star-eligible-toast',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-        await disableFeatureFlag(page, 'north_star_applicant_ui')
-      },
-    )
 
     test('shows not eligible with ineligible answer from another application', async ({
       page,
@@ -451,6 +369,108 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.submitFromReviewPage()
       await applicantQuestions.gotoApplicantHomePage()
       await applicantQuestions.seeNoEligibilityTags(fullProgramName)
+    })
+
+    test.describe('With north star flag enabled', {tag: ['@northstar']}, () => {
+
+      test.beforeEach(async({page}) => {
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+      })
+
+      test('Shows ineligible on home page', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(fullProgramName)
+
+        await test.step('fill out application and submit', async () => {
+          await applicantQuestions.answerNumberQuestion('1')
+          await applicantQuestions.clickContinue()
+          await applicantQuestions.expectIneligiblePage()
+        })
+
+        await test.step('verify question is marked ineligible', async () => {
+          await applicantQuestions.gotoApplicantHomePage()
+          await applicantQuestions.seeEligibilityTag(
+            fullProgramName,
+            /* isEligible= */ false,
+          )
+
+          await validateScreenshot(
+            page,
+            'ineligible-home-page-program-tagnorthstar',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
+      })
+
+      test('Shows eligible on home page', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(fullProgramName)
+
+        await test.step('fill out application and submit', async () => {
+          await applicantQuestions.answerNumberQuestion('5')
+          await applicantQuestions.clickContinue()
+        })
+
+        await test.step('verify question is marked eligible', async () => {
+          await applicantQuestions.gotoApplicantHomePage()
+          await applicantQuestions.seeEligibilityTag(
+            fullProgramName,
+            /* isEligible= */ true,
+          )
+
+          await validateScreenshot(
+            page,
+            'eligible-home-page-program-tagnorthstar',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        })
+      })
+
+      test(
+        'Shows may be eligible toast with an eligible answer',
+        async ({page, applicantQuestions}) => {
+          await applicantQuestions.applyProgram(fullProgramName)
+  
+          // Fill out application and without submitting.
+          await applicantQuestions.answerNumberQuestion('5')
+          await applicantQuestions.clickContinue()
+          await validateToastMessage(page, 'may qualify')
+          await validateScreenshot(
+            page,
+            'north-star-eligible-toast',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        }
+      )
+
+      test('shows not eligible on review page with ineligible answer', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(fullProgramName)
+  
+        // Fill out application and submit.
+        await applicantQuestions.answerNumberQuestion('1')
+        await applicantQuestions.clickContinue()
+        await applicantQuestions.expectIneligiblePage()
+  
+        // Verify the question is marked ineligible.
+        await applicantQuestions.gotoApplicantHomePage()
+        await applicantQuestions.seeEligibilityTag(
+          fullProgramName,
+          /* isEligible= */ false,
+        )
+        await applicantQuestions.clickApplyProgramButton(fullProgramName)
+  
+        await validateToastMessage(page, 'may not qualify')
+      })
     })
   })
 })

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -375,7 +375,7 @@ test.describe('Applicant navigation flow', () => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
-      test('Shows ineligible on home page', async ({
+      test('Shows ineligible tag on home page program cards', async ({
         page,
         applicantQuestions,
       }) => {
@@ -414,7 +414,7 @@ test.describe('Applicant navigation flow', () => {
           await applicantQuestions.clickContinue()
         })
 
-        await test.step('verify question is marked eligible', async () => {
+        await test.step('verify program is marked eligible', async () => {
           await applicantQuestions.gotoApplicantHomePage()
           await applicantQuestions.seeEligibilityTag(
             fullProgramName,
@@ -430,7 +430,7 @@ test.describe('Applicant navigation flow', () => {
         })
       })
 
-      test('Shows may be eligible toast with an eligible answer', async ({
+      test('Shows may be eligible toast on block edit page with an eligible answer', async ({
         page,
         applicantQuestions,
       }) => {
@@ -448,7 +448,7 @@ test.describe('Applicant navigation flow', () => {
         )
       })
 
-      test('shows not eligible on review page with ineligible answer', async ({
+      test('shows not eligible toast on review page with ineligible answer', async ({
         page,
         applicantQuestions,
       }) => {

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -1,7 +1,6 @@
 import {test} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -372,8 +371,7 @@ test.describe('Applicant navigation flow', () => {
     })
 
     test.describe('With north star flag enabled', {tag: ['@northstar']}, () => {
-
-      test.beforeEach(async({page}) => {
+      test.beforeEach(async ({page}) => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
@@ -432,35 +430,35 @@ test.describe('Applicant navigation flow', () => {
         })
       })
 
-      test(
-        'Shows may be eligible toast with an eligible answer',
-        async ({page, applicantQuestions}) => {
-          await applicantQuestions.applyProgram(fullProgramName)
-  
-          // Fill out application and without submitting.
-          await applicantQuestions.answerNumberQuestion('5')
-          await applicantQuestions.clickContinue()
-          await validateToastMessage(page, 'may qualify')
-          await validateScreenshot(
-            page,
-            'north-star-eligible-toast',
-            /* fullPage= */ true,
-            /* mobileScreenshot= */ true,
-          )
-        }
-      )
+      test('Shows may be eligible toast with an eligible answer', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await applicantQuestions.applyProgram(fullProgramName)
+
+        // Fill out application and without submitting.
+        await applicantQuestions.answerNumberQuestion('5')
+        await applicantQuestions.clickContinue()
+        await validateToastMessage(page, 'may qualify')
+        await validateScreenshot(
+          page,
+          'north-star-eligible-toast',
+          /* fullPage= */ true,
+          /* mobileScreenshot= */ true,
+        )
+      })
 
       test('shows not eligible on review page with ineligible answer', async ({
         page,
         applicantQuestions,
       }) => {
         await applicantQuestions.applyProgram(fullProgramName)
-  
+
         // Fill out application and submit.
         await applicantQuestions.answerNumberQuestion('1')
         await applicantQuestions.clickContinue()
         await applicantQuestions.expectIneligiblePage()
-  
+
         // Verify the question is marked ineligible.
         await applicantQuestions.gotoApplicantHomePage()
         await applicantQuestions.seeEligibilityTag(
@@ -468,7 +466,7 @@ test.describe('Applicant navigation flow', () => {
           /* isEligible= */ false,
         )
         await applicantQuestions.clickApplyProgramButton(fullProgramName)
-  
+
         await validateToastMessage(page, 'may not qualify')
       })
     })

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -106,10 +106,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
     }
 
     boolean isTrustedIntermediary = submittingProfile.get().isTrustedIntermediary();
-    Optional<ToastMessage> flashBanner =
-        request.flash().get("banner").map(m -> ToastMessage.alert(m));
-    Optional<ToastMessage> flashSuccessBanner =
-        request.flash().get("success-banner").map(m -> ToastMessage.success(m));
+    Optional<String> flashBannerMessage = request.flash().get("banner");
+    Optional<ToastMessage> flashBanner = flashBannerMessage.map(m -> ToastMessage.alert(m));
+    Optional<String> flashSuccessBannerMessage = request.flash().get("success-banner");
+    Optional<ToastMessage> flashSuccessBanner = flashSuccessBannerMessage.map(m -> ToastMessage.success(m));
     CompletionStage<ApplicantPersonalInfo> applicantStage =
         applicantService.getPersonalInfo(applicantId, request);
 
@@ -123,8 +123,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
             (roApplicantProgramService) -> {
               Messages messages = messagesApi.preferred(request);
               Optional<ToastMessage> notEligibleBanner = Optional.empty();
+              boolean shouldShowNotEligibleBanner = false;
               try {
-                if (shouldShowNotEligibleBanner(roApplicantProgramService, programId)) {
+                shouldShowNotEligibleBanner = shouldShowNotEligibleBanner(roApplicantProgramService, programId);
+                if (shouldShowNotEligibleBanner) {
                   notEligibleBanner =
                       Optional.of(
                           ToastMessage.alert(
@@ -189,6 +191,9 @@ public class ApplicantProgramReviewController extends CiviFormController {
                         .setCompletedBlockCount(completedBlockCount)
                         .setTotalBlockCount(totalBlockCount)
                         .setMessages(messages)
+                        .setAlertBannerMessage(flashBannerMessage)
+                        .setSuccessBannerMessage(flashSuccessBannerMessage)
+                        .setShouldShowNotEligibleBanner(shouldShowNotEligibleBanner)
                         .build();
                 return ok(northStarSummaryView.render(request, northStarParams))
                     .as(Http.MimeTypes.HTML);

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -109,7 +109,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
     Optional<String> flashBannerMessage = request.flash().get("banner");
     Optional<ToastMessage> flashBanner = flashBannerMessage.map(m -> ToastMessage.alert(m));
     Optional<String> flashSuccessBannerMessage = request.flash().get("success-banner");
-    Optional<ToastMessage> flashSuccessBanner = flashSuccessBannerMessage.map(m -> ToastMessage.success(m));
+    Optional<ToastMessage> flashSuccessBanner =
+        flashSuccessBannerMessage.map(m -> ToastMessage.success(m));
     CompletionStage<ApplicantPersonalInfo> applicantStage =
         applicantService.getPersonalInfo(applicantId, request);
 
@@ -123,18 +124,20 @@ public class ApplicantProgramReviewController extends CiviFormController {
             (roApplicantProgramService) -> {
               Messages messages = messagesApi.preferred(request);
               Optional<ToastMessage> notEligibleBanner = Optional.empty();
-              boolean shouldShowNotEligibleBanner = false;
+              Optional<String> notEligibleBannerMessage = Optional.empty();
               try {
-                shouldShowNotEligibleBanner = shouldShowNotEligibleBanner(roApplicantProgramService, programId);
+                boolean shouldShowNotEligibleBanner =
+                    shouldShowNotEligibleBanner(roApplicantProgramService, programId);
                 if (shouldShowNotEligibleBanner) {
-                  notEligibleBanner =
+                  notEligibleBannerMessage =
                       Optional.of(
-                          ToastMessage.alert(
-                              messages.at(
-                                  isTrustedIntermediary
-                                      ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
-                                      : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
-                                  roApplicantProgramService.getProgramTitle())));
+                          messages.at(
+                              isTrustedIntermediary
+                                  ? MessageKey.TOAST_MAY_NOT_QUALIFY_TI.getKeyName()
+                                  : MessageKey.TOAST_MAY_NOT_QUALIFY.getKeyName(),
+                              roApplicantProgramService.getProgramTitle()));
+                  notEligibleBanner =
+                      Optional.of(ToastMessage.alert(notEligibleBannerMessage.get()));
                 }
               } catch (ProgramNotFoundException e) {
                 return notFound(e.toString());
@@ -193,7 +196,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                         .setMessages(messages)
                         .setAlertBannerMessage(flashBannerMessage)
                         .setSuccessBannerMessage(flashSuccessBannerMessage)
-                        .setShouldShowNotEligibleBanner(shouldShowNotEligibleBanner)
+                        .setNotEligibleBannerMessage(notEligibleBannerMessage)
                         .build();
                 return ok(northStarSummaryView.render(request, northStarParams))
                     .as(Http.MimeTypes.HTML);

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -58,7 +58,7 @@
         </li>
       </ul>
 
-      <form th:action="${submitUrl}" method="POST">
+      <form class="cf-debounced-form" th:action="${submitUrl}" method="POST">
         <input hidden th:value="${csrfToken}" name="csrfToken" />
         <button
           th:if="${hasCompletedAllBlocks}"

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -5,6 +5,7 @@
   <body>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
     <div role="main">
+      <div th:replace="~{components/ToastFragment :: summaryToasts}"></div>
       <h1 th:text="#{title.getStarted}"></h1>
       <p th:text="#{content.reviewPageIntro}"></p>
       <ul class="usa-card-group">

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -55,6 +55,12 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
     context.setVariable(
         "hasCompletedAllBlocks", params.completedBlockCount() == params.totalBlockCount());
     context.setVariable("submitUrl", getSubmitUrl(params));
+
+    // Toasts
+    context.setVariable("alertBannerMessage", params.alertBannerMessage());
+    context.setVariable("successBannerMessage", params.successBannerMessage());
+    context.setVariable("shouldShowNotEligibleBanner", params.shouldShowNotEligibleBanner());
+
     return templateEngine.process("applicant/ApplicantProgramSummaryTemplate", context);
   }
 
@@ -117,6 +123,12 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
 
     abstract Messages messages();
 
+    abstract Optional<String> alertBannerMessage();
+
+    abstract Optional<String> successBannerMessage();
+
+    abstract boolean shouldShowNotEligibleBanner();
+
     @AutoValue.Builder
     public abstract static class Builder {
 
@@ -135,6 +147,12 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
       public abstract Builder setTotalBlockCount(int totalBlockCount);
 
       public abstract Builder setMessages(Messages messages);
+
+      public abstract Builder setAlertBannerMessage(Optional<String> alertBannerMessage);
+
+      public abstract Builder setSuccessBannerMessage(Optional<String> successBannerMessage);
+
+      public abstract Builder setShouldShowNotEligibleBanner(boolean shouldShowNotEligibleBanner);
 
       public abstract Params build();
     }

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -59,7 +59,7 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
     // Toasts
     context.setVariable("alertBannerMessage", params.alertBannerMessage());
     context.setVariable("successBannerMessage", params.successBannerMessage());
-    context.setVariable("shouldShowNotEligibleBanner", params.shouldShowNotEligibleBanner());
+    context.setVariable("notEligibleBannerMessage", params.notEligibleBannerMessage());
 
     return templateEngine.process("applicant/ApplicantProgramSummaryTemplate", context);
   }
@@ -127,7 +127,7 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
 
     abstract Optional<String> successBannerMessage();
 
-    abstract boolean shouldShowNotEligibleBanner();
+    abstract Optional<String> notEligibleBannerMessage();
 
     @AutoValue.Builder
     public abstract static class Builder {
@@ -152,7 +152,8 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
 
       public abstract Builder setSuccessBannerMessage(Optional<String> successBannerMessage);
 
-      public abstract Builder setShouldShowNotEligibleBanner(boolean shouldShowNotEligibleBanner);
+      public abstract Builder setNotEligibleBannerMessage(
+          Optional<String> notEligibleBannerMessage);
 
       public abstract Params build();
     }

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -60,6 +60,7 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarApplica
     context.setVariable("alertBannerMessage", params.alertBannerMessage());
     context.setVariable("successBannerMessage", params.successBannerMessage());
     context.setVariable("notEligibleBannerMessage", params.notEligibleBannerMessage());
+    context.setVariable("errorBannerMessage", request.flash().get("error"));
 
     return templateEngine.process("applicant/ApplicantProgramSummaryTemplate", context);
   }

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -73,7 +73,6 @@
     ></div>
   </th:block>
   <!--/* Not eligible toast */-->
-  <!-- TODO THIS DOESN'T WORK YET -->
   <th:block
     th:if="${notEligibleBannerMessage.isPresent()}"
     th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -75,12 +75,11 @@
   <!--/* Not eligible toast */-->
   <!-- TODO THIS DOESN'T WORK YET -->
   <th:block
-    th:if="${shouldShowNotEligibleBanner}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)},
-             toastMessage=${isTi ? #{toast.mayNotQualifyTi(programTitle)} : #{toast.mayNotQualify(programTitle)}}"
+    th:if="${notEligibleBannerMessage.isPresent()}"
+    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
   >
     <div
-      th:replace="~{this:: alert(${toastId}, ${toastMessage}, true, true, 0, null)}"
+      th:replace="~{this:: alert(${toastId}, ${notEligibleBannerMessage.get()}, true, false, 0, null)}"
     ></div>
   </th:block>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -23,6 +23,14 @@
 </div>
 
 <div
+  th:fragment="error(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
+>
+  <div
+    th:replace="~{this :: toast(${id}, #{toast.errorMessageOutline(${message})}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'error')}"
+  ></div>
+</div>
+
+<div
   th:fragment="success(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
 >
   <div
@@ -70,6 +78,15 @@
   >
     <div
       th:replace="~{this :: alert(${toastId}, ${alertBannerMessage.get()}, true, false, 0, null)}"
+    ></div>
+  </th:block>
+  <!--/* Error toast */-->
+  <th:block
+    th:if="${errorBannerMessage.isPresent()}"
+    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
+  >
+    <div
+      th:replace="~{this :: error(${toastId}, ${errorBannerMessage.get()}, false, false, 0, null)}"
     ></div>
   </th:block>
   <!--/* Not eligible toast */-->

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -15,6 +15,14 @@
 </div>
 
 <div
+  th:fragment="alert(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
+>
+  <div
+    th:replace="~{this :: toast(${id}, ${message}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'alert')}"
+  ></div>
+</div>
+
+<div
   th:fragment="success(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
 >
   <div
@@ -40,6 +48,39 @@
   >
     <div
       th:replace="~{this:: warning(${toastId}, #{toast.localeNotSupported}, true, true, 0, null)}"
+    ></div>
+  </th:block>
+</div>
+
+<!--/* Render the toasts used in the Review/Summary page */-->
+<div th:fragment="summaryToasts">
+  <!--/* Success toast */-->
+  <th:block
+    th:if="${successBannerMessage.isPresent()}"
+    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
+  >
+    <div
+      th:replace="~{this :: success(${toastId}, ${successBannerMessage.get()}, true, false, 0, null)}"
+    ></div>
+  </th:block>
+  <!--/* Alert toast */-->
+  <th:block
+    th:if="${alertBannerMessage.isPresent()}"
+    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
+  >
+    <div
+      th:replace="~{this :: alert(${toastId}, ${alertBannerMessage.get()}, true, false, 0, null)}"
+    ></div>
+  </th:block>
+  <!--/* Not eligible toast */-->
+  <!-- TODO THIS DOESN'T WORK YET -->
+  <th:block
+    th:if="${shouldShowNotEligibleBanner}"
+    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)},
+             toastMessage=${isTi ? #{toast.mayNotQualifyTi(programTitle)} : #{toast.mayNotQualify(programTitle)}}"
+  >
+    <div
+      th:replace="~{this:: alert(${toastId}, ${toastMessage}, true, true, 0, null)}"
     ></div>
   </th:block>
 </div>


### PR DESCRIPTION
### Description

Add toasts in the review/summary page to thymeleaf

- Not eligible [
![5vNVfti6p6XGivZ](https://github.com/civiform/civiform/assets/156004543/3d68d1b5-2dfe-4f46-b196-624b0346a9fd)
](url)
- May be eligible
- Errors

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Issue(s) this completes

Progress towards #7228