### PR TITLE
Fix localized string name in EnumeratorQuestionFragment

### DIFF
--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -97,7 +97,7 @@
       class="cf-enumerator-delete-button usa-button--unstyled"
       th:id="${deleteButtonId}"
       th:text="#{button.removeEntity(${enumeratorQuestion.getEntityType()})} + ${indexString}"
-      th:attr="onclick='if(confirm(\'' + #{dialog.confirmDelete(${enumeratorQuestion.getEntityType()})} + '\')){ return true; } else { var e = arguments[0] || window.event; e.stopImmediatePropagation(); return false; }'"
+      th:attr="onclick='if(confirm(\'' + #{dialog.confirmDeleteAllButtonsSave(${enumeratorQuestion.getEntityType()})} + '\')){ return true; } else { var e = arguments[0] || window.event; e.stopImmediatePropagation(); return false; }'"
     ></button>
   </div>
 </div>


### PR DESCRIPTION
### Description

In #7898 I changed the warning message from dialog.confirmDelete to dialog.confirmDeleteAllButtonsSave to fix #6844, but EnumeratorQuestionFragment was under development at the same time. So when I did a global find/replace I didn't find it, but it had already been copied, and the merge didn't create any conflicts.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)