### PR TITLE
Enable CSP in report only mode

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -347,6 +347,13 @@ play.filters {
   enabled += play.filters.gzip.GzipFilter
   enabled += filters.UnsupportedBrowserFilter
   enabled += filters.SettingsFilter
+  enabled += play.filters.csp.CSPFilter
+
+  csp {
+    reportOnly = true
+    nonce.enabled = true
+    directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
+  }
 
   gzip {
     threshold = 1000        # don't compress very small responses

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import play.api.mvc.request.RequestAttrKey;
 import play.mvc.Call;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
@@ -18,16 +19,14 @@ public final class FakeRequestBuilder extends RequestBuilder {
   private ImmutableMap.Builder<String, String> settingsMap = ImmutableMap.builder();
 
   public static Request fakeRequest() {
-    return new FakeRequestBuilder().build();
+    return fakeRequestBuilder().build();
   }
 
   public static FakeRequestBuilder fakeRequestBuilder() {
-    return new FakeRequestBuilder();
+    return new FakeRequestBuilder().addCSRFToken().cspNonce("do-not-assert-on-this-value-in-tests");
   }
 
-  private FakeRequestBuilder() {
-    addCSRFToken();
-  }
+  private FakeRequestBuilder() {}
 
   public FakeRequestBuilder call(Call call) {
     method(call.method());
@@ -56,6 +55,11 @@ public final class FakeRequestBuilder extends RequestBuilder {
     String encodedCreds =
         Base64.getEncoder().encodeToString(rawCredentials.getBytes(StandardCharsets.UTF_8));
     header("Authorization", "Basic " + encodedCreds);
+    return this;
+  }
+
+  public FakeRequestBuilder cspNonce(String nonce) {
+    attr(RequestAttrKey.CSPNonce().asJava(), nonce);
     return this;
   }
 

--- a/server/test/support/FakeRequestBuilderTest.java
+++ b/server/test/support/FakeRequestBuilderTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.Test;
 import play.mvc.Call;
 import play.mvc.Http.Request;
+import views.html.helper.CSPNonce;
 import views.html.helper.CSRF;
 
 public class FakeRequestBuilderTest {
@@ -43,9 +44,23 @@ public class FakeRequestBuilderTest {
   }
 
   @Test
+  public void cspNonce() {
+    Request fakeRequest = fakeRequestBuilder().cspNonce("foo bar").build();
+
+    assertThat(CSPNonce.apply(fakeRequest.asScala())).isEqualTo("foo bar");
+  }
+
+  @Test
   public void fakeRequest_hasCsrfToken() {
     Request fakeRequest = fakeRequest();
 
     assertThat(CSRF.getToken(fakeRequest.asScala()).value()).isNotEmpty();
+  }
+
+  @Test
+  public void fakeRequest_hasCspNonce() {
+    Request fakeRequest = fakeRequest();
+
+    assertThat(CSPNonce.apply(fakeRequest.asScala())).isNotEmpty();
   }
 }


### PR DESCRIPTION
### Description

Define and enable a content security policy in report-only mode. No resources will be blocked; rather the browser will log an error to the console when it would have blocked an item.

This is for #7574.

## Release notes

Define a content security policy in report-only mode. This has no impact on application behavior but logs a console error when the policy would have blocked a resource.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)