### PR TITLE
Fix API Key CIDR Validation Bug

### DIFF
--- a/server/test/services/apikey/ApiKeyServiceTest.java
+++ b/server/test/services/apikey/ApiKeyServiceTest.java
@@ -322,7 +322,7 @@ public class ApiKeyServiceTest extends ResetPostgres {
             ImmutableMap.of(
                 "keyName", "test key",
                 "expiration", "2020-01-30",
-                "subnet", "0.0.0.1/32,1.1.1.0/32",
+                "subnet", "0.0.0.1/32,1.1.1.0/32,1.1.1.0/20",
                 "grant-program-read[test-program]", "true"));
 
     ApiKeyCreationResult apiKeyCreationResult = apiKeyService.createApiKey(form, adminProfile);
@@ -336,8 +336,9 @@ public class ApiKeyServiceTest extends ResetPostgres {
     ApiKeyModel apiKey = apiKeyRepository.lookupApiKey(keyId).toCompletableFuture().join().get();
 
     assertThat(apiKey.getName()).isEqualTo("test key");
-    assertThat(apiKey.getSubnet()).isEqualTo("0.0.0.1/32,1.1.1.0/32");
-    assertThat(apiKey.getSubnetSet()).isEqualTo(ImmutableSet.of("0.0.0.1/32", "1.1.1.0/32"));
+    assertThat(apiKey.getSubnet()).isEqualTo("0.0.0.1/32,1.1.1.0/32,1.1.1.0/20");
+    assertThat(apiKey.getSubnetSet())
+        .isEqualTo(ImmutableSet.of("0.0.0.1/32", "1.1.1.0/32", "1.1.1.0/20"));
     assertThat(apiKey.getExpiration())
         .isEqualTo(dateConverter.parseIso8601DateToStartOfLocalDateInstant("2020-01-30"));
     assertThat(apiKey.getGrants().hasProgramPermission("test-program", Permission.READ)).isTrue();


### PR DESCRIPTION
### Description

Correctly handles blocking the "global" subnet when the `CIVIFORM_API_KEYS_BAN_GLOBAL_SUBNET` setting is enabled.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Fixes #7777
