### PR TITLE
Use setting for APPLICANT_PORTAL_NAME instead of binding

### DIFF
--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -2,7 +2,6 @@ package modules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import annotations.BindingAnnotations.ApplicantAuthProviderName;
 import annotations.BindingAnnotations.EnUsLang;
 import annotations.BindingAnnotations.Now;
 import auth.ProfileFactory;
@@ -55,19 +54,6 @@ public class MainModule extends AbstractModule {
   @Provides
   public ZoneId provideZoneId(Config config) {
     return ZoneId.of(checkNotNull(config).getString("civiform_time_zone_id"));
-  }
-
-  @Provides
-  @ApplicantAuthProviderName
-  public String provideApplicantAuthProviderName(Config config) {
-    checkNotNull(config);
-
-    if (config.hasPath("applicant_portal_name")
-        && !config.getString("applicant_portal_name").isBlank()) {
-      return config.getString("applicant_portal_name");
-    }
-
-    return config.getString("whitelabel_civic_entity_full_name");
   }
 
   @Provides

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellCreateAccountView.java
@@ -11,7 +11,6 @@ import static views.applicant.AuthenticateUpsellCreator.createLoginButton;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.applicant.AuthenticateUpsellCreator.createNewAccountButton;
 
-import annotations.BindingAnnotations;
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -39,17 +38,13 @@ import views.style.ReferenceClasses;
 public final class ApplicantCommonIntakeUpsellCreateAccountView extends ApplicantUpsellView {
 
   private final ApplicantLayout layout;
-  private final String authProviderName;
   private final SettingsManifest settingsManifest;
 
   @Inject
   public ApplicantCommonIntakeUpsellCreateAccountView(
-      ApplicantLayout layout,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName,
-      SettingsManifest settingsManifest) {
+      ApplicantLayout layout, SettingsManifest settingsManifest) {
     this.layout = checkNotNull(layout);
     this.settingsManifest = checkNotNull(settingsManifest);
-    this.authProviderName = checkNotNull(authProviderName);
   }
 
   /** Renders a sign-up page with a baked-in redirect. */
@@ -114,7 +109,9 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
                 .withClasses("mb-4"),
             shouldUpsell,
             messages,
-            authProviderName,
+            // The applicant portal name should always be set (there is a
+            // default setting as well).
+            settingsManifest.getApplicantPortalName(request).get(),
             actionButtonsBuilder.build());
     return layout.renderWithNav(
         request,

--- a/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
@@ -9,7 +9,6 @@ import static views.applicant.AuthenticateUpsellCreator.createLoginButton;
 import static views.applicant.AuthenticateUpsellCreator.createLoginPromptModal;
 import static views.applicant.AuthenticateUpsellCreator.createNewAccountButton;
 
-import annotations.BindingAnnotations;
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -40,19 +39,16 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
 
   private final ApplicantLayout layout;
   private final ProgramCardViewRenderer programCardViewRenderer;
-  private final String authProviderName;
   private final SettingsManifest settingsManifest;
 
   @Inject
   public ApplicantUpsellCreateAccountView(
       ApplicantLayout layout,
       ProgramCardViewRenderer programCardViewRenderer,
-      SettingsManifest settingsManifest,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName) {
+      SettingsManifest settingsManifest) {
     this.programCardViewRenderer = checkNotNull(programCardViewRenderer);
     this.layout = checkNotNull(layout);
     this.settingsManifest = checkNotNull(settingsManifest);
-    this.authProviderName = checkNotNull(authProviderName);
   }
 
   /** Renders a sign-up page with a baked-in redirect. */
@@ -129,7 +125,9 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
                     .withClasses("mb-4")),
             shouldUpsell,
             messages,
-            authProviderName,
+            // The applicant portal name should always be set (there is a
+            // default setting as well).
+            settingsManifest.getApplicantPortalName(request).get(),
             actionButtons);
 
     var htmlBundle =

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -1,8 +1,5 @@
 package views.applicant;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import annotations.BindingAnnotations;
 import auth.CiviFormProfile;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -27,7 +24,6 @@ import views.NorthStarBaseView;
 
 /** Renders a list of sections in the form with their status. */
 public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseView {
-  private final String authProviderName;
 
   @Inject
   NorthStarApplicantProgramSummaryView(
@@ -36,7 +32,6 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
       AssetsFinder assetsFinder,
       ApplicantRoutes applicantRoutes,
       SettingsManifest settingsManifest,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName,
       LanguageUtils languageUtils,
       DeploymentType deploymentType) {
     super(
@@ -47,7 +42,6 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
         settingsManifest,
         languageUtils,
         deploymentType);
-    this.authProviderName = checkNotNull(authProviderName);
   }
 
   public String render(Request request, Params params) {
@@ -87,7 +81,11 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
       context.setVariable(
           "slugLoginUrl",
           controllers.routes.LoginController.applicantLogin(Optional.of(postLoginRedirect)).url());
-      context.setVariable("authProviderName", authProviderName);
+      context.setVariable(
+          "authProviderName",
+          // The applicant portal name should always be set (there is a
+          // default setting as well).
+          settingsManifest.getApplicantPortalName(request).get());
     }
 
     return templateEngine.process("applicant/ApplicantProgramSummaryTemplate", context);

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -3,7 +3,6 @@ package views.applicant;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static services.applicant.ApplicantPersonalInfo.ApplicantType.GUEST;
 
-import annotations.BindingAnnotations;
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +29,6 @@ import views.applicant.ProgramCardsSectionParamsFactory.ProgramSectionParams;
 /** Renders a list of programs that an applicant can browse, with buttons for applying. */
 public class NorthStarProgramIndexView extends NorthStarBaseView {
   private final ProgramCardsSectionParamsFactory programCardsSectionParamsFactory;
-  private final String authProviderName;
 
   @Inject
   NorthStarProgramIndexView(
@@ -40,7 +38,6 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
       ApplicantRoutes applicantRoutes,
       ProgramCardsSectionParamsFactory programCardsSectionParamsFactory,
       SettingsManifest settingsManifest,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName,
       LanguageUtils languageUtils,
       DeploymentType deploymentType) {
     super(
@@ -52,7 +49,6 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
         languageUtils,
         deploymentType);
     this.programCardsSectionParamsFactory = checkNotNull(programCardsSectionParamsFactory);
-    this.authProviderName = checkNotNull(authProviderName);
   }
 
   public String render(
@@ -133,7 +129,11 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
             + applicationPrograms.unapplied().size());
 
     context.setVariable("sections", sectionParamsBuilder.build());
-    context.setVariable("authProviderName", authProviderName);
+    context.setVariable(
+        "authProviderName",
+        // The applicant portal name should always be set (there is a
+        // default setting as well).
+        settingsManifest.getApplicantPortalName(request).get());
     context.setVariable("createAccountLink", routes.LoginController.register().url());
     context.setVariable("isGuest", personalInfo.getType() == GUEST);
     ImmutableMap<Long, String> programIdsToLoginBypassUrls =

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
 import static services.applicant.ApplicantPersonalInfo.ApplicantType.GUEST;
 
-import annotations.BindingAnnotations;
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import controllers.routes;
@@ -37,19 +36,16 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   private final ApplicantLayout layout;
   private final SettingsManifest settingsManifest;
-  private final String authProviderName;
   private final ProgramCardViewRenderer programCardViewRenderer;
 
   @Inject
   public ProgramIndexView(
       ApplicantLayout layout,
       ProgramCardViewRenderer programCardViewRenderer,
-      SettingsManifest settingsManifest,
-      @BindingAnnotations.ApplicantAuthProviderName String authProviderName) {
+      SettingsManifest settingsManifest) {
     this.layout = checkNotNull(layout);
     this.programCardViewRenderer = checkNotNull(programCardViewRenderer);
     this.settingsManifest = checkNotNull(settingsManifest);
-    this.authProviderName = checkNotNull(authProviderName);
   }
 
   /**
@@ -105,7 +101,11 @@ public final class ProgramIndexView extends BaseHtmlView {
       // "Save time finding and applying for programs and services"
       h1Text = messages.at(MessageKey.CONTENT_SAVE_TIME.getKeyName());
       infoDivText =
-          messages.at(MessageKey.CONTENT_GUEST_DESCRIPTION.getKeyName(), authProviderName);
+          messages.at(
+              MessageKey.CONTENT_GUEST_DESCRIPTION.getKeyName(),
+              // The applicant portal name should always be set (there is a
+              // default setting as well).
+              settingsManifest.getApplicantPortalName(request).get());
       widthClass = "w-8/12";
     } else { // Logged in.
       // "Find programs"


### PR DESCRIPTION
Before we had the Settings system, we were binding APPLICANT_PORTAL_NAME directly from the config file into ApplicantAuthProviderName. Now that we have the settings system and need to pass in a Request object, this changes all the call sites to use the Settings getter instead (some had already made the change) and removes the now-unused binding.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/8051
