### PR TITLE
Translate a couple missing messages

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -197,6 +197,7 @@ public enum MessageKey {
   LINK_PROGRAM_DETAILS_SR("link.programDetailsSr"),
   LINK_SELECT_NEW_CLIENT("link.selectNewClient"),
   MEMORABLE_DATE_PLACEHOLDER("placeholder.memorableDate"),
+  MENU("header.menu"),
   MOBILE_FILE_UPLOAD_HELP("content.mobileFileUploadHelp"),
   MODAL_ERROR_SAVING_STAY_AND_FIX_BUTTON("modal.errorSaving.stayAndFixButton"),
   MODAL_ERROR_SAVING_PREVIOUS_CONTENT("modal.errorSaving.previous.content"),

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -56,7 +56,8 @@
                 class="usa-button"
                 th:href="${blockEditUrlMap.get(block.getId())}"
                 th:unless="${block.isCompletedInProgramWithoutErrors()}"
-                >Start</a
+                th:text="#{button.start}"
+                ></a
               >
             </div>
           </div>

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -57,8 +57,7 @@
                 th:href="${blockEditUrlMap.get(block.getId())}"
                 th:unless="${block.isCompletedInProgramWithoutErrors()}"
                 th:text="#{button.start}"
-                ></a
-              >
+              ></a>
             </div>
           </div>
         </li>

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -18,7 +18,7 @@
             <span>CiviForm</span>
           </em>
         </a>
-        <button type="button" class="usa-menu-btn">Menu</button>
+        <button type="button" class="usa-menu-btn" th:text="#{header.menu}"></button>
       </div>
       <nav aria-label="Primary navigation" class="usa-nav" role="navigation">
         <button type="button" class="usa-nav__close">

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -18,7 +18,11 @@
             <span>CiviForm</span>
           </em>
         </a>
-        <button type="button" class="usa-menu-btn" th:text="#{header.menu}"></button>
+        <button
+          type="button"
+          class="usa-menu-btn"
+          th:text="#{header.menu}"
+        ></button>
       </div>
       <nav aria-label="Primary navigation" class="usa-nav" role="navigation">
         <button type="button" class="usa-nav__close">

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -14,6 +14,8 @@ button.untranslatedSubmit=Submit
 footer.supportLinkDescription=For technical support, contact
 guest=Guest
 label.languageSr=Choose a language
+# A label on the button that opens the header menu shown on mobile
+header.menu=Menu
 header.endSession=End session
 toast.sessionEnded=Your session has ended.
 header.guestIndicator=You''re a guest user.


### PR DESCRIPTION
### Description

Found a couple places where we were using untranslated text, so updated those spots

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
