### PR TITLE
Enhance FakeRequestBuilder to support unit test cases

### DIFF
--- a/server/test/auth/ApiAuthenticatorTest.java
+++ b/server/test/auth/ApiAuthenticatorTest.java
@@ -3,6 +3,7 @@ package auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -36,7 +37,6 @@ import play.mvc.Http;
 import play.test.Helpers;
 import services.apikey.ApiKeyService;
 import services.settings.SettingsManifest;
-import support.FakeRequestBuilder;
 import support.ResourceCreator;
 
 public class ApiAuthenticatorTest {
@@ -106,7 +106,7 @@ public class ApiAuthenticatorTest {
     apiAuthenticator.validate(
         new UsernamePasswordCredentials(keyId, secret),
         new PlayWebContext(
-            new FakeRequestBuilder()
+            fakeRequestBuilder()
                 .rawCredentials(validRawCredentials)
                 .remoteAddress("1.1.1.1")
                 .build()),
@@ -132,7 +132,7 @@ public class ApiAuthenticatorTest {
     authenticator.validate(
         new UsernamePasswordCredentials(keyId, secret),
         new PlayWebContext(
-            new FakeRequestBuilder()
+            fakeRequestBuilder()
                 .rawCredentials(validRawCredentials)
                 .addXForwardedFor("2.2.2.2, 3.3.3.3")
                 .build()),
@@ -148,7 +148,7 @@ public class ApiAuthenticatorTest {
     String rawCredentials = "wrong" + ":" + secret;
 
     assertBadCredentialsException(
-        new FakeRequestBuilder().rawCredentials(rawCredentials).build(),
+        fakeRequestBuilder().rawCredentials(rawCredentials).build(),
         new UsernamePasswordCredentials("wrong", secret),
         "API key does not exist: wrong");
   }
@@ -159,7 +159,7 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        new FakeRequestBuilder().rawCredentials(validRawCredentials).build(),
+        fakeRequestBuilder().rawCredentials(validRawCredentials).build(),
         "API key is retired: " + keyId);
   }
 
@@ -170,7 +170,7 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        new FakeRequestBuilder().rawCredentials(validRawCredentials).build(),
+        fakeRequestBuilder().rawCredentials(validRawCredentials).build(),
         "API key is expired: " + keyId);
   }
 
@@ -180,10 +180,7 @@ public class ApiAuthenticatorTest {
     apiKey.save();
 
     assertBadCredentialsException(
-        new FakeRequestBuilder()
-            .rawCredentials(validRawCredentials)
-            .remoteAddress("4.4.4.4")
-            .build(),
+        fakeRequestBuilder().rawCredentials(validRawCredentials).remoteAddress("4.4.4.4").build(),
         String.format(
             "Resolved IP 4.4.4.4 is not in allowed range for key ID: %s, which is \"%s\"",
             keyId, "2.2.2.2/30,3.3.3.3/32"));
@@ -204,7 +201,7 @@ public class ApiAuthenticatorTest {
 
     assertBadCredentialsException(
         authenticator,
-        new FakeRequestBuilder()
+        fakeRequestBuilder()
             .addXForwardedFor("5.5.5.5, 6.6.6.6")
             .rawCredentials(validRawCredentials)
             .build(),
@@ -236,7 +233,7 @@ public class ApiAuthenticatorTest {
                 authenticator.validate(
                     new UsernamePasswordCredentials(keyId, secret),
                     new PlayWebContext(
-                        new FakeRequestBuilder()
+                        fakeRequestBuilder()
                             .addXForwardedFor("5.5.5.5, 6.6.6.6")
                             .rawCredentials(validRawCredentials)
                             .remoteAddress("7.7.7.7")
@@ -258,7 +255,7 @@ public class ApiAuthenticatorTest {
     var rawCredentials = keyId + ":" + "notthesecret";
 
     assertBadCredentialsException(
-        new FakeRequestBuilder().rawCredentials(rawCredentials).remoteAddress("1.1.1.1").build(),
+        fakeRequestBuilder().rawCredentials(rawCredentials).remoteAddress("1.1.1.1").build(),
         new UsernamePasswordCredentials(keyId, "notthesecret"),
         "Invalid secret for key ID: " + keyId);
   }

--- a/server/test/auth/ClientIpResolverTest.java
+++ b/server/test/auth/ClientIpResolverTest.java
@@ -3,14 +3,15 @@ package auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import java.util.Optional;
 import modules.ConfigurationException;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pac4j.play.PlayWebContext;
+import play.mvc.Http.Request;
 import services.settings.SettingsManifest;
-import support.FakeRequestBuilder;
 
 public class ClientIpResolverTest {
   private static final SettingsManifest MOCK_SETTINGS_MANIFEST =
@@ -21,11 +22,8 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("DIRECT"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request =
-        new FakeRequestBuilder()
-            .addXForwardedFor("3.3.3.3, 2.2.2.2")
-            .remoteAddress("4.4.4.4")
-            .build();
+    Request request =
+        fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").remoteAddress("4.4.4.4").build();
 
     assertThat(clientIpResolver.resolveClientIp(new PlayWebContext(request))).isEqualTo("4.4.4.4");
   }
@@ -36,7 +34,7 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request = new FakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
+    Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
 
     assertThat(clientIpResolver.resolveClientIp(new PlayWebContext(request))).isEqualTo("2.2.2.2");
   }
@@ -47,7 +45,7 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request = new FakeRequestBuilder().remoteAddress("3.3.3.3").build();
+    Request request = fakeRequestBuilder().remoteAddress("3.3.3.3").build();
 
     assertThatThrownBy(() -> clientIpResolver.resolveClientIp(new PlayWebContext(request)))
         .isInstanceOf(ConfigurationException.class)
@@ -60,7 +58,7 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request = new FakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
+    Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
 
     assertThat(clientIpResolver.resolveClientIp(request)).isEqualTo("2.2.2.2");
   }
@@ -71,7 +69,7 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request = new FakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2, 1.1.1.1").build();
+    Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2, 1.1.1.1").build();
 
     assertThat(clientIpResolver.resolveClientIp(request)).isEqualTo("2.2.2.2");
   }
@@ -82,8 +80,8 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request =
-        new FakeRequestBuilder()
+    Request request =
+        fakeRequestBuilder()
             .addXForwardedFor("3.3.3.3, 2.2.2.2")
             .addXForwardedFor("1.1.1.1")
             .build();
@@ -97,7 +95,7 @@ public class ClientIpResolverTest {
     when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
-    var request = new FakeRequestBuilder().addXForwardedFor("1.1.1.1").build();
+    Request request = fakeRequestBuilder().addXForwardedFor("1.1.1.1").build();
 
     assertThatThrownBy(() -> clientIpResolver.resolveClientIp(new PlayWebContext(request)))
         .isInstanceOf(ConfigurationException.class)

--- a/server/test/auth/FakeRequestBuilderTest.java
+++ b/server/test/auth/FakeRequestBuilderTest.java
@@ -1,12 +1,13 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.itextpdf.xmp.impl.Base64;
 import java.util.List;
 import org.junit.Test;
-import play.mvc.Http;
-import support.FakeRequestBuilder;
+import play.mvc.Http.Request;
 
 public class FakeRequestBuilderTest {
   @Test
@@ -14,8 +15,8 @@ public class FakeRequestBuilderTest {
     String rawCreds = "raw creds";
     String encodedCreds = Base64.encode(rawCreds);
 
-    Http.Request fakeRequest =
-        new FakeRequestBuilder()
+    Request fakeRequest =
+        fakeRequestBuilder()
             .rawCredentials(rawCreds)
             .addXForwardedFor("4.4.4.4, 5.5.5.5")
             .addXForwardedFor("6.6.6.6")
@@ -28,7 +29,7 @@ public class FakeRequestBuilderTest {
 
   @Test
   public void hasUsableDefaults() {
-    Http.Request fakeRequest = new FakeRequestBuilder().build();
+    Request fakeRequest = fakeRequest();
 
     assertThat(fakeRequest.header("Authorization")).isEmpty();
     assertThat(fakeRequest.header("X-Forwarded-For")).isEmpty();

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -2,6 +2,7 @@ package services.settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -11,7 +12,6 @@ import java.util.Optional;
 import org.junit.Test;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http;
-import support.FakeRequestBuilder;
 
 public class SettingsManifestTest {
 
@@ -74,8 +74,7 @@ public class SettingsManifestTest {
               "foo"));
 
   private static Http.Request REQUEST =
-      new FakeRequestBuilder()
-          .build()
+      fakeRequest()
           .withAttrs(
               TypedMap.empty()
                   .put(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, ImmutableMap.of("BOOL_VARIABLE", "true")));
@@ -124,6 +123,6 @@ public class SettingsManifestTest {
 
   @Test
   public void getBool_noAttrsInRequest_returnsHoconValue() {
-    assertThat(testManifest.getBool("BOOL_VARIABLE", new FakeRequestBuilder().build())).isFalse();
+    assertThat(testManifest.getBool("BOOL_VARIABLE", fakeRequest())).isFalse();
   }
 }

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -1,17 +1,37 @@
 package support;
 
+import static play.api.test.CSRFTokenHelper.addCSRFToken;
+
 import auth.ClientIpResolver;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import play.mvc.Call;
+import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
 import play.mvc.Http.RequestImpl;
 
 public final class FakeRequestBuilder extends RequestBuilder {
   private List<String> xForwardedFor = new ArrayList<>();
 
-  public FakeRequestBuilder() {}
+  public static Request fakeRequest() {
+    return new FakeRequestBuilder().build();
+  }
+
+  public static FakeRequestBuilder fakeRequestBuilder() {
+    return new FakeRequestBuilder();
+  }
+
+  private FakeRequestBuilder() {
+    addCSRFToken(this);
+  }
+
+  public FakeRequestBuilder call(Call call) {
+    method(call.method());
+    uri(call.url());
+    return this;
+  }
 
   /** Add an X-Forwarded-For header. Can be called multiple times for multiple header lines. */
   public FakeRequestBuilder addXForwardedFor(String xff) {


### PR DESCRIPTION
### Description

Prepare FakeRequestBuilder to handle all request building in unit tests:

- Add factory methods and make the constructor private
- Update existing usages from the constructor to one of the factory methods
- Add CSRF to the request by default so that each test won't have to add CSRF
- Add a call() builder method that imitates the RequestBuilder(Call) constructor so it behaves like a builder

This supports #8046.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)