### PR TITLE
Move FakeRequestBuilder from auth to support package

### DIFF
--- a/server/test/auth/ApiAuthenticatorTest.java
+++ b/server/test/auth/ApiAuthenticatorTest.java
@@ -36,6 +36,7 @@ import play.mvc.Http;
 import play.test.Helpers;
 import services.apikey.ApiKeyService;
 import services.settings.SettingsManifest;
+import support.FakeRequestBuilder;
 import support.ResourceCreator;
 
 public class ApiAuthenticatorTest {

--- a/server/test/auth/ClientIpResolverTest.java
+++ b/server/test/auth/ClientIpResolverTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.pac4j.play.PlayWebContext;
 import services.settings.SettingsManifest;
+import support.FakeRequestBuilder;
 
 public class ClientIpResolverTest {
   private static final SettingsManifest MOCK_SETTINGS_MANIFEST =

--- a/server/test/auth/FakeRequestBuilderTest.java
+++ b/server/test/auth/FakeRequestBuilderTest.java
@@ -6,6 +6,7 @@ import com.itextpdf.xmp.impl.Base64;
 import java.util.List;
 import org.junit.Test;
 import play.mvc.Http;
+import support.FakeRequestBuilder;
 
 public class FakeRequestBuilderTest {
   @Test

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -3,7 +3,6 @@ package services.settings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
 
-import auth.FakeRequestBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
@@ -12,6 +11,7 @@ import java.util.Optional;
 import org.junit.Test;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http;
+import support.FakeRequestBuilder;
 
 public class SettingsManifestTest {
 

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -1,5 +1,6 @@
-package auth;
+package support;
 
+import auth.ClientIpResolver;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;


### PR DESCRIPTION
### Description

Move FakeRequestBuilder from the auth package to the support package so it can be used more broadly across tests rather than just for auth tests.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
