### PR TITLE
Add enumerator question setting validation strings for translation

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -165,6 +165,8 @@ public enum MessageKey {
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),
   ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),
+  ENUMERATOR_VALIDATION_TOO_MANY_ENTITIES("validation.tooManyEntities"),
+  ENUMERATOR_VALIDATION_TOO_FEW_ENTITIES("validation.tooFewEntities"),
   ERROR_INCOMPLETE_DATE("error.incompleteDate"),
   FILEUPLOAD_VALIDATION_FILE_REQUIRED("validation.fileRequired"),
   FILEUPLOAD_VALIDATION_FILE_TOO_LARGE("validation.fileTooLarge"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -466,6 +466,10 @@ dialog.confirmDelete=Are you sure you want to remove this {0}? This change will 
 dialog.confirmDeleteAllButtonsSave=Are you sure you want to remove this {0}? This change will be saved when you click "Review", "Previous", or "Next" and all data associated with this {0} will be lost.
 validation.entityNameRequired=Please enter a value for each line.
 validation.duplicateEntityName=Please enter a unique value for each line.
+# Error shown if the enumerator question has a maximum answer limit and the applicant enters too many values
+validation.tooManyEntities=Please enter at most {0} values.
+# Error shown if the enumerator question has a minimum answer limit and the applicant enters too few values
+validation.tooFewEntities=Please enter at least {0} values.
 placeholder.entityName={0} name
 
 #---------------------------------------------------------------------------------#


### PR DESCRIPTION
### Description

Add the new applicant-facing strings for enumerator min/max limit validation (#7136). Implementation to follow once the strings are translated.

Preview:
<img width="320" alt="image" src="https://github.com/civiform/civiform/assets/165937506/bffeedcb-5e0c-41b5-a74e-b18791322272">
<img width="333" alt="image" src="https://github.com/civiform/civiform/assets/165937506/4af7b7bd-3545-4430-a396-eb5c7e2649d7">



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
