### PR TITLE
Adding route extractor

### DIFF
--- a/server/app/actions/RouteExtractor.java
+++ b/server/app/actions/RouteExtractor.java
@@ -74,6 +74,8 @@ public final class RouteExtractor {
   }
 
   /**
+   * The given key's value converted into a long format.
+   *
    * @param key Path parameter key name as defined in the routes file.
    * @return the given key's value converted into a long format.
    */
@@ -90,9 +92,7 @@ public final class RouteExtractor {
     }
   }
 
-  /**
-   * @return the number of parameters found
-   */
+  /** The number of parameters found */
   @VisibleForTesting
   int size() {
     return routeParameters.size();

--- a/server/app/actions/RouteExtractor.java
+++ b/server/app/actions/RouteExtractor.java
@@ -26,6 +26,7 @@ public final class RouteExtractor {
   private final ImmutableMap<String, String> routeParameters;
 
   // Example: something like /$id<[^/]+>
+  // This is the pattern used to break the route apart
   private static final String INDEX_PATTERN = "\\$(.+?)<\\[\\^/\\]\\+>";
 
   /**
@@ -79,7 +80,7 @@ public final class RouteExtractor {
    * @param key Path parameter key name as defined in the routes file.
    * @return the given key's value converted into a long format.
    */
-  public long getLongValue(String key) {
+  public long getParamLongValue(String key) {
     if (!routeParameters.containsKey(key)) {
       throw new RuntimeException(String.format("Could not find '%s' in route '%s'", key, path));
     }
@@ -88,7 +89,7 @@ public final class RouteExtractor {
       return Long.parseLong(routeParameters.get(key));
     } catch (NumberFormatException ex) {
       throw new RuntimeException(
-          String.format("Could parse value from '%s' in route '%s'", key, path), ex);
+          String.format("Could not parse value from '%s' in route '%s'", key, path), ex);
     }
   }
 

--- a/server/app/actions/RouteExtractor.java
+++ b/server/app/actions/RouteExtractor.java
@@ -1,0 +1,100 @@
+package actions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * RouteExtractor interrogates the current request URI path and route pattern allowing for a simple
+ * way to get path parameters within a custom Action
+ *
+ * <p>The Play Framework does not currently expose URI path parameters within custom Actions. This
+ * is a simple workaround originally provided on the related Github Issue on the Play Framework. <a
+ * href="https://github.com/playframework/playframework/issues/2983#issuecomment-456375489">...</a>.
+ *
+ * <p>This is modified from the original. Created by Akinniranye James Ayodele on 8/12/16 12:56 PM.
+ * Project Andromeda Version 0.1
+ */
+public final class RouteExtractor {
+  private final String routePattern;
+  private final String path;
+  private final ImmutableMap<String, String> routeParameters;
+
+  // Example: something like /$id<[^/]+>
+  private static final String INDEX_PATTERN = "\\$(.+?)<\\[\\^/\\]\\+>";
+
+  /**
+   * @param routePattern Get the routePattern from an instance of {@link play.mvc.Http.Request} like
+   *     this {@code request.attrs().get(Router.Attrs.HANDLER_DEF).path()}
+   *     <p>Example string: {@code /foo/$id<[^/]+>/edit/$james<[^/]+>}
+   * @param path The URI path value.
+   *     <p>Get it from an instance of {@link play.mvc.Http.Request} {@code request.path()}
+   */
+  public RouteExtractor(String routePattern, String path) {
+
+    this.routePattern = checkNotNull(routePattern);
+    this.path = checkNotNull(path);
+    this.routeParameters = extract();
+  }
+
+  /** Create a map containing all the matching path parameters and associated values */
+  private ImmutableMap<String, String> extract() {
+    Pattern pattern = Pattern.compile(this.replaceRoutePatternWithGroup());
+    Matcher matcher = pattern.matcher(this.path);
+    ImmutableMap.Builder<String, String> results = ImmutableMap.builder();
+
+    if (matcher.find()) {
+      this.extractPositions().forEach((key, value) -> results.put(value, matcher.group(key + 1)));
+    }
+
+    return results.build();
+  }
+
+  private String replaceRoutePatternWithGroup() {
+    Pattern pattern = Pattern.compile(INDEX_PATTERN);
+    Matcher matcher = pattern.matcher(this.routePattern);
+    return matcher.replaceAll("([^/]+)");
+  }
+
+  private Map<Integer, String> extractPositions() {
+    Pattern pattern = Pattern.compile(INDEX_PATTERN);
+    Matcher matcher = pattern.matcher(this.routePattern);
+    Map<Integer, String> results = new HashMap<>();
+
+    int index = 0;
+    while (matcher.find()) {
+      results.put(index++, matcher.group(1));
+    }
+    return results;
+  }
+
+  /**
+   * @param key Path parameter key name as defined in the routes file.
+   * @return the given key's value converted into a long format.
+   */
+  public long getLongValue(String key) {
+    if (!routeParameters.containsKey(key)) {
+      throw new RuntimeException(String.format("Could not find '%s' in route '%s'", key, path));
+    }
+
+    try {
+      return Long.parseLong(routeParameters.get(key));
+    } catch (NumberFormatException ex) {
+      throw new RuntimeException(
+          String.format("Could parse value from '%s' in route '%s'", key, path), ex);
+    }
+  }
+
+  /**
+   * @return the number of parameters found
+   */
+  @VisibleForTesting
+  int size() {
+    return routeParameters.size();
+  }
+}

--- a/server/test/actions/RouteExtractorTest.java
+++ b/server/test/actions/RouteExtractorTest.java
@@ -13,8 +13,8 @@ public final class RouteExtractorTest {
     RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
 
     assertThat(routeExtractor.size()).isEqualTo(2);
-    assertThat(routeExtractor.getLongValue("programId")).isEqualTo(1);
-    assertThat(routeExtractor.getLongValue("blockId")).isEqualTo(2);
+    assertThat(routeExtractor.getParamLongValue("programId")).isEqualTo(1);
+    assertThat(routeExtractor.getParamLongValue("blockId")).isEqualTo(2);
   }
 
   @Test
@@ -32,6 +32,6 @@ public final class RouteExtractorTest {
     String path = "/programs/1/blocks/2/edit";
     RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
 
-    assertThatThrownBy(() -> routeExtractor.getLongValue("unexpectedId"));
+    assertThatThrownBy(() -> routeExtractor.getParamLongValue("unexpectedId"));
   }
 }

--- a/server/test/actions/RouteExtractorTest.java
+++ b/server/test/actions/RouteExtractorTest.java
@@ -1,0 +1,37 @@
+package actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public final class RouteExtractorTest {
+  @Test
+  public void successfully_extracts_route_parameters() {
+    String routePattern = "/programs/$programId<[^/]+>/blocks/$blockId<[^/]+>/edit";
+    String path = "/programs/1/blocks/2/edit";
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
+
+    assertThat(routeExtractor.size()).isEqualTo(2);
+    assertThat(routeExtractor.getLongValue("programId")).isEqualTo(1);
+    assertThat(routeExtractor.getLongValue("blockId")).isEqualTo(2);
+  }
+
+  @Test
+  public void has_no_route_parameters_configured() {
+    String routePattern = "/programs/path/edit";
+    String path = "/programs/path/edit";
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
+
+    assertThat(routeExtractor.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void asking_for_route_parameter_that_does_not_exist() {
+    String routePattern = "/programs/$programId<[^/]+>/blocks/$blockId<[^/]+>/edit";
+    String path = "/programs/1/blocks/2/edit";
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
+
+    assertThatThrownBy(() -> routeExtractor.getLongValue("unexpectedId"));
+  }
+}


### PR DESCRIPTION
### Description

Adding a class that can be used within custom Play Actions to pull out path parameter values. Play doesn't current provide an easy way to access these value natively.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Related to: #5541
