### PR TITLE
Add new string for multi-select validation error

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -210,6 +210,7 @@ public enum MessageKey {
   MULTI_OPTION_ADMIN_VALIDATION("adminValidation.multiOptionAdminError"),
   MULTI_SELECT_VALIDATION_TOO_FEW("validation.tooFewSelections"),
   MULTI_SELECT_VALIDATION_TOO_MANY("validation.tooManySelections"),
+  MULTI_SELECT_VALIDATION_TOO_MANY_V2("validation.tooManySelections.v2"),
   NAME_EXAMPLE("label.nameExample"),
   NAME_LABEL_FIRST("label.firstName"),
   NAME_LABEL_LAST("label.lastName"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -503,6 +503,8 @@ validation.numberRequired=Must contain only numbers.
 
 validation.tooFewSelections=Please select at least {0}.
 validation.tooManySelections=Please select fewer than {0}.
+# Error message that indicates the applicant has selected too many choices on the multi-select question
+validation.tooManySelections.v2=Please select at most {0}.
 
 #---------------------------------------------------#
 # NAME QUESTION - text when viewing a name question #


### PR DESCRIPTION
### Description

Add a new string for the error when you select too many choices in a multi-select question. The current error message says "select fewer than X" which is inconsistent with all the other similar error messages that say "select at most X". This is the first step for fixing #7846.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)