### PR TITLE
Add constraints to min/max question settings

### DIFF
--- a/server/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/server/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -48,9 +48,25 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
 
   @Override
   ImmutableSet<CiviFormError> internalValidate(Optional<QuestionDefinition> previousDefinition) {
-    return getEntityType().hasEmptyTranslation()
-        ? ImmutableSet.of(CiviFormError.of("Enumerator question must have specified entity type"))
-        : ImmutableSet.of();
+    ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();
+    if (getEntityType().hasEmptyTranslation()) {
+      errors.add(CiviFormError.of("Enumerator question must have specified entity type"));
+    }
+
+    OptionalInt min = getMinEntities();
+    OptionalInt max = getMaxEntities();
+    if (min.isPresent() && min.getAsInt() < 0) {
+      errors.add(CiviFormError.of("Minimum entity count cannot be negative"));
+    }
+    if (max.isPresent() && max.getAsInt() < 1) {
+      errors.add(CiviFormError.of("Maximum entity count cannot be less than 1"));
+    }
+    if (min.isPresent() && max.isPresent() && min.getAsInt() > max.getAsInt()) {
+      errors.add(
+          CiviFormError.of(
+              "Minimum entity count must be less than or equal to the maximum entity count"));
+    }
+    return errors.build();
   }
 
   public LocalizedStrings getEntityType() {

--- a/server/app/services/question/types/IdQuestionDefinition.java
+++ b/server/app/services/question/types/IdQuestionDefinition.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import java.util.OptionalInt;
+import services.CiviFormError;
 
 /** Defines an id question. */
 public final class IdQuestionDefinition extends QuestionDefinition {
@@ -70,6 +73,24 @@ public final class IdQuestionDefinition extends QuestionDefinition {
   @Override
   ValidationPredicates getDefaultValidationPredicates() {
     return IdValidationPredicates.create();
+  }
+
+  @Override
+  ImmutableSet<CiviFormError> internalValidate(Optional<QuestionDefinition> previousDefinition) {
+    ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();
+    OptionalInt min = getMinLength();
+    OptionalInt max = getMaxLength();
+    if (min.isPresent() && min.getAsInt() < 0) {
+      errors.add(CiviFormError.of("Minimum length cannot be negative"));
+    }
+    if (max.isPresent() && max.getAsInt() < 1) {
+      errors.add(CiviFormError.of("Maximum length cannot be less than 1"));
+    }
+    if (min.isPresent() && max.isPresent() && min.getAsInt() > max.getAsInt()) {
+      errors.add(
+          CiviFormError.of("Minimum length must be less than or equal to the maximum length"));
+    }
+    return errors.build();
   }
 
   @JsonIgnore

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -157,8 +157,8 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
     }
 
     if (maxChoicesAllowed.isPresent()) {
-      if (maxChoicesAllowed.getAsInt() < 0) {
-        errors.add(CiviFormError.of("Maximum number of choices allowed cannot be negative"));
+      if (maxChoicesAllowed.getAsInt() < 1) {
+        errors.add(CiviFormError.of("Maximum number of choices allowed cannot be less than 1"));
       }
 
       if (maxChoicesAllowed.getAsInt() > numOptions) {
@@ -168,17 +168,13 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    if (minChoicesRequired.isPresent() && maxChoicesAllowed.isPresent()) {
-      if (minChoicesRequired.getAsInt() == 0 && maxChoicesAllowed.getAsInt() == 0) {
-        errors.add(CiviFormError.of("Cannot require exactly 0 choices"));
-      }
-
-      if (minChoicesRequired.getAsInt() > maxChoicesAllowed.getAsInt()) {
-        errors.add(
-            CiviFormError.of(
-                "Minimum number of choices required must be less than or equal to the maximum"
-                    + " choices allowed"));
-      }
+    if (minChoicesRequired.isPresent()
+        && maxChoicesAllowed.isPresent()
+        && minChoicesRequired.getAsInt() > maxChoicesAllowed.getAsInt()) {
+      errors.add(
+          CiviFormError.of(
+              "Minimum number of choices required must be less than or equal to the maximum choices"
+                  + " allowed"));
     }
 
     return errors.build();

--- a/server/app/services/question/types/NumberQuestionDefinition.java
+++ b/server/app/services/question/types/NumberQuestionDefinition.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import java.util.OptionalLong;
+import services.CiviFormError;
 
 /** Defines a number question. */
 public final class NumberQuestionDefinition extends QuestionDefinition {
@@ -71,6 +74,23 @@ public final class NumberQuestionDefinition extends QuestionDefinition {
   @Override
   ValidationPredicates getDefaultValidationPredicates() {
     return NumberValidationPredicates.create();
+  }
+
+  @Override
+  ImmutableSet<CiviFormError> internalValidate(Optional<QuestionDefinition> previousDefinition) {
+    ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();
+    OptionalLong min = getMin();
+    OptionalLong max = getMax();
+    if (min.isPresent() && min.getAsLong() < 0) {
+      errors.add(CiviFormError.of("Minimum value cannot be negative"));
+    }
+    if (max.isPresent() && max.getAsLong() < 0) {
+      errors.add(CiviFormError.of("Maximum value cannot be negative"));
+    }
+    if (min.isPresent() && max.isPresent() && min.getAsLong() > max.getAsLong()) {
+      errors.add(CiviFormError.of("Minimum value must be less than or equal to the maximum value"));
+    }
+    return errors.build();
   }
 
   @JsonIgnore

--- a/server/app/services/question/types/TextQuestionDefinition.java
+++ b/server/app/services/question/types/TextQuestionDefinition.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import java.util.OptionalInt;
+import services.CiviFormError;
 
 /** Defines a text question. */
 public final class TextQuestionDefinition extends QuestionDefinition {
@@ -71,6 +74,24 @@ public final class TextQuestionDefinition extends QuestionDefinition {
   @Override
   ValidationPredicates getDefaultValidationPredicates() {
     return TextValidationPredicates.create();
+  }
+
+  @Override
+  ImmutableSet<CiviFormError> internalValidate(Optional<QuestionDefinition> previousDefinition) {
+    ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();
+    OptionalInt min = getMinLength();
+    OptionalInt max = getMaxLength();
+    if (min.isPresent() && min.getAsInt() < 0) {
+      errors.add(CiviFormError.of("Minimum length cannot be negative"));
+    }
+    if (max.isPresent() && max.getAsInt() < 1) {
+      errors.add(CiviFormError.of("Maximum length cannot be less than 1"));
+    }
+    if (min.isPresent() && max.isPresent() && min.getAsInt() > max.getAsInt()) {
+      errors.add(
+          CiviFormError.of("Minimum length must be less than or equal to the maximum length"));
+    }
+    return errors.build();
   }
 
   @JsonIgnore

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -136,11 +136,13 @@ public final class QuestionConfig {
             .setFieldName("minLength")
             .setLabelText("Minimum length")
             .setValue(idQuestionForm.getMinLength())
+            .setMin(OptionalLong.of(0))
             .getNumberTag(),
         FieldWithLabel.number()
             .setFieldName("maxLength")
             .setLabelText("Maximum length")
             .setValue(idQuestionForm.getMaxLength())
+            .setMin(OptionalLong.of(1))
             .getNumberTag());
     return this;
   }
@@ -151,11 +153,13 @@ public final class QuestionConfig {
             .setFieldName("minLength")
             .setLabelText("Minimum length")
             .setValue(textQuestionForm.getMinLength())
+            .setMin(OptionalLong.of(0))
             .getNumberTag(),
         FieldWithLabel.number()
             .setFieldName("maxLength")
             .setLabelText("Maximum length")
             .setValue(textQuestionForm.getMaxLength())
+            .setMin(OptionalLong.of(1))
             .getNumberTag());
     return this;
   }
@@ -363,17 +367,13 @@ public final class QuestionConfig {
         FieldWithLabel.number()
             .setFieldName("minChoicesRequired")
             .setLabelText("Minimum number of choices required")
-            // Negative numbers aren't allowed. Force the admin to provide
-            // a positive number.
             .setMin(OptionalLong.of(0L))
             .setValue(multiOptionForm.getMinChoicesRequired())
             .getNumberTag(),
         FieldWithLabel.number()
             .setFieldName("maxChoicesAllowed")
             .setLabelText("Maximum number of choices allowed")
-            // Negative numbers aren't allowed. Force the admin to provide
-            // a positive number.
-            .setMin(OptionalLong.of(0L))
+            .setMin(OptionalLong.of(1L))
             .setValue(multiOptionForm.getMaxChoicesAllowed())
             .getNumberTag());
     return this;
@@ -384,11 +384,13 @@ public final class QuestionConfig {
         FieldWithLabel.number()
             .setFieldName("min")
             .setLabelText("Minimum value")
+            .setMin(OptionalLong.of(0L))
             .setValue(numberQuestionForm.getMin())
             .getNumberTag(),
         FieldWithLabel.number()
             .setFieldName("max")
             .setLabelText("Maximum value")
+            .setMin(OptionalLong.of(0L))
             .setValue(numberQuestionForm.getMax())
             .getNumberTag());
     return this;

--- a/server/test/services/question/types/IdQuestionDefinitionTest.java
+++ b/server/test/services/question/types/IdQuestionDefinitionTest.java
@@ -13,20 +13,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.CiviFormError;
 import services.LocalizedStrings;
-import services.question.types.EnumeratorQuestionDefinition.EnumeratorValidationPredicates;
+import services.question.types.IdQuestionDefinition.IdValidationPredicates;
 
 @RunWith(JUnitParamsRunner.class)
-public class EnumeratorQuestionDefinitionTest {
-  @Test
-  public void validate_withEmptyEntityString_returnsError() throws Exception {
-    QuestionDefinition question =
-        new EnumeratorQuestionDefinition(
-            makeConfigBuilder().build(), LocalizedStrings.withDefaultValue(""));
-
-    assertThat(question.validate())
-        .containsOnly(CiviFormError.of("Enumerator question must have specified entity type"));
-  }
-
+public class IdQuestionDefinitionTest {
   @SuppressWarnings("unused") // Is used via reflection by the @Parameters annotation below
   private static ImmutableList<Object[]> getValidationTestData() {
     return ImmutableList.of(
@@ -36,36 +26,33 @@ public class EnumeratorQuestionDefinitionTest {
         new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
         new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
         new Object[] {
-          OptionalInt.of(-1),
-          OptionalInt.empty(),
-          Optional.of("Minimum entity count cannot be negative")
+          OptionalInt.of(-1), OptionalInt.empty(), Optional.of("Minimum length cannot be negative")
         },
         new Object[] {
           OptionalInt.empty(),
           OptionalInt.of(0),
-          Optional.of("Maximum entity count cannot be less than 1")
+          Optional.of("Maximum length cannot be less than 1")
         },
         new Object[] {
           OptionalInt.of(2),
           OptionalInt.of(1),
-          Optional.of("Minimum entity count must be less than or equal to the maximum entity count")
+          Optional.of("Minimum length must be less than or equal to the maximum length")
         });
   }
 
   @Test
   @Parameters(method = "getValidationTestData")
   public void validate_settingConstraints(
-      OptionalInt minEntities, OptionalInt maxEntities, Optional<String> expectedErrorMessage) {
+      OptionalInt minLength, OptionalInt maxLength, Optional<String> expectedErrorMessage) {
     QuestionDefinitionConfig config =
         makeConfigBuilder()
             .setValidationPredicates(
-                EnumeratorValidationPredicates.builder()
-                    .setMinEntities(minEntities)
-                    .setMaxEntities(maxEntities)
+                IdValidationPredicates.builder()
+                    .setMinLength(minLength)
+                    .setMaxLength(maxLength)
                     .build())
             .build();
-    QuestionDefinition question =
-        new EnumeratorQuestionDefinition(config, LocalizedStrings.withDefaultValue("foo"));
+    QuestionDefinition question = new IdQuestionDefinition(config);
 
     ImmutableSet<CiviFormError> errors = question.validate();
 

--- a/server/test/services/question/types/NumberQuestionDefinitionTest.java
+++ b/server/test/services/question/types/NumberQuestionDefinitionTest.java
@@ -1,0 +1,68 @@
+package services.question.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalLong;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import services.CiviFormError;
+import services.LocalizedStrings;
+import services.question.types.NumberQuestionDefinition.NumberValidationPredicates;
+
+@RunWith(JUnitParamsRunner.class)
+public class NumberQuestionDefinitionTest {
+  @SuppressWarnings("unused") // Is used via reflection by the @Parameters annotation below
+  private static ImmutableList<Object[]> getValidationTestData() {
+    return ImmutableList.of(
+        new Object[] {OptionalLong.empty(), OptionalLong.empty(), Optional.<String>empty()},
+        new Object[] {OptionalLong.of(1), OptionalLong.empty(), Optional.<String>empty()},
+        new Object[] {OptionalLong.empty(), OptionalLong.of(1), Optional.<String>empty()},
+        new Object[] {OptionalLong.of(1), OptionalLong.of(2), Optional.<String>empty()},
+        new Object[] {OptionalLong.of(1), OptionalLong.of(1), Optional.<String>empty()},
+        new Object[] {
+          OptionalLong.of(-1), OptionalLong.empty(), Optional.of("Minimum value cannot be negative")
+        },
+        new Object[] {
+          OptionalLong.empty(), OptionalLong.of(-1), Optional.of("Maximum value cannot be negative")
+        },
+        new Object[] {
+          OptionalLong.of(2),
+          OptionalLong.of(1),
+          Optional.of("Minimum value must be less than or equal to the maximum value")
+        });
+  }
+
+  @Test
+  @Parameters(method = "getValidationTestData")
+  public void validate_settingConstraints(
+      OptionalLong min, OptionalLong max, Optional<String> expectedErrorMessage) {
+    QuestionDefinitionConfig config =
+        makeConfigBuilder()
+            .setValidationPredicates(
+                NumberValidationPredicates.builder().setMin(min).setMax(max).build())
+            .build();
+    QuestionDefinition question = new NumberQuestionDefinition(config);
+
+    ImmutableSet<CiviFormError> errors = question.validate();
+
+    assertThat(errors)
+        .isEqualTo(
+            expectedErrorMessage
+                .map(CiviFormError::of)
+                .map(ImmutableSet::of)
+                .orElse(ImmutableSet.of()));
+  }
+
+  private QuestionDefinitionConfig.Builder makeConfigBuilder() {
+    return QuestionDefinitionConfig.builder()
+        .setName("name")
+        .setDescription("description")
+        .setQuestionText(LocalizedStrings.of(Locale.US, "question?"));
+  }
+}

--- a/server/test/services/question/types/TextQuestionDefinitionTest.java
+++ b/server/test/services/question/types/TextQuestionDefinitionTest.java
@@ -13,20 +13,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.CiviFormError;
 import services.LocalizedStrings;
-import services.question.types.EnumeratorQuestionDefinition.EnumeratorValidationPredicates;
+import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 
 @RunWith(JUnitParamsRunner.class)
-public class EnumeratorQuestionDefinitionTest {
-  @Test
-  public void validate_withEmptyEntityString_returnsError() throws Exception {
-    QuestionDefinition question =
-        new EnumeratorQuestionDefinition(
-            makeConfigBuilder().build(), LocalizedStrings.withDefaultValue(""));
-
-    assertThat(question.validate())
-        .containsOnly(CiviFormError.of("Enumerator question must have specified entity type"));
-  }
-
+public class TextQuestionDefinitionTest {
   @SuppressWarnings("unused") // Is used via reflection by the @Parameters annotation below
   private static ImmutableList<Object[]> getValidationTestData() {
     return ImmutableList.of(
@@ -36,36 +26,33 @@ public class EnumeratorQuestionDefinitionTest {
         new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
         new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
         new Object[] {
-          OptionalInt.of(-1),
-          OptionalInt.empty(),
-          Optional.of("Minimum entity count cannot be negative")
+          OptionalInt.of(-1), OptionalInt.empty(), Optional.of("Minimum length cannot be negative")
         },
         new Object[] {
           OptionalInt.empty(),
           OptionalInt.of(0),
-          Optional.of("Maximum entity count cannot be less than 1")
+          Optional.of("Maximum length cannot be less than 1")
         },
         new Object[] {
           OptionalInt.of(2),
           OptionalInt.of(1),
-          Optional.of("Minimum entity count must be less than or equal to the maximum entity count")
+          Optional.of("Minimum length must be less than or equal to the maximum length")
         });
   }
 
   @Test
   @Parameters(method = "getValidationTestData")
   public void validate_settingConstraints(
-      OptionalInt minEntities, OptionalInt maxEntities, Optional<String> expectedErrorMessage) {
+      OptionalInt minLength, OptionalInt maxLength, Optional<String> expectedErrorMessage) {
     QuestionDefinitionConfig config =
         makeConfigBuilder()
             .setValidationPredicates(
-                EnumeratorValidationPredicates.builder()
-                    .setMinEntities(minEntities)
-                    .setMaxEntities(maxEntities)
+                TextValidationPredicates.builder()
+                    .setMinLength(minLength)
+                    .setMaxLength(maxLength)
                     .build())
             .build();
-    QuestionDefinition question =
-        new EnumeratorQuestionDefinition(config, LocalizedStrings.withDefaultValue("foo"));
+    QuestionDefinition question = new TextQuestionDefinition(config);
 
     ImmutableSet<CiviFormError> errors = question.validate();
 


### PR DESCRIPTION
### Description

For each question type that has min/max settings (Enumerator, Id, MultiOption, Number, Text), add constraints and validation that the input values are reasonable:

* Validate that min <= max if both are set (server-side)
* Require that min >= 0 (client-side and server-side)
* Require that max >= 1 since a max of 0 would prevent answering the question, except for Number where it validates max >= 0 since 0 is a valid Number answer (client-side and server-side)

Also included:

* Create unit test classes for several QuestionDefinition subclasses that didn't have them
* Add unit tests for the cases above

## Release notes

When an admin sets min/max settings for a question type that supports them (Number, Checkbox, ID, Text, Enumerator), CiviForm will now validate that the min <= max (if both are set), min >= 0, and max >= 1, except for Number questions where it will validate that max >= 0.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #7919
