### PR TITLE
Update i18n checklist in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,10 +29,9 @@ Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#wr
 
 #### User visible changes
 
-- [ ] Followed steps to [internationalize new strings](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#internationalization-for-application-strings)
+- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
   - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
   - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
-  - [ ] Follow the workflow [here](<https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#workflow-for-adding-or-editing-translations>)
 - [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
 - [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
 - [ ] Manually tested at 200% size


### PR DESCRIPTION
### Description

Update i18n checklist in pull request template:

- Fix broken link from rewrite of the wiki page (diff: https://github.com/civiform/civiform/wiki/Internationalization-(i18n)/_compare/892049cdb22a2d353338bbe598eede008622c46d...f91abad2a09ab0479b994de323c1300f918de143)
- Remove the checklist item for following the translation workflow, because translations are handled async by the Google.org team so the PR author just has to wait for them to be done. They can still find all the details about the translation process at the wiki linked in the parent checklist item.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
