### PR TITLE
Update tests to use java text blocks for JSON assertions

### DIFF
--- a/server/test/controllers/ApiPayloadWrapperTest.java
+++ b/server/test/controllers/ApiPayloadWrapperTest.java
@@ -24,14 +24,15 @@ public class ApiPayloadWrapperTest extends ResetPostgres {
 
     assertThat(asPrettyJsonString(result))
         .isEqualTo(
-            "{\n"
-                + "  \"nextPageToken\" : null,\n"
-                + "  \"payload\" : {\n"
-                + "    \"United States\" : {\n"
-                + "      \"New York State\" : [ \"New York City\", \"Albany\" ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}");
+            """
+            {
+              "nextPageToken" : null,
+              "payload" : {
+                "United States" : {
+                  "New York State" : [ "New York City", "Albany" ]
+                }
+              }
+            }""");
   }
 
   @Test
@@ -53,15 +54,15 @@ public class ApiPayloadWrapperTest extends ResetPostgres {
 
     assertThat(asPrettyJsonString(result))
         .isEqualTo(
-            "{\n"
-                + "  \"nextPageToken\" : \""
-                + expectedToken
-                + "\",\n"
-                + "  \"payload\" : {\n"
-                + "    \"United States\" : {\n"
-                + "      \"New York State\" : [ \"New York City\", \"Albany\" ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}");
+            """
+            {
+              "nextPageToken" : "%s",
+              "payload" : {
+                "United States" : {
+                  "New York State" : [ "New York City", "Albany" ]
+                }
+              }
+            }"""
+                .formatted(expectedToken));
   }
 }

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -323,10 +323,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".kitchen_tools",
-        "{\n"
-            + "  \"question_type\" : \"MULTI_SELECT\",\n"
-            + "  \"selections\" : [ \"pepper_grinder\", \"garlic_press\" ]\n"
-            + "}");
+        """
+        {
+          "question_type" : "MULTI_SELECT",
+          "selections" : [ "pepper_grinder", "garlic_press" ]
+        }""");
   }
 
   @Test
@@ -350,10 +351,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".kitchen_tools",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"MULTI_SELECT\",\n"
-            + "  \"selections\" : [ ]\n"
-            + "}");
+        """
+        {
+          "question_type" : "MULTI_SELECT",
+          "selections" : [ ]
+        }""");
   }
 
   @Test
@@ -377,10 +379,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_monthly_income",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"currency_dollars\" : 5444.33,\n"
-            + "  \"question_type\" : \"CURRENCY\"\n"
-            + "}");
+        """
+        {
+          "currency_dollars" : 5444.33,
+          "question_type" : "CURRENCY"
+        }""");
   }
 
   @Test
@@ -404,10 +407,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_monthly_income",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"currency_dollars\" : null,\n"
-            + "  \"question_type\" : \"CURRENCY\"\n"
-            + "}");
+        """
+        {
+          "currency_dollars" : null,
+          "question_type" : "CURRENCY"
+        }""");
   }
 
   @Test
@@ -431,10 +435,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_birth_date",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"date\" : \"2015-10-21\",\n"
-            + "  \"question_type\" : \"DATE\"\n"
-            + "}");
+        """
+        {
+          "date" : "2015-10-21",
+          "question_type" : "DATE"
+        }""");
   }
 
   @Test
@@ -458,10 +463,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_birth_date",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"date\" : null,\n"
-            + "  \"question_type\" : \"DATE\"\n"
-            + "}");
+        """
+        {
+          "date" : null,
+          "question_type" : "DATE"
+        }""");
   }
 
   @Test
@@ -487,10 +493,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_ice_cream",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "  \"selection\" : \"strawberry\"\n"
-            + "}");
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : "strawberry"
+        }""");
   }
 
   @Test
@@ -514,10 +521,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_ice_cream",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "  \"selection\" : null\n"
-            + "}");
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : null
+        }""");
   }
 
   @Test
@@ -543,10 +551,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_email_address",
-        "{\n"
-            + "  \"email\" : \"chell@aperturescience.com\",\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : "chell@aperturescience.com",
+          "question_type" : "EMAIL"
+        }""");
   }
 
   @Test
@@ -570,10 +579,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : null,\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : null,
+          "question_type" : "EMAIL"
+        }""");
   }
 
   @Test
@@ -597,10 +607,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : 42,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : 42,
+          "question_type" : "NUMBER"
+        }""");
   }
 
   @Test
@@ -624,10 +635,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : null,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : null,
+          "question_type" : "NUMBER"
+        }""");
   }
 
   @Test
@@ -653,10 +665,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_phone",
-        "{\n"
-            + "  \"phone_number\" : \"+15558675309\",\n"
-            + "  \"question_type\" : \"PHONE\"\n"
-            + "}");
+        """
+        {
+          "phone_number" : "+15558675309",
+          "question_type" : "PHONE"
+        }""");
   }
 
   @Test
@@ -680,10 +693,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_phone",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"phone_number\" : null,\n"
-            + "  \"question_type\" : \"PHONE\"\n"
-            + "}");
+        """
+        {
+          "phone_number" : null,
+          "question_type" : "PHONE"
+        }""");
   }
 
   @Test
@@ -709,10 +723,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_favorite_season",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "  \"selection\" : \"summer\"\n"
-            + "}");
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : "summer"
+        }""");
   }
 
   @Test
@@ -736,10 +751,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_favorite_season",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "  \"selection\" : null\n"
-            + "}");
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : null
+        }""");
   }
 
   @Test
@@ -763,10 +779,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"entities\" : [ ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -793,22 +810,23 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n"
-            + "  \"entities\" : [ {\n"
-            + "    \"entity_name\" : \"carly rae\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : \"stars\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"entity_name\" : \"tswift\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : \"hearts\"\n"
-            + "    }\n"
-            + "  } ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ {
+            "entity_name" : "carly rae",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : "stars"
+            }
+          }, {
+            "entity_name" : "tswift",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : "hearts"
+            }
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -833,22 +851,23 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n"
-            + "  \"entities\" : [ {\n"
-            + "    \"entity_name\" : \"carly rae\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"entity_name\" : \"tswift\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    }\n"
-            + "  } ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ {
+            "entity_name" : "carly rae",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            }
+          }, {
+            "entity_name" : "tswift",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            }
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -875,30 +894,31 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n"
-            + "  \"entities\" : [ {\n"
-            + "    \"entity_name\" : \"carly rae\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"entity_name\" : \"tswift\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  } ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ {
+            "entity_name" : "carly rae",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ ],
+              "question_type" : "ENUMERATOR"
+            }
+          }, {
+            "entity_name" : "tswift",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ ],
+              "question_type" : "ENUMERATOR"
+            }
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -928,54 +948,55 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n"
-            + "  \"entities\" : [ {\n"
-            + "    \"entity_name\" : \"carly rae\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ {\n"
-            + "        \"entity_name\" : \"singer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : null,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      }, {\n"
-            + "        \"entity_name\" : \"songwriter\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : null,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      } ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"entity_name\" : \"tswift\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ {\n"
-            + "        \"entity_name\" : \"performer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : null,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      }, {\n"
-            + "        \"entity_name\" : \"composer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : null,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      } ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  } ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ {
+            "entity_name" : "carly rae",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ {
+                "entity_name" : "singer",
+                "household_members_days_worked" : {
+                  "number" : null,
+                  "question_type" : "NUMBER"
+                }
+              }, {
+                "entity_name" : "songwriter",
+                "household_members_days_worked" : {
+                  "number" : null,
+                  "question_type" : "NUMBER"
+                }
+              } ],
+              "question_type" : "ENUMERATOR"
+            }
+          }, {
+            "entity_name" : "tswift",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ {
+                "entity_name" : "performer",
+                "household_members_days_worked" : {
+                  "number" : null,
+                  "question_type" : "NUMBER"
+                }
+              }, {
+                "entity_name" : "composer",
+                "household_members_days_worked" : {
+                  "number" : null,
+                  "question_type" : "NUMBER"
+                }
+              } ],
+              "question_type" : "ENUMERATOR"
+            }
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -1009,54 +1030,55 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_household_members",
-        "{\n"
-            + "  \"entities\" : [ {\n"
-            + "    \"entity_name\" : \"carly rae\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ {\n"
-            + "        \"entity_name\" : \"singer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : 34,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      }, {\n"
-            + "        \"entity_name\" : \"songwriter\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : 35,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      } ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"entity_name\" : \"tswift\",\n"
-            + "    \"household_member_favorite_shape\" : {\n"
-            + "      \"question_type\" : \"TEXT\",\n"
-            + "      \"text\" : null\n"
-            + "    },\n"
-            + "    \"household_members_jobs\" : {\n"
-            + "      \"entities\" : [ {\n"
-            + "        \"entity_name\" : \"performer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : 13,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      }, {\n"
-            + "        \"entity_name\" : \"composer\",\n"
-            + "        \"household_members_days_worked\" : {\n"
-            + "          \"number\" : 14,\n"
-            + "          \"question_type\" : \"NUMBER\"\n"
-            + "        }\n"
-            + "      } ],\n"
-            + "      \"question_type\" : \"ENUMERATOR\"\n"
-            + "    }\n"
-            + "  } ],\n"
-            + "  \"question_type\" : \"ENUMERATOR\"\n"
-            + "}");
+        """
+        {
+          "entities" : [ {
+            "entity_name" : "carly rae",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ {
+                "entity_name" : "singer",
+                "household_members_days_worked" : {
+                  "number" : 34,
+                  "question_type" : "NUMBER"
+                }
+              }, {
+                "entity_name" : "songwriter",
+                "household_members_days_worked" : {
+                  "number" : 35,
+                  "question_type" : "NUMBER"
+                }
+              } ],
+              "question_type" : "ENUMERATOR"
+            }
+          }, {
+            "entity_name" : "tswift",
+            "household_member_favorite_shape" : {
+              "question_type" : "TEXT",
+              "text" : null
+            },
+            "household_members_jobs" : {
+              "entities" : [ {
+                "entity_name" : "performer",
+                "household_members_days_worked" : {
+                  "number" : 13,
+                  "question_type" : "NUMBER"
+                }
+              }, {
+                "entity_name" : "composer",
+                "household_members_days_worked" : {
+                  "number" : 14,
+                  "question_type" : "NUMBER"
+                }
+              } ],
+              "question_type" : "ENUMERATOR"
+            }
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
   }
 
   @Test
@@ -1081,17 +1103,20 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     // assert answered question
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_favorite_color",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"TEXT\",\n"
-            + "  \"text\" : \"red\"\n"
-            + "}");
+        """
+        {
+          "question_type" : "TEXT",
+          "text" : "red"
+        }""");
+
     // assert hidden question is still in export
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_birth_date",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"date\" : null,\n"
-            + "  \"question_type\" : \"DATE\"\n"
-            + "}");
+        """
+        {
+          "date" : null,
+          "question_type" : "DATE"
+        }""");
   }
 
   @Test
@@ -1163,33 +1188,37 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     resultAsserter.assertJsonAtApplicationPath(
         1,
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : null,\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : null,
+          "question_type" : "EMAIL"
+        }""");
     resultAsserter.assertJsonAtApplicationPath(
         1,
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : 3,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : 3,
+          "question_type" : "NUMBER"
+        }""");
 
     // second application
     resultAsserter.assertJsonAtApplicationPath(
         0,
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : \"test@test.com\",\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : "test@test.com",
+          "question_type" : "EMAIL"
+        }""");
     resultAsserter.assertJsonAtApplicationPath(
         0,
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : 4,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : 4,
+          "question_type" : "NUMBER"
+        }""");
   }
 
   @Test
@@ -1228,33 +1257,37 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     resultAsserter.assertJsonAtApplicationPath(
         1,
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : \"test@test.com\",\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : "test@test.com",
+          "question_type" : "EMAIL"
+        }""");
     resultAsserter.assertJsonAtApplicationPath(
         1,
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : 3,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : 3,
+          "question_type" : "NUMBER"
+        }""");
 
     // second application
     resultAsserter.assertJsonAtApplicationPath(
         0,
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : null,\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : null,
+          "question_type" : "EMAIL"
+        }""");
     resultAsserter.assertJsonAtApplicationPath(
         0,
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : 4,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : 4,
+          "question_type" : "NUMBER"
+        }""");
 
     ImmutableList<ProgramDefinition> programDefinitionsForAllVersions =
         programService.getAllVersionsFullProgramDefinition(fakeProgram.id);
@@ -1300,10 +1333,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     // Assert application only includes 1 question
     programBResultAsserter.assertJsonAtApplicationPath(
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : \"test@test.com\",\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : "test@test.com",
+          "question_type" : "EMAIL"
+        }""");
     programBResultAsserter.assertJsonDoesNotContainApplicationPath(
         ".number_of_items_applicant_can_juggle");
 
@@ -1326,16 +1360,18 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     // answer in the applicant data.
     updatedProgramBResultAsserter.assertJsonAtApplicationPath(
         ".applicant_email_address",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"email\" : \"test@test.com\",\n"
-            + "  \"question_type\" : \"EMAIL\"\n"
-            + "}");
+        """
+        {
+          "email" : "test@test.com",
+          "question_type" : "EMAIL"
+        }""");
     updatedProgramBResultAsserter.assertJsonAtApplicationPath(
         ".number_of_items_applicant_can_juggle",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"number\" : null,\n"
-            + "  \"question_type\" : \"NUMBER\"\n"
-            + "}");
+        """
+        {
+          "number" : null,
+          "question_type" : "NUMBER"
+        }""");
   }
 
   @Test
@@ -1387,10 +1423,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_ice_cream",
-        "{\n" // comment to prevent fmt wrapping
-            + "  \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "  \"selection\" : \"mint\"\n"
-            + "}");
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : "mint"
+        }""");
   }
 
   private static class ResultAsserter {

--- a/server/test/services/export/JsonPrettifierTest.java
+++ b/server/test/services/export/JsonPrettifierTest.java
@@ -15,13 +15,14 @@ public class JsonPrettifierTest {
 
     assertThat(prettyJson)
         .isEqualTo(
-            "{\n"
-                + "  \"deeply\" : {\n"
-                + "    \"nested\" : {\n"
-                + "      \"age\" : 12\n"
-                + "    }\n"
-                + "  }\n"
-                + "}");
+            """
+            {
+              "deeply\" : {
+                "nested\" : {
+                  "age\" : 12
+                }
+              }
+            }""");
   }
 
   @Test
@@ -42,13 +43,14 @@ public class JsonPrettifierTest {
 
     assertThat(prettyJson)
         .isEqualTo(
-            "{\n"
-                + "  \"deeply\" : {\n"
-                + "    \"nested\" : {\n"
-                + "      \"age\" : 12\n"
-                + "    }\n"
-                + "  }\n"
-                + "}");
+            """
+            {
+              "deeply" : {
+                "nested" : {
+                  "age" : 12
+                }
+              }
+            }""");
   }
 
   @Test

--- a/server/test/services/export/ProgramJsonSamplerTest.java
+++ b/server/test/services/export/ProgramJsonSamplerTest.java
@@ -82,94 +82,93 @@ public class ProgramJsonSamplerTest extends ResetPostgres {
     String json = programJsonSampler.getSampleJson(programDefinition);
 
     String expectedJson =
-        "{\n"
-            + "  \"nextPageToken\" : null,\n"
-            + "  \"payload\" : [ {\n"
-            + "    \"applicant_id\" : 123,\n"
-            + "    \"application\" : {\n"
-            + "      \"name\" : {\n"
-            + "        \"first_name\" : \"Homer\",\n"
-            + "        \"last_name\" : \"Simpson\",\n"
-            + "        \"middle_name\" : \"Jay\",\n"
-            + "        \"question_type\" : \"NAME\"\n"
-            + "      },\n"
-            + "      \"sample_address_question\" : {\n"
-            + "        \"city\" : \"Springfield\",\n"
-            + "        \"corrected\" : \"Corrected\",\n"
-            + "        \"latitude\" : \"44.0462\",\n"
-            + "        \"line2\" : null,\n"
-            + "        \"longitude\" : \"-123.0236\",\n"
-            + "        \"question_type\" : \"ADDRESS\",\n"
-            + "        \"service_area\" :"
-            + " \"springfield_county_InArea_1709069741,portland_NotInArea_1709069741\",\n"
-            + "        \"state\" : \"OR\",\n"
-            + "        \"street\" : \"742 Evergreen Terrace\",\n"
-            + "        \"well_known_id\" : \"4326\",\n"
-            + "        \"zip\" : \"97403\"\n"
-            + "      },\n"
-            + "      \"sample_checkbox_question\" : {\n"
-            + "        \"question_type\" : \"MULTI_SELECT\",\n"
-            + "        \"selections\" : [ \"toaster\", \"pepper_grinder\" ]\n"
-            + "      },\n"
-            + "      \"sample_currency_question\" : {\n"
-            + "        \"currency_dollars\" : 123.45,\n"
-            + "        \"question_type\" : \"CURRENCY\"\n"
-            + "      },\n"
-            + "      \"sample_date_question\" : {\n"
-            + "        \"date\" : \"2023-01-02\",\n"
-            + "        \"question_type\" : \"DATE\"\n"
-            + "      },\n"
-            + "      \"sample_dropdown_question\" : {\n"
-            + "        \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "        \"selection\" : \"chocolate\"\n"
-            + "      },\n"
-            + "      \"sample_email_question\" : {\n"
-            + "        \"email\" : \"homer.simpson@springfield.gov\",\n"
-            + "        \"question_type\" : \"EMAIL\"\n"
-            + "      },\n"
-            + "      \"sample_file_upload_question\" : {\n"
-            + "        \"file_key\" :"
-            + " \"http://localhost:9000/admin/applicant-files/my-file-key\",\n"
-            + "        \"question_type\" : \"FILE_UPLOAD\"\n"
-            + "      },\n"
-            + "      \"sample_id_question\" : {\n"
-            + "        \"id\" : \"12345\",\n"
-            + "        \"question_type\" : \"ID\"\n"
-            + "      },\n"
-            + "      \"sample_number_question\" : {\n"
-            + "        \"number\" : 12321,\n"
-            + "        \"question_type\" : \"NUMBER\"\n"
-            + "      },\n"
-            + "      \"sample_phone_question\" : {\n"
-            + "        \"phone_number\" : \"+12143673764\",\n"
-            + "        \"question_type\" : \"PHONE\"\n"
-            + "      },\n"
-            + "      \"sample_predicate_date_question\" : {\n"
-            + "        \"date\" : \"2023-01-02\",\n"
-            + "        \"question_type\" : \"DATE\"\n"
-            + "      },\n"
-            + "      \"sample_radio_button_question\" : {\n"
-            + "        \"question_type\" : \"SINGLE_SELECT\",\n"
-            + "        \"selection\" : \"winter\"\n"
-            + "      },\n"
-            + "      \"sample_text_question\" : {\n"
-            + "        \"question_type\" : \"TEXT\",\n"
-            + "        \"text\" : \"I love CiviForm!\"\n"
-            + "      }\n"
-            + "    },\n"
-            + "    \"application_id\" : 456,\n"
-            + "    \"create_time\" : \"2023-05-25T13:46:15-07:00\",\n"
-            + "    \"language\" : \"en-US\",\n"
-            + "    \"program_name\" : \"test-program-admin-name\",\n"
-            + "    \"program_version_id\" : 789,\n"
-            + "    \"revision_state\" : \"CURRENT\",\n"
-            + "    \"status\" : \"Pending Review\",\n"
-            + "    \"submit_time\" : \"2023-05-26T13:46:15-07:00\",\n"
-            + "    \"submitter_type\" : \"APPLICANT\",\n"
-            + "    \"ti_email\" : null,\n"
-            + "    \"ti_organization\" : null\n"
-            + "  } ]\n"
-            + "}";
+        """
+{
+  "nextPageToken" : null,
+  "payload" : [ {
+    "applicant_id" : 123,
+    "application" : {
+      "name" : {
+        "first_name" : "Homer",
+        "last_name" : "Simpson",
+        "middle_name" : "Jay",
+        "question_type" : "NAME"
+      },
+      "sample_address_question" : {
+        "city" : "Springfield",
+        "corrected" : "Corrected",
+        "latitude" : "44.0462",
+        "line2" : null,
+        "longitude" : "-123.0236",
+        "question_type" : "ADDRESS",
+        "service_area" : "springfield_county_InArea_1709069741,portland_NotInArea_1709069741",
+        "state" : "OR",
+        "street" : "742 Evergreen Terrace",
+        "well_known_id" : "4326",
+        "zip" : "97403"
+      },
+      "sample_checkbox_question" : {
+        "question_type" : "MULTI_SELECT",
+        "selections" : [ "toaster", "pepper_grinder" ]
+      },
+      "sample_currency_question" : {
+        "currency_dollars" : 123.45,
+        "question_type" : "CURRENCY"
+      },
+      "sample_date_question" : {
+        "date" : "2023-01-02",
+        "question_type" : "DATE"
+      },
+      "sample_dropdown_question" : {
+        "question_type" : "SINGLE_SELECT",
+        "selection" : "chocolate"
+      },
+      "sample_email_question" : {
+        "email" : "homer.simpson@springfield.gov",
+        "question_type" : "EMAIL"
+      },
+      "sample_file_upload_question" : {
+        "file_key" : "http://localhost:9000/admin/applicant-files/my-file-key",
+        "question_type" : "FILE_UPLOAD"
+      },
+      "sample_id_question" : {
+        "id" : "12345",
+        "question_type" : "ID"
+      },
+      "sample_number_question" : {
+        "number" : 12321,
+        "question_type" : "NUMBER"
+      },
+      "sample_phone_question" : {
+        "phone_number" : "+12143673764",
+        "question_type" : "PHONE"
+      },
+      "sample_predicate_date_question" : {
+        "date" : "2023-01-02",
+        "question_type" : "DATE"
+      },
+      "sample_radio_button_question" : {
+        "question_type" : "SINGLE_SELECT",
+        "selection" : "winter"
+      },
+      "sample_text_question" : {
+        "question_type" : "TEXT",
+        "text" : "I love CiviForm!"
+      }
+    },
+    "application_id" : 456,
+    "create_time" : "2023-05-25T13:46:15-07:00",
+    "language" : "en-US",
+    "program_name" : "test-program-admin-name",
+    "program_version_id" : 789,
+    "revision_state" : "CURRENT",
+    "status" : "Pending Review",
+    "submit_time" : "2023-05-26T13:46:15-07:00",
+    "submitter_type" : "APPLICANT",
+    "ti_email" : null,
+    "ti_organization" : null
+  } ]
+}""";
 
     assertThat(asPrettyJsonString(json)).isEqualTo(expectedJson);
   }


### PR DESCRIPTION
### Description

Updates string formats in tests to use Java text blocks for JSON assertions in the API code.

(Thank you @gwendolyngoetz for Java 17!)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Part of #5257
