### PR TITLE
Fix converting String to QuestionType for irregular enum names

### DIFF
--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,7 +1,5 @@
 package services.question.types;
 
-import java.util.Locale;
-import java.util.Map;
 import services.applicant.question.AddressQuestion;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
@@ -41,12 +39,6 @@ public enum QuestionType {
 
   private final String label;
   private final Class<? extends Question> supportedQuestion;
-  private static final Map<String, QuestionType> irregularMappings =
-      Map.of(
-          "FILE UPLOAD", FILEUPLOAD,
-          "RADIO BUTTON", RADIO_BUTTON,
-          "STATIC TEXT", STATIC,
-          "PHONE NUMBER", PHONE);
 
   QuestionType(String label, Class<? extends Question> supportedQuestion) {
     this.label = label;
@@ -63,16 +55,12 @@ public enum QuestionType {
   }
 
   public static QuestionType of(String name) throws InvalidQuestionTypeException {
-    String upperName = name.toUpperCase(Locale.ROOT);
-    try {
-      if (irregularMappings.containsKey(upperName)) {
-        return irregularMappings.get(upperName);
+    for (QuestionType type : QuestionType.values()) {
+      if (type.getLabel().equalsIgnoreCase(name)) {
+        return type;
       }
-
-      return valueOf(upperName);
-    } catch (IllegalArgumentException e) {
-      throw new InvalidQuestionTypeException(upperName);
     }
+    throw new InvalidQuestionTypeException(name);
   }
 
   public String getLabel() {

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -56,13 +56,6 @@ public enum QuestionType {
   }
 
   public static QuestionType of(String name) throws InvalidQuestionTypeException {
-    // Match label, e.g. "Phone Number" -> PHONE
-    for (QuestionType type : QuestionType.values()) {
-      if (type.getLabel().equalsIgnoreCase(name)) {
-        return type;
-      }
-    }
-
     // Match naive string, e.g. "PHONE" -> PHONE
     String upperName = name.toUpperCase(Locale.ROOT);
     try {
@@ -70,6 +63,16 @@ public enum QuestionType {
     } catch (IllegalArgumentException e) {
       throw new InvalidQuestionTypeException(upperName);
     }
+  }
+
+  public static QuestionType fromLabel(String label) throws InvalidQuestionTypeException {
+    // Match label, e.g. "Phone Number" -> PHONE
+    for (QuestionType type : QuestionType.values()) {
+      if (type.getLabel().equalsIgnoreCase(label)) {
+        return type;
+      }
+    }
+    throw new InvalidQuestionTypeException(label);
   }
 
   public String getLabel() {

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,6 +1,7 @@
 package services.question.types;
 
 import java.util.Locale;
+import java.util.Map;
 import services.applicant.question.AddressQuestion;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
@@ -40,6 +41,12 @@ public enum QuestionType {
 
   private final String label;
   private final Class<? extends Question> supportedQuestion;
+  private static final Map<String, QuestionType> irregularMappings =
+      Map.of(
+          "FILE UPLOAD", FILEUPLOAD,
+          "RADIO BUTTON", RADIO_BUTTON,
+          "STATIC TEXT", STATIC,
+          "PHONE NUMBER", PHONE);
 
   QuestionType(String label, Class<? extends Question> supportedQuestion) {
     this.label = label;
@@ -58,6 +65,10 @@ public enum QuestionType {
   public static QuestionType of(String name) throws InvalidQuestionTypeException {
     String upperName = name.toUpperCase(Locale.ROOT);
     try {
+      if (irregularMappings.containsKey(upperName)) {
+        return irregularMappings.get(upperName);
+      }
+
       return valueOf(upperName);
     } catch (IllegalArgumentException e) {
       throw new InvalidQuestionTypeException(upperName);

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,5 +1,6 @@
 package services.question.types;
 
+import java.util.Locale;
 import services.applicant.question.AddressQuestion;
 import services.applicant.question.CurrencyQuestion;
 import services.applicant.question.DateQuestion;
@@ -55,12 +56,20 @@ public enum QuestionType {
   }
 
   public static QuestionType of(String name) throws InvalidQuestionTypeException {
+    // Match label, e.g. "Phone Number" -> PHONE
     for (QuestionType type : QuestionType.values()) {
       if (type.getLabel().equalsIgnoreCase(name)) {
         return type;
       }
     }
-    throw new InvalidQuestionTypeException(name);
+
+    // Match naive string, e.g. "PHONE" -> PHONE
+    String upperName = name.toUpperCase(Locale.ROOT);
+    try {
+      return valueOf(upperName);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidQuestionTypeException(upperName);
+    }
   }
 
   public String getLabel() {

--- a/server/test/services/question/types/QuestionTypeTest.java
+++ b/server/test/services/question/types/QuestionTypeTest.java
@@ -18,13 +18,23 @@ public class QuestionTypeTest {
   }
 
   @Test
+  public void fromLabel_regular() throws InvalidQuestionTypeException {
+    assertThat(QuestionType.fromLabel("Text")).isEqualTo(QuestionType.TEXT);
+  }
+
+  @Test
+  public void fromLabel_irregular() throws InvalidQuestionTypeException {
+    assertThat(QuestionType.fromLabel("Phone Number")).isEqualTo(QuestionType.PHONE);
+  }
+
+  @Test
   public void of_regular() throws InvalidQuestionTypeException {
     assertThat(QuestionType.of("Text")).isEqualTo(QuestionType.TEXT);
   }
 
   @Test
   public void of_irregular() throws InvalidQuestionTypeException {
-    assertThat(QuestionType.of("Phone Number")).isEqualTo(QuestionType.PHONE);
+    assertThat(QuestionType.of("Phone")).isEqualTo(QuestionType.PHONE);
   }
 
   @Test

--- a/server/test/services/question/types/QuestionTypeTest.java
+++ b/server/test/services/question/types/QuestionTypeTest.java
@@ -1,0 +1,34 @@
+package services.question.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import services.question.exceptions.InvalidQuestionTypeException;
+
+public class QuestionTypeTest {
+
+  @Test
+  public void label_regular() {
+    assertThat(QuestionType.TEXT.getLabel()).isEqualTo("Text");
+  }
+
+  @Test
+  public void label_irregular() {
+    assertThat(QuestionType.PHONE.getLabel()).isEqualTo("Phone Number");
+  }
+
+  @Test
+  public void of_regular() throws InvalidQuestionTypeException {
+    assertThat(QuestionType.of("Text")).isEqualTo(QuestionType.TEXT);
+  }
+
+  @Test
+  public void of_irregular() throws InvalidQuestionTypeException {
+    assertThat(QuestionType.of("Phone Number")).isEqualTo(QuestionType.PHONE);
+  }
+
+  @Test
+  public void of_lowercase() throws InvalidQuestionTypeException {
+    assertThat(QuestionType.of("text")).isEqualTo(QuestionType.TEXT);
+  }
+}

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -560,7 +560,8 @@ public class TestQuestionBank {
         question.loadQuestionDefinition();
       } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
         throw new IllegalArgumentException(
-            "Questions in the TestQuestionBank better be supported QuestionTypes.");
+            "Questions in the TestQuestionBank better be supported QuestionTypes. "
+                + e.getLocalizedMessage());
       }
     }
     return question;


### PR DESCRIPTION
### Description

Fix converting String to QuestionType for irregular enum names. This change supports question previews (#7490).

This PR is a part of #7835 being split off for ease of review. The code will be tested indirectly by browser tests, but feel free to request unit tests specific to QuestionType.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

n/a
### Issue(s) this completes

None
