### PR TITLE
Refactor Alert Component

### DIFF
--- a/server/app/views/AlertComponent.java
+++ b/server/app/views/AlertComponent.java
@@ -1,0 +1,123 @@
+package views;
+
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.h2;
+import static j2html.TagCreator.h3;
+import static j2html.TagCreator.h4;
+import static j2html.TagCreator.h5;
+import static j2html.TagCreator.h6;
+import static j2html.TagCreator.p;
+
+import com.google.common.collect.Lists;
+import j2html.tags.specialized.DivTag;
+import java.util.Optional;
+import services.AlertType;
+import views.style.BaseStyles;
+
+/**
+ * Render a USWDS Alert Component
+ *
+ * <p>{@see <a
+ * href="https://designsystem.digital.gov/components/alert">https://designsystem.digital.gov/components/alert</a>}
+ */
+public class AlertComponent {
+  /**
+   * Heading levels that can be used for Alerts H1 tags are limited to a single instance per page
+   * and and not allowed as headings.
+   */
+  public enum HeadingLevel {
+    H2,
+    H3,
+    H4,
+    H5,
+    H6
+  }
+
+  /**
+   * Makes a USWDS Alert component with the given text and optional title. Alert variant is
+   * determined by the {@link AlertType} passed in.
+   *
+   * @param alertType The type of {@link AlertType} alert to show
+   * @param text The text to include in the alert.
+   * @param title An optional title to be included in the alert.
+   * @param hidden Whether or not to set the hidden property on the component.
+   * @param headingLevel Allow configuring the heading level between H2-H6. Default is H4
+   * @param classes One or more additional classes to apply to the USWDS Alert component.
+   * @return DivTag containing the alert.
+   */
+  public static DivTag renderFullView(
+      AlertType alertType,
+      String text,
+      Optional<String> title,
+      boolean hidden,
+      HeadingLevel headingLevel,
+      String... classes) {
+    String alertTypeStyle =
+        switch (alertType) {
+          case INFO -> BaseStyles.ALERT_INFO;
+          case ERROR -> BaseStyles.ALERT_ERROR;
+          case SUCCESS -> BaseStyles.ALERT_SUCCESS;
+          case WARNING -> BaseStyles.ALERT_WARNING;
+          default -> "";
+        };
+
+    var headingTag =
+        switch (headingLevel) {
+          case H2 -> h2();
+          case H3 -> h3();
+          case H5 -> h5();
+          case H6 -> h6();
+          default -> h4();
+        };
+
+    return div()
+        .withCondHidden(hidden)
+        .withClasses("usa-alert", alertTypeStyle, String.join(" ", classes))
+        // Notify screen readers to read the new text when the element changes
+        .attr("aria-live", "polite")
+        .attr("role", "alert")
+        .with(
+            div()
+                .withClasses("usa-alert__body")
+                .condWith(
+                    title.isPresent(),
+                    headingTag.withClass("usa-alert__heading").withText(title.orElse("")))
+                .with(p().withClass("usa-alert__text").withText(text)));
+  }
+
+  /**
+   * Makes a USWDS Alert component with the given text and optional title. Alert variant is
+   * determined by the {@link AlertType} passed in. If using a title the element will be an H4 tag.
+   *
+   * @param alertType The type of {@link AlertType} alert to show
+   * @param text The text to include in the alert.
+   * @param title An optional title to be included in the alert.
+   * @param hidden Whether or not to set the hidden property on the component.
+   * @param classes One or more additional classes to apply to the USWDS Alert component.
+   * @return DivTag containing the alert.
+   */
+  public static DivTag renderFullView(
+      AlertType alertType, String text, Optional<String> title, boolean hidden, String... classes) {
+    return renderFullView(alertType, text, title, hidden, HeadingLevel.H4, classes);
+  }
+
+  /**
+   * Makes a slim version of a USWDS Alert component with the given text. Note that the slim version
+   * has no title. Alert variant is determined by the classes passed in.
+   * https://designsystem.digital.gov/components/alert/
+   *
+   * @param text The text to include in the alert.
+   * @param hidden Whether or not to set the hidden property on the component.
+   * @param classes One or more additional classes to apply to the USWDS Alert component.
+   * @return DivTag containing the alert.
+   */
+  public static DivTag renderSlimView(
+      AlertType alertType, String text, boolean hidden, String... classes) {
+    return renderFullView(
+        alertType,
+        text,
+        /* title= */ Optional.empty(),
+        hidden,
+        Lists.asList(BaseStyles.ALERT_SLIM, classes).toArray(new String[0]));
+  }
+}

--- a/server/app/views/AlertComponent.java
+++ b/server/app/views/AlertComponent.java
@@ -20,7 +20,7 @@ import views.style.BaseStyles;
  * <p>{@see <a
  * href="https://designsystem.digital.gov/components/alert">https://designsystem.digital.gov/components/alert</a>}
  */
-public class AlertComponent {
+public final class AlertComponent {
   /**
    * Heading levels that can be used for Alerts H1 tags are limited to a single instance per page
    * and and not allowed as headings.

--- a/server/app/views/AlertComponent.java
+++ b/server/app/views/AlertComponent.java
@@ -23,7 +23,7 @@ import views.style.BaseStyles;
 public final class AlertComponent {
   /**
    * Heading levels that can be used for Alerts. H1 tags are limited to a single instance per page
-   * and and not allowed as headings.
+   * and not allowed as headings.
    */
   public enum HeadingLevel {
     H2,
@@ -45,7 +45,7 @@ public final class AlertComponent {
    * @param classes One or more additional classes to apply to the USWDS Alert component.
    * @return DivTag containing the alert.
    */
-  public static DivTag renderFullView(
+  public static DivTag renderFullAlert(
       AlertType alertType,
       String text,
       Optional<String> title,
@@ -96,9 +96,9 @@ public final class AlertComponent {
    * @param classes One or more additional classes to apply to the USWDS Alert component.
    * @return DivTag containing the alert.
    */
-  public static DivTag renderFullView(
+  public static DivTag renderFullAlert(
       AlertType alertType, String text, Optional<String> title, boolean hidden, String... classes) {
-    return renderFullView(alertType, text, title, hidden, HeadingLevel.H4, classes);
+    return renderFullAlert(alertType, text, title, hidden, HeadingLevel.H4, classes);
   }
 
   /**
@@ -111,9 +111,9 @@ public final class AlertComponent {
    * @param classes One or more additional classes to apply to the USWDS Alert component.
    * @return DivTag containing the alert.
    */
-  public static DivTag renderSlimView(
+  public static DivTag renderSlimAlert(
       AlertType alertType, String text, boolean hidden, String... classes) {
-    return renderFullView(
+    return renderFullAlert(
         alertType,
         text,
         /* title= */ Optional.empty(),

--- a/server/app/views/AlertComponent.java
+++ b/server/app/views/AlertComponent.java
@@ -17,8 +17,8 @@ import views.style.BaseStyles;
 /**
  * Render a USWDS Alert Component
  *
- * <p>{@see <a
- * href="https://designsystem.digital.gov/components/alert">https://designsystem.digital.gov/components/alert</a>}
+ * @see <a
+ *     href="https://designsystem.digital.gov/components/alert">https://designsystem.digital.gov/components/alert</a>
  */
 public final class AlertComponent {
   /**

--- a/server/app/views/AlertComponent.java
+++ b/server/app/views/AlertComponent.java
@@ -22,7 +22,7 @@ import views.style.BaseStyles;
  */
 public final class AlertComponent {
   /**
-   * Heading levels that can be used for Alerts H1 tags are limited to a single instance per page
+   * Heading levels that can be used for Alerts. H1 tags are limited to a single instance per page
    * and and not allowed as headings.
    */
   public enum HeadingLevel {

--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.h2;
-import static j2html.TagCreator.h4;
 import static j2html.TagCreator.img;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
@@ -40,7 +39,6 @@ import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
-import services.AlertType;
 import services.DateConverter;
 import services.MessageKey;
 import services.question.types.QuestionDefinition;
@@ -368,78 +366,6 @@ public final class ViewUtils {
             "Universal %s question",
             questionDefinition.getQuestionType().getLabel().toLowerCase(Locale.getDefault())),
         Lists.asList("cf-universal-badge", classes).toArray(new String[0]));
-  }
-
-  /**
-   * Makes a USWDS Alert component with the given text and optional title. Alert variant is
-   * determined by the classes passed in. https://designsystem.digital.gov/components/alert/
-   *
-   * @param text The text to include in the alert.
-   * @param hidden Whether or not to set the hidden property on the component.
-   * @param title An optional title to be included in the alert.
-   * @param classes One or more additional classes to apply to the USWDS Alert component.
-   * @return DivTag containing the alert.
-   */
-  public static DivTag makeAlert(
-      String text, boolean hidden, Optional<String> title, String... classes) {
-    return div()
-        .withCondHidden(hidden)
-        .withClasses("usa-alert", String.join(" ", classes))
-        // Notify screen readers to read the new text when the element changes
-        .attr("aria-live", "polite")
-        .attr("role", "alert")
-        .with(
-            div()
-                .withClasses("usa-alert__body")
-                .condWith(
-                    title.isPresent(),
-                    h4().withClass("usa-alert__heading").withText(title.orElse("")))
-                .with(p().withClass("usa-alert__text").withText(text)));
-  }
-
-  /**
-   * Makes a USWDS Alert component with the given text and optional title. Alert variant is
-   * determined by the {@link AlertType} passed in.
-   * https://designsystem.digital.gov/components/alert/
-   *
-   * @param text The text to include in the alert.
-   * @param hidden Whether or not to set the hidden property on the component.
-   * @param title An optional title to be included in the alert.
-   * @param alertType The type of {@link AlertType} alert to show
-   * @param classes One or more additional classes to apply to the USWDS Alert component.
-   * @return DivTag containing the alert.
-   */
-  public static DivTag makeAlert(
-      String text, boolean hidden, Optional<String> title, AlertType alertType, String... classes) {
-    String alertTypeStyle =
-        switch (alertType) {
-          case INFO -> BaseStyles.ALERT_INFO;
-          case ERROR -> BaseStyles.ALERT_ERROR;
-          case SUCCESS -> BaseStyles.ALERT_SUCCESS;
-          case WARNING -> BaseStyles.ALERT_WARNING;
-          default -> "";
-        };
-
-    return makeAlert(
-        text, hidden, title, Lists.asList(alertTypeStyle, classes).toArray(new String[0]));
-  }
-
-  /**
-   * Makes a slim version of a USWDS Alert component with the given text. Note that the slim version
-   * has no title. Alert variant is determined by the classes passed in.
-   * https://designsystem.digital.gov/components/alert/
-   *
-   * @param text The text to include in the alert.
-   * @param hidden Whether or not to set the hidden property on the component.
-   * @param classes One or more additional classes to apply to the USWDS Alert component.
-   * @return DivTag containing the alert.
-   */
-  public static DivTag makeAlertSlim(String text, boolean hidden, String... classes) {
-    return makeAlert(
-        text,
-        hidden,
-        /* title= */ Optional.empty(),
-        Lists.asList(BaseStyles.ALERT_SLIM, classes).toArray(new String[0]));
   }
 
   /**

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -48,7 +48,7 @@ public final class AdminImportViewPartial extends BaseHtmlView {
     return div()
         .withId(PROGRAM_DATA_ID)
         .with(
-            AlertComponent.renderFullView(
+            AlertComponent.renderFullAlert(
                 AlertType.ERROR,
                 /* text= */ errorMessage,
                 /* title= */ Optional.of("Error processing JSON"),

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -7,8 +7,6 @@ import static j2html.TagCreator.h4;
 import static j2html.TagCreator.li;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.ul;
-import static views.ViewUtils.makeAlert;
-import static views.style.BaseStyles.ALERT_ERROR;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -21,12 +19,14 @@ import j2html.tags.specialized.UlTag;
 import java.util.Objects;
 import java.util.Optional;
 import play.mvc.Http;
+import services.AlertType;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import views.AlertComponent;
 import views.BaseHtmlView;
 import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
@@ -48,11 +48,13 @@ public final class AdminImportViewPartial extends BaseHtmlView {
     return div()
         .withId(PROGRAM_DATA_ID)
         .with(
-            makeAlert(
+            AlertComponent.renderFullView(
+                AlertType.ERROR,
                 /* text= */ errorMessage,
-                /* hidden= */ false,
                 /* title= */ Optional.of("Error processing JSON"),
-                /* classes...= */ ALERT_ERROR));
+                /* hidden= */ false
+
+                /* classes...= */ ));
   }
 
   /** Renders the correctly parsed program data. */

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -30,6 +30,7 @@ import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.AlertType;
 import services.LocalizedStrings;
 import services.MessageKey;
 import services.applicant.ApplicantPersonalInfo;
@@ -38,6 +39,7 @@ import services.cloud.PublicFileNameFormatter;
 import services.cloud.PublicStorageClient;
 import services.cloud.StorageUploadRequest;
 import services.program.ProgramDefinition;
+import views.AlertComponent;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.ViewUtils;
@@ -51,7 +53,6 @@ import views.components.LinkElement;
 import views.components.Modal;
 import views.components.ToastMessage;
 import views.fileupload.FileUploadViewStrategy;
-import views.style.BaseStyles;
 import views.style.StyleUtils;
 
 /** A view for admins to update the image associated with a particular program. */
@@ -211,10 +212,10 @@ public final class ProgramImageView extends BaseHtmlView {
 
     return div()
         .with(
-            ViewUtils.makeAlertSlim(
+            AlertComponent.renderSlimView(
+                AlertType.INFO,
                 "Note: Image description is required before uploading an image.",
                 /* hidden= */ false,
-                /* classes=... */ BaseStyles.ALERT_INFO,
                 "mb-2"))
         .with(
             form()

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -212,7 +212,7 @@ public final class ProgramImageView extends BaseHtmlView {
 
     return div()
         .with(
-            AlertComponent.renderSlimView(
+            AlertComponent.renderSlimAlert(
                 AlertType.INFO,
                 "Note: Image description is required before uploading an image.",
                 /* hidden= */ false,

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -269,7 +269,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               DivTag missingUniversalQuestionsWarning =
                   div()
                       .with(
-                          AlertComponent.renderFullView(
+                          AlertComponent.renderFullAlert(
                               AlertType.WARNING,
                               "Warning: This program does not use all recommended"
                                   + " universal questions.",
@@ -353,7 +353,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         div()
             .withClasses("flex-row", "space-y-6")
             .with(
-                AlertComponent.renderFullView(
+                AlertComponent.renderFullAlert(
                     AlertType.WARNING,
                     "Due to the nature of shared questions and versioning, all questions and"
                         + " programs will need to be published together.",

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -32,6 +32,7 @@ import models.ProgramTab;
 import play.mvc.Http;
 import play.mvc.Http.HttpVerbs;
 import play.twirl.api.Content;
+import services.AlertType;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
@@ -39,9 +40,9 @@ import services.question.ActiveAndDraftQuestions;
 import services.question.ReadOnlyQuestionService;
 import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
+import views.AlertComponent;
 import views.BaseHtmlView;
 import views.HtmlBundle;
-import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
@@ -53,7 +54,6 @@ import views.components.Modal;
 import views.components.ProgramCardFactory;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -269,12 +269,12 @@ public final class ProgramIndexView extends BaseHtmlView {
               DivTag missingUniversalQuestionsWarning =
                   div()
                       .with(
-                          ViewUtils.makeAlert(
+                          AlertComponent.renderFullView(
+                              AlertType.WARNING,
                               "Warning: This program does not use all recommended"
                                   + " universal questions.",
-                              /* hidden= */ false,
                               /* title= */ Optional.empty(),
-                              BaseStyles.ALERT_WARNING))
+                              /* hidden= */ false))
                       .with(
                           p("We recommend using all universal questions when possible"
                                   + " to create consistent reuse of data and question"
@@ -353,12 +353,12 @@ public final class ProgramIndexView extends BaseHtmlView {
         div()
             .withClasses("flex-row", "space-y-6")
             .with(
-                ViewUtils.makeAlert(
+                AlertComponent.renderFullView(
+                    AlertType.WARNING,
                     "Due to the nature of shared questions and versioning, all questions and"
                         + " programs will need to be published together.",
-                    /* hidden= */ false,
                     /* title= */ Optional.of("All draft questions in programs will be published."),
-                    BaseStyles.ALERT_WARNING),
+                    /* hidden= */ false),
                 div()
                     .withClasses(ReferenceClasses.ADMIN_PUBLISH_REFERENCES_PROGRAM)
                     .with(

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -553,7 +553,7 @@ public final class QuestionEditView extends BaseHtmlView {
                                           primaryApplicantInfoTag.getDisplayName()))))
                       .condWith(
                           !differentQuestionHasTag,
-                          AlertComponent.renderSlimView(
+                          AlertComponent.renderSlimAlert(
                               AlertType.INFO,
                               nonUniversalAlertText,
                               /* hidden= */ questionForm.isUniversal(),
@@ -561,7 +561,7 @@ public final class QuestionEditView extends BaseHtmlView {
                               "usa-alert-remove-top-margin"))
                       .condWith(
                           differentQuestionHasTag,
-                          AlertComponent.renderSlimView(
+                          AlertComponent.renderSlimAlert(
                               AlertType.INFO,
                               alreadySetAlertText,
                               /* hidden= */ !questionForm.isUniversal(),
@@ -569,7 +569,7 @@ public final class QuestionEditView extends BaseHtmlView {
                               "usa-alert-remove-top-margin"))
                       .condWith(
                           differentQuestionHasTag,
-                          AlertComponent.renderSlimView(
+                          AlertComponent.renderSlimAlert(
                               AlertType.INFO,
                               nonUniversalAlreadySetAlertText,
                               /* hidden= */ questionForm.isUniversal(),

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -31,6 +31,7 @@ import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
 import play.twirl.api.Content;
+import services.AlertType;
 import services.export.CsvExporterService;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionService;
@@ -40,6 +41,7 @@ import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
+import views.AlertComponent;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.ViewUtils;
@@ -551,26 +553,26 @@ public final class QuestionEditView extends BaseHtmlView {
                                           primaryApplicantInfoTag.getDisplayName()))))
                       .condWith(
                           !differentQuestionHasTag,
-                          ViewUtils.makeAlertSlim(
+                          AlertComponent.renderSlimView(
+                              AlertType.INFO,
                               nonUniversalAlertText,
                               /* hidden= */ questionForm.isUniversal(),
-                              /* classes...= */ BaseStyles.ALERT_INFO,
                               "cf-pai-not-universal-alert",
                               "usa-alert-remove-top-margin"))
                       .condWith(
                           differentQuestionHasTag,
-                          ViewUtils.makeAlertSlim(
+                          AlertComponent.renderSlimView(
+                              AlertType.INFO,
                               alreadySetAlertText,
                               /* hidden= */ !questionForm.isUniversal(),
-                              /* classes...= */ BaseStyles.ALERT_INFO,
                               "cf-pai-tag-set-alert",
                               "usa-alert-remove-top-margin"))
                       .condWith(
                           differentQuestionHasTag,
-                          ViewUtils.makeAlertSlim(
+                          AlertComponent.renderSlimView(
+                              AlertType.INFO,
                               nonUniversalAlreadySetAlertText,
                               /* hidden= */ questionForm.isUniversal(),
-                              /* classes...= */ BaseStyles.ALERT_INFO,
                               "cf-pai-tag-set-not-universal-alert",
                               "usa-alert-remove-top-margin"));
               result.with(tagSubsection);

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -32,12 +32,14 @@ import models.DisplayMode;
 import org.apache.commons.lang3.tuple.Pair;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.AlertType;
 import services.DeletionStatus;
 import services.TranslationLocales;
 import services.program.ProgramDefinition;
 import services.question.ActiveAndDraftQuestions;
 import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
+import views.AlertComponent;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.ViewUtils;
@@ -209,11 +211,11 @@ public final class QuestionsListView extends BaseHtmlView {
               .withClasses(ReferenceClasses.SORTABLE_QUESTIONS_CONTAINER)
               .with(h2("Universal questions").withClasses(AdminStyles.SEMIBOLD_HEADER))
               .with(
-                  ViewUtils.makeAlertSlim(
+                  AlertComponent.renderSlimView(
+                      AlertType.INFO,
                       "We recommend using Universal questions in your program for all personal and"
                           + " contact information questions.",
-                      /* hidden= */ false,
-                      /* classes...= */ BaseStyles.ALERT_INFO))
+                      /* hidden= */ false))
               .with(universalQuestionContent));
     }
     questionContent.with(

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -211,7 +211,7 @@ public final class QuestionsListView extends BaseHtmlView {
               .withClasses(ReferenceClasses.SORTABLE_QUESTIONS_CONTAINER)
               .with(h2("Universal questions").withClasses(AdminStyles.SEMIBOLD_HEADER))
               .with(
-                  AlertComponent.renderSlimView(
+                  AlertComponent.renderSlimAlert(
                       AlertType.INFO,
                       "We recommend using Universal questions in your program for all personal and"
                           + " contact information questions.",

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -25,22 +25,22 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import play.mvc.Http.HttpVerbs;
+import services.AlertType;
 import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
 import services.cloud.ApplicantFileNameFormatter;
 import services.cloud.ApplicantStorageClient;
 import services.cloud.StorageUploadRequest;
+import views.AlertComponent;
 import views.ApplicationBaseView;
 import views.ApplicationBaseViewParams;
-import views.ViewUtils;
 import views.components.ButtonStyles;
 import views.fileupload.FileUploadViewStrategy;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 import views.questiontypes.ApplicantQuestionRendererParams;
 import views.questiontypes.FileUploadQuestionRenderer;
 import views.style.ApplicantStyles;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
 /** A helper class for rendering the file upload question for applicants. */
@@ -114,11 +114,11 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
     result.with(createFileInputFormElement(fileInputId, ariaDescribedByIds, hasErrors));
     // TODO(#6804): Use HTMX to add these errors to the DOM only when they're needed.
     result.with(
-        ViewUtils.makeAlertSlim(
+        AlertComponent.renderSlimView(
+                AlertType.ERROR,
                 fileUploadQuestion.fileRequiredMessage().getMessage(params.messages()),
                 // file_upload.ts will un-hide this error if needed.
                 /* hidden= */ true,
-                /* classes...= */ BaseStyles.ALERT_ERROR,
                 "mb-2")
             .withId(ReferenceClasses.FILEUPLOAD_REQUIRED_ERROR_ID));
     result.with(

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -114,7 +114,7 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
     result.with(createFileInputFormElement(fileInputId, ariaDescribedByIds, hasErrors));
     // TODO(#6804): Use HTMX to add these errors to the DOM only when they're needed.
     result.with(
-        AlertComponent.renderSlimView(
+        AlertComponent.renderSlimAlert(
                 AlertType.ERROR,
                 fileUploadQuestion.fileRequiredMessage().getMessage(params.messages()),
                 // file_upload.ts will un-hide this error if needed.

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -167,7 +167,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
     if (!isSuccessfulSave) {
       return div();
     }
-    return AlertComponent.renderFullView(
+    return AlertComponent.renderFullAlert(
         AlertType.SUCCESS, successToast, optionalSuccessMessage, false, "mb-4", "w-3/5");
   }
 

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -21,14 +21,15 @@ import play.i18n.Messages;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import repository.AccountRepository;
+import services.AlertType;
 import services.DateConverter;
 import services.MessageKey;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantPersonalInfo;
 import services.ti.TrustedIntermediaryService;
+import views.AlertComponent;
 import views.ApplicationBaseView;
 import views.HtmlBundle;
-import views.ViewUtils;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
@@ -166,8 +167,8 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
     if (!isSuccessfulSave) {
       return div();
     }
-    return ViewUtils.makeAlert(
-        successToast, false, optionalSuccessMessage, BaseStyles.ALERT_SUCCESS, "mb-4", "w-3/5");
+    return AlertComponent.renderFullView(
+        AlertType.SUCCESS, successToast, optionalSuccessMessage, false, "mb-4", "w-3/5");
   }
 
   private ATag renderBackLink(String linkText) {

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -26,15 +26,16 @@ import java.util.stream.Stream;
 import org.apache.http.client.utils.URIBuilder;
 import play.mvc.Http;
 import play.mvc.Http.HttpVerbs;
+import services.AlertType;
 import services.ProgramBlockValidation;
 import services.ProgramBlockValidation.AddQuestionResult;
 import services.ProgramBlockValidationFactory;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
+import views.AlertComponent;
 import views.ViewUtils;
 import views.style.AdminStyles;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
 /** Contains methods for rendering question bank for an admin to add questions to a program. */
@@ -171,11 +172,11 @@ public final class ProgramQuestionBank {
               .withClasses(ReferenceClasses.SORTABLE_QUESTIONS_CONTAINER)
               .with(h2("Universal questions").withClasses(AdminStyles.SEMIBOLD_HEADER))
               .with(
-                  ViewUtils.makeAlertSlim(
+                  AlertComponent.renderSlimView(
+                      AlertType.INFO,
                       "We recommend using all universal questions in your program for personal and"
                           + " contact information questions.",
-                      /* hidden= */ false,
-                      /* classes...= */ BaseStyles.ALERT_INFO))
+                      /* hidden= */ false))
               .with(each(universalQuestions, qd -> renderQuestionDefinition(qd))));
     }
     contentDiv.with(

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -172,7 +172,7 @@ public final class ProgramQuestionBank {
               .withClasses(ReferenceClasses.SORTABLE_QUESTIONS_CONTAINER)
               .with(h2("Universal questions").withClasses(AdminStyles.SEMIBOLD_HEADER))
               .with(
-                  AlertComponent.renderSlimView(
+                  AlertComponent.renderSlimAlert(
                       AlertType.INFO,
                       "We recommend using all universal questions in your program for personal and"
                           + " contact information questions.",

--- a/server/app/views/fileupload/FileUploadViewStrategy.java
+++ b/server/app/views/fileupload/FileUploadViewStrategy.java
@@ -119,7 +119,7 @@ public abstract class FileUploadViewStrategy {
    * fileLimitMb}.
    */
   public static DivTag createFileTooLargeError(int fileLimitMb, Messages messages) {
-    return AlertComponent.renderSlimView(
+    return AlertComponent.renderSlimAlert(
             AlertType.ERROR,
             fileTooLargeMessage(fileLimitMb).getMessage(messages),
             // TypeScript will un-hide this error when needed.

--- a/server/app/views/fileupload/FileUploadViewStrategy.java
+++ b/server/app/views/fileupload/FileUploadViewStrategy.java
@@ -19,12 +19,12 @@ import j2html.tags.specialized.ScriptTag;
 import java.util.Optional;
 import play.i18n.Messages;
 import play.mvc.Http;
+import services.AlertType;
 import services.MessageKey;
 import services.applicant.ValidationErrorMessage;
 import services.cloud.StorageUploadRequest;
-import views.ViewUtils;
+import views.AlertComponent;
 import views.applicant.ApplicantFileUploadRenderer;
-import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
 /**
@@ -119,11 +119,11 @@ public abstract class FileUploadViewStrategy {
    * fileLimitMb}.
    */
   public static DivTag createFileTooLargeError(int fileLimitMb, Messages messages) {
-    return ViewUtils.makeAlertSlim(
+    return AlertComponent.renderSlimView(
+            AlertType.ERROR,
             fileTooLargeMessage(fileLimitMb).getMessage(messages),
             // TypeScript will un-hide this error when needed.
             /* hidden= */ true,
-            /* classes...= */ BaseStyles.ALERT_ERROR,
             "mb-4")
         .withId(ReferenceClasses.FILEUPLOAD_TOO_LARGE_ERROR_ID);
   }

--- a/server/test/views/AlertComponentTest.java
+++ b/server/test/views/AlertComponentTest.java
@@ -1,0 +1,152 @@
+package views;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import j2html.tags.specialized.DivTag;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import services.AlertType;
+import views.style.BaseStyles;
+
+@RunWith(JUnitParamsRunner.class)
+public class AlertComponentTest {
+  Map<String, String> expectResultsMap =
+      ImmutableMap.<String, String>builder()
+          .put(
+              "visibleWithTitleAndText",
+              """
+              <div class="usa-alert usa-alert--%s" aria-live="polite" role="alert">
+                  <div class="usa-alert__body">
+                      <h4 class="usa-alert__heading">
+                          title
+                      </h4>
+                      <p class="usa-alert__text">
+                          some text
+                      </p>
+                  </div>
+              </div>
+              """)
+          .put(
+              "hiddenWithTitleAndText",
+              """
+              <div hidden class="usa-alert usa-alert--%s" aria-live="polite" role="alert">
+                  <div class="usa-alert__body">
+                      <h4 class="usa-alert__heading">
+                          title
+                      </h4>
+                      <p class="usa-alert__text">
+                          some text
+                      </p>
+                  </div>
+              </div>
+              """)
+          .put(
+              "visibleWithTextOnly",
+              """
+              <div class="usa-alert usa-alert--%s" aria-live="polite" role="alert">
+                  <div class="usa-alert__body">
+                      <p class="usa-alert__text">
+                          some text
+                      </p>
+                  </div>
+              </div>
+              """)
+          .put(
+              "hiddenWithTextOnly",
+              """
+              <div hidden class="usa-alert usa-alert--%s" aria-live="polite" role="alert">
+                  <div class="usa-alert__body">
+                      <p class="usa-alert__text">
+                          some text
+                      </p>
+                  </div>
+              </div>
+              """)
+          .build();
+
+  record Param(
+      AlertType alertType,
+      String text,
+      Optional<String> title,
+      boolean hidden,
+      String expectedResultKey) {}
+
+  private Object[] alertTypeTestParameters() {
+    String text = "some text";
+    String title = "title";
+
+    return new Object[] {
+      // visible alert with title and text
+      new Param(AlertType.ERROR, text, Optional.of(title), false, "visibleWithTitleAndText"),
+      new Param(AlertType.INFO, text, Optional.of(title), false, "visibleWithTitleAndText"),
+      new Param(AlertType.SUCCESS, text, Optional.of(title), false, "visibleWithTitleAndText"),
+      new Param(AlertType.WARNING, text, Optional.of(title), false, "visibleWithTitleAndText"),
+
+      // hidden alert with title and text
+      new Param(AlertType.ERROR, text, Optional.of(title), true, "hiddenWithTitleAndText"),
+      new Param(AlertType.INFO, text, Optional.of(title), true, "hiddenWithTitleAndText"),
+      new Param(AlertType.SUCCESS, text, Optional.of(title), true, "hiddenWithTitleAndText"),
+      new Param(AlertType.WARNING, text, Optional.of(title), true, "hiddenWithTitleAndText"),
+
+      // visible alert with text only
+      new Param(AlertType.ERROR, text, Optional.empty(), false, "visibleWithTextOnly"),
+      new Param(AlertType.INFO, text, Optional.empty(), false, "visibleWithTextOnly"),
+      new Param(AlertType.SUCCESS, text, Optional.empty(), false, "visibleWithTextOnly"),
+      new Param(AlertType.WARNING, text, Optional.empty(), false, "visibleWithTextOnly"),
+
+      // hidden alert with text only
+      new Param(AlertType.ERROR, text, Optional.empty(), true, "hiddenWithTextOnly"),
+      new Param(AlertType.INFO, text, Optional.empty(), true, "hiddenWithTextOnly"),
+      new Param(AlertType.SUCCESS, text, Optional.empty(), true, "hiddenWithTextOnly"),
+      new Param(AlertType.WARNING, text, Optional.empty(), true, "hiddenWithTextOnly"),
+    };
+  }
+
+  @Test
+  @Parameters(method = "alertTypeTestParameters")
+  public void makeAlert_createsAlertComponentCorrectly(Param param) {
+    DivTag alertComponent =
+        AlertComponent.renderFullView(
+            param.alertType(), param.text(), param.title(), param.hidden());
+    assertThat(alertComponent.renderFormatted())
+        .isEqualTo(
+            expectResultsMap
+                .get(param.expectedResultKey())
+                .formatted(param.alertType().name().toLowerCase(Locale.ROOT)));
+  }
+
+  @Test
+  @Parameters(method = "alertTypeTestParameters")
+  public void makeAlertSlim_createsAlertComponentCorrectly(Param param) {
+    // The only difference between these and makeAlert is the inclusion of the
+    // class usa-alert--slim
+    DivTag alertComponent =
+        AlertComponent.renderSlimView(param.alertType(), param.text(), param.hidden());
+    assertThat(alertComponent.render()).contains(BaseStyles.ALERT_SLIM);
+  }
+
+  private Object[] headingLevelParameters() {
+    return new Object[] {
+      AlertComponent.HeadingLevel.H2,
+      AlertComponent.HeadingLevel.H3,
+      AlertComponent.HeadingLevel.H4,
+      AlertComponent.HeadingLevel.H5,
+      AlertComponent.HeadingLevel.H6
+    };
+  }
+
+  @Test
+  @Parameters(method = "headingLevelParameters")
+  public void makeAlert_usesTheCorrectHeadingLevel(AlertComponent.HeadingLevel headingLevel) {
+    DivTag alertComponent =
+        AlertComponent.renderFullView(
+            AlertType.INFO, "some text", Optional.of("title"), true, headingLevel);
+    assertThat(alertComponent.render()).contains(headingLevel.name().toLowerCase(Locale.ROOT));
+  }
+}

--- a/server/test/views/AlertComponentTest.java
+++ b/server/test/views/AlertComponentTest.java
@@ -127,7 +127,7 @@ public class AlertComponentTest {
     // The only difference between these and makeAlert is the inclusion of the
     // class usa-alert--slim
     DivTag alertComponent =
-        AlertComponent.renderSlimView(param.alertType(), param.text(), param.hidden());
+        AlertComponent.renderSlimAlert(param.alertType(), param.text(), param.hidden());
     assertThat(alertComponent.render()).contains(BaseStyles.ALERT_SLIM);
   }
 

--- a/server/test/views/AlertComponentTest.java
+++ b/server/test/views/AlertComponentTest.java
@@ -112,7 +112,7 @@ public class AlertComponentTest {
   @Parameters(method = "alertTypeTestParameters")
   public void makeAlert_createsAlertComponentCorrectly(Param param) {
     DivTag alertComponent =
-        AlertComponent.renderFullView(
+        AlertComponent.renderFullAlert(
             param.alertType(), param.text(), param.title(), param.hidden());
     assertThat(alertComponent.renderFormatted())
         .isEqualTo(
@@ -145,7 +145,7 @@ public class AlertComponentTest {
   @Parameters(method = "headingLevelParameters")
   public void makeAlert_usesTheCorrectHeadingLevel(AlertComponent.HeadingLevel headingLevel) {
     DivTag alertComponent =
-        AlertComponent.renderFullView(
+        AlertComponent.renderFullAlert(
             AlertType.INFO, "some text", Optional.of("title"), true, headingLevel);
     assertThat(alertComponent.render()).contains(headingLevel.name().toLowerCase(Locale.ROOT));
   }

--- a/server/test/views/ViewUtilsTest.java
+++ b/server/test/views/ViewUtilsTest.java
@@ -9,10 +9,8 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.LinkTag;
 import j2html.tags.specialized.ScriptTag;
-import java.util.Locale;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,9 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
-import services.AlertType;
 import services.DateConverter;
-import views.style.BaseStyles;
 
 @RunWith(JUnitParamsRunner.class)
 public class ViewUtilsTest {
@@ -57,42 +53,6 @@ public class ViewUtilsTest {
 
     assertThat(result.render())
         .isEqualTo("<link href=\"/full/asset/path.css\" rel=\"stylesheet\">");
-  }
-
-  @Test
-  public void makeAlert_createsAlertComponentWithTheCorrectClasses() {
-    DivTag alertComponent =
-        ViewUtils.makeAlert(
-            "some text", false, Optional.of("title"), BaseStyles.ALERT_INFO, BaseStyles.ALERT_SLIM);
-    assertThat(alertComponent.render())
-        .isEqualTo(
-            "<div class=\"usa-alert usa-alert--info usa-alert--slim\" aria-live=\"polite\""
-                + " role=\"alert\"><div class=\"usa-alert__body\"><h4"
-                + " class=\"usa-alert__heading\">title</h4><p class=\"usa-alert__text\">some"
-                + " text</p></div></div>");
-  }
-
-  @Test
-  public void makeAlert_doesNotIncludeTitleIfNoneIsPresent() {
-    DivTag alertComponent =
-        ViewUtils.makeAlert("some text", false, Optional.empty(), BaseStyles.ALERT_WARNING);
-    assertThat(alertComponent.render())
-        .isEqualTo(
-            "<div class=\"usa-alert usa-alert--warning\" aria-live=\"polite\" role=\"alert\"><div"
-                + " class=\"usa-alert__body\"><p class=\"usa-alert__text\">some"
-                + " text</p></div></div>");
-  }
-
-  private Object[] alertTypeTestParameters() {
-    return new Object[] {AlertType.ERROR, AlertType.INFO, AlertType.SUCCESS, AlertType.WARNING};
-  }
-
-  @Test
-  @Parameters(method = "alertTypeTestParameters")
-  public void makeAlert_withAlertType(AlertType alertType) {
-    DivTag alertComponent = ViewUtils.makeAlert("some text", false, Optional.empty(), alertType);
-    assertThat(alertComponent.render())
-        .contains(String.format("usa-alert--%s", alertType.toString().toLowerCase(Locale.ROOT)));
   }
 
   @Test


### PR DESCRIPTION
### Description

Refactoring the Alert generating code, updating tests, and adding the option to specify the header level.

Did not remove the styles from `BaseStyles`, I'm not sure if there are other USWDS components that may share the styles. We can clean that up later.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)

Related to #5541
