### PR TITLE
Refactor toast fragments to simplify logic and use default options where applicable

### DIFF
--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -58,17 +58,17 @@
   <!--/* Success toast */-->
   <div th:replace="~{this :: success(${successBannerMessage})}"></div>
   <!--/* Alert toast */-->
-  <div th:replace="~{this :: alert(alertBannerMessage)}"></div>
+  <div th:replace="~{this :: alert(${alertBannerMessage})}"></div>
   <!--/* Error toast */-->
   <div th:replace="~{this :: error(${errorBannerMessage})}"></div>
   <!--/* Not eligible toast */-->
-  <div th:replace="~{this :: alert(notEligibleBannerMessage)}"></div>
+  <div th:replace="~{this :: alert(${notEligibleBannerMessage})}"></div>
 </div>
 
 <!--/* Render the toasts used in the Program Index page */-->
 <div th:fragment="programIndexToasts">
   <!--/* Alert toast */-->
-  <div th:replace="~{this :: alert(bannerMessage)}"></div>
+  <div th:replace="~{this :: alert(${bannerMessage})}"></div>
   <!--/* Session ended toast */-->
   <div
     th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.sessionEnded}, true, false, 5000, 'session_just_ended', 'success')}"

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -6,14 +6,6 @@
   th:text="${message}"
 ></div>
 
-<div
-  th:fragment="warning(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
->
-  <div
-    th:replace="~{this :: toast(${id}, ${message}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'warning')}"
-  ></div>
-</div>
-
 <!--/* Render an alert toast with the default options */-->
 <div
   th:fragment="alert(optionalMessage)"
@@ -56,7 +48,7 @@
     th:with="toastId=${'locale-not-supported-'+ applicationParams.applicantId() + '-' + applicationParams.programId()}"
   >
     <div
-      th:replace="~{this:: warning(${toastId}, #{toast.localeNotSupported}, true, true, 0, null)}"
+      th:replace="~{this:: toast(${toastId}, #{toast.localeNotSupported}, true, true, 0, null, 'warning')}"
     ></div>
   </th:block>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -14,41 +14,42 @@
   ></div>
 </div>
 
+<!--/* Render an alert toast with the default options */-->
 <div
-  th:fragment="alert(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
+  th:fragment="alert(optionalMessage)"
+  th:if="${optionalMessage.isPresent()}"
 >
   <div
-    th:replace="~{this :: toast(${id}, ${message}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'alert')}"
+    th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, ${optionalMessage.get()}, true, false, 0, null, 'alert')}"
   ></div>
 </div>
 
+<!--/* Render an error toast with the default options. Error messages are wrapped in a "Error: " prefix.  */-->
 <div
-  th:fragment="error(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
+  th:fragment="error(optionalMessage)"
+  th:if="${optionalMessage.isPresent()}"
 >
   <div
-    th:replace="~{this :: toast(${id}, #{toast.errorMessageOutline(${message})}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'error')}"
+    th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.errorMessageOutline(${optionalMessage.get})}, false, false, 0, null, 'error')}"
   ></div>
 </div>
 
+<!--/* Render a success toast with the default options.  */-->
 <div
-  th:fragment="success(id, message, canDismiss, canIgnore, toastDuration, condOnStorageKey)"
+  th:fragment="success(optionalMessage)"
+  th:if="${optionalMessage.isPresent()}"
 >
   <div
-    th:replace="~{this :: toast(${id}, ${message}, ${canDismiss}, ${canIgnore}, ${toastDuration}, ${condOnStorageKey}, 'success')}"
+    th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, ${optionalMessage.get()}, true, false, 0, null, 'success')}"
   ></div>
 </div>
 
 <!--/* Render the toasts used in the Block Edit page */-->
 <div th:fragment="blockEditToasts">
   <!--/* Eligibility success toast */-->
-  <th:block
-    th:if="${applicationParams.bannerMessage().isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: success(${toastId}, ${applicationParams.bannerMessage().get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div
+    th:replace="~{this :: success(${applicationParams.bannerMessage()})}"
+  ></div>
   <!--/* Locale not supported toast */-->
   <th:block
     th:if="${!applicationParams.preferredLanguageSupported()}"
@@ -63,69 +64,27 @@
 <!--/* Render the toasts used in the Review/Summary page */-->
 <div th:fragment="summaryToasts">
   <!--/* Success toast */-->
-  <th:block
-    th:if="${successBannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: success(${toastId}, ${successBannerMessage.get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: success(${successBannerMessage})}"></div>
   <!--/* Alert toast */-->
-  <th:block
-    th:if="${alertBannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: alert(${toastId}, ${alertBannerMessage.get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: alert(alertBannerMessage)}"></div>
   <!--/* Error toast */-->
-  <th:block
-    th:if="${errorBannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: error(${toastId}, ${errorBannerMessage.get()}, false, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: error(${errorBannerMessage})}"></div>
   <!--/* Not eligible toast */-->
-  <th:block
-    th:if="${notEligibleBannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this:: alert(${toastId}, ${notEligibleBannerMessage.get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: alert(notEligibleBannerMessage)}"></div>
 </div>
 
 <!--/* Render the toasts used in the Program Index page */-->
 <div th:fragment="programIndexToasts">
   <!--/* Alert toast */-->
-  <th:block
-    th:if="${bannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: alert(${toastId}, ${bannerMessage.get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: alert(bannerMessage)}"></div>
   <!--/* Session ended toast */-->
   <div
-    th:replace="~{this :: success(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.sessionEnded}, true, false, 5000, 'session_just_ended')}"
+    th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.sessionEnded}, true, false, 5000, 'session_just_ended', 'success')}"
   ></div>
 </div>
 
 <!--/* Render the toasts used in the Upsell page */-->
 <div th:fragment="upsellToasts">
   <!--/* Alert toast */-->
-  <th:block
-    th:if="${bannerMessage.isPresent()}"
-    th:with="toastId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: alert(${toastId}, ${bannerMessage.get()}, true, false, 0, null)}"
-    ></div>
-  </th:block>
+  <div th:replace="~{this :: alert(bannerMessage)}"></div>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -78,5 +78,5 @@
 <!--/* Render the toasts used in the Upsell page */-->
 <div th:fragment="upsellToasts">
   <!--/* Alert toast */-->
-  <div th:replace="~{this :: alert(bannerMessage)}"></div>
+  <div th:replace="~{this :: alert(${bannerMessage})}"></div>
 </div>


### PR DESCRIPTION
### Description

Refactor ToastFragment to make it cleaner by having fragments for alert, success, and error specify default arguments, so we don't have to specify those options every time. Makes toasts that use non-default arguments call the "toast" fragment directly.
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Progress towards #7228
