### PR TITLE
Box the validateScreenshot method

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -318,51 +318,55 @@ export const validateScreenshot = async (
     return
   }
 
-  await test.step('Validate screenshot', async () => {
-    if (fullPage === undefined) {
-      fullPage = true
-    }
+  await test.step(
+    'Validate screenshot',
+    async () => {
+      if (fullPage === undefined) {
+        fullPage = true
+      }
 
-    const page = 'page' in element ? element.page() : element
-    // Normalize all variable content so that the screenshot is stable.
-    await normalizeElements(page)
-    // Also process any sub frames.
-    for (const frame of page.frames()) {
-      await normalizeElements(frame)
-    }
+      const page = 'page' in element ? element.page() : element
+      // Normalize all variable content so that the screenshot is stable.
+      await normalizeElements(page)
+      // Also process any sub frames.
+      for (const frame of page.frames()) {
+        await normalizeElements(frame)
+      }
 
-    if (fullPage) {
-      // Some tests take screenshots while scroll position in the middle. That
-      // affects header which is position fixed and on final full-page screenshots
-      // overlaps part of the page.
-      await page.evaluate(() => {
-        window.scrollTo(0, 0)
-      })
-    }
+      if (fullPage) {
+        // Some tests take screenshots while scroll position in the middle. That
+        // affects header which is position fixed and on final full-page screenshots
+        // overlaps part of the page.
+        await page.evaluate(() => {
+          window.scrollTo(0, 0)
+        })
+      }
 
-    expect(screenshotFileName).toMatch(/^[a-z0-9-]+$/)
+      expect(screenshotFileName).toMatch(/^[a-z0-9-]+$/)
 
-    await takeScreenshot(element, `${screenshotFileName}`, fullPage)
+      await takeScreenshot(element, `${screenshotFileName}`, fullPage)
 
-    const existingWidth = page.viewportSize()?.width || 1280
+      const existingWidth = page.viewportSize()?.width || 1280
 
-    if (mobileScreenshot) {
-      const height = page.viewportSize()?.height || 720
-      // Update the viewport size to different screen widths so we can test on a
-      // variety of sizes
-      await page.setViewportSize({width: 320, height})
+      if (mobileScreenshot) {
+        const height = page.viewportSize()?.height || 720
+        // Update the viewport size to different screen widths so we can test on a
+        // variety of sizes
+        await page.setViewportSize({width: 320, height})
 
-      await takeScreenshot(element, `${screenshotFileName}-mobile`, fullPage)
+        await takeScreenshot(element, `${screenshotFileName}-mobile`, fullPage)
 
-      // Medium width
-      await page.setViewportSize({width: 800, height})
+        // Medium width
+        await page.setViewportSize({width: 800, height})
 
-      await takeScreenshot(element, `${screenshotFileName}-medium`, fullPage)
+        await takeScreenshot(element, `${screenshotFileName}-medium`, fullPage)
 
-      // Reset back to original width
-      await page.setViewportSize({width: existingWidth, height})
-    }
-  }, { box: true })
+        // Reset back to original width
+        await page.setViewportSize({width: existingWidth, height})
+      }
+    },
+    {box: true},
+  )
 }
 
 const takeScreenshot = async (

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -362,7 +362,7 @@ export const validateScreenshot = async (
       // Reset back to original width
       await page.setViewportSize({width: existingWidth, height})
     }
-  })
+  }, { box: true })
 }
 
 const takeScreenshot = async (


### PR DESCRIPTION
### Description

Setting the step on the `validateScreenshot` method to be "boxed". Which means it'll output the line(s) of code that called the method when it fails so we get something much more useful.

Instead of the error showing this:

```
      375 |     .replace('.test.ts', '_test')
      376 |
    > 377 |   await expect(element).toHaveScreenshot(
          |                         ^
      378 |     [testFileName, fullScreenshotFileName + '.png'],
      379 |     {
      380 |       fullPage: fullPage,
```

You'll get this:

```
      91 |         AdminQuestions.NUMBER_QUESTION_TEXT,
      92 |       )
    > 93 |       await validateScreenshot(
         |                               ^
      94 |         page,
      95 |         'application-ineligible-same-application',
      96 |         /* fullPage= */ true,
```

The formatter thinks it knows better than me so I recommend hiding whitespace when reviewing.

![image](https://github.com/civiform/civiform/assets/195162/98c7eea2-1c00-4f11-8f74-9b23be0026bd)



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
