### PR TITLE
Force disable mf upload in test

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {
+  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   seedPrograms,
@@ -154,6 +155,10 @@ test.describe('program migration', () => {
     adminProgramMigration,
   }) => {
     await test.step('seed comprehensive program', async () => {
+      // Force this to be disabled for the time being. I think it's causing intermittent issues
+      // because the flag may have been enabled in a different run
+      await disableFeatureFlag(page, 'multiple_file_upload_enabled')
+
       await seedPrograms(page)
       await page.goto('/')
       await loginAsAdmin(page)


### PR DESCRIPTION
### Description

Force this to be disabled for the time being. I think it's causing intermittent issues because the flag may have been enabled in a different run.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
