### PR TITLE
Update plugins

### DIFF
--- a/server/project/plugins.sbt
+++ b/server/project/plugins.sbt
@@ -9,14 +9,11 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 
 // Web Assets plugins
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")
 
 // Code Coverage plugin
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.5.0")
 
 // Formatting plugin
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-
-// This is needed per https://eed3si9n.com/sbt-1.8.0-beta
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
A couple of these were out of date since the namespace changed, and were including a critical vulnerability in the container. This also removes a workaround we needed for sbt 1.8.