### PR TITLE
Fix JSON export with PAI

### DIFF
--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -83,8 +83,9 @@ public class ApplicantData extends CfJsonDocumentContext {
    * @return Formatted name of the applicant
    */
   public Optional<String> getApplicantName() {
-    Optional<String> firstName = applicant == null ? Optional.empty() : applicant.getFirstName();
-    Optional<String> lastName = applicant == null ? Optional.empty() : applicant.getLastName();
+    Optional<String> firstName =
+        Optional.ofNullable(applicant).flatMap(ApplicantModel::getFirstName);
+    Optional<String> lastName = Optional.ofNullable(applicant).flatMap(ApplicantModel::getLastName);
     if (firstName.isEmpty()) {
       // TODO (#5503): Return Optional.empty() when removing the feature flag
       return getApplicantNameAtWellKnownPath();
@@ -133,37 +134,33 @@ public class ApplicantData extends CfJsonDocumentContext {
   // that we can modify both the Primary Applicant Info columns and
   // Well Known Paths at the same time.
   public Optional<String> getApplicantFirstName() {
-    return applicant == null || applicant.getFirstName().isEmpty()
-        ? readString(WellKnownPaths.APPLICANT_FIRST_NAME)
-        : applicant.getFirstName();
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getFirstName)
+        .or(() -> readString(WellKnownPaths.APPLICANT_FIRST_NAME));
   }
 
   public Optional<String> getApplicantMiddleName() {
-    return applicant == null || applicant.getMiddleName().isEmpty()
-        ? readString(WellKnownPaths.APPLICANT_MIDDLE_NAME)
-        : applicant.getMiddleName();
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getMiddleName)
+        .or(() -> readString(WellKnownPaths.APPLICANT_MIDDLE_NAME));
   }
 
   public Optional<String> getApplicantLastName() {
-    return applicant == null || applicant.getLastName().isEmpty()
-        ? readString(WellKnownPaths.APPLICANT_LAST_NAME)
-        : applicant.getLastName();
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getLastName)
+        .or(() -> readString(WellKnownPaths.APPLICANT_LAST_NAME));
   }
 
   public Optional<String> getApplicantEmail() {
-    if (applicant == null) {
-      return Optional.empty();
-    } else {
-      return applicant
-          .getEmailAddress()
-          .or(() -> Optional.ofNullable(applicant.getAccount().getEmailAddress()));
-    }
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getEmailAddress)
+        .or(() -> Optional.ofNullable(applicant.getAccount().getEmailAddress()));
   }
 
   public Optional<String> getPhoneNumber() {
-    return applicant == null || applicant.getPhoneNumber().isEmpty()
-        ? readString(WellKnownPaths.APPLICANT_PHONE_NUMBER)
-        : applicant.getPhoneNumber();
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getPhoneNumber)
+        .or(() -> readString(WellKnownPaths.APPLICANT_PHONE_NUMBER));
   }
 
   public void setPhoneNumber(String phoneNumber) {
@@ -172,13 +169,14 @@ public class ApplicantData extends CfJsonDocumentContext {
   }
 
   public Optional<LocalDate> getDateOfBirth() {
-    if (applicant == null || applicant.getDateOfBirth().isEmpty()) {
-      Path dobPath = WellKnownPaths.APPLICANT_DOB;
-      Path deprecatedDobPath = WellKnownPaths.APPLICANT_DOB_DEPRECATED;
-      return hasPath(dobPath) ? readDate(dobPath) : readDate(deprecatedDobPath);
-    } else {
-      return applicant.getDateOfBirth();
-    }
+    return Optional.ofNullable(applicant)
+        .flatMap(ApplicantModel::getDateOfBirth)
+        .or(
+            () -> {
+              Path dobPath = WellKnownPaths.APPLICANT_DOB;
+              Path deprecatedDobPath = WellKnownPaths.APPLICANT_DOB_DEPRECATED;
+              return hasPath(dobPath) ? readDate(dobPath) : readDate(deprecatedDobPath);
+            });
   }
 
   public void setDateOfBirth(String dateOfBirth) {

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -83,8 +83,8 @@ public class ApplicantData extends CfJsonDocumentContext {
    * @return Formatted name of the applicant
    */
   public Optional<String> getApplicantName() {
-    Optional<String> firstName = applicant.getFirstName();
-    Optional<String> lastName = applicant.getLastName();
+    Optional<String> firstName = applicant == null ? Optional.empty() : applicant.getFirstName();
+    Optional<String> lastName = applicant == null ? Optional.empty() : applicant.getLastName();
     if (firstName.isEmpty()) {
       // TODO (#5503): Return Optional.empty() when removing the feature flag
       return getApplicantNameAtWellKnownPath();
@@ -133,25 +133,37 @@ public class ApplicantData extends CfJsonDocumentContext {
   // that we can modify both the Primary Applicant Info columns and
   // Well Known Paths at the same time.
   public Optional<String> getApplicantFirstName() {
-    return applicant.getFirstName().or(() -> readString(WellKnownPaths.APPLICANT_FIRST_NAME));
+    return applicant == null || applicant.getFirstName().isEmpty()
+        ? readString(WellKnownPaths.APPLICANT_FIRST_NAME)
+        : applicant.getFirstName();
   }
 
   public Optional<String> getApplicantMiddleName() {
-    return applicant.getMiddleName().or(() -> readString(WellKnownPaths.APPLICANT_MIDDLE_NAME));
+    return applicant == null || applicant.getMiddleName().isEmpty()
+        ? readString(WellKnownPaths.APPLICANT_MIDDLE_NAME)
+        : applicant.getMiddleName();
   }
 
   public Optional<String> getApplicantLastName() {
-    return applicant.getLastName().or(() -> readString(WellKnownPaths.APPLICANT_LAST_NAME));
+    return applicant == null || applicant.getLastName().isEmpty()
+        ? readString(WellKnownPaths.APPLICANT_LAST_NAME)
+        : applicant.getLastName();
   }
 
   public Optional<String> getApplicantEmail() {
-    return applicant
-        .getEmailAddress()
-        .or(() -> Optional.ofNullable(applicant.getAccount().getEmailAddress()));
+    if (applicant == null) {
+      return Optional.empty();
+    } else {
+      return applicant
+          .getEmailAddress()
+          .or(() -> Optional.ofNullable(applicant.getAccount().getEmailAddress()));
+    }
   }
 
   public Optional<String> getPhoneNumber() {
-    return applicant.getPhoneNumber().or(() -> readString(WellKnownPaths.APPLICANT_PHONE_NUMBER));
+    return applicant == null || applicant.getPhoneNumber().isEmpty()
+        ? readString(WellKnownPaths.APPLICANT_PHONE_NUMBER)
+        : applicant.getPhoneNumber();
   }
 
   public void setPhoneNumber(String phoneNumber) {
@@ -160,14 +172,13 @@ public class ApplicantData extends CfJsonDocumentContext {
   }
 
   public Optional<LocalDate> getDateOfBirth() {
-    return applicant
-        .getDateOfBirth()
-        .or(
-            () -> {
-              Path dobPath = WellKnownPaths.APPLICANT_DOB;
-              Path deprecatedDobPath = WellKnownPaths.APPLICANT_DOB_DEPRECATED;
-              return hasPath(dobPath) ? readDate(dobPath) : readDate(deprecatedDobPath);
-            });
+    if (applicant == null || applicant.getDateOfBirth().isEmpty()) {
+      Path dobPath = WellKnownPaths.APPLICANT_DOB;
+      Path deprecatedDobPath = WellKnownPaths.APPLICANT_DOB_DEPRECATED;
+      return hasPath(dobPath) ? readDate(dobPath) : readDate(deprecatedDobPath);
+    } else {
+      return applicant.getDateOfBirth();
+    }
   }
 
   public void setDateOfBirth(String dateOfBirth) {


### PR DESCRIPTION
When getting the ReadOnlyApplicantProgramService inside the JsonExporterService, we are passing it an ApplicantData object without the ApplicantModel inside it. We're doing this intentionally so that any questions not in the application's program version are exported as "unanswered". This caused the lookup of data for a PAI name question (and probably any other PAI question) to fail since it relies on that ApplicantModel object.

This modifies the getters in ApplicantData to handle when the ApplicantModel is null.

In the future, we should probably figure out how to untangle this a bit to standardize how the ApplicantData object is created and used, but this fixes the immediate issue.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/7752
