### PR TITLE
Fix bug where block translations were not being applied

### DIFF
--- a/browser-test/src/admin/admin_program_translation.test.ts
+++ b/browser-test/src/admin/admin_program_translation.test.ts
@@ -50,6 +50,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: publicName,
       description: publicDescription,
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [],
     })
     await adminPrograms.gotoDraftProgramManageTranslationsPage(programName)
@@ -115,6 +117,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: publicName,
       description: publicDescription,
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [],
     })
     await adminPrograms.gotoDraftProgramManageTranslationsPage(programName)
@@ -139,6 +143,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: publicName,
       description: publicDescription,
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [
         {
           configuredStatusText: statusWithEmailName,
@@ -193,6 +199,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: 'Spanish name',
       description: 'Spanish description',
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [],
     })
     await adminTranslations.editProgramImageDescription(
@@ -231,6 +239,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: 'Spanish name',
       description: 'Spanish description',
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [],
     })
     await adminTranslations.editProgramImageDescription(
@@ -271,6 +281,8 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.editProgramTranslations({
       name: 'Spanish name',
       description: 'Spanish description',
+      blockName: 'Spanish block name',
+      blockDescription: 'Spanish block description',
       statuses: [],
     })
     await adminTranslations.editProgramImageDescription(
@@ -288,4 +300,43 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.selectLanguage('Spanish')
     await adminTranslations.expectNoProgramImageDescription()
   })
+
+  test(
+    'Add translations for block name and description',
+    {tag: ['@northstar']},
+    async ({page, adminPrograms, adminQuestions, adminTranslations}) => {
+      await loginAsAdmin(page)
+
+      await adminQuestions.addTextQuestion({questionName: 'text-question'})
+
+      const programName = 'Program with blocks'
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockUsingSpec(programName, {
+        name: 'Screen 1',
+        description: 'first screen',
+        questions: [{name: 'text-question'}],
+      })
+
+      await test.step('Update translations', async () => {
+        await adminPrograms.gotoDraftProgramManageTranslationsPage(programName)
+        await adminTranslations.selectLanguage('Spanish')
+        await adminTranslations.editProgramTranslations({
+          name: 'Spanish name',
+          description: 'Spanish description',
+          blockName: 'Spanish block name',
+          blockDescription: 'Spanish block description',
+          statuses: [],
+        })
+      })
+
+      await test.step('Verify translations in translations page', async () => {
+        await adminPrograms.gotoDraftProgramManageTranslationsPage(programName)
+        await adminTranslations.selectLanguage('Spanish')
+        await adminTranslations.expectBlockTranslations(
+          'Spanish block name',
+          'Spanish block description',
+        )
+      })
+    },
+  )
 })

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -24,10 +24,14 @@ export class AdminTranslations {
   async editProgramTranslations({
     name,
     description,
+    blockName,
+    blockDescription,
     statuses = [],
   }: {
     name: string
     description: string
+    blockName: string
+    blockDescription: string
     statuses: ProgramStatusTranslationParams[]
   }) {
     await this.page.fill('text=Program name', name)
@@ -51,6 +55,9 @@ export class AdminTranslations {
         )
       }
     }
+
+    await this.page.fill('text=Screen name', blockName)
+    await this.page.fill('text=Screen description', blockDescription)
 
     await this.page.click('#update-localizations-button')
     await waitForPageJsLoad(this.page)
@@ -137,6 +144,13 @@ export class AdminTranslations {
       'Program image description',
     )
     await expect(imageDescriptionValue).toHaveValue(expectImageDescription)
+  }
+
+  async expectBlockTranslations(blockName: string, blockDescription: string) {
+    const blockNameValue = this.page.getByLabel('Screen name')
+    await expect(blockNameValue).toHaveValue(blockName)
+    const blockDescriptionValue = this.page.getByLabel('Screen description')
+    await expect(blockDescriptionValue).toHaveValue(blockDescription)
   }
 
   async editQuestionTranslations(

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -189,7 +189,7 @@ public final class ProgramTranslationView extends TranslationFormView {
               .add(
                   fieldWithDefaultLocaleTextHint(
                       FieldWithLabel.input()
-                          .setFieldName(ProgramTranslationForm.localizedScreenName(i))
+                          .setFieldName(ProgramTranslationForm.localizedScreenName(block.id()))
                           .setLabelText("Screen name")
                           .setScreenReaderText("Screen name")
                           .setValue(screenUpdateData.localizedName())
@@ -198,7 +198,8 @@ public final class ProgramTranslationView extends TranslationFormView {
               .add(
                   fieldWithDefaultLocaleTextHint(
                       FieldWithLabel.input()
-                          .setFieldName(ProgramTranslationForm.localizedScreenDescription(i))
+                          .setFieldName(
+                              ProgramTranslationForm.localizedScreenDescription(block.id()))
                           .setLabelText("Screen description")
                           .setScreenReaderText("Screen description")
                           .setValue(screenUpdateData.localizedDescription())


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/7702 introduced a bug where the translations for the block names and descriptions weren't applied because the inputs were improperly named. This fixes that and adds the corresponding test.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
