### PR TITLE
Make methods in BaseHtmlView static

### DIFF
--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -155,7 +155,7 @@ public abstract class BaseHtmlView {
    * @param optionalMessages Optional messages to be used for i18n
    * @return NavTag
    */
-  protected NavTag renderPagination(
+  protected static NavTag renderPagination(
       int page,
       int pageCount,
       Function<Integer, Call> linkForPage,
@@ -226,7 +226,7 @@ public abstract class BaseHtmlView {
                     page != pageCount, renderNextPageButton(page, linkForPage, optionalMessages)));
   }
 
-  private LiTag renderPaginationPageButton(
+  private static LiTag renderPaginationPageButton(
       int page, boolean isCurrentPage, Function<Integer, Call> linkForPage) {
     return li().withClass("usa-pagination__item usa-pagination__page-no")
         .with(
@@ -238,7 +238,7 @@ public abstract class BaseHtmlView {
                 .condAttr(isCurrentPage, "aria-current", "page"));
   }
 
-  private LiTag renderPreviousPageButton(
+  private static LiTag renderPreviousPageButton(
       int page, Function<Integer, Call> linkForPage, Optional<Messages> optionalMessages) {
     return li().withClass("usa-pagination__item usa-pagination__arrow")
         .with(
@@ -258,7 +258,7 @@ public abstract class BaseHtmlView {
                         .withClass("usa-pagination__link-text")));
   }
 
-  private LiTag renderNextPageButton(
+  private static LiTag renderNextPageButton(
       int page, Function<Integer, Call> linkForPage, Optional<Messages> optionalMessages) {
     return li().withClass("usa-pagination__item usa-pagination__arrow")
         .with(
@@ -276,7 +276,7 @@ public abstract class BaseHtmlView {
                         .attr("aria-hidden", "true")));
   }
 
-  private LiTag renderPaginationEllipses() {
+  private static LiTag renderPaginationEllipses() {
     return li().withClass("usa-pagination__item usa-pagination__overflow")
         .attr("aria-label", "ellipsis indicating non-visible pages")
         .with(span("..."));


### PR DESCRIPTION
### Description

Make the few methods in BaseHtmlView static that were not already, to enforce its self-description of being stateless.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
