### PR TITLE
Remove unneeded calls to disableFeatureFlag

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -2,7 +2,6 @@ import {test, expect} from '../support/civiform_fixtures'
 import {
   ApplicantQuestions,
   AdminPrograms,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   loginAsProgramAdmin,
@@ -327,10 +326,7 @@ test.describe('applicant program index page', () => {
         applicantQuestions,
         page,
       }) => {
-        // TODO (#7377): Remove once we have a header with login/logout.
-        await disableFeatureFlag(page, 'north_star_applicant_ui')
         await loginAsTestUser(page)
-        await enableFeatureFlag(page, 'north_star_applicant_ui')
 
         await test.step('Programs start in not started', async () => {
           await applicantQuestions.expectPrograms({
@@ -374,10 +370,8 @@ test.describe('applicant program index page', () => {
         })
 
         await test.step('When logged out, everything appears unsubmitted (https://github.com/civiform/civiform/pull/3487)', async () => {
-          // TODO (#7377): Remove once we have a header with login/logout.
-          await disableFeatureFlag(page, 'north_star_applicant_ui')
           await logout(page, false)
-          await enableFeatureFlag(page, 'north_star_applicant_ui')
+
           await applicantQuestions.expectPrograms({
             wantNotStartedPrograms: [otherProgramName, primaryProgramName],
             wantInProgressPrograms: [],

--- a/browser-test/src/applicant/applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant/applicant_application_statuses.test.ts
@@ -1,6 +1,5 @@
 import {test} from '../support/civiform_fixtures'
 import {
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   loginAsProgramAdmin,
@@ -54,10 +53,10 @@ test.describe('with program statuses', () => {
     {tag: ['@northstar']},
     () => {
       test('displays status', async ({page}) => {
-        await loginAsTestUser(page)
         await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+        await loginAsTestUser(page)
         await validateScreenshot(page, 'program-list-with-status-northstar')
-        await disableFeatureFlag(page, 'north_star_applicant_ui')
         await logout(page)
       })
     },

--- a/browser-test/src/applicant/questions/checkbox.test.ts
+++ b/browser-test/src/applicant/questions/checkbox.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminPrograms,
   AdminQuestions,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -22,7 +21,6 @@ test.describe('Checkbox question for applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('Updates options in preview', async ({page, adminQuestions}) => {

--- a/browser-test/src/applicant/questions/id.test.ts
+++ b/browser-test/src/applicant/questions/id.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminPrograms,
   AdminQuestions,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -22,7 +21,6 @@ test.describe('Id question for applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {

--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -25,7 +24,6 @@ test.describe('name applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {

--- a/browser-test/src/applicant/questions/number_input.test.ts
+++ b/browser-test/src/applicant/questions/number_input.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -24,7 +23,6 @@ test.describe('Number question for applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {

--- a/browser-test/src/applicant/questions/radio_button.test.ts
+++ b/browser-test/src/applicant/questions/radio_button.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -22,7 +21,6 @@ test.describe('Radio button question for applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('Updates options in preview', async ({page, adminQuestions}) => {

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -34,7 +33,6 @@ test.describe('Static text question for applicant flow', () => {
         adminQuestions,
         adminPrograms,
       )
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('displays static text', async ({applicantQuestions}) => {

--- a/browser-test/src/applicant/questions/text.test.ts
+++ b/browser-test/src/applicant/questions/text.test.ts
@@ -1,6 +1,5 @@
 import {test, expect} from '../../support/civiform_fixtures'
 import {
-  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -27,7 +26,6 @@ test.describe('Text question for applicant flow', () => {
       )
 
       await logout(page)
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
     })
 
     test('validate screenshot', async ({page, applicantQuestions}) => {


### PR DESCRIPTION
### Description

We have a few cases in tests where we enabled/disabled the north_star_applicant_ui flag. Some were leftover from before we had a functional login/logout in the header and others were from before the fixtures migration.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)

