### PR TITLE
Fix broken end session button

### DIFF
--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -243,9 +243,9 @@ function attachFormDebouncers() {
 function attachRedirectToPageListeners() {
   addEventListenerToElements('[data-redirect-to]', 'click', (e: Event) => {
     e.stopPropagation()
-    window.location.href = assertNotNull(
-      (e.currentTarget as HTMLElement).dataset.redirectTo,
-    )
+    const destination = assertNotNull(
+      (e.currentTarget as HTMLElement).dataset.redirectTo)
+    window.location.href = destination
   })
 }
 

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -243,9 +243,9 @@ function attachFormDebouncers() {
 function attachRedirectToPageListeners() {
   addEventListenerToElements('[data-redirect-to]', 'click', (e: Event) => {
     e.stopPropagation()
-    const destination = assertNotNull(
-      (e.currentTarget as HTMLElement).dataset.redirectTo)
-    window.location.href = destination
+    window.location.href = assertNotNull(
+      (e.currentTarget as HTMLElement).dataset.redirectTo,
+    )
   })
 }
 

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -50,20 +50,20 @@
 <th:block th:fragment="loginOrLogout">
   <th:block th:if="${isGuest}">
     <span th:text="#{header.guestIndicator}" class="padding-right-1"></span>
-    <button
+    <a
       type="button"
       class="usa-button usa-button--outline"
       th:text="#{header.endSession}"
       id="logout-button"
-      th:attr="data-redirect-to=${logoutLink}"
-    ></button>
-    <button
+      th:href="${logoutLink}"
+    ></a>
+    <a
       type="button"
       class="usa-button usa-button--outline"
       th:text="#{button.login}"
       id="login-button"
-      th:attr="data-redirect-to=${loginLink}"
-    ></button>
+      th:href="${loginLink}"
+    ></a>
   </th:block>
 
   <th:block th:if="${!isGuest}">
@@ -71,13 +71,13 @@
       th:text="#{header.userName(${loggedInAs})}"
       class="padding-right-1"
     ></span>
-    <button
+    <a
       type="button"
       class="usa-button usa-button--outline"
       th:text="#{button.logout}"
       id="logout-button"
-      th:attr="data-redirect-to=${logoutLink}"
-    ></button>
+      th:href="${logoutLink}"
+    ></a>
   </th:block>
 </th:block>
 

--- a/server/app/views/applicant/NorthStarApplicantBaseView.java
+++ b/server/app/views/applicant/NorthStarApplicantBaseView.java
@@ -84,7 +84,7 @@ public abstract class NorthStarApplicantBaseView {
 
     context.setVariable("isTrustedIntermediary", isTi);
     context.setVariable("isGuest", isGuest);
-    context.setVariable("endSessionLink", org.pac4j.play.routes.LogoutController.logout().url());
+    context.setVariable("logoutLink", org.pac4j.play.routes.LogoutController.logout().url());
     context.setVariable("loginLink", routes.LoginController.applicantLogin(Optional.empty()).url());
     if (!isGuest) {
       context.setVariable(


### PR DESCRIPTION
### Description

We were mistakenly not piping in the /logout link for the end session button. This fixes that, and swaps the buttons for links so we don't have to rely on ts event listeners

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

#### New Features

- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Fixes #7792
