### PR TITLE
[Multiple File Upload] Add max files to questions, and admin UI to modify it

### DIFF
--- a/server/app/forms/FileUploadQuestionForm.java
+++ b/server/app/forms/FileUploadQuestionForm.java
@@ -33,8 +33,7 @@ public class FileUploadQuestionForm extends QuestionForm {
     if (maxFiles.isEmpty()) {
       this.maxFiles = OptionalInt.empty();
     } else {
-      Integer maxFilesInt = Integer.parseInt(maxFiles);
-      this.maxFiles = maxFilesInt <= 0 ? OptionalInt.empty() : OptionalInt.of(maxFilesInt);
+      this.maxFiles = OptionalInt.of(Integer.parseInt(maxFiles));
     }
   }
 

--- a/server/app/forms/FileUploadQuestionForm.java
+++ b/server/app/forms/FileUploadQuestionForm.java
@@ -1,20 +1,56 @@
 package forms;
 
+import java.util.OptionalInt;
 import services.question.types.FileUploadQuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
 /** Form for updating a file upload question. */
 public class FileUploadQuestionForm extends QuestionForm {
+  private OptionalInt maxFiles;
+
   public FileUploadQuestionForm() {
     super();
+    maxFiles = OptionalInt.empty();
   }
 
   public FileUploadQuestionForm(FileUploadQuestionDefinition qd) {
     super(qd);
+    maxFiles = qd.getMaxFiles();
+  }
+
+  public OptionalInt getMaxFiles() {
+    return maxFiles;
+  }
+
+  /**
+   * We use a string parameter here so that if the field is empty (i.e. unset), we can correctly set
+   * to an empty OptionalInt. Since the HTML input is type "number", we can be sure this string is
+   * in fact an integer when we parse it. If we instead used an int here, we see an "Invalid value"
+   * error when binding the empty value in the form.
+   */
+  public void setMaxFiles(String maxFiles) {
+    if (maxFiles.isEmpty()) {
+      this.maxFiles = OptionalInt.empty();
+    } else {
+      Integer maxFilesInt = Integer.parseInt(maxFiles);
+      this.maxFiles = maxFilesInt <= 0 ? OptionalInt.empty() : OptionalInt.of(maxFilesInt);
+    }
   }
 
   @Override
   public QuestionType getQuestionType() {
     return QuestionType.FILEUPLOAD;
+  }
+
+  @Override
+  public QuestionDefinitionBuilder getBuilder() {
+    FileUploadQuestionDefinition.FileUploadValidationPredicates.Builder
+        fileUploadPredicatesBuilder =
+            FileUploadQuestionDefinition.FileUploadValidationPredicates.builder();
+
+    fileUploadPredicatesBuilder.setMaxFiles(getMaxFiles());
+
+    return super.getBuilder().setValidationPredicates(fileUploadPredicatesBuilder.build());
   }
 }

--- a/server/app/services/question/types/FileUploadQuestionDefinition.java
+++ b/server/app/services/question/types/FileUploadQuestionDefinition.java
@@ -1,7 +1,10 @@
 package services.question.types;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import java.util.OptionalInt;
 
 /** Defines a file upload question. */
 public final class FileUploadQuestionDefinition extends QuestionDefinition {
@@ -10,6 +13,8 @@ public final class FileUploadQuestionDefinition extends QuestionDefinition {
     super(config);
   }
 
+  @JsonDeserialize(
+      builder = AutoValue_FileUploadQuestionDefinition_FileUploadValidationPredicates.Builder.class)
   @AutoValue
   public abstract static class FileUploadValidationPredicates extends ValidationPredicates {
 
@@ -23,13 +28,33 @@ public final class FileUploadQuestionDefinition extends QuestionDefinition {
       }
     }
 
+    @JsonProperty("maxFiles")
+    public abstract OptionalInt maxFiles();
+
     public static FileUploadValidationPredicates create() {
-      return new AutoValue_FileUploadQuestionDefinition_FileUploadValidationPredicates();
+      return builder().setMaxFiles(OptionalInt.empty()).build();
+    }
+
+    public static Builder builder() {
+      return new AutoValue_FileUploadQuestionDefinition_FileUploadValidationPredicates.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      @JsonProperty("maxFiles")
+      public abstract Builder setMaxFiles(OptionalInt allowMultipleUpload);
+
+      public abstract FileUploadValidationPredicates build();
     }
   }
 
   public FileUploadValidationPredicates getFileUploadValidationPredicates() {
     return (FileUploadValidationPredicates) getValidationPredicates();
+  }
+
+  public OptionalInt getMaxFiles() {
+    return getFileUploadValidationPredicates().maxFiles();
   }
 
   @Override

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -11,6 +11,7 @@ import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.AddressQuestionDefinition.AddressValidationPredicates;
+import services.question.types.FileUploadQuestionDefinition.FileUploadValidationPredicates;
 import services.question.types.IdQuestionDefinition.IdValidationPredicates;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
@@ -208,6 +209,10 @@ public final class QuestionDefinitionBuilder {
         return new EmailQuestionDefinition(builder.build());
 
       case FILEUPLOAD:
+        if (!validationPredicatesString.isEmpty()) {
+          builder.setValidationPredicates(
+              FileUploadValidationPredicates.parse(validationPredicatesString));
+        }
         return new FileUploadQuestionDefinition(builder.build());
 
       case ID:

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import forms.AddressQuestionForm;
 import forms.EnumeratorQuestionForm;
+import forms.FileUploadQuestionForm;
 import forms.IdQuestionForm;
 import forms.MultiOptionQuestionForm;
 import forms.NumberQuestionForm;
@@ -44,7 +45,8 @@ public final class QuestionConfig {
 
   private QuestionConfig() {}
 
-  public static Optional<DivTag> buildQuestionConfig(QuestionForm questionForm, Messages messages) {
+  public static Optional<DivTag> buildQuestionConfig(
+      QuestionForm questionForm, Messages messages, boolean multipleFileUpload) {
     QuestionConfig config = new QuestionConfig();
     switch (questionForm.getQuestionType()) {
       case ADDRESS:
@@ -79,8 +81,14 @@ public final class QuestionConfig {
             config
                 .addMultiOptionQuestionFields((MultiOptionQuestionForm) questionForm, messages)
                 .getContainer());
+      case FILEUPLOAD:
+        return multipleFileUpload
+            ? Optional.of(
+                config
+                    .addFileUploadQuestionFields((FileUploadQuestionForm) questionForm)
+                    .getContainer())
+            : Optional.empty();
       case CURRENCY: // fallthrough intended - no options
-      case FILEUPLOAD: // fallthrough intended
       case NAME: // fallthrough intended - no options
       case DATE: // fallthrough intended
       case EMAIL: // fallthrough intended
@@ -107,6 +115,17 @@ public final class QuestionConfig {
             .setValue("true")
             .setChecked(addressQuestionForm.getDisallowPoBox())
             .getCheckboxTag());
+    return this;
+  }
+
+  private QuestionConfig addFileUploadQuestionFields(
+      FileUploadQuestionForm fileUploadQuestionForm) {
+    content.with(
+        FieldWithLabel.number()
+            .setFieldName("maxFiles")
+            .setLabelText("Maximum number of file uploads")
+            .setValue(fileUploadQuestionForm.getMaxFiles())
+            .getNumberTag());
     return this;
   }
 

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -125,6 +125,7 @@ public final class QuestionConfig {
             .setFieldName("maxFiles")
             .setLabelText("Maximum number of file uploads")
             .setValue(fileUploadQuestionForm.getMaxFiles())
+            .setMin(OptionalLong.of(1))
             .getNumberTag());
     return this;
   }

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -436,7 +436,9 @@ public final class QuestionEditView extends BaseHtmlView {
         enumeratorOptions.setDisabled(!forCreate).getSelectTag());
 
     ImmutableList.Builder<DomContent> questionSettingsContentBuilder = ImmutableList.builder();
-    Optional<DivTag> questionConfig = QuestionConfig.buildQuestionConfig(questionForm, messages);
+    Optional<DivTag> questionConfig =
+        QuestionConfig.buildQuestionConfig(
+            questionForm, messages, settingsManifest.getMultipleFileUploadEnabled(request));
     if (questionConfig.isPresent()) {
       questionSettingsContentBuilder.add(questionConfig.get());
     }

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -1,8 +1,10 @@
 package forms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Locale;
+import java.util.OptionalInt;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.FileUploadQuestionDefinition;
@@ -18,6 +20,7 @@ public class FileUploadQuestionFormTest {
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setMaxFiles("4");
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     FileUploadQuestionDefinition expected =
@@ -27,6 +30,10 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.builder()
+                        .setMaxFiles(OptionalInt.of(4))
+                        .build())
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -43,6 +50,10 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setValidationPredicates(
+                    FileUploadQuestionDefinition.FileUploadValidationPredicates.builder()
+                        .setMaxFiles(OptionalInt.of(4))
+                        .build())
                 .build());
 
     FileUploadQuestionForm form = new FileUploadQuestionForm(originalQd);
@@ -51,5 +62,24 @@ public class FileUploadQuestionFormTest {
     QuestionDefinition actual = builder.build();
 
     assertThat(actual).isEqualTo(originalQd);
+  }
+
+  @Test
+  public void setMaxFiles_emptyStringClearsMaxFiles() throws Exception {
+    FileUploadQuestionForm form = new FileUploadQuestionForm();
+    form.setMaxFiles("4");
+
+    assertThat(form.getMaxFiles().getAsInt()).isEqualTo(4);
+
+    form.setMaxFiles("");
+
+    assertThat(form.getMaxFiles()).isEmpty();
+  }
+
+  @Test
+  public void setMaxFiles_invalidStringThrowsException() throws Exception {
+    FileUploadQuestionForm form = new FileUploadQuestionForm();
+
+    assertThrows(NumberFormatException.class, () -> form.setMaxFiles("four"));
   }
 }

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -27,6 +27,14 @@ public class QuestionConfigTest {
       stubMessagesApi().preferred(ImmutableSet.of(Lang.defaultLang()));
 
   @Test
+  public void fileUpload_withAllowMultipleFlag() throws Exception {
+    QuestionForm questionForm = QuestionFormBuilder.create(QuestionType.FILEUPLOAD);
+    Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(questionForm, messages, true);
+    assertThat(maybeConfig).isPresent();
+    assertThat(maybeConfig.get().renderFormatted()).contains("Maximum number of file uploads");
+  }
+
+  @Test
   @Parameters(source = QuestionType.class)
   public void resultForAllQuestions(QuestionType questionType) throws Exception {
     // A null question type is not allowed to be created and won't show in the list
@@ -35,7 +43,8 @@ public class QuestionConfigTest {
     }
 
     QuestionForm questionForm = QuestionFormBuilder.create(questionType);
-    Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(questionForm, messages);
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(questionForm, messages, false);
     switch (questionType) {
       case ADDRESS:
         assertThat(maybeConfig).isPresent();
@@ -115,7 +124,7 @@ public class QuestionConfigTest {
     form.setNewOptions(ImmutableList.of("new-option-c", "new-option-d"));
     form.setNewOptionAdminNames(ImmutableList.of("new-option-admin-c", "new-option-admin-d"));
 
-    Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(form, messages);
+    Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(form, messages, false);
     assertThat(maybeConfig).isPresent();
     String result = maybeConfig.get().renderFormatted();
 

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -26,6 +26,10 @@ public class QuestionConfigTest {
   private final Messages messages =
       stubMessagesApi().preferred(ImmutableSet.of(Lang.defaultLang()));
 
+  // This tests just the file upload behavior from resultForAllQuestions to test the new
+  // multipleFileUpload feature.
+  // When that flag is removed, we will need to move this logic to the test below, and remove this
+  // test.
   @Test
   public void fileUpload_withAllowMultipleFlag() throws Exception {
     QuestionForm questionForm = QuestionFormBuilder.create(QuestionType.FILEUPLOAD);


### PR DESCRIPTION
### Description

Adds "maxFiles" to FileUploadQuestionDefinition. Adds UI for setting it (protected by a flag). Doesn't actually use max files yet.

TDD: https://docs.google.com/document/d/1NQjkUjnY70dVMDSiG-wGNXZhqT4hjB58CHrLKsQ7-To/edit#heading=h.bknox3ib8wpb

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
