### PR TITLE
Disable SettingsMigrationModule in unit tests

### DIFF
--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -4,6 +4,7 @@ play.modules {
   # Don't seed the database in test mode, many unit tests expect a completely
   # empty empty database at setup time.
   disabled += modules.DatabaseSeedModule
+  disabled += modules.SettingsMigrationModule
 }
 
 db {


### PR DESCRIPTION
### Description

Sometimes the unit tests fail with `io.ebean.DuplicateKeyException: Error[ERROR: duplicate key value violates unique constraint "civiform_settings_create_time"`.

I don't think we need to do this in the unit tests.

This disables the `SettingsMigrationModule` in the application.test.conf.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
