### PR TITLE
Move TI clear search button javascript from inline to a script

### DIFF
--- a/server/app/assets/javascripts/applicant_entry_point.ts
+++ b/server/app/assets/javascripts/applicant_entry_point.ts
@@ -14,6 +14,7 @@ import * as azureDelete from './azure_delete'
 import * as azureUpload from './azure_upload'
 import * as phoneNumber from './phone'
 import * as apiDocs from './api_docs'
+import * as trustedIntermediary from './trusted_intermediary'
 
 window.addEventListener('load', () => {
   main.init()
@@ -28,4 +29,5 @@ window.addEventListener('load', () => {
   phoneNumber.init()
   // API docs are publicly visible, so we need the supporting scripts here.
   apiDocs.init()
+  trustedIntermediary.init()
 })

--- a/server/app/assets/javascripts/trusted_intermediary.ts
+++ b/server/app/assets/javascripts/trusted_intermediary.ts
@@ -1,0 +1,20 @@
+// Javascript handling for the trusted intermediary page
+
+import {addEventListenerToElements} from './util'
+
+export function init() {
+  addEventListenerToElements('#cf-ti-clear-search', 'click', clearSearchForm)
+}
+
+/** Clear the client search form when the clear link is clicked. */
+function clearSearchForm() {
+  const inputIds = [
+    'name-query',
+    'date_of_birth_day',
+    'date_of_birth_month',
+    'date_of_birth_year',
+  ]
+  for (const inputId of inputIds) {
+    ;(document.getElementById(inputId) as HTMLInputElement).value = ''
+  }
+}

--- a/server/app/views/applicant/TrustedIntermediaryClientListView.java
+++ b/server/app/views/applicant/TrustedIntermediaryClientListView.java
@@ -57,6 +57,7 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.ToastMessage;
 import views.style.BaseStyles;
+import views.style.ReferenceClasses;
 
 /** Renders a page for a trusted intermediary to manage their clients. */
 public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashboardView {
@@ -201,14 +202,9 @@ public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashbo
 
   private ATag renderClearSearchLink(Messages messages) {
     return new LinkElement()
+        .setId(ReferenceClasses.TI_CLEAR_SEARCH)
         .setText(messages.at(MessageKey.BUTTON_CLEAR_SEARCH.getKeyName()))
-        .asAnchorText()
-        .attr(
-            "onClick",
-            "document.getElementById('name-query').value = '';"
-                + "document.getElementById('date_of_birth_day').value = '';"
-                + "document.getElementById('date_of_birth_month').value = '';"
-                + "document.getElementById('date_of_birth_year').value = '';");
+        .asAnchorText();
   }
 
   private DivTag renderClientList(

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -97,6 +97,8 @@ public final class ReferenceClasses {
   public static final String CONTINUE_BUTTON = "cf-continue-button";
   public static final String SUBMIT_BUTTON = "cf-submit-button";
 
+  public static final String TI_CLEAR_SEARCH = "cf-ti-clear-search";
+
   /////////////////////////////////////////////////////////////////////////////////////////////////
   // Question reference classes
   /////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description

Move the javascript for the clear search button on the TI client view page from inline to a script

* Add a trusted_intermediary.ts script and load it in applicant_entry_point.ts
* Move the javascript from onclick on the <a> element to a click event listener
* Refactor to reduce duplicated code

This is a necessary step to enforce a content security policy (#7574), and it's also cleaner and more consistent with how the rest of the application works.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)