### PR TITLE
Fit and finish for the not prod banner

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -950,8 +950,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   /**
    * Enabling this will add a banner to the site to tell applicants this is not Production and that
    * they shouldn't submit real applications. Configure the CIVIC_ENTITY_PRODUCTION_URL setting to
-   * also include a link to your production site. This banner will not show on Production sites even
-   * if this setting is enabled.
+   * also include a link to your production site.
    */
   public boolean getShowNotProductionBannerEnabled(RequestHeader request) {
     return getBool("SHOW_NOT_PRODUCTION_BANNER_ENABLED", request);
@@ -1981,8 +1980,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "Enabling this will add a banner to the site to tell applicants this is not"
                           + " Production and that they shouldn't submit real applications."
                           + " Configure the CIVIC_ENTITY_PRODUCTION_URL setting to also include a"
-                          + " link to your production site. This banner will not show on Production"
-                          + " sites even if this setting is enabled.",
+                          + " link to your production site.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE))),

--- a/server/app/views/components/PageNotProductionBanner.java
+++ b/server/app/views/components/PageNotProductionBanner.java
@@ -11,18 +11,15 @@ import com.google.inject.Inject;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import play.i18n.Messages;
 import play.mvc.Http;
-import services.DeploymentType;
 import services.MessageKey;
 import services.settings.SettingsManifest;
 
 /**
  * This will build a sticky banner that follows the user as they scroll. Enable the
- * SHOW_NOT_PRODUCTION_BANNER_ENABLED setting to add this banner to the page. It will not show on a
- * production site even if the SHOW_NOT_PRODUCTION_BANNER_ENABLED setting is enabled.
+ * SHOW_NOT_PRODUCTION_BANNER_ENABLED setting to add this banner to the page. It will show on a
+ * production site if the SHOW_NOT_PRODUCTION_BANNER_ENABLED setting is enabled. Default is false.
  *
  * <p>Set the CIVIC_ENTITY_PRODUCTION_URL to include an optional link to the production site.
  *
@@ -31,14 +28,11 @@ import services.settings.SettingsManifest;
  */
 public final class PageNotProductionBanner {
 
-  private static final Logger logger = LoggerFactory.getLogger(PageNotProductionBanner.class);
   private final SettingsManifest settingsManifest;
-  private final DeploymentType deploymentType;
 
   @Inject
-  public PageNotProductionBanner(SettingsManifest settingsManifest, DeploymentType deploymentType) {
+  public PageNotProductionBanner(SettingsManifest settingsManifest) {
     this.settingsManifest = checkNotNull(settingsManifest);
-    this.deploymentType = checkNotNull(deploymentType);
   }
 
   public Optional<DivTag> render(Http.Request request, Messages messages) {
@@ -46,15 +40,10 @@ public final class PageNotProductionBanner {
       return Optional.empty();
     }
 
-    if (!deploymentType.isDevOrStaging()) {
-      logger.debug("Don't show this banner on production");
-      return Optional.empty();
-    }
-
     String productionUrl = settingsManifest.getCivicEntityProductionUrl(request).orElse("");
 
     ATag link =
-        a(settingsManifest.getWhitelabelCivicEntityShortName(request).orElse("") + " CiviForm")
+        a(settingsManifest.getWhitelabelCivicEntityFullName(request).orElse("") + " CiviForm")
             .withHref(productionUrl)
             .withClasses("font-bold", "underline", "hover:no-underline");
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -796,7 +796,7 @@
       },
       "SHOW_NOT_PRODUCTION_BANNER_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
-        "description": "Enabling this will add a banner to the site to tell applicants this is not Production and that they shouldn't submit real applications. Configure the CIVIC_ENTITY_PRODUCTION_URL setting to also include a link to your production site. This banner will not show on Production sites even if this setting is enabled.",
+        "description": "Enabling this will add a banner to the site to tell applicants this is not Production and that they shouldn't submit real applications. Configure the CIVIC_ENTITY_PRODUCTION_URL setting to also include a link to your production site.",
         "type": "bool"
       }
     }

--- a/server/test/views/components/PageNotProductionBannerTest.java
+++ b/server/test/views/components/PageNotProductionBannerTest.java
@@ -50,7 +50,7 @@ public class PageNotProductionBannerTest {
   }
 
   @Test
-  public void whenShowBannerSettingEnabled_returnsEmpty() {
+  public void whenShowBannerSettingEnabled_returnsComponent() {
     String productionUrl = "https://civiform.example.com";
     when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(true);
     when(settingsManifest.getCivicEntityProductionUrl(request))
@@ -72,7 +72,7 @@ public class PageNotProductionBannerTest {
   }
 
   @Test
-  public void whenShowBannerSettingEnabled_andNoProductionUrlSetting_returnsDivTag() {
+  public void whenShowBannerSettingEnabled_andNoProductionUrlSetting_returnsComponent() {
     when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(true);
     when(settingsManifest.getCivicEntityProductionUrl(request)).thenReturn(Optional.empty());
 

--- a/server/test/views/components/PageNotProductionBannerTest.java
+++ b/server/test/views/components/PageNotProductionBannerTest.java
@@ -14,7 +14,6 @@ import play.i18n.Langs;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
-import services.DeploymentType;
 import services.MessageKey;
 import services.settings.SettingsManifest;
 
@@ -41,70 +40,25 @@ public class PageNotProductionBannerTest {
   }
 
   @Test
-  public void devEnvironment_withShowBannerSettingSettingDisabled_returnsEmpty() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ true, /* isStaging */ false);
-    assertEnvironmentWithShowBannerSettingDisabledReturnsEmpty(deploymentType);
-  }
-
-  @Test
-  public void stagingEnvironment_withShowBannerSettingSettingDisabled_returnsEmpty() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ false, /* isStaging */ true);
-    assertEnvironmentWithShowBannerSettingDisabledReturnsEmpty(deploymentType);
-  }
-
-  @Test
-  public void productionEnvironment_withShowBannerSettingSettingDisabled_returnsEmpty() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ false, /* isStaging */ false);
-    assertEnvironmentWithShowBannerSettingDisabledReturnsEmpty(deploymentType);
-  }
-
-  private void assertEnvironmentWithShowBannerSettingDisabledReturnsEmpty(
-      DeploymentType deploymentType) {
+  public void whenShowBannerSettingDisabled_returnsEmpty() {
     when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(false);
 
-    PageNotProductionBanner component =
-        new PageNotProductionBanner(settingsManifest, deploymentType);
+    PageNotProductionBanner component = new PageNotProductionBanner(settingsManifest);
 
     var actual = component.render(request, messages);
     assertThat(actual).isEqualTo(Optional.empty());
   }
 
   @Test
-  public void productionEnvironment_withShowBannerSettingEnabled_returnsEmpty() {
-    when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(true);
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ false, /* isStaging */ false);
-
-    PageNotProductionBanner component =
-        new PageNotProductionBanner(settingsManifest, deploymentType);
-
-    var actual = component.render(request, messages);
-    assertThat(actual).isEqualTo(Optional.empty());
-  }
-
-  @Test
-  public void devEnvironment_withShowBannerSettingEnabled_andProductionUrlSetting_returnsDivTag() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ true, /* isStaging */ false);
-    assertEnvironmentShowsFullBanner(deploymentType);
-  }
-
-  @Test
-  public void
-      stagingEnvironment_withShowBannerSettingEnabled_andProductionUrlSetting_returnsDivTag() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ false, /* isStaging */ true);
-    assertEnvironmentShowsFullBanner(deploymentType);
-  }
-
-  private void assertEnvironmentShowsFullBanner(DeploymentType deploymentType) {
-
+  public void whenShowBannerSettingEnabled_returnsEmpty() {
     String productionUrl = "https://civiform.example.com";
     when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(true);
     when(settingsManifest.getCivicEntityProductionUrl(request))
         .thenReturn(Optional.of(productionUrl));
-    when(settingsManifest.getWhitelabelCivicEntityShortName(request))
-        .thenReturn(Optional.of("shortname"));
+    when(settingsManifest.getWhitelabelCivicEntityFullName(request))
+        .thenReturn(Optional.of("civic-entity-name"));
 
-    PageNotProductionBanner component =
-        new PageNotProductionBanner(settingsManifest, deploymentType);
+    PageNotProductionBanner component = new PageNotProductionBanner(settingsManifest);
 
     var actual = component.render(request, messages);
     assertThat(actual).isNotEqualTo(Optional.empty());
@@ -118,25 +72,11 @@ public class PageNotProductionBannerTest {
   }
 
   @Test
-  public void
-      devEnvironment_withShowBannerSettingEnabled_andNoProductionUrlSetting_returnsDivTag() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ true, /* isStaging */ false);
-    assertEnvironmentShowsPartialBanner(deploymentType);
-  }
-
-  @Test
-  public void
-      stagingEnvironment_withShowBannerSettingEnabled_andNoProductionUrlSetting_returnsDivTag() {
-    DeploymentType deploymentType = new DeploymentType(/* isDev */ false, /* isStaging */ true);
-    assertEnvironmentShowsPartialBanner(deploymentType);
-  }
-
-  private void assertEnvironmentShowsPartialBanner(DeploymentType deploymentType) {
+  public void whenShowBannerSettingEnabled_andNoProductionUrlSetting_returnsDivTag() {
     when(settingsManifest.getShowNotProductionBannerEnabled(request)).thenReturn(true);
     when(settingsManifest.getCivicEntityProductionUrl(request)).thenReturn(Optional.empty());
 
-    PageNotProductionBanner component =
-        new PageNotProductionBanner(settingsManifest, deploymentType);
+    PageNotProductionBanner component = new PageNotProductionBanner(settingsManifest);
 
     var actual = component.render(request, messages);
     assertThat(actual).isNotEqualTo(Optional.empty());


### PR DESCRIPTION
### Description

- Remove the hard block on prod. Doing this because you have to run a test server in prod mode to hide the dev tools buttons. Default for the setting to show the banner is still false.
- Changing the prod link text to use the civic entity full name to make it more clear. Example "Go to Seattle CiviForm" vs "Go to City of Seattle CiviForm". The latter makes it more clear it's for the civic entity.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
