### PR TITLE
Add command to set application to another program

### DIFF
--- a/server/app/models/ApplicationModel.java
+++ b/server/app/models/ApplicationModel.java
@@ -176,4 +176,16 @@ public class ApplicationModel extends BaseModel {
   void setLatestStatusForTest(String latestStatus) {
     this.latestStatus = latestStatus;
   }
+
+  /**
+   * Point the application to a new {@link ProgramModel}.
+   *
+   * <p>This typically doesn't need to be done aside from when we want to migrate an application to
+   * a newer version of a program.
+   *
+   * @param program {@link ProgramModel}
+   */
+  public void setProgram(ProgramModel program) {
+    this.program = program;
+  }
 }

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.ExpressionList;
+import io.ebean.Transaction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -319,5 +320,44 @@ public final class ApplicationRepository {
               .collect(ImmutableSet.toImmutableSet());
         },
         executionContext.current());
+  }
+
+  /**
+   * Updates an application to point to a new program
+   *
+   * @param applicantId the applicant ID
+   * @param programId the program ID
+   */
+  public void updateDraftApplicationProgram(long applicantId, long programId) {
+    Optional<ProgramModel> programOptional =
+        programRepository.lookupProgram(programId).toCompletableFuture().join();
+
+    if (programOptional.isEmpty()) {
+      throw new RuntimeException(new ProgramNotFoundException(programId));
+    }
+
+    ProgramModel program = programOptional.get();
+
+    try (Transaction transaction = database.beginTransaction()) {
+      ApplicationModel existingDraft =
+          database
+              .createQuery(ApplicationModel.class)
+              .where()
+              .eq("applicant.id", applicantId)
+              .eq(
+                  "program.name",
+                  programRepository.getShallowProgramDefinition(program).adminName())
+              .eq("lifecycle_stage", LifecycleStage.DRAFT)
+              .setLabel("ApplicationModel.findById")
+              .setProfileLocation(
+                  queryProfileLocationBuilder.create("updateDraftApplicationProgram"))
+              .findOne();
+
+      // Update the existing draft
+      existingDraft.setProgram(program);
+      existingDraft.save();
+
+      transaction.commit();
+    }
   }
 }

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -371,7 +371,7 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     repo.updateDraftApplicationProgram(applicant.id, programV2.id);
 
     // Reload the application and check that it points to program v2
-    application = repo.getApplication(applicant.id).toCompletableFuture().join().get();
+    application = repo.getApplication(application.id).toCompletableFuture().join().get();
     assertThat(application.getProgram().id).isEqualTo(programV2.id);
   }
 

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -356,6 +356,42 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     assertThat(result).isEmpty();
   }
 
+  @Test
+  public void updateDraftApplicationProgram_updatesExistingDraft() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    ProgramModel programV1 = createActiveProgram("Program");
+
+    // Check the application points to program v1
+    ApplicationModel application =
+        repo.createOrUpdateDraft(applicant, programV1).toCompletableFuture().join();
+    assertThat(application.getProgram().id).isEqualTo(programV1.id);
+
+    // Update the application program v2
+    ProgramModel programV2 = createActiveProgram("Program");
+    repo.updateDraftApplicationProgram(applicant.id, programV2.id);
+
+    // Reload the application and check that it points to program v2
+    application = repo.getApplication(applicant.id).toCompletableFuture().join().get();
+    assertThat(application.getProgram().id).isEqualTo(programV2.id);
+  }
+
+  @Test
+  public void updateDraftApplicationProgram_throwIfProgramNotFound() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    ProgramModel programV1 = createActiveProgram("Program");
+
+    // Check the application points to program v1
+    ApplicationModel application =
+        repo.createOrUpdateDraft(applicant, programV1).toCompletableFuture().join();
+    assertThat(application.getProgram().id).isEqualTo(programV1.id);
+
+    // Update the application program v2
+    long fakeProgramV2Id = -1;
+    assertThatThrownBy(() -> repo.updateDraftApplicationProgram(applicant.id, fakeProgramV2Id))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Program not found");
+  }
+
   private ApplicantModel saveApplicant(String name) {
     AccountModel account = new AccountModel();
     // TODO (#5503): This can be removed when we are no longer checking name


### PR DESCRIPTION
### Description

In most cases applications are fixed to a program when the record is initially created and never change.

This provides a method to update the program an application uses in the rare case we need it, such as the program fast forward feature.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Related to: #5541
