### PR TITLE
Use toBeDisabled in browser test assertions

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -317,9 +317,7 @@ test.describe('End to end enumerator test', () => {
       await test.step('Add button is enabled with a non-blank entity', async () => {
         await applicantQuestions.addEnumeratorAnswer('Bugs')
 
-        await expect(
-          page.locator('#enumerator-field-add-button'),
-        ).not.toHaveAttribute('disabled')
+        await expect(page.locator('#enumerator-field-add-button')).toBeEnabled()
       })
 
       await test.step('Add button is disabled if an entity is blank', async () => {
@@ -327,24 +325,20 @@ test.describe('End to end enumerator test', () => {
 
         await expect(
           page.locator('#enumerator-field-add-button'),
-        ).toHaveAttribute('disabled')
+        ).toBeDisabled()
       })
 
       await test.step('Add button is re-enabled when the blank item is removed', async () => {
         await applicantQuestions.deleteEnumeratorEntityByIndex(2)
 
-        await expect(
-          page.locator('#enumerator-field-add-button'),
-        ).not.toHaveAttribute('disabled')
+        await expect(page.locator('#enumerator-field-add-button')).toBeEnabled()
       })
 
       await test.step('Add button is still enabled after navigating away and back', async () => {
         await applicantQuestions.clickNext()
         await applicantQuestions.clickPrevious()
 
-        await expect(
-          page.locator('#enumerator-field-add-button'),
-        ).not.toHaveAttribute('disabled')
+        await expect(page.locator('#enumerator-field-add-button')).toBeEnabled()
       })
 
       await test.step('Add button is disabled when an existing item is blanked', async () => {
@@ -352,7 +346,7 @@ test.describe('End to end enumerator test', () => {
 
         await expect(
           page.locator('#enumerator-field-add-button'),
-        ).toHaveAttribute('disabled')
+        ).toBeDisabled()
       })
 
       await test.step('Add button is still disabled after trying to save', async () => {
@@ -365,7 +359,7 @@ test.describe('End to end enumerator test', () => {
 
         await expect(
           page.locator('#enumerator-field-add-button'),
-        ).toHaveAttribute('disabled')
+        ).toBeDisabled()
       })
     })
 
@@ -617,7 +611,7 @@ test.describe('End to end enumerator test', () => {
         page.locator(
           '.cf-program-question:has-text("enumerator-ete-householdmembers") >> .cf-remove-question-button',
         ),
-      ).toHaveAttribute('disabled')
+      ).toBeDisabled()
     })
 
     await test.step('Create the rest of the program.', async () => {


### PR DESCRIPTION
### Description

* Replace occurrences of toHaveAttribute('disabled') with toBeDisabled().
* Replace occurrences of not.toHaveAttribute('disabled') with toBeEnabled().

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)