### PR TITLE
Add flash key to fastforward action

### DIFF
--- a/server/app/actions/ProgramFastForwardApplicationAction.java
+++ b/server/app/actions/ProgramFastForwardApplicationAction.java
@@ -3,6 +3,7 @@ package actions;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.ProfileUtils;
+import controllers.FlashKey;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -49,8 +50,10 @@ public class ProgramFastForwardApplicationAction extends Action.Simple {
 
       return CompletableFuture.completedFuture(
           redirect(
-              controllers.applicant.routes.ApplicantProgramReviewController.review(latestProgramId)
-                  .url()));
+                  controllers.applicant.routes.ApplicantProgramReviewController.review(
+                          latestProgramId)
+                      .url())
+              .flashing(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true"));
     }
 
     return delegate.call(request);


### PR DESCRIPTION
### Description

Add a flash key message to be consumed at a later point. This is not currently active.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Related to: #5541
