### PR TITLE
Adding ApplicantAuthorizationAction

### DIFF
--- a/server/app/actions/ApplicantAuthorizationAction.java
+++ b/server/app/actions/ApplicantAuthorizationAction.java
@@ -1,0 +1,93 @@
+package actions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import auth.ProfileUtils;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import play.mvc.Action;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import play.routing.Router;
+import repository.VersionRepository;
+
+/**
+ * Check if the profile is authorized to view requested applicant and program data. If no, redirect
+ * home. If yes, continue on.
+ */
+public class ApplicantAuthorizationAction extends Action.Simple {
+  private final ProfileUtils profileUtils;
+  private final VersionRepository versionRepository;
+
+  @Inject
+  public ApplicantAuthorizationAction(
+      ProfileUtils profileUtils, VersionRepository versionRepository) {
+    this.profileUtils = checkNotNull(profileUtils);
+    this.versionRepository = checkNotNull(versionRepository);
+  }
+
+  @Override
+  public CompletionStage<Result> call(Request request) {
+    String routePattern = request.attrs().get(Router.Attrs.HANDLER_DEF).path();
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, request.path());
+
+    long programId = routeExtractor.getParamLongValue("programId");
+    long applicantId = getApplicantId(request, routeExtractor);
+
+    return checkApplicantAuthorization(request, applicantId)
+        .handle(
+            (applicantAuthResult, applicantAuthThrowable) -> {
+              if (applicantAuthThrowable != null) {
+                return handleException(applicantAuthThrowable);
+              }
+
+              return checkProgramAuthorization(request, programId)
+                  .handle(
+                      (programAuthResult, programAuthThrowable) ->
+                          programAuthThrowable != null
+                              ? handleException(programAuthThrowable)
+                              : delegate.call(request))
+                  .thenCompose(resultStage -> resultStage);
+            })
+        .thenCompose(resultStage -> resultStage);
+  }
+
+  private static CompletableFuture<Result> handleException(Throwable throwable) {
+    if (throwable instanceof CompletionException) {
+      Throwable cause = throwable.getCause();
+      if (cause instanceof SecurityException) {
+        return CompletableFuture.completedFuture(
+            redirect(controllers.routes.HomeController.index().url()));
+      }
+      throw new RuntimeException(cause);
+    }
+    throw new RuntimeException(throwable);
+  }
+
+  /** Get the applicantId. Check the user profile first, and fallback to a route parameter */
+  private long getApplicantId(Request request, RouteExtractor routeExtractor) {
+    Optional<Long> applicantIdOptional = profileUtils.getApplicantId(request);
+    return applicantIdOptional.orElseGet(() -> routeExtractor.getParamLongValue("applicantId"));
+  }
+
+  /** Check if the profile is authorized to access the applicant's data. */
+  private CompletionStage<Void> checkApplicantAuthorization(Request request, long applicantId) {
+    return profileUtils.currentUserProfile(request).orElseThrow().checkAuthorization(applicantId);
+  }
+
+  /** Checks that the profile is authorized to access the specified program. */
+  private CompletionStage<Void> checkProgramAuthorization(Request request, Long programId) {
+    return versionRepository
+        .isDraftProgramAsync(programId)
+        .thenAccept(
+            (isDraftProgram) -> {
+              if (isDraftProgram
+                  && !profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+                throw new SecurityException();
+              }
+            });
+  }
+}

--- a/server/test/actions/ApplicantAuthorizationActionTest.java
+++ b/server/test/actions/ApplicantAuthorizationActionTest.java
@@ -35,7 +35,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
   }
 
   @Test
-  public void pass_applicant_and_program_auth_then_moves_to_next_step_in_the_chain() {
+  public void when_applicant_and_program_auth_pass_then_moves_to_next_step_in_the_chain() {
     // Setup mocks
     Action.Simple nextActionInChainMock = mock(Action.Simple.class);
     ApplicantModel applicant = createApplicantWithMockedProfile();
@@ -69,7 +69,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
   }
 
   @Test
-  public void pass_applicant_auth_fail_program_auth_redirects_to_home()
+  public void when_applicant_auth_passes_and_program_auth_fails_redirects_to_home()
       throws ExecutionException, InterruptedException {
     // Setup mocks
     ApplicantModel applicant = createApplicantWithMockedProfile();
@@ -100,7 +100,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
   }
 
   @Test
-  public void fail_applicant_auth_redirects_to_home()
+  public void when_applicant_auth_fails_redirect_home()
       throws ExecutionException, InterruptedException {
     // Setup mocks
     long applicantId = 20000L;

--- a/server/test/actions/ApplicantAuthorizationActionTest.java
+++ b/server/test/actions/ApplicantAuthorizationActionTest.java
@@ -1,0 +1,164 @@
+package actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import auth.CiviFormProfile;
+import auth.ProfileUtils;
+import controllers.WithMockedProfiles;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import models.ApplicantModel;
+import models.ProgramModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import play.api.routing.HandlerDef;
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import play.routing.Router;
+import play.test.Helpers;
+import repository.VersionRepository;
+import scala.jdk.javaapi.CollectionConverters;
+import support.ProgramBuilder;
+
+public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
+  @Before
+  public void setUpWithFreshApplicants() {
+    resetDatabase();
+  }
+
+  @Test
+  public void pass_applicant_and_program_auth_then_moves_to_next_step_in_the_chain() {
+    // Setup mocks
+    Action.Simple nextActionInChainMock = mock(Action.Simple.class);
+    ApplicantModel applicant = createApplicantWithMockedProfile();
+
+    ProgramModel activeProgram =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    // Setup fakeRequest and configure it to use the specified route pattern
+    Request request =
+        createFakeRequest(
+            "/programs/$programId<[^/]+>/applicant/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit",
+            String.format(
+                "/programs/%d/applicant/%d/blocks/2/edit", activeProgram.id, applicant.id));
+
+    // The action to test
+    ApplicantAuthorizationAction action = instanceOf(ApplicantAuthorizationAction.class);
+
+    // Configure a fake secondary action to serve as a stand in for the last action in the chain
+    // (i.e. controller)
+    when(nextActionInChainMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = nextActionInChainMock;
+
+    // Result from running the action
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // All the assertions and verifications
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void pass_applicant_auth_fail_program_auth_redirects_to_home()
+      throws ExecutionException, InterruptedException {
+    // Setup mocks
+    ApplicantModel applicant = createApplicantWithMockedProfile();
+    ProgramModel draftProgram =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().applicantName())
+            .build();
+
+    // Setup fakeRequest and configure it to use the specified route pattern
+    Request request =
+        createFakeRequest(
+            "/programs/$programId<[^/]+>/applicants/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit",
+            String.format(
+                "/programs/%d/applicants/%d/blocks/2/edit", draftProgram.id, applicant.id));
+
+    // The action to test
+    ApplicantAuthorizationAction action = instanceOf(ApplicantAuthorizationAction.class);
+
+    // Result from running the action
+    Result result = action.call(request).toCompletableFuture().get();
+
+    // All the assertions and verifications
+    assertThat(result).isNotNull();
+    assertThat(result.redirectLocation().isPresent()).isTrue();
+    assertThat(result.redirectLocation().get())
+        .isEqualTo(controllers.routes.HomeController.index().url());
+  }
+
+  @Test
+  public void fail_applicant_auth_redirects_to_home()
+      throws ExecutionException, InterruptedException {
+    // Setup mocks
+    long applicantId = 20000L;
+    long programId = 100000L;
+
+    CiviFormProfile profile = mock(CiviFormProfile.class);
+    when(profile.checkAuthorization(applicantId))
+        .thenReturn(
+            CompletableFuture.runAsync(
+                () -> {
+                  throw new SecurityException();
+                }));
+
+    ProfileUtils profileUtils = Mockito.mock(ProfileUtils.class);
+    when(profileUtils.getApplicantId(any(Http.Request.class))).thenReturn(Optional.of(applicantId));
+    when(profileUtils.currentUserProfile(any(Http.RequestHeader.class)))
+        .thenReturn(Optional.of(profile));
+
+    // Setup fakeRequest and configure it to use the specified route pattern
+    Request request =
+        createFakeRequest(
+            "/programs/$programId<[^/]+>/applicants/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit",
+            String.format("/programs/%d/applicants/%d/blocks/2/edit", programId, applicantId));
+
+    // The action to test
+    ApplicantAuthorizationAction action =
+        new ApplicantAuthorizationAction(profileUtils, instanceOf(VersionRepository.class));
+
+    // Result from running the action
+    Result result = action.call(request).toCompletableFuture().get();
+
+    // All the assertions and verifications
+    assertThat(result).isNotNull();
+    assertThat(result.redirectLocation().isPresent()).isTrue();
+    assertThat(result.redirectLocation().get())
+        .isEqualTo(controllers.routes.HomeController.index().url());
+  }
+
+  /**
+   * Create a {@link Request} object with customized route information
+   *
+   * @param routePattern is the pattern for the routes
+   * @param path is the current URI route
+   * @return {@link Request}
+   */
+  private Request createFakeRequest(String routePattern, String path) {
+    HandlerDef handlerDef =
+        new HandlerDef(
+            getClass().getClassLoader(),
+            "router",
+            "controllers.MyFakeController",
+            "index",
+            CollectionConverters.asScala(Collections.<Class<?>>emptyList()).toSeq(),
+            "GET",
+            routePattern,
+            "",
+            CollectionConverters.asScala(Collections.<String>emptyList()).toSeq());
+
+    return Helpers.fakeRequest("GET", path).build().addAttr(Router.Attrs.HANDLER_DEF, handlerDef);
+  }
+}


### PR DESCRIPTION
### Description

Many of the applicant controllers actions constantly do these two steps:

```java
applicantStage
    .thenComposeAsync(v -> checkApplicantAuthorization(request, applicantId))
    .thenComposeAsync(v -> checkProgramAuthorization(request, programId))
    .thenBlah....()
```

This custom action now does the same checks, but can be reused. It'll cut down on boilerplate. Additionally when composed with other actions this action can be set to run first, which is something I need.

> [!NOTE]
> This new action is not yet wired into any controller.

## Release notes

Simplify authorization checks

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Related to: #5541
