### PR TITLE
Adding query to get the most recent program id

### DIFF
--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -870,4 +870,41 @@ public class ProgramRepositoryTest extends ResetPostgres {
     assertThat(paginationResult.getPageContents().size()).isEqualTo(1);
     assertThat(paginationResult.getPageContents().get(0).getApplicant()).isEqualTo(applicantOne);
   }
+
+  @Test
+  public void getMostRecentActiveProgramVersion_returnsDifferentProgramIdWhichIsTheLatest() {
+    ProgramModel programModel1 = resourceCreator.insertActiveProgram("program-name-1");
+    ProgramModel programModel2 = resourceCreator.insertActiveProgram("program-name-2");
+    ProgramModel programModel3 = resourceCreator.insertActiveProgram("program-name-1");
+    ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-1");
+    ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
+
+    long latestId = repo.getMostRecentActiveProgramId(programModel1.id);
+
+    assertThat(latestId).isEqualTo(programModel4.id);
+  }
+
+  @Test
+  public void getMostRecentActiveProgramVersion_returnsSameProgramIdWhichIsTheLatest() {
+    ProgramModel programModel1 = resourceCreator.insertActiveProgram("program-name-1");
+    ProgramModel programModel2 = resourceCreator.insertActiveProgram("program-name-2");
+    ProgramModel programModel3 = resourceCreator.insertActiveProgram("program-name-3");
+    ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-4");
+    ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
+
+    long latestId = repo.getMostRecentActiveProgramId(programModel1.id);
+
+    assertThat(latestId).isEqualTo(programModel1.id);
+  }
+
+  @Test
+  public void getMostRecentActiveProgramVersion_throwsWhenProgramIdDoesNotExist() {
+    ProgramModel programModel1 = resourceCreator.insertActiveProgram("program-name-1");
+    ProgramModel programModel2 = resourceCreator.insertActiveProgram("program-name-2");
+    ProgramModel programModel3 = resourceCreator.insertActiveProgram("program-name-3");
+    ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-4");
+    ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
+
+    assertThatThrownBy(() -> repo.getMostRecentActiveProgramId(-1));
+  }
 }


### PR DESCRIPTION
### Description

This new query can go get the latest active program id from any program id supplied.

We need for this to always get the most recent active program ID, thus we are unable to cache the value without building out a much more complicated caching solution. This will be called frequently enough (mostly once per page load of any applicant application edit/review page) that I'm electing to go with a native sql query.  Attempts to have ebeans build the sql resulted in slower queries and much more difficult to follow queries. 

This is taking less than 1ms locally in dev. Based on calling it 100,000 times passing in a random program id from a list of 50 candidate programs and using Seattle's real program data.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)



Related to #5541 
