### PR TITLE
Adding step boxing to test methods

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -287,17 +287,20 @@ export const closeWarningMessage = async (page: Page) => {
   }
 }
 
+/**
+ * Run accessibility tests using axe accessibility testing engine
+ * @param {Page} page Playwright page to operate against
+ */
 export const validateAccessibility = async (page: Page) => {
-  await test.step('Validate accessiblity', async () => {
-    const results = await new AxeBuilder({page}).analyze()
-    const errorMessage = `Found ${results.violations.length} axe accessibility violations:\n ${JSON.stringify(
-      results.violations,
-      null,
-      2,
-    )}`
-
-    expect(results.violations, errorMessage).toEqual([])
-  })
+  await test.step(
+    'Validate accessiblity',
+    async () => {
+      const results = await new AxeBuilder({page}).analyze()
+      const errorMessage = `Found ${results.violations.length} axe accessibility violations\nOn page: ${page.url()}`
+      expect(results.violations, errorMessage).toEqual([])
+    },
+    {box: true},
+  )
 }
 
 /**
@@ -423,9 +426,20 @@ const normalizeElements = async (page: Frame | Page) => {
   })
 }
 
+/**
+ * Check if the toast message contains the expected value
+ * @param {Page} page Playwright page to operate against
+ * @param {string} value Text to look for within the toast message
+ */
 export const validateToastMessage = async (page: Page, value: string) => {
-  const toastMessages = await page.innerText('#toast-container')
-  expect(toastMessages).toContain(value)
+  await test.step(
+    'Validate toast message',
+    async () => {
+      const toastMessages = await page.innerText('#toast-container')
+      expect(toastMessages).toContain(value)
+    },
+    {box: true},
+  )
 }
 
 type LocalstackSesResponse = {


### PR DESCRIPTION
### Description

This will make the errors show the calling location and not inside each method. 


#### Example

Instead of the error showing this:

```
      375 |     .replace('.test.ts', '_test')
      376 |
    > 377 |   await expect(element).toHaveScreenshot(
          |                         ^
      378 |     [testFileName, fullScreenshotFileName + '.png'],
      379 |     {
      380 |       fullPage: fullPage,
```

You'll get this:

```
      91 |         AdminQuestions.NUMBER_QUESTION_TEXT,
      92 |       )
    > 93 |       await validateScreenshot(
         |                               ^
      94 |         page,
      95 |         'application-ineligible-same-application',
      96 |         /* fullPage= */ true,
```



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
