### PR TITLE
Replace Play's fakeRequest() with FakeRequestBuilder

### DIFF
--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -3,8 +3,8 @@ package actions;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -41,7 +41,7 @@ public class ProgramDisabledActionTest extends WithApplication {
   public void testProgramSlugIsNotAvailable() {
     ProgramService programService = instanceOf(ProgramService.class);
     ProgramDisabledAction action = new ProgramDisabledAction(programService);
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
 
     // Set up a mock for the delegate action
     Action.Simple delegateMock = mock(Action.Simple.class);

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -3,6 +3,7 @@ package actions;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -40,7 +41,7 @@ public class ProgramDisabledActionTest extends WithApplication {
   public void testProgramSlugIsNotAvailable() {
     ProgramService programService = instanceOf(ProgramService.class);
     ProgramDisabledAction action = new ProgramDisabledAction(programService);
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
 
     // Set up a mock for the delegate action
     Action.Simple delegateMock = mock(Action.Simple.class);

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -3,6 +3,7 @@ package actions;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
@@ -17,7 +18,6 @@ import play.inject.Injector;
 import play.mvc.Action;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import play.test.Helpers;
 import play.test.WithApplication;
 import repository.VersionRepository;
 import services.LocalizedStrings;
@@ -61,7 +61,7 @@ public class ProgramDisabledActionTest extends WithApplication {
 
     Map<String, String> flashData = new HashMap<>();
     flashData.put("redirected-from-program-slug", "disabledprogram1");
-    Request request = Helpers.fakeRequest().flash(flashData).build();
+    Request request = fakeRequestBuilder().flash(flashData).build();
     ProgramModel program =
         new ProgramModel(
             /* adminName */ "disabledprogram1",
@@ -93,7 +93,7 @@ public class ProgramDisabledActionTest extends WithApplication {
     ProgramDisabledAction action = new ProgramDisabledAction(programService);
     Map<String, String> flashData = new HashMap<>();
     flashData.put("redirected-from-program-slug", "publicprogram1");
-    Request request = Helpers.fakeRequest().flash(flashData).build();
+    Request request = fakeRequestBuilder().flash(flashData).build();
     ProgramModel program =
         new ProgramModel(
             /* adminName */ "publicprogram1",

--- a/server/test/app/ApiAuthenticationTest.java
+++ b/server/test/app/ApiAuthenticationTest.java
@@ -2,8 +2,8 @@ package app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.Helpers.testServerPort;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -32,7 +32,10 @@ public class ApiAuthenticationTest extends ResetPostgres {
   @Test
   public void nonApiRoutes_doNotRequireApiAuth() {
     Result result =
-        doGetRequest(fakeRequest("GET", controllers.routes.HomeController.index().url()));
+        doGetRequest(
+            fakeRequestBuilder()
+                .method("GET")
+                .uri(controllers.routes.HomeController.index().url()));
     // The HomeController index page redirects to the programs page.
     assertThat(result.status()).isEqualTo(HttpConstants.SEE_OTHER);
   }
@@ -45,7 +48,9 @@ public class ApiAuthenticationTest extends ResetPostgres {
 
     Result result =
         doGetRequest(
-            fakeRequest("GET", API_CHECK_URL)
+            fakeRequestBuilder()
+                .method("GET")
+                .uri(API_CHECK_URL)
                 .remoteAddress("1.1.1.1")
                 .header("Authorization", "Basic " + creds));
 
@@ -60,7 +65,9 @@ public class ApiAuthenticationTest extends ResetPostgres {
 
     Result result =
         doGetRequest(
-            fakeRequest("GET", API_CHECK_URL)
+            fakeRequestBuilder()
+                .method("GET")
+                .uri(API_CHECK_URL)
                 .remoteAddress("1.1.1.1")
                 .header("Authorization", "Basic " + creds));
 

--- a/server/test/auth/CiviFormHttpActionAdapterTest.java
+++ b/server/test/auth/CiviFormHttpActionAdapterTest.java
@@ -1,7 +1,7 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
@@ -15,7 +15,8 @@ public class CiviFormHttpActionAdapterTest {
   @Test
   public void testApiUnauthorizedAction() {
     CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
-    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/api/v1/checkAuth").build());
+    PlayWebContext context =
+        new PlayWebContext(fakeRequestBuilder().method("GET").uri("/api/v1/checkAuth").build());
 
     Result result = adapter.adapt(new StatusAction(HttpConstants.UNAUTHORIZED), context);
 
@@ -26,7 +27,8 @@ public class CiviFormHttpActionAdapterTest {
   @Test
   public void testNonApiForbiddenAction() {
     CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
-    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/non-api").build());
+    PlayWebContext context =
+        new PlayWebContext(fakeRequestBuilder().method("GET").uri("/non-api").build());
 
     Result result = adapter.adapt(new StatusAction(HttpConstants.FORBIDDEN), context);
 
@@ -39,7 +41,8 @@ public class CiviFormHttpActionAdapterTest {
   @Test
   public void testNonApiUnauthorizedAction() {
     CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
-    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/non-api").build());
+    PlayWebContext context =
+        new PlayWebContext(fakeRequestBuilder().method("GET").uri("/non-api").build());
 
     Result result = adapter.adapt(new StatusAction(HttpConstants.UNAUTHORIZED), context);
 
@@ -52,7 +55,8 @@ public class CiviFormHttpActionAdapterTest {
   @Test
   public void testOkAction() {
     CiviFormHttpActionAdapter adapter = new CiviFormHttpActionAdapter();
-    PlayWebContext context = new PlayWebContext(fakeRequest("GET", "/arbitrary").build());
+    PlayWebContext context =
+        new PlayWebContext(fakeRequestBuilder().method("GET").uri("/arbitrary").build());
 
     Result result = adapter.adapt(new StatusAction(HttpConstants.OK), context);
 

--- a/server/test/auth/FakeRequestBuilderTest.java
+++ b/server/test/auth/FakeRequestBuilderTest.java
@@ -1,8 +1,8 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.itextpdf.xmp.impl.Base64;
 import java.util.List;
@@ -29,7 +29,7 @@ public class FakeRequestBuilderTest {
 
   @Test
   public void hasUsableDefaults() {
-    Request fakeRequest = fakeRequest();
+    Request fakeRequest = fakeRequestNew();
 
     assertThat(fakeRequest.header("Authorization")).isEmpty();
     assertThat(fakeRequest.header("X-Forwarded-For")).isEmpty();

--- a/server/test/auth/FakeRequestBuilderTest.java
+++ b/server/test/auth/FakeRequestBuilderTest.java
@@ -1,8 +1,8 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.itextpdf.xmp.impl.Base64;
 import java.util.List;
@@ -29,7 +29,7 @@ public class FakeRequestBuilderTest {
 
   @Test
   public void hasUsableDefaults() {
-    Request fakeRequest = fakeRequestNew();
+    Request fakeRequest = fakeRequest();
 
     assertThat(fakeRequest.header("Authorization")).isEmpty();
     assertThat(fakeRequest.header("X-Forwarded-For")).isEmpty();

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -2,7 +2,7 @@ package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.oidc.IdTokensFactory;
 import auth.oidc.InvalidOidcProfileException;
@@ -62,11 +62,11 @@ public class ProfileMergeTest extends ResetPostgres {
                 CfTestHelpers.userRepositoryProvider(accountRepository)));
     samlProfileCreator =
         new SamlProfileCreator(
-            /* configuration = */ null,
-            /* client = */ null,
+            /* configuration= */ null,
+            /* client= */ null,
             profileFactory,
             CfTestHelpers.userRepositoryProvider(accountRepository));
-    context = new PlayWebContext(fakeRequest().build());
+    context = new PlayWebContext(fakeRequestNew());
   }
 
   private OidcProfile createOidcProfile(String email, String issuer, String subject) {
@@ -91,7 +91,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -108,7 +108,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData existingProfileWithoutAuthority =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
     AccountModel account =
         database.find(AccountModel.class).where().eq("email_address", "foo@example.com").findOne();
     account.setAuthorityId(null);
@@ -134,7 +134,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThat(
             idcsApplicantProfileCreator
@@ -154,7 +154,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -173,7 +173,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -192,7 +192,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -208,7 +208,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -227,7 +227,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -246,7 +246,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsApplicantProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile, context);
+            /* maybeCiviFormProfile= */ Optional.empty(), oidcProfile, context);
 
     assertThatThrownBy(
             () ->
@@ -263,7 +263,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -277,7 +277,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThat(
             samlProfileCreator
@@ -294,7 +294,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -313,7 +313,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -332,7 +332,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -349,7 +349,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -366,7 +366,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileCreator.mergeCiviFormProfile(
-            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile= */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -2,7 +2,7 @@ package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.oidc.IdTokensFactory;
 import auth.oidc.InvalidOidcProfileException;
@@ -66,7 +66,7 @@ public class ProfileMergeTest extends ResetPostgres {
             /* client= */ null,
             profileFactory,
             CfTestHelpers.userRepositoryProvider(accountRepository));
-    context = new PlayWebContext(fakeRequestNew());
+    context = new PlayWebContext(fakeRequest());
   }
 
   private OidcProfile createOidcProfile(String email, String issuer, String subject) {

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -3,7 +3,7 @@ package auth.oidc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.when;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -95,7 +95,7 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
   }
 
   WebContext getWebContext() {
-    return new PlayWebContext(fakeRequestNew());
+    return new PlayWebContext(fakeRequest());
   }
 
   @Test

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -3,7 +3,7 @@ package auth.oidc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.when;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -95,7 +95,7 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
   }
 
   WebContext getWebContext() {
-    return new PlayWebContext(fakeRequest().build());
+    return new PlayWebContext(fakeRequestNew());
   }
 
   @Test

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -3,7 +3,7 @@ package auth.oidc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
@@ -176,7 +176,9 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     // Create a web context containing a session id.
     PlayWebContext context =
         new PlayWebContext(
-            fakeRequest().session(CiviformOidcProfileCreator.SESSION_ID, SESSION_ID).build());
+            fakeRequestBuilder()
+                .session(CiviformOidcProfileCreator.SESSION_ID, SESSION_ID)
+                .build());
     CiviformOidcProfileCreator oidcProfileAdapter =
         getOidcProfileCreatorWithEnhancedLogoutEnabled();
 

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -140,7 +141,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
 
   @Test
   public void mergeCiviFormProfile_succeeds_new_user() {
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
     // Execute.
     CiviFormProfileData profileData =
@@ -221,7 +222,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     CiviFormProfileData fakeProfileData = new CiviFormProfileData(123L);
     when(trustedIntermediary.getProfileData()).thenReturn(fakeProfileData);
 
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
 
     // Execute.

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -3,8 +3,8 @@ package auth.oidc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -141,7 +141,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
 
   @Test
   public void mergeCiviFormProfile_succeeds_new_user() {
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
     // Execute.
     CiviFormProfileData profileData =
@@ -224,7 +224,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     CiviFormProfileData fakeProfileData = new CiviFormProfileData(123L);
     when(trustedIntermediary.getProfileData()).thenReturn(fakeProfileData);
 
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviformOidcProfileCreator oidcProfileAdapter = getOidcProfileCreator();
 
     // Execute.

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -62,7 +62,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 
@@ -78,7 +78,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 
@@ -94,7 +94,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -62,7 +62,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 
@@ -78,7 +78,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 
@@ -94,7 +94,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", "issuer");
     profile.setId("subject");
 
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviFormProfileData profileData =
         genericOidcProfileCreator.mergeCiviFormProfile(Optional.empty(), profile, context);
 

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
@@ -35,7 +35,7 @@ public class Auth0ProviderTest extends ResetPostgres {
   private static final String CLIENT_ID = "someFakeClientId";
 
   private static final SessionStore mockSessionStore = Mockito.mock(SessionStore.class);
-  private static final Request requestMock = fakeRequest().remoteAddress("1.1.1.1").build();
+  private static final Request requestMock = fakeRequestBuilder().remoteAddress("1.1.1.1").build();
   private static final PlayWebContext webContext = new PlayWebContext(requestMock);
 
   @Before

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -71,7 +71,7 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", ISSUER);
     profile.setId(SUBJECT);
 
-    PlayWebContext context = new PlayWebContext(fakeRequest().build());
+    PlayWebContext context = new PlayWebContext(fakeRequestNew());
     CiviFormProfileData profileData =
         oidcProfileAdapter.mergeCiviFormProfile(Optional.empty(), profile, context);
     assertThat(profileData).isNotNull();

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.CiviFormProfileData;
 import auth.IdentityProviderType;
@@ -71,7 +71,7 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("iss", ISSUER);
     profile.setId(SUBJECT);
 
-    PlayWebContext context = new PlayWebContext(fakeRequestNew());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviFormProfileData profileData =
         oidcProfileAdapter.mergeCiviFormProfile(Optional.empty(), profile, context);
     assertThat(profileData).isNotNull();

--- a/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
@@ -1,7 +1,7 @@
 package auth.oidc.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
@@ -38,7 +38,7 @@ public class LoginGovClientProviderTest extends ResetPostgres {
   private static final String CLIENT_ID = "login:gov:client";
 
   private static final SessionStore mockSessionStore = Mockito.mock(SessionStore.class);
-  private static final Request requestMock = fakeRequest().remoteAddress("1.1.1.1").build();
+  private static final Request requestMock = fakeRequestBuilder().remoteAddress("1.1.1.1").build();
   private static final PlayWebContext webContext = new PlayWebContext(requestMock);
 
   @Before

--- a/server/test/controllers/ErrorHandlerTest.java
+++ b/server/test/controllers/ErrorHandlerTest.java
@@ -3,7 +3,7 @@ package controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.INTERNAL_SERVER_ERROR;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableSet;
 import controllers.admin.NotChangeableException;
@@ -57,24 +57,21 @@ public class ErrorHandlerTest extends ResetPostgres {
   public void onServerError_defaultBehaviorWorks() {
     // A non overriden type is handled by the framework still.
     Throwable exception = new RuntimeException("test exception");
-    Result result =
-        handler.onServerError(fakeRequest().build(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(INTERNAL_SERVER_ERROR);
   }
 
   @Test
   public void onServerError_handlesOverride_NotChangeableException() {
     Throwable exception = new NotChangeableException("test exception");
-    Result result =
-        handler.onServerError(fakeRequest().build(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
   public void onServerError_handlesOverride_ProgramNotFoundException() {
     Throwable exception = new ProgramNotFoundException("test exception");
-    Result result =
-        handler.onServerError(fakeRequest().build(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
@@ -83,7 +80,7 @@ public class ErrorHandlerTest extends ResetPostgres {
     Throwable exception = new ProgramNotFoundException("test exception");
     Throwable wrappedException = new CompletionException(exception);
     Result result =
-        handler.onServerError(fakeRequest().build(), wrappedException).toCompletableFuture().join();
+        handler.onServerError(fakeRequestNew(), wrappedException).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
@@ -93,15 +90,14 @@ public class ErrorHandlerTest extends ResetPostgres {
     Throwable exception = new RuntimeException("test exception");
     Throwable wrappedException = new CompletionException(exception);
     Result result =
-        handler.onServerError(fakeRequest().build(), wrappedException).toCompletableFuture().join();
+        handler.onServerError(fakeRequestNew(), wrappedException).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(INTERNAL_SERVER_ERROR);
   }
 
   @Test
   public void onServerError_handlesOverride_ApiKeyNotFoundException() {
     Throwable exception = new ApiKeyNotFoundException("test exception");
-    Result result =
-        handler.onServerError(fakeRequest().build(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 }

--- a/server/test/controllers/ErrorHandlerTest.java
+++ b/server/test/controllers/ErrorHandlerTest.java
@@ -3,7 +3,7 @@ package controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.INTERNAL_SERVER_ERROR;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableSet;
 import controllers.admin.NotChangeableException;
@@ -57,21 +57,21 @@ public class ErrorHandlerTest extends ResetPostgres {
   public void onServerError_defaultBehaviorWorks() {
     // A non overriden type is handled by the framework still.
     Throwable exception = new RuntimeException("test exception");
-    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequest(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(INTERNAL_SERVER_ERROR);
   }
 
   @Test
   public void onServerError_handlesOverride_NotChangeableException() {
     Throwable exception = new NotChangeableException("test exception");
-    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequest(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
   public void onServerError_handlesOverride_ProgramNotFoundException() {
     Throwable exception = new ProgramNotFoundException("test exception");
-    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequest(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
@@ -80,7 +80,7 @@ public class ErrorHandlerTest extends ResetPostgres {
     Throwable exception = new ProgramNotFoundException("test exception");
     Throwable wrappedException = new CompletionException(exception);
     Result result =
-        handler.onServerError(fakeRequestNew(), wrappedException).toCompletableFuture().join();
+        handler.onServerError(fakeRequest(), wrappedException).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
@@ -90,14 +90,14 @@ public class ErrorHandlerTest extends ResetPostgres {
     Throwable exception = new RuntimeException("test exception");
     Throwable wrappedException = new CompletionException(exception);
     Result result =
-        handler.onServerError(fakeRequestNew(), wrappedException).toCompletableFuture().join();
+        handler.onServerError(fakeRequest(), wrappedException).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(INTERNAL_SERVER_ERROR);
   }
 
   @Test
   public void onServerError_handlesOverride_ApiKeyNotFoundException() {
     Throwable exception = new ApiKeyNotFoundException("test exception");
-    Result result = handler.onServerError(fakeRequestNew(), exception).toCompletableFuture().join();
+    Result result = handler.onServerError(fakeRequest(), exception).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 }

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -6,7 +6,7 @@ import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -26,7 +26,7 @@ public class FileControllerTest extends WithMockedProfiles {
 
   private FileController controller;
   private SettingsManifest mockSettingsManifest;
-  private final Request request = fakeRequestNew();
+  private final Request request = fakeRequest();
 
   @Before
   public void setUp() {

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -6,7 +6,7 @@ import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -26,7 +26,7 @@ public class FileControllerTest extends WithMockedProfiles {
 
   private FileController controller;
   private SettingsManifest mockSettingsManifest;
-  private final Request request = fakeRequest().build();
+  private final Request request = fakeRequestNew();
 
   @Before
   public void setUp() {

--- a/server/test/controllers/HomeControllerTest.java
+++ b/server/test/controllers/HomeControllerTest.java
@@ -2,8 +2,8 @@ package controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.Helpers.testServerPort;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
@@ -20,7 +20,8 @@ public class HomeControllerTest extends ResetPostgres {
     // The test ensures that the requester gets a pac4j profile so that it can access
     // the resource.
     Http.RequestBuilder request =
-        fakeRequest(routes.HomeController.securePlayIndex())
+        fakeRequestBuilder()
+            .call(routes.HomeController.securePlayIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
         CfTestHelpers.doRequestWithInternalRedirects(app, request);
@@ -33,7 +34,8 @@ public class HomeControllerTest extends ResetPostgres {
   @Test
   public void testFavicon() {
     Http.RequestBuilder request =
-        fakeRequest(routes.HomeController.favicon())
+        fakeRequestBuilder()
+            .call(routes.HomeController.favicon())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     ResultWithFinalRequestUri resultWithFinalRequestUri =
         CfTestHelpers.doRequestWithInternalRedirects(app, request);
@@ -45,7 +47,8 @@ public class HomeControllerTest extends ResetPostgres {
   @Test
   public void testPlayIndex() {
     Http.RequestBuilder request =
-        fakeRequest(routes.HomeController.playIndex())
+        fakeRequestBuilder()
+            .call(routes.HomeController.playIndex())
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort());
     Result result = route(app, request);
     assertThat(result.status()).isEqualTo(200);

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -2,7 +2,7 @@ package controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
 import auth.controllers.MissingOptionalException;
@@ -32,7 +32,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
   public void testLanguageSelectorShown() {
     ApplicantModel applicant = createApplicantWithMockedProfile();
     HomeController controller = instanceOf(HomeController.class);
-    Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
+    Result result = controller.index(fakeRequestNew()).toCompletableFuture().join();
     assertThat(result.redirectLocation())
         .contains(
             controllers.applicant.routes.ApplicantInformationController.setLangFromBrowser(
@@ -61,7 +61,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             instanceOf(ClassLoaderExecutionContext.class),
             languageUtils,
             new ApplicantRoutes());
-    Result result = controller.index(fakeRequest().build()).toCompletableFuture().join();
+    Result result = controller.index(fakeRequestNew()).toCompletableFuture().join();
     assertThat(result.redirectLocation()).isNotEmpty();
     assertThat(
             result.redirectLocation().orElseThrow(() -> new MissingOptionalException(String.class)))

--- a/server/test/controllers/HomeControllerWithProfileTest.java
+++ b/server/test/controllers/HomeControllerWithProfileTest.java
@@ -2,7 +2,7 @@ package controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.ProfileUtils;
 import auth.controllers.MissingOptionalException;
@@ -32,7 +32,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
   public void testLanguageSelectorShown() {
     ApplicantModel applicant = createApplicantWithMockedProfile();
     HomeController controller = instanceOf(HomeController.class);
-    Result result = controller.index(fakeRequestNew()).toCompletableFuture().join();
+    Result result = controller.index(fakeRequest()).toCompletableFuture().join();
     assertThat(result.redirectLocation())
         .contains(
             controllers.applicant.routes.ApplicantInformationController.setLangFromBrowser(
@@ -61,7 +61,7 @@ public class HomeControllerWithProfileTest extends WithMockedProfiles {
             instanceOf(ClassLoaderExecutionContext.class),
             languageUtils,
             new ApplicantRoutes());
-    Result result = controller.index(fakeRequestNew()).toCompletableFuture().join();
+    Result result = controller.index(fakeRequest()).toCompletableFuture().join();
     assertThat(result.redirectLocation()).isNotEmpty();
     assertThat(
             result.redirectLocation().orElseThrow(() -> new MissingOptionalException(String.class)))

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -8,6 +8,8 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -40,7 +42,6 @@ import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import play.test.Helpers;
 import repository.AccountRepository;
 import repository.ApplicationStatusesRepository;
 import repository.DatabaseExecutionContext;
@@ -113,10 +114,9 @@ public class AdminApplicationControllerTest extends ResetPostgres {
   @Test
   public void index_noUser_errors() throws Exception {
     long programId = ProgramBuilder.newActiveProgram().buildDefinition().id();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     Result result =
         controller.index(
-            request,
+            fakeRequestNew(),
             programId,
             /* search= */ Optional.empty(),
             /* page= */ Optional.of(1), // Needed to skip redirect.
@@ -137,10 +137,9 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
     application.refresh();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     Result result =
         controller.index(
-            request,
+            fakeRequestNew(),
             program.id,
             /* search= */ Optional.empty(),
             /* page= */ Optional.of(1), // Needed to skip redirect.
@@ -158,8 +157,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    assertThatThrownBy(() -> controller.updateStatus(request, Long.MAX_VALUE, application.id))
+    assertThatThrownBy(
+            () -> controller.updateStatus(fakeRequestNew(), Long.MAX_VALUE, application.id))
         .isInstanceOf(ProgramNotFoundException.class);
   }
 
@@ -170,8 +169,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    Result result = controller.updateStatus(request, program.id, application.id);
+    Result result = controller.updateStatus(fakeRequestNew(), program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
@@ -190,7 +188,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -223,7 +221,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -258,7 +256,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -291,7 +289,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -324,7 +322,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -368,7 +366,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -407,7 +405,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -452,7 +450,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     Request request =
         addCSRFToken(
-                Helpers.fakeRequest()
+                fakeRequestBuilder()
                     .bodyForm(
                         Map.of(
                             "redirectUri",
@@ -485,8 +483,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    assertThatThrownBy(() -> controller.updateNote(request, Long.MAX_VALUE, application.id))
+    assertThatThrownBy(
+            () -> controller.updateNote(fakeRequestNew(), Long.MAX_VALUE, application.id))
         .isInstanceOf(ProgramNotFoundException.class);
   }
 
@@ -497,8 +495,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    Result result = controller.updateNote(request, program.id, application.id);
+    Result result = controller.updateNote(fakeRequestNew(), program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
@@ -512,9 +509,8 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     // Execute.
-    Result result = controller.updateNote(request, program.id, application.id);
+    Result result = controller.updateNote(fakeRequestNew(), program.id, application.id);
 
     // Verify.
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
@@ -534,7 +530,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
+        addCSRFToken(fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
             .build();
 
     // Execute.
@@ -564,7 +560,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(Helpers.fakeRequest().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
+        addCSRFToken(fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
             .build();
 
     // Execute.

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -8,8 +8,8 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -116,7 +116,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     long programId = ProgramBuilder.newActiveProgram().buildDefinition().id();
     Result result =
         controller.index(
-            fakeRequestNew(),
+            fakeRequest(),
             programId,
             /* search= */ Optional.empty(),
             /* page= */ Optional.of(1), // Needed to skip redirect.
@@ -139,7 +139,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     application.refresh();
     Result result =
         controller.index(
-            fakeRequestNew(),
+            fakeRequest(),
             program.id,
             /* search= */ Optional.empty(),
             /* page= */ Optional.of(1), // Needed to skip redirect.
@@ -157,8 +157,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    assertThatThrownBy(
-            () -> controller.updateStatus(fakeRequestNew(), Long.MAX_VALUE, application.id))
+    assertThatThrownBy(() -> controller.updateStatus(fakeRequest(), Long.MAX_VALUE, application.id))
         .isInstanceOf(ProgramNotFoundException.class);
   }
 
@@ -169,7 +168,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Result result = controller.updateStatus(fakeRequestNew(), program.id, application.id);
+    Result result = controller.updateStatus(fakeRequest(), program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
@@ -483,8 +482,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    assertThatThrownBy(
-            () -> controller.updateNote(fakeRequestNew(), Long.MAX_VALUE, application.id))
+    assertThatThrownBy(() -> controller.updateNote(fakeRequest(), Long.MAX_VALUE, application.id))
         .isInstanceOf(ProgramNotFoundException.class);
   }
 
@@ -495,7 +493,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
     ApplicationModel application =
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
-    Result result = controller.updateNote(fakeRequestNew(), program.id, application.id);
+    Result result = controller.updateNote(fakeRequest(), program.id, application.id);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
@@ -510,7 +508,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     // Execute.
-    Result result = controller.updateNote(fakeRequestNew(), program.id, application.id);
+    Result result = controller.updateNote(fakeRequest(), program.id, application.id);
 
     // Verify.
     assertThat(result.status()).isEqualTo(BAD_REQUEST);

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -9,7 +9,7 @@ import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
@@ -101,7 +101,7 @@ public class AdminExportControllerTest extends ResetPostgres {
     Result result =
         controller.hxExportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programId", String.valueOf(Long.MAX_VALUE))))
                 .build());
@@ -118,7 +118,7 @@ public class AdminExportControllerTest extends ResetPostgres {
     Result result =
         controller.hxExportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programId", String.valueOf(activeProgram.id))))
                 .build());
@@ -136,7 +136,7 @@ public class AdminExportControllerTest extends ResetPostgres {
     Result result =
         controller.downloadJson(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programJson", String.valueOf(""))))
                 .build(),

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -10,6 +10,7 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
@@ -51,7 +52,7 @@ public class AdminExportControllerTest extends ResetPostgres {
   public void index_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("export is not enabled");
@@ -69,7 +70,7 @@ public class AdminExportControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram(activeProgramB).build();
     ProgramBuilder.newDraftProgram(draftProgramA).build();
 
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
     String stringResult = contentAsString(result);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -87,7 +88,7 @@ public class AdminExportControllerTest extends ResetPostgres {
   public void hxExportProgram_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.hxExportProgram(addCSRFToken(fakeRequest()).build());
+    Result result = controller.hxExportProgram(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("export is not enabled");

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -9,8 +9,8 @@ import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
@@ -52,7 +52,7 @@ public class AdminExportControllerTest extends ResetPostgres {
   public void index_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("export is not enabled");
@@ -70,7 +70,7 @@ public class AdminExportControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram(activeProgramB).build();
     ProgramBuilder.newDraftProgram(draftProgramA).build();
 
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
     String stringResult = contentAsString(result);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -88,7 +88,7 @@ public class AdminExportControllerTest extends ResetPostgres {
   public void hxExportProgram_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.hxExportProgram(fakeRequestNew());
+    Result result = controller.hxExportProgram(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("export is not enabled");

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -9,8 +9,8 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static services.migration.ProgramMigrationServiceTest.EXAMPLE_PROGRAM_JSON;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
@@ -102,7 +102,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     Result result =
         controller.hxImportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programJson", "{\"adminName : \"admin-name\"}")))
                 .build());
@@ -119,7 +119,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     Result result =
         controller.hxImportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(
                             ImmutableMap.of(
@@ -141,7 +141,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     Result result =
         controller.hxImportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(
                             ImmutableMap.of(
@@ -162,7 +162,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     Result result =
         controller.hxImportProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON)))
                 .build());
@@ -180,7 +180,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     Result result =
         controller.saveProgram(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON)))
                 .build());

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -11,6 +11,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static services.migration.ProgramMigrationServiceTest.EXAMPLE_PROGRAM_JSON;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
@@ -55,7 +56,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void index_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("import is not enabled");
@@ -68,7 +69,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram("active-program-2").build();
     ProgramBuilder.newDraftProgram("draft-program").build();
 
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Import a program");
@@ -78,7 +79,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void hxImportProgram_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.hxImportProgram(addCSRFToken(fakeRequest()).build());
+    Result result = controller.hxImportProgram(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("import is not enabled");
@@ -88,7 +89,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void hxImportProgram_noRequestBody_redirectsToIndex() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
 
-    Result result = controller.hxImportProgram(addCSRFToken(fakeRequest()).build());
+    Result result = controller.hxImportProgram(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminImportController.index().url());

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -10,8 +10,8 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static services.migration.ProgramMigrationServiceTest.EXAMPLE_PROGRAM_JSON;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
@@ -56,7 +56,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void index_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("import is not enabled");
@@ -69,7 +69,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram("active-program-2").build();
     ProgramBuilder.newDraftProgram("draft-program").build();
 
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Import a program");
@@ -79,7 +79,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void hxImportProgram_migrationNotEnabled_notFound() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
-    Result result = controller.hxImportProgram(fakeRequestNew());
+    Result result = controller.hxImportProgram(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
     assertThat(contentAsString(result)).contains("import is not enabled");
@@ -89,7 +89,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public void hxImportProgram_noRequestBody_redirectsToIndex() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
 
-    Result result = controller.hxImportProgram(fakeRequestNew());
+    Result result = controller.hxImportProgram(fakeRequest());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminImportController.index().url());

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -6,6 +6,7 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import models.ProgramModel;
 import org.junit.Before;
@@ -42,7 +43,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.editVisibility(
-                    fakeRequest().build(), /* programId= */ 1, /* blockDefinitionId= */ 1))
+                    fakeRequestNew(), /* programId= */ 1, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -51,7 +52,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.editEligibility(
-                    fakeRequest().build(), /* programId= */ 1, /* blockDefinitionId= */ 1))
+                    fakeRequestNew(), /* programId= */ 1, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -80,8 +81,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
             () ->
-                controller.editVisibility(
-                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+                controller.editVisibility(fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -90,8 +90,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
             () ->
-                controller.editEligibility(
-                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+                controller.editEligibility(fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -150,7 +149,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateVisibility(
-                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+                    fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -160,7 +159,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateEligibility(
-                    fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+                    fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -2,16 +2,13 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
-import static play.test.Helpers.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
-import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.ResetPostgres;
@@ -58,20 +55,18 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withInvalidBlock_notFound() {
-    Http.Request request = addCSRFToken(fakeRequest()).build();
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
 
-    Result result = controller.editEligibility(request, program.id, 543L);
+    Result result = controller.editEligibility(fakeRequestNew(), program.id, 543L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test
   public void editEligibility_withInvalidBlock_notFound() {
-    Http.Request request = addCSRFToken(fakeRequest()).build();
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
 
-    Result result = controller.editEligibility(request, program.id, 543L);
+    Result result = controller.editEligibility(fakeRequestNew(), program.id, 543L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -96,9 +91,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withFirstBlock_displaysEmptyList() {
-    Http.Request request = addCSRFToken(fakeRequest()).build();
-
-    Result result = controller.editVisibility(request, programWithThreeBlocks.id, 1L);
+    Result result = controller.editVisibility(fakeRequestNew(), programWithThreeBlocks.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -112,9 +105,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void editEligibility_withFirstBlock_displaysFirstBlock() {
-    Http.Request request = addCSRFToken(fakeRequest()).build();
-
-    Result result = controller.editEligibility(request, programWithThreeBlocks.id, 1L);
+    Result result = controller.editEligibility(fakeRequestNew(), programWithThreeBlocks.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -126,9 +117,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withThirdBlock_displaysQuestionsFromFirstAndSecondBlock() {
-    Http.Request request = addCSRFToken(fakeRequest()).build();
-
-    Result result = controller.editVisibility(request, programWithThreeBlocks.id, 3L);
+    Result result = controller.editVisibility(fakeRequestNew(), programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import models.ProgramModel;
 import org.junit.Before;
@@ -40,7 +40,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.editVisibility(
-                    fakeRequestNew(), /* programId= */ 1, /* blockDefinitionId= */ 1))
+                    fakeRequest(), /* programId= */ 1, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -49,7 +49,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.editEligibility(
-                    fakeRequestNew(), /* programId= */ 1, /* blockDefinitionId= */ 1))
+                    fakeRequest(), /* programId= */ 1, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -57,7 +57,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
 
-    Result result = controller.editEligibility(fakeRequestNew(), program.id, 543L);
+    Result result = controller.editEligibility(fakeRequest(), program.id, 543L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -66,7 +66,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void editEligibility_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
 
-    Result result = controller.editEligibility(fakeRequestNew(), program.id, 543L);
+    Result result = controller.editEligibility(fakeRequest(), program.id, 543L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -75,8 +75,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void edit_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () ->
-                controller.editVisibility(fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
+            () -> controller.editVisibility(fakeRequest(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -84,14 +83,13 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void editEligibility_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () ->
-                controller.editEligibility(fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
+            () -> controller.editEligibility(fakeRequest(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void edit_withFirstBlock_displaysEmptyList() {
-    Result result = controller.editVisibility(fakeRequestNew(), programWithThreeBlocks.id, 1L);
+    Result result = controller.editVisibility(fakeRequest(), programWithThreeBlocks.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -105,7 +103,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void editEligibility_withFirstBlock_displaysFirstBlock() {
-    Result result = controller.editEligibility(fakeRequestNew(), programWithThreeBlocks.id, 1L);
+    Result result = controller.editEligibility(fakeRequest(), programWithThreeBlocks.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -117,7 +115,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withThirdBlock_displaysQuestionsFromFirstAndSecondBlock() {
-    Result result = controller.editVisibility(fakeRequestNew(), programWithThreeBlocks.id, 3L);
+    Result result = controller.editVisibility(fakeRequest(), programWithThreeBlocks.id, 3L);
 
     assertThat(result.status()).isEqualTo(OK);
     String content = Helpers.contentAsString(result);
@@ -136,9 +134,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   public void update_activeProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
-            () ->
-                controller.updateVisibility(
-                    fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
+            () -> controller.updateVisibility(fakeRequest(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -147,8 +143,7 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
     assertThatThrownBy(
             () ->
-                controller.updateEligibility(
-                    fakeRequestNew(), programId, /* blockDefinitionId= */ 1))
+                controller.updateEligibility(fakeRequest(), programId, /* blockDefinitionId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -71,7 +71,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void create_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThatThrownBy(() -> controller.create(fakeRequestNew(), programId, /* blockId= */ 1))
+    assertThatThrownBy(() -> controller.create(fakeRequest(), programId, /* blockId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -91,7 +91,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.setOptional(
-                    fakeRequestNew(),
+                    fakeRequest(),
                     programId,
                     /* blockDefinitionId= */ 1,
                     /* questionDefinitionId= */ 1))

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -6,6 +6,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -69,7 +70,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void create_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThatThrownBy(() -> controller.create(fakeRequest().build(), programId, /* blockId= */ 1))
+    assertThatThrownBy(() -> controller.create(fakeRequestNew(), programId, /* blockId= */ 1))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -89,7 +90,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.setOptional(
-                    fakeRequest().build(),
+                    fakeRequestNew(),
                     programId,
                     /* blockDefinitionId= */ 1,
                     /* questionDefinitionId= */ 1))

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
@@ -53,7 +53,8 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Execute.
     Request request =
-        fakeRequest(
+        fakeRequestBuilder()
+            .call(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.create(program.id, 1))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .bodyForm(ImmutableMap.of("question-", activeId.toString()))
@@ -114,7 +115,8 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Execute. Move "name" question to position 1.
     Request request =
-        fakeRequest(
+        fakeRequestBuilder()
+            .call(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.move(
                     program.id, block.id(), nameQuestion.getId()))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
@@ -146,7 +148,8 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Missing position value.
     Request requestWithNoPosition =
-        fakeRequest(
+        fakeRequestBuilder()
+            .call(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.move(
                     program.id, block.id(), nameQuestion.getId()))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
@@ -159,7 +162,8 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Position is not a number.
     Request requestWithInvalidPosition =
-        fakeRequest(
+        fakeRequestBuilder()
+            .call(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.move(
                     program.id, block.id(), nameQuestion.getId()))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -7,8 +7,8 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
 
 import auth.ProfileUtils;
@@ -659,7 +659,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         .isThrownBy(
             () ->
                 controller.deleteFileKey(
-                    fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name()));
+                    fakeRequest(), program.id, ProgramEditStatus.CREATION.name()));
   }
 
   @Test
@@ -668,7 +668,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         .isThrownBy(
             () ->
                 controller.deleteFileKey(
-                    fakeRequestNew(),
+                    fakeRequest(),
                     /* programId= */ Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()));
   }
@@ -677,7 +677,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   public void deleteFileKey_noFileKeyPresent_stillNoKey() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
-    controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
+    controller.deleteFileKey(fakeRequest(), program.id, ProgramEditStatus.CREATION.name());
 
     ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey().isEmpty()).isTrue();
@@ -688,7 +688,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
     setValidFileKeyOnProgram(program);
 
-    controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
+    controller.deleteFileKey(fakeRequest(), program.id, ProgramEditStatus.CREATION.name());
 
     ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isEmpty();
@@ -700,7 +700,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     setValidFileKeyOnProgram(program);
 
     Result result =
-        controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
+        controller.deleteFileKey(fakeRequest(), program.id, ProgramEditStatus.CREATION.name());
 
     assertThat(result.flash().data()).containsOnlyKeys("success");
     assertThat(result.flash().data().get("success")).contains("Image removed");
@@ -711,7 +711,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Result result =
-        controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
+        controller.deleteFileKey(fakeRequest(), program.id, ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -8,6 +8,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
 
@@ -62,7 +63,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.index(
-            addCSRFToken(fakeRequest().method("GET")).build(),
+            addCSRFToken(fakeRequestBuilder().method("GET")).build(),
             program.id,
             ProgramEditStatus.CREATION.name());
 
@@ -77,7 +78,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequest().method("GET")).build(),
+                    addCSRFToken(fakeRequestBuilder().method("GET")).build(),
                     program.id,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -88,7 +89,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequest().method("GET")).build(),
+                    addCSRFToken(fakeRequestBuilder().method("GET")).build(),
                     Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -104,7 +105,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.index(
-            addCSRFToken(fakeRequest().method("GET")).build(),
+            addCSRFToken(fakeRequestBuilder().method("GET")).build(),
             program.id,
             ProgramEditStatus.CREATION.name());
 
@@ -119,7 +120,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateDescription(
-                    addCSRFToken(fakeRequest().method("POST")).build(),
+                    addCSRFToken(fakeRequestBuilder().method("POST")).build(),
                     program.id,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -130,7 +131,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateDescription(
-                    addCSRFToken(fakeRequest().method("POST")).build(),
+                    addCSRFToken(fakeRequestBuilder().method("POST")).build(),
                     Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -144,7 +145,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
                 .build(),
@@ -170,7 +171,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "second description")))
                 .build(),
@@ -202,7 +203,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "new US description")))
                 .build(),
@@ -232,7 +233,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
                 .build(),
@@ -257,7 +258,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
                 .build(),
@@ -284,7 +285,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "    ")))
                 .build(),
@@ -310,7 +311,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "    ")))
                 .build(),
@@ -340,7 +341,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
                 .build(),
@@ -359,7 +360,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
                 .build(),
@@ -381,7 +382,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
                 .build(),
@@ -404,7 +405,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
                 .build(),
@@ -423,7 +424,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateDescription(
             addCSRFToken(
-                    fakeRequest()
+                    fakeRequestBuilder()
                         .method("POST")
                         .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
                 .build(),
@@ -443,7 +444,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Http.Request request =
         addCSRFToken(
-                fakeRequest()
+                fakeRequestBuilder()
                     .method("POST")
                     .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey")))
             .build();
@@ -457,7 +458,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   public void updateFileKey_missingProgram_throws() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest()
+                fakeRequestBuilder()
                     .method("POST")
                     .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey")))
             .build();

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -7,7 +7,6 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
@@ -476,8 +475,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
-                    "POST", createUriWithQueryString(ImmutableMap.of("key", "fakeFileKey"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(createUriWithQueryString(ImmutableMap.of("key", "fakeFileKey"))))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -492,8 +492,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
-                    "POST", createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME))))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -508,9 +509,11 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME + "abc"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(
+                        createUriWithQueryString(
+                            ImmutableMap.of("bucket", FAKE_BUCKET_NAME + "abc"))))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -525,10 +528,12 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "applicant-10/myFile"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(
+                        createUriWithQueryString(
+                            ImmutableMap.of(
+                                "bucket", FAKE_BUCKET_NAME, "key", "applicant-10/myFile"))))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -543,14 +548,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     controller.updateFileKey(
         addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of(
-                            "bucket",
-                            FAKE_BUCKET_NAME,
-                            "key",
-                            "program-summary-image/program-15/myImage.png"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(
+                        createUriWithQueryString(
+                            ImmutableMap.of(
+                                "bucket",
+                                FAKE_BUCKET_NAME,
+                                "key",
+                                "program-summary-image/program-15/myImage.png"))))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -577,14 +583,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     controller.updateFileKey(
         addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of(
-                            "bucket",
-                            FAKE_BUCKET_NAME,
-                            "key",
-                            "program-summary-image/program-15/oldImage.png"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(
+                        createUriWithQueryString(
+                            ImmutableMap.of(
+                                "bucket",
+                                FAKE_BUCKET_NAME,
+                                "key",
+                                "program-summary-image/program-15/oldImage.png"))))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -597,14 +604,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     // WHEN the key is updated
     controller.updateFileKey(
         addCSRFToken(
-                fakeRequest(
-                    "POST",
-                    createUriWithQueryString(
-                        ImmutableMap.of(
-                            "bucket",
-                            FAKE_BUCKET_NAME,
-                            "key",
-                            "program-summary-image/program-15/newImage.png"))))
+                fakeRequestBuilder()
+                    .method("POST")
+                    .uri(
+                        createUriWithQueryString(
+                            ImmutableMap.of(
+                                "bucket",
+                                FAKE_BUCKET_NAME,
+                                "key",
+                                "program-summary-image/program-15/newImage.png"))))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -623,14 +631,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateFileKey(
             addCSRFToken(
-                    fakeRequest(
-                        "POST",
-                        createUriWithQueryString(
-                            ImmutableMap.of(
-                                "bucket",
-                                FAKE_BUCKET_NAME,
-                                "key",
-                                "program-summary-image/program-15/newImage.png"))))
+                    fakeRequestBuilder()
+                        .method("POST")
+                        .uri(
+                            createUriWithQueryString(
+                                ImmutableMap.of(
+                                    "bucket",
+                                    FAKE_BUCKET_NAME,
+                                    "key",
+                                    "program-summary-image/program-15/newImage.png"))))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -723,10 +732,12 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     Result result =
         controller.updateFileKey(
             addCSRFToken(
-                    fakeRequest(
-                        "POST",
-                        createUriWithQueryString(
-                            ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", VALID_FILE_KEY))))
+                    fakeRequestBuilder()
+                        .method("POST")
+                        .uri(
+                            createUriWithQueryString(
+                                ImmutableMap.of(
+                                    "bucket", FAKE_BUCKET_NAME, "key", VALID_FILE_KEY))))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -8,6 +8,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
 
 import auth.ProfileUtils;
@@ -648,9 +649,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         .isThrownBy(
             () ->
                 controller.deleteFileKey(
-                    addCSRFToken(fakeRequest()).build(),
-                    program.id,
-                    ProgramEditStatus.CREATION.name()));
+                    fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name()));
   }
 
   @Test
@@ -659,7 +658,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
         .isThrownBy(
             () ->
                 controller.deleteFileKey(
-                    addCSRFToken(fakeRequest()).build(),
+                    fakeRequestNew(),
                     /* programId= */ Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()));
   }
@@ -668,8 +667,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   public void deleteFileKey_noFileKeyPresent_stillNoKey() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
-    controller.deleteFileKey(
-        addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
+    controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
 
     ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey().isEmpty()).isTrue();
@@ -680,8 +678,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
     setValidFileKeyOnProgram(program);
 
-    controller.deleteFileKey(
-        addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
+    controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
 
     ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
     assertThat(updatedProgram.summaryImageFileKey()).isEmpty();
@@ -693,8 +690,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     setValidFileKeyOnProgram(program);
 
     Result result =
-        controller.deleteFileKey(
-            addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
+        controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
 
     assertThat(result.flash().data()).containsOnlyKeys("success");
     assertThat(result.flash().data().get("success")).contains("Image removed");
@@ -705,8 +701,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Result result =
-        controller.deleteFileKey(
-            addCSRFToken(fakeRequest()).build(), program.id, ProgramEditStatus.CREATION.name());
+        controller.deleteFileKey(fakeRequestNew(), program.id, ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())

--- a/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import controllers.WithMockedProfiles;
 import models.AccountModel;
@@ -28,7 +28,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   public void preview_redirectsToProgramReviewPage() {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     long programId = 0;
-    Result result = controller.preview(fakeRequestNew(), programId);
+    Result result = controller.preview(fakeRequest(), programId);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
@@ -39,14 +39,14 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
 
   @Test
   public void preview_noProfile_throwsException() {
-    assertThatThrownBy(() -> controller.preview(fakeRequestNew(), /*p rogramId =*/ 0))
+    assertThatThrownBy(() -> controller.preview(fakeRequest(), /*p rogramId =*/ 0))
         .isInstanceOf(RuntimeException.class);
   }
 
   @Test
   public void back_draftProgram_redirectsToProgramEditView() {
     ProgramModel program = resourceCreator().insertDraftProgram("some program");
-    Result result = controller.back(fakeRequestNew(), program.id).toCompletableFuture().join();
+    Result result = controller.back(fakeRequest(), program.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(controllers.admin.routes.AdminProgramBlocksController.index(program.id).url());
@@ -55,7 +55,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   @Test
   public void back_nonDraftProgram_redirectsToProgramReadOnlyView() {
     ProgramModel program = resourceCreator().insertActiveProgram("another program");
-    Result result = controller.back(fakeRequestNew(), program.id).toCompletableFuture().join();
+    Result result = controller.back(fakeRequest(), program.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
@@ -66,8 +66,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   public void pdfPreview_draft_okAndHasPdf() throws ProgramNotFoundException {
     ProgramModel program = resourceCreator().insertDraftProgram("draft program");
 
-    Result result =
-        controller.pdfPreview(fakeRequestNew(), program.id).toCompletableFuture().join();
+    Result result = controller.pdfPreview(fakeRequest(), program.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType().get()).isEqualTo("application/pdf");
@@ -80,8 +79,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   public void pdfPreview_active_okAndHasPdf() throws ProgramNotFoundException {
     ProgramModel program = resourceCreator().insertActiveProgram("active program");
 
-    Result result =
-        controller.pdfPreview(fakeRequestNew(), program.id).toCompletableFuture().join();
+    Result result = controller.pdfPreview(fakeRequest(), program.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType().get()).isEqualTo("application/pdf");

--- a/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import controllers.WithMockedProfiles;
 import models.AccountModel;
@@ -11,7 +12,6 @@ import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Result;
-import play.test.Helpers;
 import services.program.ProgramNotFoundException;
 
 public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
@@ -28,7 +28,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   public void preview_redirectsToProgramReviewPage() {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     long programId = 0;
-    Result result = controller.preview(Helpers.fakeRequest().build(), programId);
+    Result result = controller.preview(fakeRequestNew(), programId);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
@@ -39,15 +39,14 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
 
   @Test
   public void preview_noProfile_throwsException() {
-    assertThatThrownBy(() -> controller.preview(Helpers.fakeRequest().build(), /*p rogramId =*/ 0))
+    assertThatThrownBy(() -> controller.preview(fakeRequestNew(), /*p rogramId =*/ 0))
         .isInstanceOf(RuntimeException.class);
   }
 
   @Test
   public void back_draftProgram_redirectsToProgramEditView() {
     ProgramModel program = resourceCreator().insertDraftProgram("some program");
-    Result result =
-        controller.back(Helpers.fakeRequest().build(), program.id).toCompletableFuture().join();
+    Result result = controller.back(fakeRequestNew(), program.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(controllers.admin.routes.AdminProgramBlocksController.index(program.id).url());
@@ -56,8 +55,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   @Test
   public void back_nonDraftProgram_redirectsToProgramReadOnlyView() {
     ProgramModel program = resourceCreator().insertActiveProgram("another program");
-    Result result =
-        controller.back(Helpers.fakeRequest().build(), program.id).toCompletableFuture().join();
+    Result result = controller.back(fakeRequestNew(), program.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
@@ -69,10 +67,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
     ProgramModel program = resourceCreator().insertDraftProgram("draft program");
 
     Result result =
-        controller
-            .pdfPreview(Helpers.fakeRequest().build(), program.id)
-            .toCompletableFuture()
-            .join();
+        controller.pdfPreview(fakeRequestNew(), program.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType().get()).isEqualTo("application/pdf");
@@ -86,10 +81,7 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
     ProgramModel program = resourceCreator().insertActiveProgram("active program");
 
     Result result =
-        controller
-            .pdfPreview(Helpers.fakeRequest().build(), program.id)
-            .toCompletableFuture()
-            .join();
+        controller.pdfPreview(fakeRequestNew(), program.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType().get()).isEqualTo("application/pdf");

--- a/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
@@ -7,7 +7,7 @@ import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -85,7 +85,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   public void index_ok_get() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name", "test description").build();
 
-    Result result = controller.index(addCSRFToken(fakeRequest().method("GET")).build(), program.id);
+    Result result =
+        controller.index(addCSRFToken(fakeRequestBuilder().method("GET")).build(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("No statuses have been created yet");
@@ -106,7 +107,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
                             .build())))
             .build();
 
-    Result result = controller.index(addCSRFToken(fakeRequest().method("GET")).build(), program.id);
+    Result result =
+        controller.index(addCSRFToken(fakeRequestBuilder().method("GET")).build(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Status with no email");
@@ -533,7 +535,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequest().method(httpMethod)).build(), Long.MAX_VALUE))
+                    addCSRFToken(fakeRequestBuilder().method(httpMethod)).build(), Long.MAX_VALUE))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -545,7 +547,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequest().method(httpMethod)).build(), program.id))
+                    addCSRFToken(fakeRequestBuilder().method(httpMethod)).build(), program.id))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -624,12 +626,12 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   private Result makeCreateOrUpdateRequest(Long programId, ImmutableMap<String, String> formData)
       throws ProgramNotFoundException {
     return controller.createOrUpdate(
-        addCSRFToken(fakeRequest().method("POST").bodyForm(formData)).build(), programId);
+        addCSRFToken(fakeRequestBuilder().method("POST").bodyForm(formData)).build(), programId);
   }
 
   private Result makeDeleteRequest(Long programId, ImmutableMap<String, String> formData)
       throws ProgramNotFoundException {
     return controller.delete(
-        addCSRFToken(fakeRequest().method("POST").bodyForm(formData)).build(), programId);
+        addCSRFToken(fakeRequestBuilder().method("POST").bodyForm(formData)).build(), programId);
   }
 }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -6,8 +6,8 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -61,7 +61,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Result result =
-        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "en-US");
+        controller.edit(fakeRequest(), program.getProgramDefinition().adminName(), "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
@@ -75,7 +75,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Result result =
-        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "es-US");
+        controller.edit(fakeRequest(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -105,7 +105,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_NO_EMAIL);
 
     Result result =
-        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "es-US");
+        controller.edit(fakeRequest(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -128,8 +128,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_programNotFound_returnsNotFound() {
-    assertThatThrownBy(
-            () -> controller.edit(fakeRequestNew(), "non-existent program name", "es-US"))
+    assertThatThrownBy(() -> controller.edit(fakeRequest(), "non-existent program name", "es-US"))
         .hasMessage("No draft found for program: \"non-existent program name\"")
         .isInstanceOf(BadRequestException.class);
   }
@@ -209,8 +208,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void update_programNotFound() {
-    assertThatThrownBy(
-            () -> controller.update(fakeRequestNew(), "non-existent program name", "es-US"))
+    assertThatThrownBy(() -> controller.update(fakeRequest(), "non-existent program name", "es-US"))
         .hasMessage("No draft found for program: \"non-existent program name\"")
         .isInstanceOf(BadRequestException.class);
   }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -7,6 +7,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,10 +61,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Result result =
-        controller.edit(
-            addCSRFToken(fakeRequest()).build(),
-            program.getProgramDefinition().adminName(),
-            "en-US");
+        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
@@ -77,10 +75,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Result result =
-        controller.edit(
-            addCSRFToken(fakeRequest()).build(),
-            program.getProgramDefinition().adminName(),
-            "es-US");
+        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -110,10 +105,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_NO_EMAIL);
 
     Result result =
-        controller.edit(
-            addCSRFToken(fakeRequest()).build(),
-            program.getProgramDefinition().adminName(),
-            "es-US");
+        controller.edit(fakeRequestNew(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -137,9 +129,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
   @Test
   public void edit_programNotFound_returnsNotFound() {
     assertThatThrownBy(
-            () ->
-                controller.edit(
-                    addCSRFToken(fakeRequest()).build(), "non-existent program name", "es-US"))
+            () -> controller.edit(fakeRequestNew(), "non-existent program name", "es-US"))
         .hasMessage("No draft found for program: \"non-existent program name\"")
         .isInstanceOf(BadRequestException.class);
   }
@@ -220,9 +210,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
   @Test
   public void update_programNotFound() {
     assertThatThrownBy(
-            () ->
-                controller.update(
-                    addCSRFToken(fakeRequest()).build(), "non-existent program name", "es-US"))
+            () -> controller.update(fakeRequestNew(), "non-existent program name", "es-US"))
         .hasMessage("No draft found for program: \"non-existent program name\"")
         .isInstanceOf(BadRequestException.class);
   }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -6,7 +6,7 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableList;
@@ -139,7 +139,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Http.RequestBuilder requestBuilder =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put("displayName", "updated spanish program display name")
@@ -221,7 +221,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Http.RequestBuilder requestBuilder =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put("displayName", "")
@@ -261,7 +261,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
     ProgramModel program = createDraftProgramEnglishAndSpanish(STATUSES_WITH_EMAIL);
 
     Http.RequestBuilder requestBuilder =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put("displayName", "updated spanish program display name")

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -6,7 +6,7 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
@@ -96,7 +96,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   public void update_addsNewLocalesAndRedirects() throws TranslationNotFoundException {
     QuestionModel question = createDraftQuestionEnglishOnly();
     Http.RequestBuilder requestBuilder =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "questionText",
@@ -130,7 +130,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
       throws TranslationNotFoundException, UnsupportedQuestionTypeException {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
     Http.RequestBuilder requestBuilder =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "questionText",
@@ -172,7 +172,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
       throws UnsupportedQuestionTypeException {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
     Http.RequestBuilder requestBuilder =
-        fakeRequest().bodyForm(ImmutableMap.of("questionText", "", "questionHelpText", ""));
+        fakeRequestBuilder().bodyForm(ImmutableMap.of("questionText", "", "questionHelpText", ""));
 
     Result result =
         controller.update(

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -7,6 +7,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.BadRequestException;
@@ -55,10 +56,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller.edit(
-            addCSRFToken(fakeRequest()).build(),
-            question.getQuestionDefinition().getName(),
-            "en-US");
+        controller.edit(fakeRequestNew(), question.getQuestionDefinition().getName(), "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminQuestionController.index().url());
@@ -72,10 +70,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller.edit(
-            addCSRFToken(fakeRequest()).build(),
-            question.getQuestionDefinition().getName(),
-            "es-US");
+        controller.edit(fakeRequestNew(), question.getQuestionDefinition().getName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -92,9 +87,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   @Test
   public void edit_questionNotFound_returnsNotFound() {
     assertThatThrownBy(
-            () ->
-                controller.edit(
-                    addCSRFToken(fakeRequest()).build(), "non-existent question name", "es-US"))
+            () -> controller.edit(fakeRequestNew(), "non-existent question name", "es-US"))
         .hasMessage("No draft found for question: \"non-existent question name\"")
         .isInstanceOf(BadRequestException.class);
   }
@@ -169,9 +162,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   @Test
   public void update_questionNotFound_returnsNotFound() {
     assertThatThrownBy(
-            () ->
-                controller.update(
-                    addCSRFToken(fakeRequest()).build(), "non-existent question name", "es-US"))
+            () -> controller.update(fakeRequestNew(), "non-existent question name", "es-US"))
         .hasMessage("No draft found for question: \"non-existent question name\"")
         .isInstanceOf(BadRequestException.class);
   }

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -6,8 +6,8 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.BadRequestException;
@@ -56,7 +56,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller.edit(fakeRequestNew(), question.getQuestionDefinition().getName(), "en-US");
+        controller.edit(fakeRequest(), question.getQuestionDefinition().getName(), "en-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminQuestionController.index().url());
@@ -70,7 +70,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
     QuestionModel question = createDraftQuestionEnglishAndSpanish();
 
     Result result =
-        controller.edit(fakeRequestNew(), question.getQuestionDefinition().getName(), "es-US");
+        controller.edit(fakeRequest(), question.getQuestionDefinition().getName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -86,8 +86,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
   @Test
   public void edit_questionNotFound_returnsNotFound() {
-    assertThatThrownBy(
-            () -> controller.edit(fakeRequestNew(), "non-existent question name", "es-US"))
+    assertThatThrownBy(() -> controller.edit(fakeRequest(), "non-existent question name", "es-US"))
         .hasMessage("No draft found for question: \"non-existent question name\"")
         .isInstanceOf(BadRequestException.class);
   }
@@ -162,7 +161,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
   @Test
   public void update_questionNotFound_returnsNotFound() {
     assertThatThrownBy(
-            () -> controller.update(fakeRequestNew(), "non-existent question name", "es-US"))
+            () -> controller.update(fakeRequest(), "non-existent question name", "es-US"))
         .hasMessage("No draft found for question: \"non-existent question name\"")
         .isInstanceOf(BadRequestException.class);
   }

--- a/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
+++ b/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
@@ -5,7 +5,7 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
@@ -72,7 +72,8 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
     account.setEmailAddress(email);
     account.save();
 
-    Http.Request request = fakeRequest().bodyForm(ImmutableMap.of("adminEmail", email)).build();
+    Http.Request request =
+        fakeRequestBuilder().bodyForm(ImmutableMap.of("adminEmail", email)).build();
 
     Result result = controller.add(request, program.id);
 
@@ -97,7 +98,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
         .isNotEmpty();
 
     Http.Request request =
-        fakeRequest().bodyForm(ImmutableMap.of("adminEmail", deleteEmail)).build();
+        fakeRequestBuilder().bodyForm(ImmutableMap.of("adminEmail", deleteEmail)).build();
     Result result = controller.delete(request, program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -121,7 +122,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
         .isNotEmpty();
 
     Http.Request request =
-        fakeRequest().bodyForm(ImmutableMap.of("adminEmail", "nonExistentEmail")).build();
+        fakeRequestBuilder().bodyForm(ImmutableMap.of("adminEmail", "nonExistentEmail")).build();
     Result result = controller.delete(request, program.id);
 
     // The controller doesn't return an error in this case.

--- a/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
+++ b/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
@@ -5,8 +5,8 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import models.AccountModel;
@@ -35,7 +35,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
   public void edit_rendersForm() {
     ProgramModel program = ProgramBuilder.newDraftProgram("Success").build();
 
-    Result result = controller.edit(fakeRequestNew(), program.id);
+    Result result = controller.edit(fakeRequest(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Manage admins for program: Success");
@@ -49,7 +49,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
     existingAdmin.addAdministeredProgram(program);
     existingAdmin.save();
 
-    Result result = controller.edit(fakeRequestNew(), program.id());
+    Result result = controller.edit(fakeRequest(), program.id());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("test@test.com");
@@ -57,7 +57,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
 
   @Test
   public void edit_programNotFound() {
-    Result result = controller.edit(fakeRequestNew(), 1234L);
+    Result result = controller.edit(fakeRequest(), 1234L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
+++ b/server/test/controllers/admin/ProgramAdminManagementControllerTest.java
@@ -1,12 +1,12 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import models.AccountModel;
@@ -35,7 +35,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
   public void edit_rendersForm() {
     ProgramModel program = ProgramBuilder.newDraftProgram("Success").build();
 
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), program.id);
+    Result result = controller.edit(fakeRequestNew(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Manage admins for program: Success");
@@ -49,7 +49,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
     existingAdmin.addAdministeredProgram(program);
     existingAdmin.save();
 
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), program.id());
+    Result result = controller.edit(fakeRequestNew(), program.id());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("test@test.com");
@@ -57,7 +57,7 @@ public class ProgramAdminManagementControllerTest extends ResetPostgres {
 
   @Test
   public void edit_programNotFound() {
-    Result result = controller.edit(addCSRFToken(fakeRequest()).build(), 1234L);
+    Result result = controller.edit(fakeRequestNew(), 1234L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/api/ApiDocsControllerTest.java
+++ b/server/test/controllers/api/ApiDocsControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import java.util.Optional;
 import org.junit.Before;
@@ -28,7 +28,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void index_redirectsToArbitraryProgramActiveDocs() {
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     Result result = instanceOf(ApiDocsController.class).index(request);
 
     // SEE_OTHER is the redirect code
@@ -39,7 +39,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void activeDocsForSlug_programExists() {
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     Result result =
         instanceOf(ApiDocsController.class).activeDocsForSlug(request, "test-program-1");
 
@@ -49,7 +49,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void activeDocsForSlug_programDoesNotExist() {
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     Result result =
         instanceOf(ApiDocsController.class).activeDocsForSlug(request, "non-existent-program");
 
@@ -59,7 +59,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void draftDocsForSlug_noDraftAvailable() {
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     Result result = instanceOf(ApiDocsController.class).draftDocsForSlug(request, "test-program-1");
 
     assertThat(result.status()).isEqualTo(OK);
@@ -70,7 +70,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
   public void draftDocsForSlug_draftAvailable() {
     ProgramBuilder.newDraftProgram("Test Program 1").buildDefinition();
 
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     Result result = instanceOf(ApiDocsController.class).draftDocsForSlug(request, "test-program-1");
 
     assertThat(result.status()).isEqualTo(OK);

--- a/server/test/controllers/api/ApiDocsControllerTest.java
+++ b/server/test/controllers/api/ApiDocsControllerTest.java
@@ -4,13 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import play.test.Helpers;
 import repository.ResetPostgres;
 import support.ProgramBuilder;
 
@@ -28,7 +28,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void index_redirectsToArbitraryProgramActiveDocs() {
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
     Result result = instanceOf(ApiDocsController.class).index(request);
 
     // SEE_OTHER is the redirect code
@@ -39,7 +39,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void activeDocsForSlug_programExists() {
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
     Result result =
         instanceOf(ApiDocsController.class).activeDocsForSlug(request, "test-program-1");
 
@@ -49,7 +49,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void activeDocsForSlug_programDoesNotExist() {
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
     Result result =
         instanceOf(ApiDocsController.class).activeDocsForSlug(request, "non-existent-program");
 
@@ -59,7 +59,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
 
   @Test
   public void draftDocsForSlug_noDraftAvailable() {
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
     Result result = instanceOf(ApiDocsController.class).draftDocsForSlug(request, "test-program-1");
 
     assertThat(result.status()).isEqualTo(OK);
@@ -70,7 +70,7 @@ public class ApiDocsControllerTest extends ResetPostgres {
   public void draftDocsForSlug_draftAvailable() {
     ProgramBuilder.newDraftProgram("Test Program 1").buildDefinition();
 
-    Request request = Helpers.fakeRequest().build();
+    Request request = fakeRequestNew();
     Result result = instanceOf(ApiDocsController.class).draftDocsForSlug(request, "test-program-1");
 
     assertThat(result.status()).isEqualTo(OK);

--- a/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
+++ b/server/test/controllers/api/ProgramApplicationsApiControllerTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.Helpers.testServerPort;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ApiKeyGrants;
 import auth.UnauthorizedApiRequestException;
@@ -153,7 +153,9 @@ public class ProgramApplicationsApiControllerTest extends AbstractExporterTest {
   private Result doRequest(String requestUrl) {
     return route(
         app,
-        fakeRequest("GET", requestUrl)
+        fakeRequestBuilder()
+            .method("GET")
+            .uri(requestUrl)
             .remoteAddress("1.1.1.1")
             .header("Authorization", "Basic " + serializedApiKey)
             .header(Http.HeaderNames.HOST, "localhost:" + testServerPort()));

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
-import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +46,8 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromBrowser_updatesLanguageCode_usingRequestHeaders() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantInformationController.setLangFromBrowser(
                             currentApplicant.id))
                     .header("Accept-Language", "es-US"))
@@ -77,7 +78,8 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromSwitcher_redirectsToProgramIndex_withNonEnglishLocale() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantInformationController.setLangFromSwitcher(
                             currentApplicant.id))
                     .bodyForm(ImmutableMap.of("locale", "es-US")))
@@ -98,7 +100,8 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromSwitcher_ignoresExistingLangCookie() {
     Http.Request request =
         addCSRFToken(
-                fakeRequest(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantInformationController.setLangFromSwitcher(
                             currentApplicant.id))
                     .bodyForm(ImmutableMap.of("locale", "es-US")))

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -5,8 +5,8 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
@@ -36,7 +36,7 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromBrowser_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .setLangFromBrowser(fakeRequestNew(), currentApplicant.id + 1)
+            .setLangFromBrowser(fakeRequest(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
@@ -68,7 +68,7 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromSwitcher_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .setLangFromSwitcher(fakeRequestNew(), currentApplicant.id + 1)
+            .setLangFromSwitcher(fakeRequest(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -6,6 +6,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
@@ -35,7 +36,7 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromBrowser_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .setLangFromBrowser(fakeRequest().build(), currentApplicant.id + 1)
+            .setLangFromBrowser(fakeRequestNew(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
@@ -66,7 +67,7 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   public void setLangFromSwitcher_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .setLangFromSwitcher(fakeRequest().build(), currentApplicant.id + 1)
+            .setLangFromSwitcher(fakeRequestNew(), currentApplicant.id + 1)
             .toCompletableFuture()
             .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -11,6 +11,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
 import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import controllers.WithMockedProfiles;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import play.test.Helpers;
 import repository.VersionRepository;
 import services.Path;
 import services.applicant.ApplicantData;
@@ -108,7 +108,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void indexWithApplicantId_clearsRedirectToSessionKey() {
     Request request =
-        addCSRFToken(Helpers.fakeRequest().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
+        addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
     assertThat(result.session().get(REDIRECT_TO_SESSION_KEY)).isEmpty();

--- a/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
+++ b/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
@@ -91,7 +91,7 @@ public class EligibilityAlertSettingsCalculatorTest {
 
   private Http.Request createFakeRequest(boolean isFastForwarded) {
     if (isFastForwarded) {
-      return fakeRequest().flash(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true").build();
+      return fakeRequestBuilder().flash(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true").build();
     }
 
     return fakeRequestNew();

--- a/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
+++ b/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -93,7 +94,7 @@ public class EligibilityAlertSettingsCalculatorTest {
       return fakeRequest().flash(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true").build();
     }
 
-    return fakeRequest().build();
+    return fakeRequestNew();
   }
 
   private record ParamValue(
@@ -159,7 +160,7 @@ public class EligibilityAlertSettingsCalculatorTest {
 
     AlertSettings result =
         eligibilityAlertSettingsCalculator.calculate(
-            fakeRequest().build(), false, true, /* programId */ 1L);
+            fakeRequestNew(), false, true, /* programId */ 1L);
 
     assertThat(result.show()).isEqualTo(isEligibilityGating);
   }

--- a/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
+++ b/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
-import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
@@ -94,7 +94,7 @@ public class EligibilityAlertSettingsCalculatorTest {
       return fakeRequestBuilder().flash(FlashKey.SHOW_FAST_FORWARDED_MESSAGE, "true").build();
     }
 
-    return fakeRequestNew();
+    return fakeRequest();
   }
 
   private record ParamValue(
@@ -160,7 +160,7 @@ public class EligibilityAlertSettingsCalculatorTest {
 
     AlertSettings result =
         eligibilityAlertSettingsCalculator.calculate(
-            fakeRequestNew(), false, true, /* programId */ 1L);
+            fakeRequest(), false, true, /* programId */ 1L);
 
     assertThat(result.show()).isEqualTo(isEligibilityGating);
   }

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
@@ -6,6 +6,7 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import controllers.FlashKey;
 import java.util.Optional;
@@ -106,7 +107,7 @@ public class DevDatabaseSeedControllerTest {
   @Test
   public void index_inNonDevMode_returnsNotFound() {
     setupControllerInMode(Mode.TEST);
-    Result result = controller.index(fakeRequest().build());
+    Result result = controller.index(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -115,7 +116,7 @@ public class DevDatabaseSeedControllerTest {
   public void data_inNonDevMode_returnsNotFound() {
 
     setupControllerInMode(Mode.TEST);
-    Result result = controller.data(fakeRequest().build());
+    Result result = controller.data(fakeRequestNew());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
@@ -1,11 +1,9 @@
 package controllers.dev.seeding;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestNew;
 
 import controllers.FlashKey;
@@ -43,7 +41,7 @@ public class DevDatabaseSeedControllerTest {
     setupControllerInMode(Mode.DEV);
     controller.clear();
     // Navigate to index before seeding - should not have the fake program.
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
@@ -51,12 +49,12 @@ public class DevDatabaseSeedControllerTest {
     result = controller.seedPrograms();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
-    result = controller.index(addCSRFToken(fakeRequest()).build());
+    result = controller.index(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
     // Go to seed data display page.
-    result = controller.data(addCSRFToken(fakeRequest()).build());
+    result = controller.data(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("comprehensive-sample-program");
 
@@ -64,7 +62,7 @@ public class DevDatabaseSeedControllerTest {
     result = controller.clear();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been cleared");
-    result = controller.index(addCSRFToken(fakeRequest()).build());
+    result = controller.index(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
   }
@@ -81,7 +79,7 @@ public class DevDatabaseSeedControllerTest {
         .isFalse();
 
     // Navigate to index before seeding - should not have the fake program.
-    Result result = controller.index(addCSRFToken(fakeRequest()).build());
+    Result result = controller.index(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
@@ -89,7 +87,7 @@ public class DevDatabaseSeedControllerTest {
     result = controller.seedPrograms();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
-    result = controller.index(addCSRFToken(fakeRequest()).build());
+    result = controller.index(fakeRequestNew());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import controllers.FlashKey;
 import java.util.Optional;
@@ -41,7 +41,7 @@ public class DevDatabaseSeedControllerTest {
     setupControllerInMode(Mode.DEV);
     controller.clear();
     // Navigate to index before seeding - should not have the fake program.
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
@@ -49,12 +49,12 @@ public class DevDatabaseSeedControllerTest {
     result = controller.seedPrograms();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
-    result = controller.index(fakeRequestNew());
+    result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
     // Go to seed data display page.
-    result = controller.data(fakeRequestNew());
+    result = controller.data(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("comprehensive-sample-program");
 
@@ -62,7 +62,7 @@ public class DevDatabaseSeedControllerTest {
     result = controller.clear();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been cleared");
-    result = controller.index(fakeRequestNew());
+    result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
   }
@@ -79,7 +79,7 @@ public class DevDatabaseSeedControllerTest {
         .isFalse();
 
     // Navigate to index before seeding - should not have the fake program.
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
@@ -87,7 +87,7 @@ public class DevDatabaseSeedControllerTest {
     result = controller.seedPrograms();
     assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
-    result = controller.index(fakeRequestNew());
+    result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).doesNotContain("comprehensive-sample-program");
 
@@ -105,7 +105,7 @@ public class DevDatabaseSeedControllerTest {
   @Test
   public void index_inNonDevMode_returnsNotFound() {
     setupControllerInMode(Mode.TEST);
-    Result result = controller.index(fakeRequestNew());
+    Result result = controller.index(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
@@ -114,7 +114,7 @@ public class DevDatabaseSeedControllerTest {
   public void data_inNonDevMode_returnsNotFound() {
 
     setupControllerInMode(Mode.TEST);
-    Result result = controller.data(fakeRequestNew());
+    Result result = controller.data(fakeRequest());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -6,7 +6,6 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
 import static support.CfTestHelpers.requestBuilderWithSettings;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
@@ -83,7 +82,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
         .isEqualTo("2022-07-18");
     Http.RequestBuilder requestBuilder2 =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -169,7 +168,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
         .isEqualTo("2022-07-18");
     Http.RequestBuilder requestBuilder2 =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -8,6 +8,7 @@ import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileFactory;
 import auth.ProfileUtils;
@@ -21,7 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http;
 import play.mvc.Result;
-import play.test.Helpers;
 import repository.AccountRepository;
 import services.applicant.exception.ApplicantNotFoundException;
 
@@ -47,7 +47,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
       throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -114,7 +114,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     account.save();
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -136,7 +136,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   public void testEditClient_AllFieldsUpdated() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -225,7 +225,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     createTIWithMockedProfile(managedApplicant);
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -257,7 +257,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   public void addClient_WithAllInformation() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -290,7 +290,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   private AccountModel setupForEditClient(String email) {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            Helpers.fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",

--- a/server/test/filters/CiviFormProfileFilterTest.java
+++ b/server/test/filters/CiviFormProfileFilterTest.java
@@ -2,6 +2,7 @@ package filters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
 import java.util.concurrent.CompletableFuture;
@@ -17,7 +18,7 @@ public class CiviFormProfileFilterTest extends WithApplication {
     ProfileUtils profileUtils = instanceOf(ProfileUtils.class);
     CiviFormProfileFilter filter = new CiviFormProfileFilter(mat, profileUtils);
 
-    Http.RequestBuilder request = fakeRequest();
+    Http.RequestBuilder request = fakeRequestBuilder();
 
     CompletionStage<Result> stage =
         filter.apply(

--- a/server/test/filters/CiviFormProfileFilterTest.java
+++ b/server/test/filters/CiviFormProfileFilterTest.java
@@ -1,7 +1,6 @@
 package filters;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
@@ -43,7 +42,7 @@ public class CiviFormProfileFilterTest extends WithApplication {
     CiviFormProfileFilter filter = new CiviFormProfileFilter(mat, profileUtils);
 
     // This is not a user-facing request.
-    Http.RequestBuilder request = fakeRequest("GET", "/playIndex");
+    Http.RequestBuilder request = fakeRequestBuilder().method("GET").uri("/playIndex");
 
     CompletionStage<Result> stage =
         filter.apply(

--- a/server/test/filters/RecordCookieSizeFilterTest.java
+++ b/server/test/filters/RecordCookieSizeFilterTest.java
@@ -1,7 +1,7 @@
 package filters;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import akka.stream.testkit.NoMaterializer$;
 import com.google.common.collect.ImmutableList;
@@ -27,7 +27,7 @@ public class RecordCookieSizeFilterTest {
       throws Exception {
     Http.Cookie playSessionCookie =
         Http.Cookie.builder("PLAY_SESSION", "*".repeat(cookieSize)).build();
-    Http.Request request = fakeRequest().cookie(playSessionCookie).build();
+    Http.Request request = fakeRequestBuilder().cookie(playSessionCookie).build();
     return filter
         .apply(EssentialAction.of(r -> Accumulator.done(Results.ok("OK"))))
         .apply(request)

--- a/server/test/filters/UnsupportedBrowserFilterTest.java
+++ b/server/test/filters/UnsupportedBrowserFilterTest.java
@@ -1,7 +1,7 @@
 package filters;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import akka.stream.testkit.NoMaterializer$;
 import com.google.common.collect.ImmutableList;
@@ -42,7 +42,7 @@ public class UnsupportedBrowserFilterTest {
 
   @Test
   public void testMissingUserAgentDoesNotTriggerRedirect() throws Exception {
-    Result res = runFilter(fakeRequest(), Results.ok(""));
+    Result res = runFilter(fakeRequestBuilder(), Results.ok(""));
     assertThat(res.status()).isEqualTo(200);
   }
 
@@ -50,7 +50,8 @@ public class UnsupportedBrowserFilterTest {
   @Parameters(method = "getUnsupportedBrowsers")
   public void testOldIETriggerRedirect(String userAgent) throws Exception {
     Result res =
-        runFilter(fakeRequest().header(Http.HeaderNames.USER_AGENT, userAgent), Results.ok(""));
+        runFilter(
+            fakeRequestBuilder().header(Http.HeaderNames.USER_AGENT, userAgent), Results.ok(""));
     assertThat(res.status()).isEqualTo(303);
     assertThat(res.headers()).containsEntry(Http.HeaderNames.LOCATION, unsupportedBrowserPath);
   }
@@ -63,7 +64,8 @@ public class UnsupportedBrowserFilterTest {
   @Parameters(method = "getSupportedBrowsers")
   public void testModernBrowsersPassThrough(String userAgent) throws Exception {
     Result res =
-        runFilter(fakeRequest().header(Http.HeaderNames.USER_AGENT, userAgent), Results.ok(""));
+        runFilter(
+            fakeRequestBuilder().header(Http.HeaderNames.USER_AGENT, userAgent), Results.ok(""));
     assertThat(res.status()).isEqualTo(200);
   }
 
@@ -75,7 +77,9 @@ public class UnsupportedBrowserFilterTest {
   public void testRequestToUnsupportedBrowserPageIsNotRedirected() throws Exception {
     Result res =
         runFilter(
-            fakeRequest().header(Http.HeaderNames.USER_AGENT, IE11).path(unsupportedBrowserPath),
+            fakeRequestBuilder()
+                .header(Http.HeaderNames.USER_AGENT, IE11)
+                .path(unsupportedBrowserPath),
             Results.ok(""));
     assertThat(res.status()).isEqualTo(200);
   }
@@ -84,7 +88,7 @@ public class UnsupportedBrowserFilterTest {
   public void testAssertsAreNotRedirected() throws Exception {
     Result res =
         runFilter(
-            fakeRequest().header(Http.HeaderNames.USER_AGENT, IE11).path("/assets/foo.js"),
+            fakeRequestBuilder().header(Http.HeaderNames.USER_AGENT, IE11).path("/assets/foo.js"),
             Results.ok(""));
     assertThat(res.status()).isEqualTo(200);
   }

--- a/server/test/forms/admin/ProgramImageDescriptionFormTest.java
+++ b/server/test/forms/admin/ProgramImageDescriptionFormTest.java
@@ -1,7 +1,7 @@
 package forms.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
@@ -23,7 +23,7 @@ public class ProgramImageDescriptionFormTest extends ResetPostgres {
   public void bindFromRequest_hasDescription() {
     ImmutableMap<String, String> requestData =
         ImmutableMap.of(ProgramImageDescriptionForm.SUMMARY_IMAGE_DESCRIPTION, "fake description");
-    Http.Request request = fakeRequest().bodyForm(requestData).build();
+    Http.Request request = fakeRequestBuilder().bodyForm(requestData).build();
 
     ProgramImageDescriptionForm form =
         formFactory

--- a/server/test/forms/translation/ProgramTranslationFormTest.java
+++ b/server/test/forms/translation/ProgramTranslationFormTest.java
@@ -1,7 +1,7 @@
 package forms.translation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -44,7 +44,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
 
   @Test
   public void bindFromRequest() throws Exception {
-    Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
+    Request request = fakeRequestBuilder().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
     ImmutableList<Long> blockIds = ImmutableList.of();
 
@@ -79,7 +79,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
 
   @Test
   public void bindFromRequest_extraStatusesInFormBodyBeyondSpecifiedAreIgnored() throws Exception {
-    Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
+    Request request = fakeRequestBuilder().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
     ImmutableList<Long> blockIds = ImmutableList.of();
 
@@ -109,7 +109,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
 
   @Test
   public void bindFromRequest_missingStatusesInFormBodyAreOmmitted() throws Exception {
-    Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
+    Request request = fakeRequestBuilder().bodyForm(REQUEST_DATA_WITH_TWO_TRANSLATIONS).build();
 
     ImmutableList<Long> blockIds = ImmutableList.of();
 
@@ -147,7 +147,8 @@ public class ProgramTranslationFormTest extends ResetPostgres {
 
   @Test
   public void bindFromRequest_includesScreenNameAndDescription() throws Exception {
-    Request request = fakeRequest().bodyForm(REQUEST_DATA_WITH_TWO_BLOCKS_TRANSLATED).build();
+    Request request =
+        fakeRequestBuilder().bodyForm(REQUEST_DATA_WITH_TWO_BLOCKS_TRANSLATED).build();
 
     ImmutableList<Long> blockIds = ImmutableList.of(0l, 1l);
 
@@ -183,7 +184,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   @Test
   public void bindFromRequest_emptyStatusOrEmailIsConsideredNotProvided() throws Exception {
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
@@ -234,7 +235,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   @Test
   public void bindFromRequest_hasSummaryImageDescriptionFalse_notIncluded() {
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
@@ -259,7 +260,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   @Test
   public void bindFromRequest_hasSummaryImageDescriptionFalse_formContentDropped() {
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
@@ -291,7 +292,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   @Test
   public void bindFromRequest_hasSummaryImageDescriptionTrue_included() {
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
@@ -322,7 +323,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   public void bindFromRequest_missingSummaryImageDescriptionIsOmitted() {
     // When the request doesn't have an image description set...
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")
@@ -351,7 +352,7 @@ public class ProgramTranslationFormTest extends ResetPostgres {
   @Test
   public void bindFromRequest_emptyImageDescriptionUsed() {
     Request request =
-        fakeRequest()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.<String, String>builder()
                     .put(ProgramTranslationForm.DISPLAY_NAME_FORM_NAME, "display name")

--- a/server/test/services/apikey/ApiKeyServiceTest.java
+++ b/server/test/services/apikey/ApiKeyServiceTest.java
@@ -2,7 +2,7 @@ package services.apikey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ApiKeyGrants.Permission;
 import auth.CiviFormProfile;
@@ -523,7 +523,7 @@ public class ApiKeyServiceTest extends ResetPostgres {
   }
 
   private DynamicForm buildForm(ImmutableMap<String, String> formContents) {
-    return formFactory.form().bindFromRequest(fakeRequest().bodyForm(formContents).build());
+    return formFactory.form().bindFromRequest(fakeRequestBuilder().bodyForm(formContents).build());
   }
 
   private static String getApiKeyExpirationDate(Instant expiration) {

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3,8 +3,8 @@ package services.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
@@ -41,7 +41,6 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
-import play.test.Helpers;
 import repository.AccountRepository;
 import repository.ApplicationRepository;
 import repository.ResetPostgres;
@@ -808,11 +807,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
 
@@ -916,10 +914,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
-            .submitApplication(applicant.id, progDef.id(), trustedIntermediaryProfile, request)
+            .submitApplication(
+                applicant.id, progDef.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
 
@@ -986,7 +984,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     var storedFile = new StoredFileModel().setName(fileKey);
     storedFile.save();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Request request = fakeRequestNew();
     subject
         .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, request)
         .toCompletableFuture()
@@ -1020,7 +1018,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Request request = fakeRequestNew();
     ApplicationModel oldApplication =
         subject
             .submitApplication(
@@ -1068,11 +1066,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1102,11 +1099,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1182,11 +1178,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1257,11 +1252,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1317,10 +1311,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
-            .submitApplication(applicant.id, programDefinition.id(), applicantProfile, request)
+            .submitApplication(
+                applicant.id, programDefinition.id(), applicantProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1357,7 +1351,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Request request = fakeRequestNew();
     ApplicationModel application =
         subject
             .submitApplication(
@@ -1372,14 +1366,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void submitApplication_failsWithApplicationSubmissionException() {
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), request)
+                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), fakeRequestNew())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationSubmissionException.class)
@@ -1406,13 +1398,15 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                        applicant.id,
+                        programDefinition.id(),
+                        trustedIntermediaryProfile,
+                        fakeRequestNew())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationNotEligibleException.class)
@@ -1440,11 +1434,10 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
             .toCompletableFuture()
             .join();
 
@@ -1574,14 +1567,15 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                        applicant.id,
+                        programDefinition.id(),
+                        trustedIntermediaryProfile,
+                        fakeRequestNew())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationOutOfDateException.class)
@@ -3861,7 +3855,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
         .toCompletableFuture()
         .join();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Request request = fakeRequestNew();
 
     ApplicationModel ineligibleApplication =
         subject

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static support.CfTestHelpers.requestBuilderWithSettings;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
@@ -810,7 +810,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -917,7 +917,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, progDef.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, progDef.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -984,7 +984,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     var storedFile = new StoredFileModel().setName(fileKey);
     storedFile.save();
 
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     subject
         .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, request)
         .toCompletableFuture()
@@ -1018,7 +1018,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     ApplicationModel oldApplication =
         subject
             .submitApplication(
@@ -1069,7 +1069,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1102,7 +1102,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1181,7 +1181,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1255,7 +1255,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1314,7 +1314,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), applicantProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), applicantProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1351,7 +1351,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
     ApplicationModel application =
         subject
             .submitApplication(
@@ -1371,7 +1371,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             () ->
                 subject
                     .submitApplication(
-                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), fakeRequestNew())
+                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationSubmissionException.class)
@@ -1406,7 +1406,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                         applicant.id,
                         programDefinition.id(),
                         trustedIntermediaryProfile,
-                        fakeRequestNew())
+                        fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationNotEligibleException.class)
@@ -1437,7 +1437,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequestNew())
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -1575,7 +1575,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                         applicant.id,
                         programDefinition.id(),
                         trustedIntermediaryProfile,
-                        fakeRequestNew())
+                        fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationOutOfDateException.class)
@@ -3855,7 +3855,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
         .toCompletableFuture()
         .join();
-    Request request = fakeRequestNew();
+    Request request = fakeRequest();
 
     ApplicationModel ineligibleApplication =
         subject

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 import static services.LocalizedStrings.DEFAULT_LOCALE;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -74,7 +74,7 @@ public class ProgramServiceTest extends ResetPostgres {
   private ProgramService ps;
   private SyncCacheApi programDefCache;
   private SettingsManifest mockSettingsManifest;
-  private final Request request = fakeRequestNew();
+  private final Request request = fakeRequest();
   private ApplicationStatusesRepository applicationStatusesRepo;
 
   @Before

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
-import static play.test.Helpers.fakeRequest;
 import static services.LocalizedStrings.DEFAULT_LOCALE;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -74,7 +74,7 @@ public class ProgramServiceTest extends ResetPostgres {
   private ProgramService ps;
   private SyncCacheApi programDefCache;
   private SettingsManifest mockSettingsManifest;
-  private final Request request = fakeRequest().build();
+  private final Request request = fakeRequestNew();
   private ApplicationStatusesRepository applicationStatusesRepo;
 
   @Before

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -2,7 +2,7 @@ package services.program.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -801,6 +801,6 @@ public class PredicateGeneratorTest extends ResetPostgres {
   }
 
   private DynamicForm buildForm(ImmutableMap<String, String> formContents) {
-    return formFactory.form().bindFromRequest(fakeRequest().bodyForm(formContents).build());
+    return formFactory.form().bindFromRequest(fakeRequestBuilder().bodyForm(formContents).build());
   }
 }

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -2,7 +2,7 @@ package services.settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
-import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,7 +74,7 @@ public class SettingsManifestTest {
               "foo"));
 
   private static Http.Request REQUEST =
-      fakeRequest()
+      fakeRequestNew()
           .withAttrs(
               TypedMap.empty()
                   .put(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, ImmutableMap.of("BOOL_VARIABLE", "true")));
@@ -123,6 +123,6 @@ public class SettingsManifestTest {
 
   @Test
   public void getBool_noAttrsInRequest_returnsHoconValue() {
-    assertThat(testManifest.getBool("BOOL_VARIABLE", fakeRequest())).isFalse();
+    assertThat(testManifest.getBool("BOOL_VARIABLE", fakeRequestNew())).isFalse();
   }
 }

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -2,7 +2,7 @@ package services.settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,7 +74,7 @@ public class SettingsManifestTest {
               "foo"));
 
   private static Http.Request REQUEST =
-      fakeRequestNew()
+      fakeRequest()
           .withAttrs(
               TypedMap.empty()
                   .put(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, ImmutableMap.of("BOOL_VARIABLE", "true")));
@@ -123,6 +123,6 @@ public class SettingsManifestTest {
 
   @Test
   public void getBool_noAttrsInRequest_returnsHoconValue() {
-    assertThat(testManifest.getBool("BOOL_VARIABLE", fakeRequestNew())).isFalse();
+    assertThat(testManifest.getBool("BOOL_VARIABLE", fakeRequest())).isFalse();
   }
 }

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
@@ -17,7 +18,6 @@ import models.SettingsGroupModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http;
-import play.test.Helpers;
 import repository.ResetPostgres;
 import repository.SettingsGroupRepository;
 
@@ -143,7 +143,7 @@ public class SettingsServiceTest extends ResetPostgres {
   @Test
   public void applySettingsToRequest_addsTheSettingsToTheRequestAttributes() {
     createTestSettings();
-    Http.Request request = Helpers.fakeRequest().build();
+    Http.Request request = fakeRequestNew();
 
     Http.RequestHeader resultRequest =
         settingsService.applySettingsToRequest(request).toCompletableFuture().join();
@@ -155,7 +155,7 @@ public class SettingsServiceTest extends ResetPostgres {
   @Test
   public void applySettingsToRequest_doesNotAlterAttributesIfNoSettingsFound() {
     DB.getDefault().truncate(SettingsGroupModel.class);
-    Http.Request request = Helpers.fakeRequest().build();
+    Http.Request request = fakeRequestNew();
 
     settingsService.applySettingsToRequest(request).toCompletableFuture().join();
 

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
@@ -143,7 +143,7 @@ public class SettingsServiceTest extends ResetPostgres {
   @Test
   public void applySettingsToRequest_addsTheSettingsToTheRequestAttributes() {
     createTestSettings();
-    Http.Request request = fakeRequestNew();
+    Http.Request request = fakeRequest();
 
     Http.RequestHeader resultRequest =
         settingsService.applySettingsToRequest(request).toCompletableFuture().join();
@@ -155,7 +155,7 @@ public class SettingsServiceTest extends ResetPostgres {
   @Test
   public void applySettingsToRequest_doesNotAlterAttributesIfNoSettingsFound() {
     DB.getDefault().truncate(SettingsGroupModel.class);
-    Http.Request request = fakeRequestNew();
+    Http.Request request = fakeRequest();
 
     settingsService.applySettingsToRequest(request).toCompletableFuture().join();
 

--- a/server/test/services/ti/TrustedIntermediaryServiceTest.java
+++ b/server/test/services/ti/TrustedIntermediaryServiceTest.java
@@ -3,7 +3,7 @@ package services.ti;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileFactory;
 import com.google.common.collect.ImmutableMap;
@@ -80,7 +80,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_withMissingDob() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -110,7 +110,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_withInvalidDob() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -141,7 +141,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_withUnformattedDob() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -172,7 +172,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_withInvalidLastName() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -202,7 +202,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_WithInvalidFirstName() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -232,7 +232,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_WithEmailAddressExistsError() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -271,7 +271,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_WithEmptyEmailAddress() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -312,7 +312,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void addClient_WithAllInformation() {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -465,7 +465,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -509,7 +509,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_PhoneLengthValidationFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -540,7 +540,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
       throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -570,7 +570,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_PhoneNumberValidationFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -600,7 +600,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_EmptyPhoneNumberDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -629,7 +629,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_EmptyEmailDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -658,7 +658,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_EmptyTiNotesDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -689,7 +689,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -722,7 +722,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -754,7 +754,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",
@@ -784,7 +784,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_throwsException() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
         addCSRFToken(
-            fakeRequest()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "firstName",

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -3,6 +3,8 @@ package support;
 import static org.mockito.Mockito.mockStatic;
 import static play.test.Helpers.route;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
+import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Clock;
@@ -95,14 +97,14 @@ public class CfTestHelpers {
     return PredicateValue.of(localDate);
   }
 
-  public static final Http.Request EMPTY_REQUEST = play.test.Helpers.fakeRequest().build();
+  public static final Http.Request EMPTY_REQUEST = fakeRequest();
 
   public static Http.RequestBuilder requestBuilderWithSettings(Call call, String... settings) {
-    return CfTestHelpers.requestBuilderWithSettings(play.test.Helpers.fakeRequest(call), settings);
+    return CfTestHelpers.requestBuilderWithSettings(fakeRequestBuilder().call(call), settings);
   }
 
   public static Http.RequestBuilder requestBuilderWithSettings(String... settings) {
-    return CfTestHelpers.requestBuilderWithSettings(play.test.Helpers.fakeRequest(), settings);
+    return CfTestHelpers.requestBuilderWithSettings(fakeRequestBuilder(), settings);
   }
 
   public static Http.RequestBuilder requestBuilderWithSettings(

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -15,7 +15,7 @@ import play.mvc.Http.RequestImpl;
 public final class FakeRequestBuilder extends RequestBuilder {
   private List<String> xForwardedFor = new ArrayList<>();
 
-  public static Request fakeRequest() {
+  public static Request fakeRequestNew() {
     return new FakeRequestBuilder().build();
   }
 

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -15,7 +15,7 @@ import play.mvc.Http.RequestImpl;
 public final class FakeRequestBuilder extends RequestBuilder {
   private List<String> xForwardedFor = new ArrayList<>();
 
-  public static Request fakeRequestNew() {
+  public static Request fakeRequest() {
     return new FakeRequestBuilder().build();
   }
 

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.test.Helpers.contentAsString;
-import static support.FakeRequestBuilder.fakeRequestNew;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import controllers.AssetsFinder;
@@ -52,7 +52,7 @@ public class AdminLayoutTest extends ResetPostgres {
     when(settingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
     HtmlBundle bundle =
-        adminLayout.getBundle(new HtmlBundle(fakeRequestNew(), instanceOf(ViewUtils.class)));
+        adminLayout.getBundle(new HtmlBundle(fakeRequest(), instanceOf(ViewUtils.class)));
 
     Content content = bundle.render();
     assertThat(contentAsString(content)).doesNotContain("Export");
@@ -64,7 +64,7 @@ public class AdminLayoutTest extends ResetPostgres {
     when(settingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
 
     HtmlBundle bundle =
-        adminLayout.getBundle(new HtmlBundle(fakeRequestNew(), instanceOf(ViewUtils.class)));
+        adminLayout.getBundle(new HtmlBundle(fakeRequest(), instanceOf(ViewUtils.class)));
 
     Content content = bundle.render();
     assertThat(contentAsString(content)).contains("Export");

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.test.Helpers.contentAsString;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestNew;
 
 import com.google.common.collect.ImmutableList;
 import controllers.AssetsFinder;
@@ -52,7 +52,7 @@ public class AdminLayoutTest extends ResetPostgres {
     when(settingsManifest.getProgramMigrationEnabled(any())).thenReturn(false);
 
     HtmlBundle bundle =
-        adminLayout.getBundle(new HtmlBundle(fakeRequest().build(), instanceOf(ViewUtils.class)));
+        adminLayout.getBundle(new HtmlBundle(fakeRequestNew(), instanceOf(ViewUtils.class)));
 
     Content content = bundle.render();
     assertThat(contentAsString(content)).doesNotContain("Export");
@@ -64,7 +64,7 @@ public class AdminLayoutTest extends ResetPostgres {
     when(settingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
 
     HtmlBundle bundle =
-        adminLayout.getBundle(new HtmlBundle(fakeRequest().build(), instanceOf(ViewUtils.class)));
+        adminLayout.getBundle(new HtmlBundle(fakeRequestNew(), instanceOf(ViewUtils.class)));
 
     Content content = bundle.render();
     assertThat(contentAsString(content)).contains("Export");

--- a/server/test/views/admin/migration/AdminProgramExportFormTest.java
+++ b/server/test/views/admin/migration/AdminProgramExportFormTest.java
@@ -2,7 +2,7 @@ package views.admin.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.inject.NewInstanceInjector.instanceOf;
-import static play.test.Helpers.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
@@ -23,7 +23,7 @@ public class AdminProgramExportFormTest extends ResetPostgres {
   public void bindFromRequest_hasProgramId() {
     ImmutableMap<String, String> requestData =
         ImmutableMap.of(AdminProgramExportForm.PROGRAM_ID_FIELD, "78");
-    Http.Request request = fakeRequest().bodyForm(requestData).build();
+    Http.Request request = fakeRequestBuilder().bodyForm(requestData).build();
 
     AdminProgramExportForm form =
         formFactory


### PR DESCRIPTION
### Description

Replace all usages of play.test.Helpers.fakeRequest() with our FakeRequestBuilder.

* Replace Helpers.fakeRequest().build() with FakeRequestBuilder.fakeRequest()
* Replace Helpers.fakeRequest() with FakeRequestBuilder.fakeRequestBuilder()
* Replace Helpers.fakeRequest(Call) with FakeRequestBuilder.fakeRequestBuilder().call(Call)
* Replace Helpers.fakeRequest(String method, String uri) with FakeRequestBuilder.fakeRequestBuilder().method(method).uri(uri)

This supports #8046.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)