### PR TITLE
Clean up SAVE_ON_ALL_ACTIONS feature flag

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -16,9 +16,6 @@ export function init() {
     return
   }
 
-  // This event listener should only trigger if the SAVE_ON_ALL_ACTIONS flag is on
-  // because the file-upload-action-button class is only added when that flag is on
-  // (see {@link views.applicant.ApplicantFileUploadRenderer.java}).
   addEventListenerToElements(
     '.file-upload-action-button',
     'click',

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -1014,9 +1014,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
           });
     }
 
-    // TODO(#6450): With the SAVE_ON_ALL_ACTIONS flag enabled, when you enter an address that
-    // requires correction but but then click "Previous", you're still taken forward to the
-    // address correction screen which is unexpected.
+    // TODO(#7893): When you enter an address that requires correction but then click "Previous",
+    // you're still taken forward to the address correction screen which is unexpected.
     if (settingsManifest.getEsriAddressCorrectionEnabled(request)
         && thisBlockUpdated.hasAddressWithCorrectionEnabled()) {
 

--- a/server/app/services/cloud/aws/AwsApplicantStorage.java
+++ b/server/app/services/cloud/aws/AwsApplicantStorage.java
@@ -18,7 +18,6 @@ import play.Environment;
 import play.inject.ApplicationLifecycle;
 import services.cloud.ApplicantStorageClient;
 import services.cloud.StorageServiceName;
-import services.settings.SettingsManifest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -35,7 +34,6 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
   private final AwsStorageUtils awsStorageUtils;
   private final Region region;
   private final Credentials credentials;
-  private final SettingsManifest settingsManifest;
   private final String bucket;
   private final int fileLimitMb;
   private final Client client;
@@ -45,14 +43,12 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
       AwsStorageUtils awsStorageUtils,
       AwsRegion region,
       Credentials credentials,
-      SettingsManifest settingsManifest,
       Config config,
       Environment environment,
       ApplicationLifecycle appLifecycle) {
     this.awsStorageUtils = checkNotNull(awsStorageUtils);
     this.region = checkNotNull(region).get();
     this.credentials = checkNotNull(credentials);
-    this.settingsManifest = checkNotNull(settingsManifest);
     this.bucket = checkNotNull(config).getString(AWS_S3_BUCKET_CONF_PATH);
     this.fileLimitMb = checkNotNull(config).getInt(AWS_S3_FILE_LIMIT_CONF_PATH);
     if (environment.isDev()) {
@@ -99,26 +95,15 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
   @Override
   public SignedS3UploadRequest getSignedUploadRequest(
       String fileKey, String successActionRedirectUrl) {
-    if (settingsManifest.getSaveOnAllActions()) {
-      // For the file upload question, assets/javascripts/file_upload.ts may modify the
-      // applicant-requested action part of the success_action_redirect URL to specify where the
-      // user should be taken after the file has been successfully uploaded. So, the redirect
-      // URL we send to {@link SignedS3UploadRequest} needs to have that action removed and needs
-      // the redirect URL to be considered just a prefix so that the applicant-requested action at
-      // the end of the URL can be changed without causing an AWS policy error. See {@link
-      // SignedS3UploadRequest#useSuccessActionRedirectAsPrefix} for more details.
-      String successActionRedirectPrefix =
-          ApplicantRequestedAction.stripActionFromEndOfUrl(successActionRedirectUrl);
-      return awsStorageUtils.getSignedUploadRequest(
-          credentials,
-          region,
-          fileLimitMb,
-          bucket,
-          client.actionLink(),
-          fileKey,
-          successActionRedirectPrefix,
-          /* useSuccessActionRedirectAsPrefix= */ true);
-    }
+    // For the file upload question, assets/javascripts/file_upload.ts may modify the
+    // applicant-requested action part of the success_action_redirect URL to specify where the
+    // user should be taken after the file has been successfully uploaded. So, the redirect
+    // URL we send to {@link SignedS3UploadRequest} needs to have that action removed and needs
+    // the redirect URL to be considered just a prefix so that the applicant-requested action at
+    // the end of the URL can be changed without causing an AWS policy error. See {@link
+    // SignedS3UploadRequest#useSuccessActionRedirectAsPrefix} for more details.
+    String successActionRedirectPrefix =
+        ApplicantRequestedAction.stripActionFromEndOfUrl(successActionRedirectUrl);
     return awsStorageUtils.getSignedUploadRequest(
         credentials,
         region,
@@ -126,8 +111,8 @@ public class AwsApplicantStorage implements ApplicantStorageClient {
         bucket,
         client.actionLink(),
         fileKey,
-        successActionRedirectUrl,
-        /* useSuccessActionRedirectAsPrefix= */ false);
+        successActionRedirectPrefix,
+        /* useSuccessActionRedirectAsPrefix= */ true);
   }
 
   @Override

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -927,14 +927,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE", request);
   }
 
-  /**
-   * Save an applicant's answers when they take any action ('Review'/'Previous'/'Save and next')
-   * instead of only saving on 'Save and next'.
-   */
-  public boolean getSaveOnAllActions() {
-    return getBool("SAVE_ON_ALL_ACTIONS");
-  }
-
   /** Enables showing new UI with an updated user experience in Applicant flows */
   public boolean getNorthStarApplicantUi(RequestHeader request) {
     return getBool("NORTH_STAR_APPLICANT_UI", request);
@@ -1957,14 +1949,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
-                  SettingDescription.create(
-                      "SAVE_ON_ALL_ACTIONS",
-                      "Save an applicant's answers when they take any action"
-                          + " ('Review'/'Previous'/'Save and next') instead of only saving on 'Save"
-                          + " and next'.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
-                      SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "NORTH_STAR_APPLICANT_UI",
                       "Enables showing new UI with an updated user experience in Applicant flows",

--- a/server/app/views/ApplicationBaseView.java
+++ b/server/app/views/ApplicationBaseView.java
@@ -1,18 +1,15 @@
 package views;
 
-import static j2html.TagCreator.a;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.span;
 
 import controllers.applicant.ApplicantRequestedAction;
 import j2html.tags.DomContent;
-import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.PTag;
 import j2html.tags.specialized.SpanTag;
 import play.i18n.Messages;
 import services.MessageKey;
-import services.settings.SettingsManifest;
 import views.components.ButtonStyles;
 import views.style.BaseStyles;
 
@@ -20,11 +17,10 @@ public class ApplicationBaseView extends BaseHtmlView {
   final String REVIEW_APPLICATION_BUTTON_ID = "review-application-button";
 
   /**
-   * Renders a "Review" button that will also save the applicant's data before redirecting to the
-   * review page (if the SAVE_ON_ALL_ACTIONS feature flag is on).
+   * Renders a "Review" button that will save the applicant's data before redirecting to the review
+   * page.
    */
-  protected DomContent renderReviewButton(
-      SettingsManifest settingsManifest, ApplicationBaseViewParams params) {
+  protected DomContent renderReviewButton(ApplicationBaseViewParams params) {
     String formAction =
         params
             .applicantRoutes()
@@ -36,43 +32,16 @@ public class ApplicationBaseView extends BaseHtmlView {
                 params.inReview(),
                 ApplicantRequestedAction.REVIEW_PAGE)
             .url();
-    return renderReviewButton(settingsManifest, params, formAction);
-  }
-
-  /** Renders a "Review" button with a custom action. */
-  protected DomContent renderReviewButton(
-      SettingsManifest settingsManifest, ApplicationBaseViewParams params, String formAction) {
-    if (settingsManifest.getSaveOnAllActions()) {
-      return submitButton(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
-          .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)
-          .withFormaction(formAction);
-    }
-
-    return renderOldReviewButton(params);
+    return submitButton(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
+        .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)
+        .withFormaction(formAction);
   }
 
   /**
-   * Returns a "Review" button that will redirect the applicant to the review page *without* saving
-   * the applicant's data.
+   * Renders a "Previous" button that will save the applicant's data before redirecting to the
+   * previous block.
    */
-  protected ATag renderOldReviewButton(ApplicationBaseViewParams params) {
-    String reviewUrl =
-        params
-            .applicantRoutes()
-            .review(params.profile(), params.applicantId(), params.programId())
-            .url();
-    return a().withHref(reviewUrl)
-        .withText(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
-        .withId(REVIEW_APPLICATION_BUTTON_ID)
-        .withClasses(ButtonStyles.OUTLINED_TRANSPARENT);
-  }
-
-  /**
-   * Renders a "Previous" button that will also save the applicant's data before redirecting to the
-   * previous block (if the SAVE_ON_ALL_ACTIONS feature flag is on).
-   */
-  protected DomContent renderPreviousButton(
-      SettingsManifest settingsManifest, ApplicationBaseViewParams params) {
+  protected DomContent renderPreviousButton(ApplicationBaseViewParams params) {
     String formAction =
         params
             .applicantRoutes()
@@ -84,42 +53,9 @@ public class ApplicationBaseView extends BaseHtmlView {
                 params.inReview(),
                 ApplicantRequestedAction.PREVIOUS_BLOCK)
             .url();
-    return renderPreviousButton(settingsManifest, params, formAction);
-  }
-
-  /**
-   * Renders a "Previous" button with a custom action (if the SAVE_ON_ALL_ACTIONS feature flag is
-   * on).
-   */
-  protected DomContent renderPreviousButton(
-      SettingsManifest settingsManifest, ApplicationBaseViewParams params, String formAction) {
-    if (settingsManifest.getSaveOnAllActions()) {
-      return submitButton(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
-          .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)
-          .withFormaction(formAction);
-    }
-    return renderOldPreviousButton(params);
-  }
-
-  /**
-   * Returns a "Previous" button that will redirect the applicant to the previous block *without*
-   * saving the applicant's data.
-   */
-  protected ATag renderOldPreviousButton(ApplicationBaseViewParams params) {
-    String redirectUrl =
-        params
-            .applicantRoutes()
-            .blockPreviousOrReview(
-                params.profile(),
-                params.applicantId(),
-                params.programId(),
-                /* currentBlockIndex= */ params.blockIndex(),
-                params.inReview())
-            .url();
-    return a().withHref(redirectUrl)
-        .withText(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
+    return submitButton(params.messages().at(MessageKey.BUTTON_PREVIOUS_SCREEN.getKeyName()))
         .withClasses(ButtonStyles.OUTLINED_TRANSPARENT)
-        .withId("cf-block-previous");
+        .withFormaction(formAction);
   }
 
   /**

--- a/server/app/views/applicant/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/AddressCorrectionBlockView.java
@@ -7,13 +7,10 @@ import static j2html.TagCreator.h2;
 import static j2html.TagCreator.h3;
 import static j2html.TagCreator.label;
 
-import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.ApplicantRequestedAction;
 import controllers.applicant.ApplicantRoutes;
 import j2html.TagCreator;
-import j2html.tags.DomContent;
-import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
@@ -30,15 +27,11 @@ import services.Address;
 import services.MessageKey;
 import services.geo.AddressSuggestion;
 import services.geo.AddressSuggestionGroup;
-import services.settings.SettingsManifest;
 import views.ApplicationBaseView;
 import views.ApplicationBaseViewParams;
 import views.HtmlBundle;
 import views.components.ButtonStyles;
-import views.components.Icons;
-import views.components.LinkElement;
 import views.style.ApplicantStyles;
-import views.style.StyleUtils;
 
 /**
  * Renders a page asking the applicant to confirm their address from a list of corrected addresses.
@@ -50,14 +43,11 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
   public static final String SELECTED_ADDRESS_NAME = "selectedAddress";
   private final ApplicantLayout layout;
   private final ApplicantRoutes applicantRoutes;
-  private final SettingsManifest settingsManifest;
 
   @Inject
-  AddressCorrectionBlockView(
-      ApplicantLayout layout, ApplicantRoutes applicantRoutes, SettingsManifest settingsManifest) {
+  AddressCorrectionBlockView(ApplicantLayout layout, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
     this.applicantRoutes = checkNotNull(applicantRoutes);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   public Content render(
@@ -136,12 +126,12 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
           div()
               .withClasses("mb-8")
               .with(
-                  renderAsEnteredHeading(
-                      params.applicantId(),
-                      params.programId(),
-                      params.block().getId(),
-                      messages,
-                      params.profile()),
+                  div()
+                      .withClass("flex flex-nowrap mb-2")
+                      .with(
+                          h3(messages.at(
+                                  MessageKey.ADDRESS_CORRECTION_AS_ENTERED_HEADING.getKeyName()))
+                              .withClass("font-bold mb-2 w-full")),
                   renderAddress(
                       addressAsEntered,
                       /* selected= */ !anySuggestions,
@@ -162,42 +152,6 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
     form.with(renderBottomNavButtons(params, applicantRequestedAction));
 
     return form;
-  }
-
-  private DivTag renderAsEnteredHeading(
-      long applicantId,
-      long programId,
-      String blockId,
-      Messages messages,
-      CiviFormProfile profile) {
-    DivTag containerDiv = div().withClass("flex flex-nowrap mb-2");
-    containerDiv.with(
-        h3(messages.at(MessageKey.ADDRESS_CORRECTION_AS_ENTERED_HEADING.getKeyName()))
-            .withClass("font-bold mb-2 w-full"));
-
-    // When the SAVE_ON_ALL_ACTIONS flag is on, the "Edit" action will be a button in the bottom
-    // navigation. When the flag is off, the "Edit" action should be part of the "As entered"
-    // heading.
-    if (!settingsManifest.getSaveOnAllActions()) {
-      ATag editElement =
-          new LinkElement()
-              .setStyles(
-                  "bottom-0", "right-0", "text-blue-600", StyleUtils.hover("text-blue-700"), "mb-2")
-              .setHref(
-                  applicantRoutes
-                      .blockReview(
-                          profile,
-                          applicantId,
-                          programId,
-                          blockId,
-                          /* questionName= */ Optional.empty())
-                      .url())
-              .setText(messages.at(MessageKey.LINK_EDIT.getKeyName()))
-              .setIcon(Icons.EDIT, LinkElement.IconPosition.START)
-              .asAnchorText();
-      containerDiv.with(editElement);
-    }
-    return containerDiv;
   }
 
   private ImmutableList<LabelTag> renderSuggestedAddresses(
@@ -262,69 +216,33 @@ public final class AddressCorrectionBlockView extends ApplicationBaseView {
       ApplicationBaseViewParams params, ApplicantRequestedAction applicantRequestedAction) {
     DivTag bottomNavButtonsContainer = div().withClasses(ApplicantStyles.APPLICATION_NAV_BAR);
 
-    // If the SAVE_ON_ALL_ACTIONS flag is on, the address correction screen becomes an intermediate
-    // step that only provides two actions:
+    // The address correction screen is an intermediate step that only provides two actions:
     //   1. "Confirm address": Save the address the user selected and take them to wherever they had
     //      requested to go previously: "Review" -> review page, "Save & next" -> block *after* the
     //      block with the address question, "Previous" -> block *before* the block with the address
     //      question.
     //   2. "Go back and edit": Go back to the block with the address question to edit the address
     //      they'd entered.
-    if (settingsManifest.getSaveOnAllActions()) {
-      ButtonTag confirmAddressButton =
-          submitButton(
-                  params.messages().at(MessageKey.ADDRESS_CORRECTION_CONFIRM_BUTTON.getKeyName()))
-              .withClass(ButtonStyles.SOLID_BLUE)
-              .withFormaction(getFormAction(params, applicantRequestedAction));
-      ButtonTag goBackAndEditButton =
-          redirectButton(
-                  params.messages().at(MessageKey.BUTTON_GO_BACK_AND_EDIT.getKeyName()),
-                  applicantRoutes
-                      .blockEditOrBlockReview(
-                          params.profile(),
-                          params.applicantId(),
-                          params.programId(),
-                          params.block().getId(),
-                          params.inReview())
-                      .url())
-              // Set this as "button" type so that it doesn't submit the form.
-              .withType("button")
-              .withClasses(ButtonStyles.OUTLINED_TRANSPARENT);
-      return bottomNavButtonsContainer.with(goBackAndEditButton, confirmAddressButton);
-    }
-
-    // If the SAVE_ON_ALL_ACTIONS flag is off, then the address correction screen looks more like
-    // any other block, with the three classic actions of "Review", "Previous", and "Save & next".
-    return bottomNavButtonsContainer
-        .with(
-            renderReviewButton(
-                settingsManifest,
-                params,
-                getFormAction(params, ApplicantRequestedAction.REVIEW_PAGE)))
-        .with(renderAddressCorrectionSpecificPreviousButton(params))
-        .with(renderNextButton(params));
-  }
-
-  private ButtonTag renderNextButton(ApplicationBaseViewParams params) {
-    return submitButton(params.messages().at(MessageKey.BUTTON_NEXT_SCREEN.getKeyName()))
-        .withClasses(ButtonStyles.SOLID_BLUE)
-        .withId("cf-block-submit");
-  }
-
-  private DomContent renderAddressCorrectionSpecificPreviousButton(
-      ApplicationBaseViewParams params) {
-    if (!settingsManifest.getSaveOnAllActions()) {
-      // Set the block index to the next block, so that the renderPreviousButton
-      // method will render the correct block.
-      ApplicationBaseViewParams newParams =
-          params.toBuilder().setBlockIndex(params.blockIndex() + 1).build();
-      return renderOldPreviousButton(newParams);
-    }
-    // In the new previous button, ApplicantProgramBlocksController will handle adjusting the block
-    // index so that the Previous button correctly takes the applicant back to the block with the
-    // address question.
-    return renderPreviousButton(
-        settingsManifest, params, getFormAction(params, ApplicantRequestedAction.PREVIOUS_BLOCK));
+    ButtonTag confirmAddressButton =
+        submitButton(
+                params.messages().at(MessageKey.ADDRESS_CORRECTION_CONFIRM_BUTTON.getKeyName()))
+            .withClass(ButtonStyles.SOLID_BLUE)
+            .withFormaction(getFormAction(params, applicantRequestedAction));
+    ButtonTag goBackAndEditButton =
+        redirectButton(
+                params.messages().at(MessageKey.BUTTON_GO_BACK_AND_EDIT.getKeyName()),
+                applicantRoutes
+                    .blockEditOrBlockReview(
+                        params.profile(),
+                        params.applicantId(),
+                        params.programId(),
+                        params.block().getId(),
+                        params.inReview())
+                    .url())
+            // Set this as "button" type so that it doesn't submit the form.
+            .withType("button")
+            .withClasses(ButtonStyles.OUTLINED_TRANSPARENT);
+    return bottomNavButtonsContainer.with(goBackAndEditButton, confirmAddressButton);
   }
 
   private String getFormAction(

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -31,7 +31,6 @@ import services.applicant.question.FileUploadQuestion;
 import services.cloud.ApplicantFileNameFormatter;
 import services.cloud.ApplicantStorageClient;
 import services.cloud.StorageUploadRequest;
-import services.settings.SettingsManifest;
 import views.ApplicationBaseView;
 import views.ApplicationBaseViewParams;
 import views.ViewUtils;
@@ -51,14 +50,13 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
   private static final String BLOCK_FORM_ID = "cf-block-form";
   private static final String FILEUPLOAD_CONTINUE_FORM_ID = "cf-fileupload-continue-form";
   private static final String FILEUPLOAD_DELETE_FORM_ID = "cf-fileupload-delete-form";
-  private static final String FILEUPLOAD_SUBMIT_FORM_ID = "cf-block-submit";
   private static final String FILEUPLOAD_DELETE_BUTTON_ID = "fileupload-delete-button";
   private static final String FILEUPLOAD_SKIP_BUTTON_ID = "fileupload-skip-button";
   private static final String FILEUPLOAD_CONTINUE_BUTTON_ID = "fileupload-continue-button";
 
   /**
    * A data key that points to a redirect URL that should be used if the user has uploaded a file.
-   * Should be set on each action button if the SAVE_ON_ALL_ACTIONS flag is enabled.
+   * Should be set on each action button.
    *
    * <p>Should be kept in sync with {@link assets.javascripts.file_upload.ts}.
    */
@@ -66,11 +64,11 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
 
   /**
    * A data key that points to a redirect URL that should be used if the user has *not* uploaded a
-   * file. If the SAVE_ON_ALL_ACTIONS flag is enabled, this should be set on any button whose action
-   * should be permitted even if the user hasn't uploaded a file. Right now, we allow users to
-   * navigate to the review page and previous page if they haven't uploaded a file, but we *don't*
-   * allow them to navigate to the next page without uploading a file. (Note that optional file
-   * upload questions have a separate Skip button -- see {@link #maybeRenderSkipOrDeleteButton}.)
+   * file. This should be set on any button whose action should be permitted even if the user hasn't
+   * uploaded a file. Right now, we allow users to navigate to the review page and previous page if
+   * they haven't uploaded a file, but we *don't* allow them to navigate to the next page without
+   * uploading a file. (Note that optional file upload questions have a separate Skip button -- see
+   * {@link #maybeRenderSkipOrDeleteButton}.)
    *
    * <p>Should be kept in sync with {@link assets.javascripts.file_upload.ts}.
    */
@@ -79,18 +77,15 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
   private final FileUploadViewStrategy fileUploadViewStrategy;
   private final ApplicantRoutes applicantRoutes;
   private final ApplicantStorageClient applicantStorageClient;
-  private final SettingsManifest settingsManifest;
 
   @Inject
   public ApplicantFileUploadRenderer(
       FileUploadViewStrategy fileUploadViewStrategy,
       ApplicantRoutes applicantRoutes,
-      ApplicantStorageClient applicantStorageClient,
-      SettingsManifest settingsManifest) {
+      ApplicantStorageClient applicantStorageClient) {
     this.fileUploadViewStrategy = checkNotNull(fileUploadViewStrategy);
     this.applicantRoutes = checkNotNull(applicantRoutes);
     this.applicantStorageClient = checkNotNull(applicantStorageClient);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   /**
@@ -315,17 +310,6 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
     return div(continueForm, deleteForm).withClasses("hidden");
   }
 
-  private ButtonTag renderOldNextButton(ApplicationBaseViewParams params) {
-    String styles = ButtonStyles.SOLID_BLUE;
-    if (hasUploadedFile(params)) {
-      styles = ButtonStyles.OUTLINED_TRANSPARENT;
-    }
-    return submitButton(params.messages().at(MessageKey.BUTTON_NEXT_SCREEN.getKeyName()))
-        .withForm(BLOCK_FORM_ID)
-        .withClasses(styles)
-        .withId(FILEUPLOAD_SUBMIT_FORM_ID);
-  }
-
   private DivTag renderFileKeyField(
       ApplicantQuestion question, ApplicantQuestionRendererParams params) {
     return FileUploadQuestionRenderer.renderFileKeyField(question, params, false);
@@ -367,22 +351,6 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
 
   private DomContent renderButton(
       ApplicationBaseViewParams params, ApplicantRequestedAction action) {
-    if (!settingsManifest.getSaveOnAllActions()) {
-      switch (action) {
-        case NEXT_BLOCK:
-          return renderOldNextButton(params);
-        case PREVIOUS_BLOCK:
-          return renderOldPreviousButton(params);
-        case REVIEW_PAGE:
-          return renderOldReviewButton(params);
-        default:
-          throw new IllegalStateException("Action not handled: " + action.name());
-      }
-    }
-
-    // If the SAVE_ON_ALL_ACTIONS flag is on, all buttons should submit the form but
-    // should have different text and different redirects.
-
     MessageKey buttonMessage;
     @Nullable String redirectWithoutFile;
     switch (action) {

--- a/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
@@ -28,13 +28,11 @@
           <button
             type="submit"
             th:formaction="${previousFormAction}"
-            id="cf-block-previous"
             class="usa-button usa-button--outline margin-bottom-1"
             th:text="#{button.back}"
           ></button>
           <button
             type="submit"
-            id="cf-block-submit"
             class="usa-button margin-bottom-1"
             th:text="#{button.continue}"
           ></button>

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -24,7 +24,6 @@ import play.twirl.api.Content;
 import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import services.question.types.QuestionDefinition;
-import services.settings.SettingsManifest;
 import views.ApplicationBaseView;
 import views.ApplicationBaseViewParams;
 import views.HtmlBundle;
@@ -43,7 +42,6 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
   private final ApplicantFileUploadRenderer applicantFileUploadRenderer;
   private final ApplicantQuestionRendererFactory applicantQuestionRendererFactory;
   private final ApplicantRoutes applicantRoutes;
-  private final SettingsManifest settingsManifest;
   private final EditOrDiscardAnswersModalCreator editOrDiscardAnswersModalCreator;
 
   @Inject
@@ -52,14 +50,12 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
       ApplicantFileUploadRenderer applicantFileUploadRenderer,
       @Assisted ApplicantQuestionRendererFactory applicantQuestionRendererFactory,
       ApplicantRoutes applicantRoutes,
-      EditOrDiscardAnswersModalCreator editOrDiscardAnswersModalCreator,
-      SettingsManifest settingsManifest) {
+      EditOrDiscardAnswersModalCreator editOrDiscardAnswersModalCreator) {
     this.layout = checkNotNull(layout);
     this.applicantFileUploadRenderer = checkNotNull(applicantFileUploadRenderer);
     this.applicantQuestionRendererFactory = checkNotNull(applicantQuestionRendererFactory);
     this.applicantRoutes = checkNotNull(applicantRoutes);
     this.editOrDiscardAnswersModalCreator = checkNotNull(editOrDiscardAnswersModalCreator);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   public Content render(ApplicationBaseViewParams params) {
@@ -77,8 +73,7 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
     }
 
     ImmutableList.Builder<Modal> modals = ImmutableList.builder();
-    if (settingsManifest.getSaveOnAllActions()
-        && shouldShowErrorsWithModal(params.errorDisplayMode())) {
+    if (shouldShowErrorsWithModal(params.errorDisplayMode())) {
       modals.add(editOrDiscardAnswersModalCreator.createModal(params));
     }
 
@@ -249,14 +244,13 @@ public final class ApplicantProgramBlockEditView extends ApplicationBaseView {
   private DivTag renderBottomNavButtons(ApplicationBaseViewParams params) {
     return div()
         .withClasses(ApplicantStyles.APPLICATION_NAV_BAR)
-        .with(renderReviewButton(settingsManifest, params))
-        .with(renderPreviousButton(settingsManifest, params))
+        .with(renderReviewButton(params))
+        .with(renderPreviousButton(params))
         .with(renderNextButton(params));
   }
 
   private ButtonTag renderNextButton(ApplicationBaseViewParams params) {
     return submitButton(params.messages().at(MessageKey.BUTTON_NEXT_SCREEN.getKeyName()))
-        .withClasses(ButtonStyles.SOLID_BLUE)
-        .withId("cf-block-submit");
+        .withClasses(ButtonStyles.SOLID_BLUE);
   }
 }

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -43,5 +43,4 @@ esri_address_service_area_validation_attributes = ["CITYNAME"]
 api_generated_docs_enabled = true
 application_exportable = true
 primary_applicant_info_questions_enabled = true
-save_on_all_actions = true
 program_filtering_enabled = true

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -774,11 +774,6 @@
         "description": "Add programs cards to the confirmation screen that an applicant sees after finishing an application.",
         "type": "bool"
       },
-      "SAVE_ON_ALL_ACTIONS": {
-        "mode": "ADMIN_READABLE",
-        "description": "Save an applicant's answers when they take any action ('Review'/'Previous'/'Save and next') instead of only saving on 'Save and next'.",
-        "type": "bool"
-      },
       "NORTH_STAR_APPLICANT_UI": {
         "mode": "ADMIN_WRITEABLE",
         "description": "Enables showing new UI with an updated user experience in Applicant flows",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -57,10 +57,6 @@ primary_applicant_info_questions_enabled = ${?PRIMARY_APPLICANT_INFO_QUESTIONS_E
 suggest_programs_on_application_confirmation_page = false
 suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE}
 
-# Save applicant answers on all actions
-save_on_all_actions = true
-save_on_all_actions = ${?SAVE_ON_ALL_ACTIONS}
-
 # North Star Applicant UI
 north_star_applicant_ui = false
 north_star_applicant_ui = ${?NORTH_STAR_APPLICANT_UI}

--- a/server/test/services/cloud/aws/AwsApplicantStorageTest.java
+++ b/server/test/services/cloud/aws/AwsApplicantStorageTest.java
@@ -12,7 +12,6 @@ import play.Environment;
 import play.Mode;
 import play.inject.ApplicationLifecycle;
 import repository.ResetPostgres;
-import services.settings.SettingsManifest;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
@@ -33,7 +32,6 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(AwsStorageUtils.class),
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
-            instanceOf(SettingsManifest.class),
             instanceOf(Config.class),
             new Environment(new File("."), Environment.class.getClassLoader(), Mode.PROD),
             instanceOf(ApplicationLifecycle.class));
@@ -52,7 +50,6 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(AwsStorageUtils.class),
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
-            instanceOf(SettingsManifest.class),
             instanceOf(Config.class),
             new Environment(new File("."), Environment.class.getClassLoader(), Mode.DEV),
             instanceOf(ApplicationLifecycle.class));
@@ -74,7 +71,6 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(AwsStorageUtils.class),
             region,
             credentials,
-            instanceOf(SettingsManifest.class),
             instanceOf(Config.class),
             instanceOf(Environment.class),
             instanceOf(ApplicationLifecycle.class));
@@ -141,7 +137,6 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(AwsStorageUtils.class),
             instanceOf(AwsRegion.class),
             credentials,
-            instanceOf(SettingsManifest.class),
             instanceOf(Config.class),
             instanceOf(Environment.class),
             instanceOf(ApplicationLifecycle.class));
@@ -165,7 +160,6 @@ public class AwsApplicantStorageTest extends ResetPostgres {
             instanceOf(AwsStorageUtils.class),
             instanceOf(AwsRegion.class),
             credentials,
-            instanceOf(SettingsManifest.class),
             instanceOf(Config.class),
             instanceOf(Environment.class),
             instanceOf(ApplicationLifecycle.class));
@@ -178,19 +172,15 @@ public class AwsApplicantStorageTest extends ResetPostgres {
 
   /** Regression test for https://github.com/civiform/civiform/issues/6737. */
   @Test
-  public void getSignedUploadRequest_saveOnAllActionsFlagOn_successActionRedirectTreatedAsPrefix() {
-    SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
+  public void getSignedUploadRequest_successActionRedirectTreatedAsPrefix() {
     AwsApplicantStorage awsApplicantStorage =
         new AwsApplicantStorage(
             instanceOf(AwsStorageUtils.class),
             instanceOf(AwsRegion.class),
             instanceOf(Credentials.class),
-            mockSettingsManifest,
             instanceOf(Config.class),
             instanceOf(Environment.class),
             instanceOf(ApplicationLifecycle.class));
-
-    when(mockSettingsManifest.getSaveOnAllActions()).thenReturn(true);
 
     SignedS3UploadRequest uploadRequest =
         awsApplicantStorage.getSignedUploadRequest(
@@ -202,32 +192,5 @@ public class AwsApplicantStorageTest extends ResetPostgres {
         .isEqualTo("https://civiform.dev/programs/4/blocks/1/updateFile/true");
     // Verify that the redirect URL is treated as a prefix.
     assertThat(uploadRequest.useSuccessActionRedirectAsPrefix()).isTrue();
-  }
-
-  @Test
-  public void
-      getSignedUploadRequest_saveOnAllActionsFlagOff_successActionRedirectTreatedAsExactMatch() {
-    SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    AwsApplicantStorage awsApplicantStorage =
-        new AwsApplicantStorage(
-            instanceOf(AwsStorageUtils.class),
-            instanceOf(AwsRegion.class),
-            instanceOf(Credentials.class),
-            mockSettingsManifest,
-            instanceOf(Config.class),
-            instanceOf(Environment.class),
-            instanceOf(ApplicationLifecycle.class));
-
-    when(mockSettingsManifest.getSaveOnAllActions()).thenReturn(false);
-
-    SignedS3UploadRequest uploadRequest =
-        awsApplicantStorage.getSignedUploadRequest(
-            "fileKey", "https://civiform.dev/programs/4/blocks/1/updateFile/true/NEXT_BLOCK");
-
-    // Verify the redirect URL wasn't modified
-    assertThat(uploadRequest.successActionRedirect())
-        .isEqualTo("https://civiform.dev/programs/4/blocks/1/updateFile/true/NEXT_BLOCK");
-    // Verify that the redirect URL is not being treated as a prefix.
-    assertThat(uploadRequest.useSuccessActionRedirectAsPrefix()).isFalse();
   }
 }

--- a/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
+++ b/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import repository.ResetPostgres;
 import services.question.types.QuestionDefinition;
-import services.settings.SettingsManifest;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 import views.questiontypes.ApplicantQuestionRendererParams;
 
@@ -27,8 +26,7 @@ public class ApplicantProgramBlockEditViewTest extends ResetPostgres {
           Mockito.mock(ApplicantFileUploadRenderer.class),
           Mockito.mock(ApplicantQuestionRendererFactory.class),
           applicantRoutes,
-          new EditOrDiscardAnswersModalCreator(),
-          Mockito.mock(SettingsManifest.class));
+          new EditOrDiscardAnswersModalCreator());
 
   @Test
   public void

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -5,9 +5,7 @@ import static j2html.TagCreator.html;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.stubMessagesApi;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.typesafe.config.ConfigFactory;
 import controllers.applicant.ApplicantRoutes;
 import j2html.tags.specialized.DivTag;
 import junitparams.JUnitParamsRunner;
@@ -18,7 +16,6 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionType;
-import services.settings.SettingsManifest;
 import support.cloud.FakeApplicantStorageClient;
 import views.applicant.ApplicantFileUploadRenderer;
 import views.fileupload.AwsFileUploadViewStrategy;
@@ -50,8 +47,7 @@ public class ApplicantQuestionRendererFactoryTest {
             new ApplicantFileUploadRenderer(
                 new AwsFileUploadViewStrategy(),
                 applicantRoutes,
-                new FakeApplicantStorageClient(),
-                new SettingsManifest(ConfigFactory.parseMap(ImmutableMap.of()))));
+                new FakeApplicantStorageClient()));
 
     ApplicantQuestionRenderer sampleRenderer = factory.getSampleRenderer(type);
 
@@ -78,8 +74,7 @@ public class ApplicantQuestionRendererFactoryTest {
             new ApplicantFileUploadRenderer(
                 new AwsFileUploadViewStrategy(),
                 applicantRoutes,
-                new FakeApplicantStorageClient(),
-                new SettingsManifest(ConfigFactory.parseMap(ImmutableMap.of()))));
+                new FakeApplicantStorageClient()));
 
     ApplicantQuestionRenderer sampleRenderer = factory.getSampleRenderer(type);
 


### PR DESCRIPTION
### Description

Finish removing the SAVE_ON_ALL_ACTIONS feature flag.

## Release notes

Removed the SAVE_ON_ALL_ACTIONS feature flag from the codebase. This feature was enabled by default in April 2024, so the only change is it can no longer be overridden in the config file.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #6860