### PR TITLE
Uses optional instead of throwing exception

### DIFF
--- a/server/app/actions/ProgramFastForwardApplicationAction.java
+++ b/server/app/actions/ProgramFastForwardApplicationAction.java
@@ -43,15 +43,15 @@ public class ProgramFastForwardApplicationAction extends Action.Simple {
     long programId = routeExtractor.getParamLongValue("programId");
     long applicantId = getApplicantId(request, routeExtractor);
 
-    long latestProgramId = programRepository.getMostRecentActiveProgramId(programId);
+    Optional<Long> latestProgramId = programRepository.getMostRecentActiveProgramId(programId);
 
-    if (latestProgramId > programId) {
-      applicationRepository.updateDraftApplicationProgram(applicantId, latestProgramId);
+    if (latestProgramId.isPresent() && latestProgramId.get() > programId) {
+      applicationRepository.updateDraftApplicationProgram(applicantId, latestProgramId.get());
 
       return CompletableFuture.completedFuture(
           redirect(
                   controllers.applicant.routes.ApplicantProgramReviewController.review(
-                          latestProgramId)
+                          latestProgramId.get())
                       .url())
               .flashing(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true"));
     }

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -501,12 +501,13 @@ public final class ProgramRepository {
   }
 
   /**
-   * Get the most recent id for the active program
+   * Get the most recent id for the active program. In the case that there are no active versions of
+   * a program, an empty value is returned.
    *
    * @param programId to use when looking for the most recent program
-   * @return The programId of the most recent program
+   * @return The programId of the most recent active program or empty.
    */
-  public long getMostRecentActiveProgramId(long programId) {
+  public Optional<Long> getMostRecentActiveProgramId(long programId) {
     /*
      * We need for this to always get the most recent active program ID, thus we are unable to
      * cache the value without building out a much more complicated caching solution. This will
@@ -541,14 +542,6 @@ public final class ProgramRepository {
             .mapToScalar(Long.class)
             .findOne();
 
-    if (latestProgramId == null) {
-      throw new RuntimeException(
-          String.format(
-              "ProgramRepository.getMostRecentActiveProgramId could not find the latest program id"
-                  + " for programId: %d",
-              programId));
-    }
-
-    return latestProgramId;
+    return Optional.ofNullable(latestProgramId);
   }
 }

--- a/server/test/actions/ProgramFastForwardApplicationActionTest.java
+++ b/server/test/actions/ProgramFastForwardApplicationActionTest.java
@@ -47,7 +47,47 @@ public class ProgramFastForwardApplicationActionTest extends WithApplication {
     // Set up mocked return values
     when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.of(applicantId));
     when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
-        .thenReturn(currentProgramId);
+        .thenReturn(Optional.of(currentProgramId));
+
+    // The action to test
+    ProgramFastForwardApplicationAction action =
+        new ProgramFastForwardApplicationAction(
+            profileUtilsMock, programRepositoryMock, applicationRepositoryMock);
+
+    // Configure a fake secondary action to serve as a stand in for the last action in the chain
+    // (i.e. controller)
+    when(nextActionInChainMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = nextActionInChainMock;
+
+    // Result from running the action
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // All the assertions and verifications
+    assertThat(result).isNull();
+
+    // This is the main reason for this action and must not have run given the inputs for this test
+    verify(applicationRepositoryMock, Mockito.times(0))
+        .updateDraftApplicationProgram(any(Long.class), any(Long.class));
+  }
+
+  @Test
+  public void continue_to_next_action_when_program_only_has_draft_version() {
+    // Setup mocks
+    ProfileUtils profileUtilsMock = mock(ProfileUtils.class);
+    ProgramRepository programRepositoryMock = mock(ProgramRepository.class);
+    ApplicationRepository applicationRepositoryMock = mock(ApplicationRepository.class);
+    Action.Simple nextActionInChainMock = mock(Action.Simple.class);
+
+    // Setup fakeRequest and configure it to use the specified route pattern
+    Request request =
+        createFakeRequest(
+            "/programs/$programId<[^/]+>/blocks/$blockId<[^/]+>/edit",
+            String.format("/programs/%d/blocks/2/edit", currentProgramId));
+
+    // Set up mocked return values
+    when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.of(applicantId));
+    when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
+        .thenReturn(Optional.empty());
 
     // The action to test
     ProgramFastForwardApplicationAction action =
@@ -86,7 +126,7 @@ public class ProgramFastForwardApplicationActionTest extends WithApplication {
     // Set up mocked return values
     when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.of(applicantId));
     when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
-        .thenReturn(latestProgramId);
+        .thenReturn(Optional.of(latestProgramId));
 
     // The action to test
     ProgramFastForwardApplicationAction action =
@@ -124,7 +164,7 @@ public class ProgramFastForwardApplicationActionTest extends WithApplication {
     // Set up mocked return values
     when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.empty());
     when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
-        .thenReturn(latestProgramId);
+        .thenReturn(Optional.of(latestProgramId));
 
     // The action to test
     ProgramFastForwardApplicationAction action =
@@ -159,7 +199,7 @@ public class ProgramFastForwardApplicationActionTest extends WithApplication {
     // Set up mocked return values
     when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.empty());
     when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
-        .thenReturn(latestProgramId);
+        .thenReturn(Optional.of(latestProgramId));
 
     // The action to test
     ProgramFastForwardApplicationAction action =
@@ -188,7 +228,7 @@ public class ProgramFastForwardApplicationActionTest extends WithApplication {
     // Set up mocked return values
     when(profileUtilsMock.getApplicantId(request)).thenReturn(Optional.empty());
     when(programRepositoryMock.getMostRecentActiveProgramId(any(Long.class)))
-        .thenReturn(latestProgramId);
+        .thenReturn(Optional.of(latestProgramId));
 
     // The action to test
     ProgramFastForwardApplicationAction action =

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -879,9 +879,10 @@ public class ProgramRepositoryTest extends ResetPostgres {
     ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-1");
     ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
 
-    long latestId = repo.getMostRecentActiveProgramId(programModel1.id);
+    Optional<Long> latestId = repo.getMostRecentActiveProgramId(programModel1.id);
 
-    assertThat(latestId).isEqualTo(programModel4.id);
+    assertThat(latestId.isPresent()).isTrue();
+    assertThat(latestId.get()).isEqualTo(programModel4.id);
   }
 
   @Test
@@ -892,19 +893,34 @@ public class ProgramRepositoryTest extends ResetPostgres {
     ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-4");
     ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
 
-    long latestId = repo.getMostRecentActiveProgramId(programModel1.id);
+    Optional<Long> latestId = repo.getMostRecentActiveProgramId(programModel1.id);
 
-    assertThat(latestId).isEqualTo(programModel1.id);
+    assertThat(latestId.isPresent()).isTrue();
+    assertThat(latestId.get()).isEqualTo(programModel1.id);
   }
 
   @Test
-  public void getMostRecentActiveProgramVersion_throwsWhenProgramIdDoesNotExist() {
+  public void getMostRecentActiveProgramVersion_returnsEmptyWhenIdDoesNotExist() {
     ProgramModel programModel1 = resourceCreator.insertActiveProgram("program-name-1");
     ProgramModel programModel2 = resourceCreator.insertActiveProgram("program-name-2");
     ProgramModel programModel3 = resourceCreator.insertActiveProgram("program-name-3");
     ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-4");
     ProgramModel programModel5 = resourceCreator.insertDraftProgram("program-name-1");
 
-    assertThatThrownBy(() -> repo.getMostRecentActiveProgramId(-1));
+    Optional<Long> latestId = repo.getMostRecentActiveProgramId(-1);
+
+    assertThat(latestId.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void getMostRecentActiveProgramVersion_returnsEmptyWhenNoActiveProgramExists() {
+    ProgramModel programModel1 = resourceCreator.insertDraftProgram("program-name-1");
+    ProgramModel programModel2 = resourceCreator.insertActiveProgram("program-name-2");
+    ProgramModel programModel3 = resourceCreator.insertActiveProgram("program-name-3");
+    ProgramModel programModel4 = resourceCreator.insertActiveProgram("program-name-4");
+
+    Optional<Long> latestId = repo.getMostRecentActiveProgramId(programModel1.id);
+
+    assertThat(latestId.isEmpty()).isTrue();
   }
 }


### PR DESCRIPTION
### Description

In the case there a program is newly created and has never been published there will be no latest active version. This needs to not throw in that case and can be handled by the caller.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Related to: #5541
