### PR TITLE
Create toast shown when the environment is dev or staging

### DIFF
--- a/server/app/views/applicant/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/AddressCorrectionBlockTemplate.html
@@ -13,8 +13,10 @@
       th:with="suggestions=${addressSuggestionGroup.getAddressSuggestions()},
                anySuggestions=${suggestions.size() > 0}"
     >
-    <div th:replace="~{components/ToastFragment :: devOrStagingToast($isDevOrStaging)}"></div>
-    <input hidden th:value="${csrfToken}" name="csrfToken" />
+      <div
+        th:replace="~{components/ToastFragment :: devOrStagingToast($isDevOrStaging)}"
+      ></div>
+      <input hidden th:value="${csrfToken}" name="csrfToken" />
       <div th:replace="~{applicant/ApplicantBaseFragment :: progressBar}"></div>
 
       <h2 th:text="#{title.confirmAddress}"></h2>

--- a/server/app/views/applicant/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/AddressCorrectionBlockTemplate.html
@@ -13,7 +13,8 @@
       th:with="suggestions=${addressSuggestionGroup.getAddressSuggestions()},
                anySuggestions=${suggestions.size() > 0}"
     >
-      <input hidden th:value="${csrfToken}" name="csrfToken" />
+    <div th:replace="~{components/ToastFragment :: devOrStagingToast($isDevOrStaging)}"></div>
+    <input hidden th:value="${csrfToken}" name="csrfToken" />
       <div th:replace="~{applicant/ApplicantBaseFragment :: progressBar}"></div>
 
       <h2 th:text="#{title.confirmAddress}"></h2>

--- a/server/app/views/applicant/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/AddressCorrectionBlockTemplate.html
@@ -14,7 +14,7 @@
                anySuggestions=${suggestions.size() > 0}"
     >
       <div
-        th:replace="~{components/ToastFragment :: devOrStagingToast($isDevOrStaging)}"
+        th:replace="~{components/ToastFragment :: devOrStagingToast(${isDevOrStaging})}"
       ></div>
       <input hidden th:value="${csrfToken}" name="csrfToken" />
       <div th:replace="~{applicant/ApplicantBaseFragment :: progressBar}"></div>

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -11,6 +11,7 @@
       questionParams=${questionRendererParams.get(question.getQuestionDefinition().getId())},
       fileUploadQuestion=${question.createFileUploadQuestion()}"
     >
+      <div th:replace="~{components/ToastFragment :: blockEditToasts}"></div>
       <form
         enctype="multipart/form-data"
         method="POST"

--- a/server/app/views/applicant/IneligibleTemplate.html
+++ b/server/app/views/applicant/IneligibleTemplate.html
@@ -5,6 +5,9 @@
   <body>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
     <div role="main" class="margin-2">
+      <div
+        th:replace="~{components/ToastFragment :: devOrStagingToast(${isDevOrStaging})}"
+      ></div>
       <h1
         th:text="${isTrustedIntermediary} ? #{title.applicantNotEligibleTi(${programName})} : #{title.applicantNotEligible(${programName})}"
       ></h1>

--- a/server/app/views/applicant/NorthStarApplicantBaseView.java
+++ b/server/app/views/applicant/NorthStarApplicantBaseView.java
@@ -90,6 +90,9 @@ public abstract class NorthStarApplicantBaseView {
       context.setVariable(
           "loggedInAs", getAccountIdentifier(isTi, profile, applicantPersonalInfo, messages));
     }
+
+    context.setVariable("isDevOrStaging", isDevOrStaging);
+
     boolean showDebugTools = isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins();
     context.setVariable("showDebugTools", showDebugTools);
     if (showDebugTools) {

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -36,6 +36,13 @@
   ></div>
 </div>
 
+<!--/* A toast shown on all pages in dev and staging environments to warn against submitting real user data. */-->
+<div th:fragment="devOrStagingToast(isDevOrStaging)" th:if="${isDevOrStaging}">
+  <div
+    th:replace="~{this :: toast('warning-message', 'Do not enter actual or personal data in this demo site', true, true, 0, null, 'warning')}"
+  ></div>
+</div>
+
 <!--/* Render the toasts used in the Block Edit page */-->
 <div th:fragment="blockEditToasts">
   <!--/* Eligibility success toast */-->
@@ -83,10 +90,4 @@
   <!--/* Alert toast */-->
   <div th:replace="~{this :: alert(${bannerMessage})}"></div>
   <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
-</div>
-
-<div th:fragment="devOrStagingToast(isDevOrStaging)" th:if="${isDevOrStaging}">
-  <div
-  th:replace="~{this :: toast('warning-message', 'Do not enter actual or personal data in this demo site', true, true, 0, null, 'warning')}"
-></div>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -88,6 +88,6 @@
 <!--/* Render the toasts used in the Upsell page */-->
 <div th:fragment="upsellToasts">
   <!--/* Alert toast */-->
-<div th:replace="~{this :: alert(${bannerMessage})}"></div>
-<div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
+  <div th:replace="~{this :: alert(${bannerMessage})}"></div>
+  <div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -58,7 +58,7 @@
       th:replace="~{this:: toast(${toastId}, #{toast.localeNotSupported}, true, true, 0, null, 'warning')}"
     ></div>
   </th:block>
-  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
+  <div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>
 
 <!--/* Render the toasts used in the Review/Summary page */-->
@@ -71,7 +71,7 @@
   <div th:replace="~{this :: error(${errorBannerMessage})}"></div>
   <!--/* Not eligible toast */-->
   <div th:replace="~{this :: alert(${notEligibleBannerMessage})}"></div>
-  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
+  <div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>
 
 <!--/* Render the toasts used in the Program Index page */-->
@@ -82,12 +82,12 @@
   <div
     th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.sessionEnded}, true, false, 5000, 'session_just_ended', 'success')}"
   ></div>
-  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
+  <div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>
 
 <!--/* Render the toasts used in the Upsell page */-->
 <div th:fragment="upsellToasts">
   <!--/* Alert toast */-->
-  <div th:replace="~{this :: alert(${bannerMessage})}"></div>
-  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
+<div th:replace="~{this :: alert(${bannerMessage})}"></div>
+<div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -51,6 +51,7 @@
       th:replace="~{this:: toast(${toastId}, #{toast.localeNotSupported}, true, true, 0, null, 'warning')}"
     ></div>
   </th:block>
+  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
 </div>
 
 <!--/* Render the toasts used in the Review/Summary page */-->
@@ -63,6 +64,7 @@
   <div th:replace="~{this :: error(${errorBannerMessage})}"></div>
   <!--/* Not eligible toast */-->
   <div th:replace="~{this :: alert(${notEligibleBannerMessage})}"></div>
+  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
 </div>
 
 <!--/* Render the toasts used in the Program Index page */-->
@@ -73,10 +75,18 @@
   <div
     th:replace="~{this :: toast(${'id-' + #strings.randomAlphanumeric(8)}, #{toast.sessionEnded}, true, false, 5000, 'session_just_ended', 'success')}"
   ></div>
+  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
 </div>
 
 <!--/* Render the toasts used in the Upsell page */-->
 <div th:fragment="upsellToasts">
   <!--/* Alert toast */-->
   <div th:replace="~{this :: alert(${bannerMessage})}"></div>
+  <div th:replace="~{this :: devOrStagingToast($isDevOrStaging)}"></div>
+</div>
+
+<div th:fragment="devOrStagingToast(isDevOrStaging)" th:if="${isDevOrStaging}">
+  <div
+  th:replace="~{this :: toast('warning-message', 'Do not enter actual or personal data in this demo site', true, true, 0, null, 'warning')}"
+></div>
 </div>


### PR DESCRIPTION
### Description

Create toast shown on all pages warning not to submit real data to a dev or staging environment

![5jZ28CC4njVbA6N](https://github.com/civiform/civiform/assets/156004543/4ac2f333-b8c7-4934-bf94-38edb8df5014)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #7228
