### PR TITLE
Adding new overload for creating alerts

### DIFF
--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -36,7 +36,6 @@ import j2html.tags.specialized.PTag;
 import j2html.tags.specialized.ScriptTag;
 import j2html.tags.specialized.SpanTag;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -421,11 +420,8 @@ public final class ViewUtils {
           default -> "";
         };
 
-    // Add the alert type class to the classes list
-    String[] updatedClasses = Arrays.copyOf(classes, classes.length + 1);
-    updatedClasses[classes.length] = alertTypeStyle;
-
-    return makeAlert(text, hidden, title, updatedClasses);
+    return makeAlert(
+        text, hidden, title, Lists.asList(alertTypeStyle, classes).toArray(new String[0]));
   }
 
   /**

--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -36,10 +36,12 @@ import j2html.tags.specialized.PTag;
 import j2html.tags.specialized.ScriptTag;
 import j2html.tags.specialized.SpanTag;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
+import services.AlertType;
 import services.DateConverter;
 import services.MessageKey;
 import services.question.types.QuestionDefinition;
@@ -394,6 +396,36 @@ public final class ViewUtils {
                     title.isPresent(),
                     h4().withClass("usa-alert__heading").withText(title.orElse("")))
                 .with(p().withClass("usa-alert__text").withText(text)));
+  }
+
+  /**
+   * Makes a USWDS Alert component with the given text and optional title. Alert variant is
+   * determined by the {@link AlertType} passed in.
+   * https://designsystem.digital.gov/components/alert/
+   *
+   * @param text The text to include in the alert.
+   * @param hidden Whether or not to set the hidden property on the component.
+   * @param title An optional title to be included in the alert.
+   * @param alertType The type of {@link AlertType} alert to show
+   * @param classes One or more additional classes to apply to the USWDS Alert component.
+   * @return DivTag containing the alert.
+   */
+  public static DivTag makeAlert(
+      String text, boolean hidden, Optional<String> title, AlertType alertType, String... classes) {
+    String alertTypeStyle =
+        switch (alertType) {
+          case INFO -> BaseStyles.ALERT_INFO;
+          case ERROR -> BaseStyles.ALERT_ERROR;
+          case SUCCESS -> BaseStyles.ALERT_SUCCESS;
+          case WARNING -> BaseStyles.ALERT_WARNING;
+          default -> "";
+        };
+
+    // Add the alert type class to the classes list
+    String[] updatedClasses = Arrays.copyOf(classes, classes.length + 1);
+    updatedClasses[classes.length] = alertTypeStyle;
+
+    return makeAlert(text, hidden, title, updatedClasses);
   }
 
   /**

--- a/server/test/views/ViewUtilsTest.java
+++ b/server/test/views/ViewUtilsTest.java
@@ -9,17 +9,23 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.LinkTag;
 import j2html.tags.specialized.ScriptTag;
+import java.util.Locale;
 import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
+import services.AlertType;
 import services.DateConverter;
 import views.style.BaseStyles;
 
+@RunWith(JUnitParamsRunner.class)
 public class ViewUtilsTest {
 
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
@@ -75,6 +81,18 @@ public class ViewUtilsTest {
             "<div class=\"usa-alert usa-alert--warning\" aria-live=\"polite\" role=\"alert\"><div"
                 + " class=\"usa-alert__body\"><p class=\"usa-alert__text\">some"
                 + " text</p></div></div>");
+  }
+
+  private Object[] alertTypeTestParameters() {
+    return new Object[] {AlertType.ERROR, AlertType.INFO, AlertType.SUCCESS, AlertType.WARNING};
+  }
+
+  @Test
+  @Parameters(method = "alertTypeTestParameters")
+  public void makeAlert_withAlertType(AlertType alertType) {
+    DivTag alertComponent = ViewUtils.makeAlert("some text", false, Optional.empty(), alertType);
+    assertThat(alertComponent.render())
+        .contains(String.format("usa-alert--%s", alertType.toString().toLowerCase(Locale.ROOT)));
   }
 
   @Test


### PR DESCRIPTION
### Description

Adding an overload to the `makeAlert` methods that uses the new `AlertType` enum.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)

### Issue(s) this completes

Fixes #5541
