### PR TITLE
Replace CfTestHelpers.requestBuilderWithSettings with FakeRequestBuilder

### DIFF
--- a/server/test/auth/CiviFormProfileTest.java
+++ b/server/test/auth/CiviFormProfileTest.java
@@ -2,8 +2,8 @@ package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static support.CfTestHelpers.requestBuilderWithSettings;
 import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableList;
 import models.AccountModel;
@@ -124,7 +124,9 @@ public class CiviFormProfileTest extends ResetPostgres {
     CiviFormProfileData data = profileFactory.createNewAdmin();
     CiviFormProfile profile = profileFactory.wrapProfileData(data);
     Request civiformAdminAllowedRequest =
-        requestBuilderWithSettings("ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS", "true").build();
+        fakeRequestBuilder()
+            .addCiviFormSetting("ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS", "true")
+            .build();
 
     assertThat(profile.checkProgramAuthorization("program1", civiformAdminAllowedRequest).join())
         .isEqualTo(null);

--- a/server/test/auth/CiviFormProfileTest.java
+++ b/server/test/auth/CiviFormProfileTest.java
@@ -3,6 +3,7 @@ package auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableList;
 import models.AccountModel;
@@ -77,11 +78,7 @@ public class CiviFormProfileTest extends ResetPostgres {
     CiviFormProfileData data = profileFactory.createNewProgramAdmin();
     CiviFormProfile profile = profileFactory.wrapProfileData(data);
 
-    assertThatThrownBy(
-            () ->
-                profile
-                    .checkProgramAuthorization("program1", requestBuilderWithSettings().build())
-                    .join())
+    assertThatThrownBy(() -> profile.checkProgramAuthorization("program1", fakeRequest()).join())
         .hasCauseInstanceOf(SecurityException.class);
   }
 
@@ -92,11 +89,7 @@ public class CiviFormProfileTest extends ResetPostgres {
     ProgramDefinition programOne = ProgramBuilder.newActiveProgram("program1").buildDefinition();
     profile.getAccount().join().addAdministeredProgram(programOne);
 
-    assertThatThrownBy(
-            () ->
-                profile
-                    .checkProgramAuthorization("program2", requestBuilderWithSettings().build())
-                    .join())
+    assertThatThrownBy(() -> profile.checkProgramAuthorization("program2", fakeRequest()).join())
         .hasCauseInstanceOf(SecurityException.class);
   }
 
@@ -115,22 +108,14 @@ public class CiviFormProfileTest extends ResetPostgres {
         .join();
 
     profile.getAccount().join().addAdministeredProgram(programOne);
-    assertThat(
-            profile
-                .checkProgramAuthorization("program1", requestBuilderWithSettings().build())
-                .join())
-        .isEqualTo(null);
+    assertThat(profile.checkProgramAuthorization("program1", fakeRequest()).join()).isEqualTo(null);
   }
 
   @Test
   public void checkProgramAuthorization_CiviformAdmin_fail() {
     CiviFormProfileData data = profileFactory.createNewAdmin();
     CiviFormProfile profile = profileFactory.wrapProfileData(data);
-    assertThatThrownBy(
-            () ->
-                profile
-                    .checkProgramAuthorization("program1", requestBuilderWithSettings().build())
-                    .join())
+    assertThatThrownBy(() -> profile.checkProgramAuthorization("program1", fakeRequest()).join())
         .hasCauseInstanceOf(SecurityException.class);
   }
 

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -7,7 +7,8 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import models.ProgramModel;
@@ -71,14 +72,14 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void create_withInvalidProgram_notFound() {
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     assertThatThrownBy(() -> controller.create(request, /* programId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void create_withProgram_addsBlock() {
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     Result result = controller.create(request, program.id);
 
@@ -101,8 +102,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
-    Request request =
-        requestBuilderWithSettings().bodyForm(ImmutableMap.of("enumeratorId", "1")).build();
+    Request request = fakeRequestBuilder().bodyForm(ImmutableMap.of("enumeratorId", "1")).build();
     Result result = controller.create(request, program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -119,7 +119,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void show_withNoneActiveProgram_throwsNotViewableException() throws Exception {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     ProgramModel program = ProgramBuilder.newDraftProgram("test program").build();
 
     assertThatThrownBy(() -> controller.show(request, program.id, /* blockId= */ 1L))
@@ -128,7 +128,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void show_withInvalidProgram_notFound() {
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     assertThatThrownBy(() -> controller.show(request, /* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotViewableException.class);
   }
@@ -136,7 +136,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void show_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newActiveProgram().build();
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     Result result = controller.show(request, program.id, /* blockId= */ 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -153,7 +153,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result = controller.show(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -171,7 +171,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withInvalidProgram_notFound() {
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     assertThatThrownBy(() -> controller.edit(request, /* programId= */ 1L, /* blockId= */ 1L))
         .isInstanceOf(NotChangeableException.class);
   }
@@ -179,7 +179,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void edit_withInvalidBlock_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
     Result result = controller.edit(request, program.id, /* blockId= */ 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -196,7 +196,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -218,7 +218,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
 
     questionService.update(otherQuestionDef);
-    request = addCSRFToken(requestBuilderWithSettings()).build();
+    request = addCSRFToken(fakeRequestBuilder()).build();
     result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -231,7 +231,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   @Test
   public void update_withInvalidProgram_notFound() {
     Request request =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
@@ -243,7 +243,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   public void update_withInvalidBlockId_notFound() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     Request request =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
@@ -256,7 +256,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   public void update_overwritesExistingBlock() {
     ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
     Request request =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(ImmutableMap.of("name", "updated name", "description", "updated description"))
             .build();
 
@@ -275,7 +275,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
     Result redirectResult =
         controller.edit(
-            addCSRFToken(requestBuilderWithSettings()).build(),
+            addCSRFToken(fakeRequestBuilder()).build(),
             program.id(),
             program.getBlockDefinitionByIndex(/* blockIndex= */ 0).get().id());
     assertThat(contentAsString(redirectResult)).contains("updated name");

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -7,7 +7,8 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
@@ -65,7 +66,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void index_withNoPrograms() {
-    Result result = controller.index(requestBuilderWithSettings().build());
+    Result result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
     assertThat(result.charset()).hasValue("utf-8");
@@ -77,7 +78,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newDraftProgram("one").build();
     ProgramBuilder.newDraftProgram("two").build();
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result = controller.index(request);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -87,7 +88,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void newOne_returnsExpectedForm() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
 
     Result result = controller.newOne(request);
 
@@ -99,7 +100,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_returnsFormWithErrorMessage() {
     RequestBuilder requestBuilder =
-        requestBuilderWithSettings().bodyForm(ImmutableMap.of("name", "", "description", ""));
+        fakeRequestBuilder().bodyForm(ImmutableMap.of("name", "", "description", ""));
     Request request = addCSRFToken(requestBuilder).build();
 
     Result result = controller.create(request);
@@ -114,7 +115,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_showsNewProgramInList() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -132,8 +133,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     controller.create(requestBuilder.build());
 
-    Result programDashboardResult =
-        controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result programDashboardResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(programDashboardResult)).contains("External program name");
     assertThat(contentAsString(programDashboardResult)).contains("External program description");
   }
@@ -142,7 +142,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_redirectsToProgramImage() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -178,7 +178,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_returnsNewProgramWithAcls() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -214,7 +214,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(newProgram.get().getProgramDefinition().acls().getTiProgramViewAcls())
         .containsExactly(1L);
 
-    Result programDashboard = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(programDashboard)).contains("External program name with acls");
     assertThat(contentAsString(programDashboard))
         .contains("External program description with acls");
@@ -224,7 +224,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_eligibilityIsGating_false() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -260,7 +260,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_eligibilityIsGating_true() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -297,7 +297,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram("Existing One").build();
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -328,7 +328,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
             routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
                 .url());
 
-    Result programDashboard = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(programDashboard)).contains("Existing One");
     assertThat(contentAsString(programDashboard)).contains("External program name");
     assertThat(contentAsString(programDashboard)).contains("External program description");
@@ -339,7 +339,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -371,7 +371,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -401,7 +401,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -436,7 +436,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
             routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
                 .url());
 
-    Result programDashboard = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(programDashboard)).contains("External program name");
     assertThat(contentAsString(programDashboard)).contains("External program description");
   }
@@ -450,7 +450,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     String programDescription = "External program description";
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminName",
@@ -480,14 +480,14 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(newProgram).isPresent();
     assertThat(newProgram.get().getProgramDefinition().isCommonIntakeForm()).isTrue();
 
-    Result programDashboard = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(programDashboard)).contains(programName);
     assertThat(contentAsString(programDashboard)).contains(programDescription);
   }
 
   @Test
   public void edit_withInvalidProgram_throwsProgramNotFoundException() {
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
 
     assertThatThrownBy(() -> controller.edit(request, 1L, ProgramEditStatus.EDIT.name()))
         .isInstanceOf(ProgramNotFoundException.class);
@@ -495,7 +495,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsExpectedForm() throws Exception {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     ProgramModel program = ProgramBuilder.newDraftProgram("test program").build();
 
     Result result = controller.edit(request, program.id, ProgramEditStatus.EDIT.name());
@@ -509,7 +509,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withNonDraftProgram_throwsNotChangeableException() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     ProgramModel program = ProgramBuilder.newActiveProgram("test program").build();
 
     assertThatThrownBy(() -> controller.edit(request, program.id, ProgramEditStatus.EDIT.name()))
@@ -520,7 +520,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void newVersionFrom_onlyActive_editActiveReturnsNewDraft() {
     // When there's a draft, editing the active one instead edits the existing draft.
     String programName = "test program";
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram(programName, "active description").build();
 
@@ -545,7 +545,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void newVersionFrom_withDraft_editActiveReturnsDraft() {
     // When there's a draft, editing the active one instead edits the existing draft.
     String programName = "test program";
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram(programName, "active description").build();
     ProgramModel draftProgram =
@@ -568,7 +568,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void update_invalidProgram_returnsNotFound() {
     Request request =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(ImmutableMap.of("name", "name", "description", "description"))
             .build();
 
@@ -582,7 +582,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram("fakeName", "active description").build();
 
-    Request request = requestBuilderWithSettings().build();
+    Request request = fakeRequest();
 
     assertThatThrownBy(
             () ->
@@ -595,7 +595,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_invalidInput_returnsFormWithErrors() throws Exception {
     ProgramModel program = ProgramBuilder.newDraftProgram("Existing One").build();
     Request request =
-        addCSRFToken(requestBuilderWithSettings())
+        addCSRFToken(fakeRequestBuilder())
             .bodyForm(ImmutableMap.of("name", "", "description", ""))
             .build();
 
@@ -611,7 +611,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
     RequestBuilder requestBuilder =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
@@ -631,7 +631,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     controller.update(
         addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
 
-    Result indexResult = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result indexResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(indexResult))
         .contains(
             "Create new program", "New external program name", "New external program description");
@@ -642,7 +642,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_statusEdit_redirectsToProgramEditBlocks() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("Program", "description").build();
     RequestBuilder requestBuilder =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
@@ -673,7 +673,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_statusCreation_redirectsToProgramImage() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("Program", "description").build();
     RequestBuilder requestBuilder =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
@@ -706,7 +706,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_statusCreationEdit_redirectsToProgramImage() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("Program", "description").build();
     RequestBuilder requestBuilder =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
@@ -746,7 +746,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminDescription",
@@ -781,7 +781,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminDescription",
@@ -814,7 +814,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminDescription",
@@ -847,7 +847,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
-    Result redirectResult = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result redirectResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(redirectResult)).contains("New external program name");
   }
 
@@ -861,7 +861,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     String newProgramDescription = "External program description";
     RequestBuilder requestBuilder =
         addCSRFToken(
-            requestBuilderWithSettings()
+            fakeRequestBuilder()
                 .bodyForm(
                     ImmutableMap.of(
                         "adminDescription",
@@ -891,7 +891,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());
 
-    Result redirectResult = controller.index(addCSRFToken(requestBuilderWithSettings()).build());
+    Result redirectResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
     assertThat(contentAsString(redirectResult)).contains(newProgramName);
     assertThat(contentAsString(redirectResult)).contains(newProgramDescription);
   }
@@ -902,7 +902,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(program.getProgramDefinition().eligibilityIsGating()).isTrue();
 
     RequestBuilder request =
-        requestBuilderWithSettings()
+        fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
@@ -933,7 +933,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void publishProgram() throws Exception {
     ProgramModel program = ProgramBuilder.newDraftProgram("one").build();
     Result result =
-        controller.publishProgram(addCSRFToken(requestBuilderWithSettings()).build(), program.id);
+        controller.publishProgram(addCSRFToken(fakeRequestBuilder()).build(), program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
@@ -945,9 +945,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void publishProgram_nonDraftProgram_throwsException() throws Exception {
     ProgramModel program = ProgramBuilder.newActiveProgram("active").build();
     assertThatThrownBy(
-            () ->
-                controller.publishProgram(
-                    addCSRFToken(requestBuilderWithSettings()).build(), program.id))
+            () -> controller.publishProgram(addCSRFToken(fakeRequestBuilder()).build(), program.id))
         .isInstanceOf(NotChangeableException.class);
   }
 }

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -14,7 +14,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -73,7 +73,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void edit_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.editWithApplicantId(
                     badApplicantId, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
@@ -98,9 +99,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.editWithApplicantId(
-                        applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
+                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
@@ -124,9 +126,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.editWithApplicantId(
-                        applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
+                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
@@ -144,9 +147,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.editWithApplicantId(
-                        applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
+                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
     Result result =
         subject
@@ -166,12 +170,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void edit_toAProgramThatDoesNotExist_returns404() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.editWithApplicantId(
-                        applicant.id,
-                        program.id + 1000,
-                        "1",
-                        /* questionName= */ Optional.empty())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
+                            applicant.id,
+                            program.id + 1000,
+                            "1",
+                            /* questionName= */ Optional.empty())))
             .build();
 
     Result result =
@@ -188,9 +193,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void edit_toAnExistingBlock_rendersTheBlock() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.editWithApplicantId(
-                        applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.editWithApplicantId(
+                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
             .build();
 
     Result result =
@@ -206,7 +212,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void edit_toABlockThatDoesNotExist_returns404() {
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.editWithApplicantId(
                     applicant.id, program.id, "9999", /* questionName= */ Optional.empty()))
             .build();
@@ -225,7 +232,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void edit_withMessages_returnsCorrectButtonText() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.editWithApplicantId(
                             applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
                     .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()))
@@ -246,9 +254,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void previous_toAnExistingBlock_rendersTheBlock() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                        applicant.id, program.id, 0, true)))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                            applicant.id, program.id, 0, true)))
             .build();
 
     Result result =
@@ -270,9 +279,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                        applicant.id, draftProgram.id, 0, true)))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                            applicant.id, draftProgram.id, 0, true)))
             .build();
     Result result =
         subject
@@ -295,9 +305,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                        applicant.id, draftProgram.id, 0, true)))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                            applicant.id, draftProgram.id, 0, true)))
             .build();
     Result result =
         subject
@@ -314,9 +325,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                        applicant.id, obsoleteProgram.id, 0, true)))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                            applicant.id, obsoleteProgram.id, 0, true)))
             .build();
     Result result =
         subject
@@ -331,7 +343,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     badApplicantId,
                     program.id,
@@ -365,13 +378,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                        applicant.id,
-                        draftProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                            applicant.id,
+                            draftProgram.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .build();
     Result result =
         subject
@@ -400,13 +414,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                        applicant.id,
-                        draftProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                            applicant.id,
+                            draftProgram.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .build();
     Result result =
         subject
@@ -433,13 +448,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                        applicant.id,
-                        obsoleteProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                            applicant.id,
+                            obsoleteProgram.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .build();
     Result result =
         subject
@@ -460,7 +476,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_invalidProgram_returnsBadRequest() {
     long badProgramId = program.id + 1000;
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     badProgramId,
@@ -488,7 +505,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_invalidBlock_returnsBadRequest() {
     String badBlockId = "1000";
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -515,7 +533,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_invalidPathsInRequest_returnsBadRequest() {
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -544,7 +563,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_reservedPathsInRequest_returnsBadRequest() {
     String reservedPath = Path.create("metadata").join(Scalar.PROGRAM_UPDATED_IN).toString();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -573,7 +593,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_withValidationErrors_isOK() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -613,7 +634,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_withValidationErrors_requestedActionReview_staysOnBlockAndShowsErrors() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -654,7 +676,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void update_withValidationErrors_requestedActionPrevious_staysOnBlockAndShowsErrors() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -703,7 +726,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -754,7 +778,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -806,7 +831,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -855,7 +881,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -906,7 +933,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request requestWithAnswer =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -938,7 +966,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // Then, try to delete the answer
     Request requestWithoutAnswer =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -989,7 +1018,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request requestWithAnswer =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -1021,7 +1051,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // Then, delete the answer
     Request requestWithoutAnswer =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -1069,7 +1100,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantAddress())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1114,7 +1146,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantAddress())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1154,7 +1187,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1199,7 +1233,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantEmail())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1242,7 +1277,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1282,7 +1318,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1325,7 +1362,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantEmail())
             .build();
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1362,7 +1400,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -1421,7 +1460,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     program.id,
@@ -1459,13 +1499,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void updateFile_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                badApplicantId,
-                program.id,
-                /* blockId= */ "2",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    badApplicantId,
+                    program.id,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1493,13 +1534,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                        applicant.id,
-                        draftProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper(NEXT_BLOCK))))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                            applicant.id,
+                            draftProgram.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper(NEXT_BLOCK))))
             .build();
 
     Result result =
@@ -1529,13 +1571,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                    applicant.id,
-                    draftProgram.id,
-                    /* blockId= */ "1",
-                    /* inReview= */ false,
-                    new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                        applicant.id,
+                        draftProgram.id,
+                        /* blockId= */ "1",
+                        /* inReview= */ false,
+                        new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -1564,13 +1607,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                    applicant.id,
-                    obsoleteProgram.id,
-                    /* blockId= */ "1",
-                    /* inReview= */ false,
-                    new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                        applicant.id,
+                        obsoleteProgram.id,
+                        /* blockId= */ "1",
+                        /* inReview= */ false,
+                        new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -1593,13 +1637,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void updateFile_invalidProgram_returnsBadRequest() {
     long badProgramId = program.id + 1000;
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                badProgramId,
-                /* blockId= */ "2",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    badProgramId,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1621,13 +1666,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void updateFile_invalidBlock_returnsBadRequest() {
     String badBlockId = "1000";
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                badBlockId,
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    badBlockId,
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1649,13 +1695,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void updateFile_notFileUploadBlock_returnsBadRequest() {
     String badBlockId = "1";
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                badBlockId,
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    badBlockId,
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1676,13 +1723,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void updateFile_missingFileKeyAndBucket_returnsBadRequest() {
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "2",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
 
     Result result =
         subject
@@ -1709,13 +1757,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantAddress())
             .build();
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "1",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1752,13 +1801,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .build();
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "2",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(PREVIOUS_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(PREVIOUS_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1797,13 +1847,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantAddress())
             .build();
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "1",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(REVIEW_PAGE)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(REVIEW_PAGE)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1836,13 +1887,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "1",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1885,13 +1937,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     storedFile.save();
 
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                applicant.id,
-                program.id,
-                /* blockId= */ "1",
-                /* inReview= */ false,
-                new ApplicantRequestedActionWrapper(REVIEW_PAGE)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(REVIEW_PAGE)));
     addQueryString(request, ImmutableMap.of("key", fileKey, "bucket", "fake-bucket"));
 
     Result result =
@@ -1916,9 +1969,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void addFile_invalidApplicant_returnsUnauthorized() {
     long badApplicantId = applicant.id + 1000;
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                badApplicantId, program.id, /* blockId= */ "2", /* inReview= */ false));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    badApplicantId, program.id, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -1945,9 +1999,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false)))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                            applicant.id,
+                            draftProgram.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false)))
             .build();
     Result result =
         subject
@@ -1971,9 +2029,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false)));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -2001,9 +2060,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, obsoleteProgram.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id,
+                        obsoleteProgram.id,
+                        /* blockId= */ "1",
+                        /* inReview= */ false)));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -2025,9 +2088,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void addFile_invalidProgram_returnsBadRequest() {
     long badProgramId = program.id + 1000;
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                applicant.id, badProgramId, /* blockId= */ "2", /* inReview= */ false));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, badProgramId, /* blockId= */ "2", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -2048,9 +2112,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void addFile_invalidBlock_returnsBadRequest() {
     String badBlockId = "1000";
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                applicant.id, program.id, badBlockId, /* inReview= */ false));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -2067,9 +2132,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void addFile_notFileUploadBlock_returnsBadRequest() {
     String badBlockId = "1";
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                applicant.id, program.id, badBlockId, /* inReview= */ false));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, badBlockId, /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -2085,9 +2151,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void addFile_missingFileKeyAndBucket_returnsBadRequest() {
     RequestBuilder request =
-        requestBuilderWithSettings(
-            routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                applicant.id, program.id, /* blockId= */ "2", /* inReview= */ false));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, /* blockId= */ "2", /* inReview= */ false));
 
     Result result =
         subject
@@ -2114,9 +2181,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -2147,9 +2215,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     RequestBuilder requestOne =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
     addQueryString(requestOne, ImmutableMap.of("key", "keyOne", "bucket", "fake-bucket"));
 
     subject
@@ -2160,9 +2229,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     RequestBuilder requestTwo =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
     addQueryString(requestTwo, ImmutableMap.of("key", "keyTwo", "bucket", "fake-bucket"));
 
     subject
@@ -2196,9 +2266,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
     RequestBuilder request =
         addCSRFToken(
-            requestBuilderWithSettings(
-                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+            fakeRequestBuilder()
+                .call(
+                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     var result =
@@ -2247,7 +2318,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badApplicantId = Long.MAX_VALUE;
 
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                     badApplicantId,
                     program.id,
@@ -2282,13 +2354,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                        applicant.id,
-                        program.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                            applicant.id,
+                            program.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2318,13 +2391,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                        applicant.id,
-                        program.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                            applicant.id,
+                            program.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2352,13 +2426,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                        applicant.id,
-                        program.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                            applicant.id,
+                            program.id,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2382,13 +2457,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
-                    routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                        applicant.id,
-                        badProgramId,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper())))
+                fakeRequestBuilder()
+                    .call(
+                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                            applicant.id,
+                            badProgramId,
+                            /* blockId= */ "1",
+                            /* inReview= */ false,
+                            new ApplicantRequestedActionWrapper())))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
 
@@ -2411,7 +2487,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void confirmAddress_noAddressJson_throws() {
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2453,7 +2530,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // First, answer the address question
     Request answerAddressQuestionRequest =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2498,7 +2576,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // Then, send a confirmAddress request but don't fill in SELECTED_ADDRESS_NAME in the form body
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2579,7 +2658,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // suggestions (set in the session with the key ADDRESS_JSON_SESSION_KEY).
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2634,7 +2714,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2686,7 +2767,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2740,7 +2822,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // First, answer the address question
     Request answerAddressQuestionRequest =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.updateWithApplicantId(
                             applicant.id,
                             program.id,
@@ -2781,7 +2864,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // Then, choose the original address during address correction
     Request confirmAddressRequest =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
                             applicant.id,
                             program.id,

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -6,7 +6,7 @@ import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -279,7 +279,8 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramReviewController.reviewWithApplicantId(
                             applicantId, programId))
                     .header(skipUserProfile, shouldSkipUserProfile.toString()))
@@ -294,7 +295,8 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         addCSRFToken(
-                requestBuilderWithSettings(
+                fakeRequestBuilder()
+                    .call(
                         routes.ApplicantProgramReviewController.submitWithApplicantId(
                             applicantId, programId))
                     .header(skipUserProfile, shouldSkipUserProfile.toString()))
@@ -307,7 +309,8 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
   private void answer(long programId) {
     Request request =
-        requestBuilderWithSettings(
+        fakeRequestBuilder()
+            .call(
                 routes.ApplicantProgramBlocksController.updateWithApplicantId(
                     applicant.id,
                     programId,

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -10,7 +10,7 @@ import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import controllers.WithMockedProfiles;
@@ -55,7 +55,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_differentApplicant_redirectsToHome() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .indexWithApplicantId(request, currentApplicant.id + 1)
@@ -67,7 +67,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_applicantWithoutProfile_redirectsToHome() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .indexWithApplicantId(request, applicantWithoutProfile.id)
@@ -79,7 +79,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_withNoPrograms_returnsEmptyResult() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -95,7 +95,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     resourceCreator().insertActiveProgram("two");
     resourceCreator().insertDraftProgram("three");
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -126,7 +126,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     resourceCreator().insertDraftProgram(programName);
     this.versionRepository.publishNewSynchronizedVersion();
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -152,7 +152,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_withProgram_includesApplyButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -165,7 +165,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_withCommonIntakeform_includesStartHereButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveCommonIntakeForm("benefits");
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -178,7 +178,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_usesMessagesForUserPreferredLocale() {
     // Set the PLAY_LANG cookie
     Http.Request request =
-        addCSRFToken(requestBuilderWithSettings())
+        addCSRFToken(fakeRequestBuilder())
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .build();
 
@@ -196,7 +196,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     // Set the PLAY_LANG cookie
     Http.Request request =
-        addCSRFToken(requestBuilderWithSettings())
+        addCSRFToken(fakeRequestBuilder())
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .build();
 
@@ -212,7 +212,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void showWithApplicantId_includesApplyButton() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .showWithApplicantId(request, currentApplicant.id, program.id)
@@ -228,7 +228,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void showWithApplicantId_invalidProgram_returnsBadRequest() {
     Result result =
         controller
-            .showWithApplicantId(requestBuilderWithSettings().build(), currentApplicant.id, 9999)
+            .showWithApplicantId(fakeRequest(), currentApplicant.id, 9999)
             .toCompletableFuture()
             .join();
 
@@ -246,7 +246,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     currentApplicant.getApplicantData().setPreferredLocale(Locale.US);
     currentApplicant.save();
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
 
     String alphaNumProgramParam = program.getSlug();
     Result result = controller.show(request, alphaNumProgramParam).toCompletableFuture().join();
@@ -262,7 +262,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     Map<String, String> flashData = new HashMap<>();
     flashData.put("redirected-from-program-slug", "disabledProgram");
-    Request request = addCSRFToken(requestBuilderWithSettings()).flash(flashData).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).flash(flashData).build();
 
     Result result =
         controller.showInfoDisabledProgram(request, "disabledProgram").toCompletableFuture().join();
@@ -271,7 +271,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void edit_differentApplicant_redirectsToHome() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id + 1, 1L)
@@ -283,7 +283,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void edit_applicantWithoutProfile_redirectsToHome() {
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, applicantWithoutProfile.id, 1L)
@@ -296,7 +296,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_applicantAccessToDraftProgram_redirectsToHome() {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, draftProgram.id)
@@ -312,7 +312,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     long adminApplicantId = adminAccount.newestApplicant().orElseThrow().id;
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, adminApplicantId, draftProgram.id)
@@ -326,7 +326,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_invalidProgram_returnsBadRequest() {
     Result result =
         controller
-            .editWithApplicantId(requestBuilderWithSettings().build(), currentApplicant.id, 9999L)
+            .editWithApplicantId(fakeRequest(), currentApplicant.id, 9999L)
             .toCompletableFuture()
             .join();
 
@@ -336,7 +336,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_applicantAccessToObsoleteProgram_isOk() {
     ProgramModel obsoleteProgram = ProgramBuilder.newObsoleteProgram("name").build();
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, obsoleteProgram.id)
@@ -354,7 +354,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)
@@ -387,7 +387,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     QuestionAnswerer.addMetadata(currentApplicant.getApplicantData(), colorPath, 456L, 12345L);
     currentApplicant.save();
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)
@@ -408,7 +408,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_whenNoMoreIncompleteBlocks_redirectsToListOfPrograms() {
     ProgramModel program = resourceCreator().insertActiveProgram("My Program");
 
-    Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
@@ -90,9 +91,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(
-                        requestBuilderWithSettings()
-                            .session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
+                addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
                     .build(),
                 programDefinition.slug())
             .toCompletableFuture()
@@ -113,9 +112,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(
-                        requestBuilderWithSettings()
-                            .session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
+                addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
                     .build(),
                 "non-existing-program-slug")
             .toCompletableFuture()
@@ -136,9 +133,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     Result result =
         handler
             .showProgram(
-                controller,
-                addCSRFToken(requestBuilderWithSettings()).build(),
-                programDefinition.slug())
+                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -177,9 +172,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     Result result =
         handler
             .showProgram(
-                controller,
-                addCSRFToken(requestBuilderWithSettings()).build(),
-                programDefinition.slug())
+                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())
@@ -217,9 +210,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     Result result =
         handler
             .showProgram(
-                controller,
-                addCSRFToken(requestBuilderWithSettings()).build(),
-                programDefinition.slug())
+                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -4,7 +4,6 @@ import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
-import static support.CfTestHelpers.requestBuilderWithSettings;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
@@ -62,7 +61,9 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(requestBuilderWithSettings("FASTFORWARD_ENABLED", "false")).build(),
+                addCSRFToken(
+                        fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "false"))
+                    .build(),
                 programDefinition.slug())
             .toCompletableFuture()
             .join();

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -6,7 +6,7 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileFactory;
 import controllers.WithMockedProfiles;
@@ -50,7 +50,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(requestBuilderWithSettings()).build(),
+                addCSRFToken(fakeRequestBuilder()).build(),
                 applicant.id,
                 programDefinition.id(),
                 application.id,
@@ -106,7 +106,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(requestBuilderWithSettings()).build(),
+                addCSRFToken(fakeRequestBuilder()).build(),
                 applicant.id,
                 commonIntakeForm.id(),
                 application.id,
@@ -164,7 +164,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(requestBuilderWithSettings()).build(),
+                addCSRFToken(fakeRequestBuilder()).build(),
                 applicant.id,
                 commonIntakeForm.id(),
                 application.id,
@@ -189,8 +189,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(
-                  addCSRFToken(requestBuilderWithSettings()).build(), application.id, applicant.id)
+              .download(addCSRFToken(fakeRequestBuilder()).build(), application.id, applicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -215,9 +214,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
       result =
           instanceOf(UpsellController.class)
               .download(
-                  addCSRFToken(requestBuilderWithSettings()).build(),
-                  application.id,
-                  managedApplicant.id)
+                  addCSRFToken(fakeRequestBuilder()).build(), application.id, managedApplicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -243,9 +240,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
       result =
           instanceOf(UpsellController.class)
               .download(
-                  addCSRFToken(requestBuilderWithSettings()).build(),
-                  application.id,
-                  unmanagedApplicant.id)
+                  addCSRFToken(fakeRequestBuilder()).build(), application.id, unmanagedApplicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -266,7 +261,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(addCSRFToken(requestBuilderWithSettings()).build(), application.id, 0)
+              .download(addCSRFToken(fakeRequestBuilder()).build(), application.id, 0)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -286,7 +281,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(addCSRFToken(requestBuilderWithSettings()).build(), 0, applicant.id)
+              .download(addCSRFToken(fakeRequestBuilder()).build(), 0, applicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -3,7 +3,7 @@ package controllers.dev;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
@@ -28,7 +28,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
   @Test
   public void disable_nonDevMode_fails() {
     // Execute
-    var result = controller.disable(requestBuilderWithSettings().build(), FLAG_NAME);
+    var result = controller.disable(fakeRequest(), FLAG_NAME);
 
     // Verify
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -43,7 +43,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
             new DeploymentType(/* isDev= */ true, /* isStaging= */ true));
 
     // Execute
-    var result = controller.disable(requestBuilderWithSettings().build(), FLAG_NAME);
+    var result = controller.disable(fakeRequest(), FLAG_NAME);
 
     // Verify
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -53,7 +53,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
   @Test
   public void enable_nonDevMode_fails() {
     // Execute
-    var result = controller.enable(requestBuilderWithSettings().build(), FLAG_NAME);
+    var result = controller.enable(fakeRequest(), FLAG_NAME);
 
     // Verify
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -68,7 +68,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
             new DeploymentType(/* isDev= */ true, /* isStaging= */ true));
 
     // Execute
-    var result = controller.enable(requestBuilderWithSettings().build(), FLAG_NAME);
+    var result = controller.enable(fakeRequest(), FLAG_NAME);
 
     // Verify
     assertThat(result.status()).isEqualTo(SEE_OTHER);

--- a/server/test/controllers/dev/ProfileControllerTest.java
+++ b/server/test/controllers/dev/ProfileControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static support.CfTestHelpers.requestBuilderWithSettings;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import controllers.WithMockedProfiles;
 import models.ApplicantModel;
@@ -27,7 +27,7 @@ public class ProfileControllerTest extends WithMockedProfiles {
   @Test
   public void testIndexWithNoProfile() {
     Http.Request request =
-        addCSRFToken(requestBuilderWithSettings().header(skipUserProfile, "true")).build();
+        addCSRFToken(fakeRequestBuilder().header(skipUserProfile, "true")).build();
     Result result = controller.index(request);
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).isEqualTo("No profile present");
@@ -36,7 +36,7 @@ public class ProfileControllerTest extends WithMockedProfiles {
   @Test
   public void testIndexWithProfile() {
     Http.Request request =
-        addCSRFToken(requestBuilderWithSettings().header(skipUserProfile, "false")).build();
+        addCSRFToken(fakeRequestBuilder().header(skipUserProfile, "false")).build();
     Result result = controller.index(request);
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -6,7 +6,6 @@ import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
-import static support.CfTestHelpers.requestBuilderWithSettings;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileFactory;
@@ -213,7 +212,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   @Test
   public void testShowEditClientFormCall() {
     AccountModel account = setupForEditClient("test33@test.com");
-    Http.Request request = addCSRFToken(requestBuilderWithSettings()).build();
+    Http.Request request = addCSRFToken(fakeRequestBuilder()).build();
     Result result = tiController.showEditClientForm(account.id, request);
     assertThat(result.status()).isEqualTo(OK);
   }

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3,8 +3,8 @@ package services.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static support.CfTestHelpers.requestBuilderWithSettings;
 import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
@@ -1747,7 +1747,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   private Request createRequestWithFastForwardDisabled() {
-    return requestBuilderWithSettings("FASTFORWARD_ENABLED", "false").build();
+    return fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "false").build();
   }
 
   @Test

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -103,11 +103,7 @@ public class CfTestHelpers {
     return CfTestHelpers.requestBuilderWithSettings(fakeRequestBuilder().call(call), settings);
   }
 
-  public static Http.RequestBuilder requestBuilderWithSettings(String... settings) {
-    return CfTestHelpers.requestBuilderWithSettings(fakeRequestBuilder(), settings);
-  }
-
-  public static Http.RequestBuilder requestBuilderWithSettings(
+  private static Http.RequestBuilder requestBuilderWithSettings(
       Http.RequestBuilder requestBuilder, String... settings) {
     if (settings.length % 2 != 0) {
       throw new IllegalArgumentException(

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -2,7 +2,6 @@ package support;
 
 import static org.mockito.Mockito.mockStatic;
 import static play.test.Helpers.route;
-import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Clock;
@@ -92,8 +91,6 @@ public class CfTestHelpers {
     LocalDate localDate = LocalDate.parse(rawDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     return PredicateValue.of(localDate);
   }
-
-  public static final Http.Request EMPTY_REQUEST = fakeRequest();
 
   /** Class to hold a Result as well as the final request URI after internal redirects. */
   public static class ResultWithFinalRequestUri {

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -2,9 +2,7 @@ package support;
 
 import static org.mockito.Mockito.mockStatic;
 import static play.test.Helpers.route;
-import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
 import static support.FakeRequestBuilder.fakeRequest;
-import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Clock;
@@ -12,14 +10,12 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import javax.inject.Provider;
 import org.mockito.MockedStatic;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import play.Application;
 import play.api.test.Helpers;
-import play.mvc.Call;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.AccountRepository;
@@ -98,28 +94,6 @@ public class CfTestHelpers {
   }
 
   public static final Http.Request EMPTY_REQUEST = fakeRequest();
-
-  public static Http.RequestBuilder requestBuilderWithSettings(Call call, String... settings) {
-    return CfTestHelpers.requestBuilderWithSettings(fakeRequestBuilder().call(call), settings);
-  }
-
-  private static Http.RequestBuilder requestBuilderWithSettings(
-      Http.RequestBuilder requestBuilder, String... settings) {
-    if (settings.length % 2 != 0) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Odd number of args specified for settings map, must be key-value pairs: %s",
-              Arrays.toString(settings)));
-    }
-
-    ImmutableMap.Builder<String, String> settingsMap = ImmutableMap.builder();
-
-    for (int i = 0; i < settings.length; i += 2) {
-      settingsMap.put(settings[i], settings[i + 1]);
-    }
-
-    return requestBuilder.attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settingsMap.build());
-  }
 
   /** Class to hold a Result as well as the final request URI after internal redirects. */
   public static class ResultWithFinalRequestUri {

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -1,8 +1,10 @@
 package support;
 
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
 
 import auth.ClientIpResolver;
+import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -14,6 +16,7 @@ import play.mvc.Http.RequestImpl;
 
 public final class FakeRequestBuilder extends RequestBuilder {
   private List<String> xForwardedFor = new ArrayList<>();
+  private ImmutableMap.Builder<String, String> settingsMap = ImmutableMap.builder();
 
   public static Request fakeRequest() {
     return new FakeRequestBuilder().build();
@@ -30,6 +33,12 @@ public final class FakeRequestBuilder extends RequestBuilder {
   public FakeRequestBuilder call(Call call) {
     method(call.method());
     uri(call.url());
+    return this;
+  }
+
+  /** Add an entry in the CiviForm settings map. Can be called multiple times. */
+  public FakeRequestBuilder addCiviFormSetting(String key, String value) {
+    settingsMap.put(key, value);
     return this;
   }
 
@@ -53,6 +62,7 @@ public final class FakeRequestBuilder extends RequestBuilder {
       // values and set them once at the end
       header(ClientIpResolver.X_FORWARDED_FOR, xForwardedFor);
     }
+    attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settingsMap.build());
     return super.build();
   }
 }

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -62,7 +62,10 @@ public final class FakeRequestBuilder extends RequestBuilder {
       // values and set them once at the end
       header(ClientIpResolver.X_FORWARDED_FOR, xForwardedFor);
     }
-    attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settingsMap.build());
+    ImmutableMap<String, String> settings = settingsMap.build();
+    if (!settings.isEmpty()) {
+      attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settings);
+    }
     return super.build();
   }
 }

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -2,7 +2,7 @@ package views;
 
 import static j2html.TagCreator.link;
 import static org.assertj.core.api.Assertions.assertThat;
-import static support.CfTestHelpers.EMPTY_REQUEST;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.ConfigFactory;
@@ -41,7 +41,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
   @Test
   public void addsDefaultContent() {
-    HtmlBundle bundle = layout.getBundle(EMPTY_REQUEST);
+    HtmlBundle bundle = layout.getBundle(fakeRequest());
     Content content = layout.render(bundle);
 
     assertThat(content.body()).contains("<!DOCTYPE html><html lang=\"en\">");
@@ -68,7 +68,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
             new SettingsManifest(ConfigFactory.parseMap(config)),
             instanceOf(DeploymentType.class),
             instanceOf(AssetsFinder.class));
-    HtmlBundle bundle = layout.getBundle(EMPTY_REQUEST);
+    HtmlBundle bundle = layout.getBundle(fakeRequest());
     Content content = layout.render(bundle);
 
     assertThat(content.body())
@@ -79,7 +79,7 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
   @Test
   public void canAddContentBefore() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, instanceOf(ViewUtils.class));
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), instanceOf(ViewUtils.class));
 
     // Add stylesheet before default.
     LinkTag linkTag = link().withHref("moose.css").withRel("stylesheet");
@@ -99,14 +99,14 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
 
   @Test
   public void withNoExplicitTitle() {
-    Content content = layout.render(layout.getBundle(EMPTY_REQUEST));
+    Content content = layout.render(layout.getBundle(fakeRequest()));
 
     assertThat(content.body()).contains("<title>CiviForm</title>");
   }
 
   @Test
   public void withProvidedTitle() {
-    Content content = layout.render(layout.getBundle(EMPTY_REQUEST).setTitle("A title"));
+    Content content = layout.render(layout.getBundle(fakeRequest()).setTitle("A title"));
 
     assertThat(content.body()).contains("<title>A title — CiviForm</title>");
   }

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -2,7 +2,7 @@ package views;
 
 import static j2html.TagCreator.div;
 import static org.assertj.core.api.Assertions.assertThat;
-import static support.CfTestHelpers.EMPTY_REQUEST;
+import static support.FakeRequestBuilder.fakeRequest;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +20,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testSetTitle() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, viewUtils);
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), viewUtils);
     bundle.setTitle("My title").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
@@ -29,7 +29,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testFavicon() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, viewUtils);
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), viewUtils);
     bundle.setFavicon("www.civiform.com/favicon").setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();
@@ -38,7 +38,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void testNoFavicon() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, viewUtils);
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), viewUtils);
 
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
@@ -47,7 +47,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void emptyBundleRendersOutline() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, viewUtils);
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), viewUtils);
 
     bundle.setJsBundle(JsBundle.APPLICANT);
     Content content = bundle.render();
@@ -64,7 +64,7 @@ public class HtmlBundleTest extends ResetPostgres {
 
   @Test
   public void rendersContentInOrder() {
-    HtmlBundle bundle = new HtmlBundle(EMPTY_REQUEST, viewUtils);
+    HtmlBundle bundle = new HtmlBundle(fakeRequest(), viewUtils);
     bundle.addMainContent(div("One")).addMainContent(div("Two")).setJsBundle(JsBundle.APPLICANT);
 
     Content content = bundle.render();


### PR DESCRIPTION
### Description

Replace the CfTestHelpers.requestBuilderWithSettings helper methods with FakeRequestBuilder.

* Replace CfTestHelpers.requestBuilderWithSettings().build() with FakeRequestBuilder.fakeRequest()
* Replace CfTestHelpers.requestBuilderWithSettings() with FakeRequestBuilder.fakeRequestBuilder()
* Replace CfTestHelpers.requestBuilderWithSettings(String... settings) with FakeRequestBuilder.fakeRequest().addCiviFormSetting(key, value)
* Replace CfTestHelpers.requestBuilderWithSettings(Call call) with FakeRequestBuilder.fakeRequest().call(call)
* Inline CfTestHelpers.EMPTY_REQUEST because it's not really an empty request and it's equivalent to fakeRequest() which is used most places.
* Remove the helpers from CfTestHelpers

This supports #8046.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)