### PR TITLE
Remove redundant calls to addCSRFToken

### DIFF
--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -186,18 +185,17 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "sendEmail",
-                            "",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT,
-                            "newStatus",
-                            "NOT A REAL STATUS")))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    "sendEmail",
+                    "",
+                    "currentStatus",
+                    UNSET_STATUS_TEXT,
+                    "newStatus",
+                    "NOT A REAL STATUS"))
             .build();
 
     // Execute
@@ -219,18 +217,17 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "sendEmail",
-                            "",
-                            "currentStatus",
-                            "unset shouldn't have a value",
-                            "newStatus",
-                            APPROVED_STATUS.statusText())))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    "sendEmail",
+                    "",
+                    "currentStatus",
+                    "unset shouldn't have a value",
+                    "newStatus",
+                    APPROVED_STATUS.statusText()))
             .build();
 
     // Execute
@@ -254,16 +251,9 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "sendEmail",
-                            "",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT)))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of("redirectUri", "/", "sendEmail", "", "currentStatus", UNSET_STATUS_TEXT))
             .build();
 
     // Execute
@@ -287,16 +277,10 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "sendEmail",
-                            "",
-                            "newStatus",
-                            APPROVED_STATUS.statusText())))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri", "/", "sendEmail", "", "newStatus", APPROVED_STATUS.statusText()))
             .build();
 
     // Execute
@@ -320,19 +304,18 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT,
-                            "newStatus",
-                            APPROVED_STATUS.statusText(),
-                            // Only "on" is a valid checkbox state.
-                            "sendEmail",
-                            "false")))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    "currentStatus",
+                    UNSET_STATUS_TEXT,
+                    "newStatus",
+                    APPROVED_STATUS.statusText(),
+                    // Only "on" is a valid checkbox state.
+                    "sendEmail",
+                    "false"))
             .build();
 
     // Execute
@@ -364,18 +347,17 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         adminAccount);
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "sendEmail",
-                            "",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT,
-                            "newStatus",
-                            APPROVED_STATUS.statusText())))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    "sendEmail",
+                    "",
+                    "currentStatus",
+                    UNSET_STATUS_TEXT,
+                    "newStatus",
+                    APPROVED_STATUS.statusText()))
             .build();
 
     // Execute
@@ -403,18 +385,17 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT,
-                            "newStatus",
-                            APPROVED_STATUS.statusText(),
-                            "sendEmail",
-                            "on")))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    "currentStatus",
+                    UNSET_STATUS_TEXT,
+                    "newStatus",
+                    APPROVED_STATUS.statusText(),
+                    "sendEmail",
+                    "on"))
             .build();
 
     // Execute
@@ -448,19 +429,18 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .bodyForm(
-                        Map.of(
-                            "redirectUri",
-                            "/",
-                            // Only "on" is a valid checkbox state.
-                            "sendEmail",
-                            "",
-                            "currentStatus",
-                            UNSET_STATUS_TEXT,
-                            "newStatus",
-                            APPROVED_STATUS.statusText())))
+        fakeRequestBuilder()
+            .bodyForm(
+                Map.of(
+                    "redirectUri",
+                    "/",
+                    // Only "on" is a valid checkbox state.
+                    "sendEmail",
+                    "",
+                    "currentStatus",
+                    UNSET_STATUS_TEXT,
+                    "newStatus",
+                    APPROVED_STATUS.statusText()))
             .build();
 
     // Execute
@@ -528,8 +508,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
-            .build();
+        fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)).build();
 
     // Execute.
     Result result = controller.updateNote(request, program.id, application.id);
@@ -558,8 +537,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
         ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
 
     Request request =
-        addCSRFToken(fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)))
-            .build();
+        fakeRequestBuilder().bodyForm(Map.of("redirectUri", "/", "note", noteText)).build();
 
     // Execute.
     Result result = controller.updateNote(request, program.id, application.id);

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -100,10 +99,9 @@ public class AdminExportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxExportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programId", String.valueOf(Long.MAX_VALUE))))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programId", String.valueOf(Long.MAX_VALUE)))
                 .build());
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
@@ -117,10 +115,9 @@ public class AdminExportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxExportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programId", String.valueOf(activeProgram.id))))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programId", String.valueOf(activeProgram.id)))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);
@@ -135,10 +132,9 @@ public class AdminExportControllerTest extends ResetPostgres {
 
     Result result =
         controller.downloadJson(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programJson", String.valueOf(""))))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programJson", String.valueOf("")))
                 .build(),
             adminName);
 

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -101,10 +100,9 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxImportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programJson", "{\"adminName : \"admin-name\"}")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programJson", "{\"adminName : \"admin-name\"}"))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);
@@ -118,14 +116,13 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxImportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(
-                            ImmutableMap.of(
-                                "programJson",
-                                "{ \"id\" : 32, \"adminName\" : \"admin-name\","
-                                    + " \"adminDescription\" : \"description\"}")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(
+                    ImmutableMap.of(
+                        "programJson",
+                        "{ \"id\" : 32, \"adminName\" : \"admin-name\","
+                            + " \"adminDescription\" : \"description\"}"))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);
@@ -140,14 +137,13 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxImportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(
-                            ImmutableMap.of(
-                                "programJson",
-                                "{ \"program\": { \"adminName\" : \"admin-name\","
-                                    + " \"adminDescription\" : \"description\"}}")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(
+                    ImmutableMap.of(
+                        "programJson",
+                        "{ \"program\": { \"adminName\" : \"admin-name\","
+                            + " \"adminDescription\" : \"description\"}}"))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);
@@ -161,10 +157,9 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     Result result =
         controller.hxImportProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON)))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);
@@ -179,10 +174,9 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     Result result =
         controller.saveProgram(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON)))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programJson", EXAMPLE_PROGRAM_JSON))
                 .build());
 
     assertThat(result.status()).isEqualTo(OK);

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -119,7 +118,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
   @Test
   public void show_withNoneActiveProgram_throwsNotViewableException() throws Exception {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     ProgramModel program = ProgramBuilder.newDraftProgram("test program").build();
 
     assertThatThrownBy(() -> controller.show(request, program.id, /* blockId= */ 1L))
@@ -153,7 +152,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.show(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -196,7 +195,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
     QuestionModel applicantName = testQuestionBank.applicantName();
     applicantName.save();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -218,7 +217,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .build();
 
     questionService.update(otherQuestionDef);
-    request = addCSRFToken(fakeRequestBuilder()).build();
+    request = fakeRequestBuilder().build();
     result = controller.edit(request, program.id, /* blockId= */ 1L);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -275,7 +274,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
 
     Result redirectResult =
         controller.edit(
-            addCSRFToken(fakeRequestBuilder()).build(),
+            fakeRequestBuilder().build(),
             program.id(),
             program.getBlockDefinitionByIndex(/* blockIndex= */ 0).get().id());
     assertThat(contentAsString(redirectResult)).contains("updated name");

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -3,7 +3,6 @@ package controllers.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -78,7 +77,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newDraftProgram("one").build();
     ProgramBuilder.newDraftProgram("two").build();
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.index(request);
 
     assertThat(result.status()).isEqualTo(OK);
@@ -88,7 +87,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void newOne_returnsExpectedForm() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().addCSRFToken().build();
 
     Result result = controller.newOne(request);
 
@@ -99,9 +98,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void create_returnsFormWithErrorMessage() {
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder().bodyForm(ImmutableMap.of("name", "", "description", ""));
-    Request request = addCSRFToken(requestBuilder).build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .bodyForm(ImmutableMap.of("name", "", "description", ""))
+            .build();
 
     Result result = controller.create(request);
 
@@ -114,26 +115,25 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_showsNewProgramInList() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue())));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue()));
 
     controller.create(requestBuilder.build());
 
-    Result programDashboardResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result programDashboardResult = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(programDashboardResult)).contains("External program name");
     assertThat(contentAsString(programDashboardResult)).contains("External program description");
   }
@@ -141,22 +141,21 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_redirectsToProgramImage() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue())));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue()));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -177,24 +176,23 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_returnsNewProgramWithAcls() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-with-acls",
-                        "adminDescription",
-                        "Internal program description with acls",
-                        "localizedDisplayName",
-                        "External program name with acls",
-                        "localizedDisplayDescription",
-                        "External program description with acls",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.SELECT_TI.getValue(),
-                        "tiGroups[]",
-                        "1")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-with-acls",
+                    "adminDescription",
+                    "Internal program description with acls",
+                    "localizedDisplayName",
+                    "External program name with acls",
+                    "localizedDisplayDescription",
+                    "External program description with acls",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.SELECT_TI.getValue(),
+                    "tiGroups[]",
+                    "1"));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -214,7 +212,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(newProgram.get().getProgramDefinition().acls().getTiProgramViewAcls())
         .containsExactly(1L);
 
-    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result programDashboard = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(programDashboard)).contains("External program name with acls");
     assertThat(contentAsString(programDashboard))
         .contains("External program description with acls");
@@ -223,24 +221,23 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_eligibilityIsGating_false() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "eligibilityIsGating",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "eligibilityIsGating",
+                    "false"));
 
     controller.create(requestBuilder.build());
 
@@ -259,24 +256,23 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_eligibilityIsGating_true() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "eligibilityIsGating",
-                        "true")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "eligibilityIsGating",
+                    "true"));
 
     controller.create(requestBuilder.build());
 
@@ -296,22 +292,21 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newActiveProgram("Existing One").build();
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue())));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue()));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -328,7 +323,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
             routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
                 .url());
 
-    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result programDashboard = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(programDashboard)).contains("Existing One");
     assertThat(contentAsString(programDashboard)).contains("External program name");
     assertThat(contentAsString(programDashboard)).contains("External program description");
@@ -338,26 +333,25 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -370,26 +364,25 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_promptsUserToConfirmCommonIntakeChange() {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -400,26 +393,25 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        "internal-program-name",
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        "External program name",
-                        "localizedDisplayDescription",
-                        "External program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -436,7 +428,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
             routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
                 .url());
 
-    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result programDashboard = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(programDashboard)).contains("External program name");
     assertThat(contentAsString(programDashboard)).contains("External program description");
   }
@@ -449,28 +441,27 @@ public class AdminProgramControllerTest extends ResetPostgres {
     String programName = "External program name";
     String programDescription = "External program description";
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminName",
-                        adminName,
-                        "adminDescription",
-                        "Internal program description",
-                        "localizedDisplayName",
-                        programName,
-                        "localizedDisplayDescription",
-                        programDescription,
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "true",
-                        "tiGroups[]",
-                        "1")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    adminName,
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    programName,
+                    "localizedDisplayDescription",
+                    programDescription,
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "true",
+                    "tiGroups[]",
+                    "1"));
 
     controller.create(requestBuilder.build());
 
@@ -480,7 +471,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(newProgram).isPresent();
     assertThat(newProgram.get().getProgramDefinition().isCommonIntakeForm()).isTrue();
 
-    Result programDashboard = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result programDashboard = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(programDashboard)).contains(programName);
     assertThat(contentAsString(programDashboard)).contains(programDescription);
   }
@@ -495,7 +486,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsExpectedForm() throws Exception {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().addCSRFToken().build();
     ProgramModel program = ProgramBuilder.newDraftProgram("test program").build();
 
     Result result = controller.edit(request, program.id, ProgramEditStatus.EDIT.name());
@@ -509,7 +500,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withNonDraftProgram_throwsNotChangeableException() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     ProgramModel program = ProgramBuilder.newActiveProgram("test program").build();
 
     assertThatThrownBy(() -> controller.edit(request, program.id, ProgramEditStatus.EDIT.name()))
@@ -520,7 +511,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void newVersionFrom_onlyActive_editActiveReturnsNewDraft() {
     // When there's a draft, editing the active one instead edits the existing draft.
     String programName = "test program";
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram(programName, "active description").build();
 
@@ -545,7 +536,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void newVersionFrom_withDraft_editActiveReturnsDraft() {
     // When there's a draft, editing the active one instead edits the existing draft.
     String programName = "test program";
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram(programName, "active description").build();
     ProgramModel draftProgram =
@@ -595,7 +586,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_invalidInput_returnsFormWithErrors() throws Exception {
     ProgramModel program = ProgramBuilder.newDraftProgram("Existing One").build();
     Request request =
-        addCSRFToken(fakeRequestBuilder())
+        fakeRequestBuilder()
+            .addCSRFToken()
             .bodyForm(ImmutableMap.of("name", "", "description", ""))
             .build();
 
@@ -628,10 +620,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
                     "true",
                     "tiGroups[]",
                     "1"));
-    controller.update(
-        addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+    controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
-    Result indexResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result indexResult = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(indexResult))
         .contains(
             "Create new program", "New external program name", "New external program description");
@@ -661,8 +652,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
                     "1"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
@@ -692,8 +682,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
                     "1"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.CREATION.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
@@ -726,9 +715,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            program.id,
-            ProgramEditStatus.CREATION_EDIT.name());
+            requestBuilder.build(), program.id, ProgramEditStatus.CREATION_EDIT.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
@@ -745,28 +732,26 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
 
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminDescription",
-                        "New internal program description",
-                        "localizedDisplayName",
-                        "",
-                        "localizedDisplayDescription",
-                        "New external program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    "",
+                    "localizedDisplayDescription",
+                    "New external program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -780,28 +765,26 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
 
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminDescription",
-                        "New internal program description",
-                        "localizedDisplayName",
-                        "New external program name",
-                        "localizedDisplayDescription",
-                        "New external program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    "New external program name",
+                    "localizedDisplayDescription",
+                    "New external program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("confirm-common-intake-change");
@@ -813,28 +796,26 @@ public class AdminProgramControllerTest extends ResetPostgres {
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
 
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminDescription",
-                        "New internal program description",
-                        "localizedDisplayName",
-                        "New external program name",
-                        "localizedDisplayDescription",
-                        "New external program description",
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "false")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    "New external program name",
+                    "localizedDisplayDescription",
+                    "New external program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "false"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     long programId =
@@ -847,7 +828,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
-    Result redirectResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result redirectResult = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(redirectResult)).contains("New external program name");
   }
 
@@ -860,28 +841,26 @@ public class AdminProgramControllerTest extends ResetPostgres {
     String newProgramName = "External program name";
     String newProgramDescription = "External program description";
     RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "adminDescription",
-                        "New internal program description",
-                        "localizedDisplayName",
-                        newProgramName,
-                        "localizedDisplayDescription",
-                        newProgramDescription,
-                        "externalLink",
-                        "https://external.program.link",
-                        "displayMode",
-                        DisplayMode.PUBLIC.getValue(),
-                        "isCommonIntakeForm",
-                        "true",
-                        "confirmedChangeCommonIntakeForm",
-                        "true")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    newProgramName,
+                    "localizedDisplayDescription",
+                    newProgramDescription,
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "isCommonIntakeForm",
+                    "true",
+                    "confirmedChangeCommonIntakeForm",
+                    "true"));
 
     Result result =
-        controller.update(
-            addCSRFToken(requestBuilder).build(), program.id, ProgramEditStatus.EDIT.name());
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     Optional<ProgramModel> newProgram =
@@ -891,7 +870,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.redirectLocation())
         .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());
 
-    Result redirectResult = controller.index(addCSRFToken(fakeRequestBuilder()).build());
+    Result redirectResult = controller.index(fakeRequestBuilder().build());
     assertThat(contentAsString(redirectResult)).contains(newProgramName);
     assertThat(contentAsString(redirectResult)).contains(newProgramDescription);
   }
@@ -917,8 +896,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
                     DisplayMode.PUBLIC.getValue(),
                     "eligibilityIsGating",
                     "false"));
-    Result result =
-        controller.update(addCSRFToken(request).build(), program.id, ProgramEditStatus.EDIT.name());
+    Result result = controller.update(request.build(), program.id, ProgramEditStatus.EDIT.name());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
@@ -932,8 +910,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void publishProgram() throws Exception {
     ProgramModel program = ProgramBuilder.newDraftProgram("one").build();
-    Result result =
-        controller.publishProgram(addCSRFToken(fakeRequestBuilder()).build(), program.id);
+    Result result = controller.publishProgram(fakeRequestBuilder().build(), program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
@@ -944,8 +921,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void publishProgram_nonDraftProgram_throwsException() throws Exception {
     ProgramModel program = ProgramBuilder.newActiveProgram("active").build();
-    assertThatThrownBy(
-            () -> controller.publishProgram(addCSRFToken(fakeRequestBuilder()).build(), program.id))
+    assertThatThrownBy(() -> controller.publishProgram(fakeRequestBuilder().build(), program.id))
         .isInstanceOf(NotChangeableException.class);
   }
 }

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -3,7 +3,6 @@ package controllers.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -62,7 +61,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.index(
-            addCSRFToken(fakeRequestBuilder().method("GET")).build(),
+            fakeRequestBuilder().method("GET").build(),
             program.id,
             ProgramEditStatus.CREATION.name());
 
@@ -77,7 +76,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequestBuilder().method("GET")).build(),
+                    fakeRequestBuilder().method("GET").build(),
                     program.id,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -88,7 +87,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.index(
-                    addCSRFToken(fakeRequestBuilder().method("GET")).build(),
+                    fakeRequestBuilder().method("GET").build(),
                     Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -104,7 +103,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.index(
-            addCSRFToken(fakeRequestBuilder().method("GET")).build(),
+            fakeRequestBuilder().method("GET").build(),
             program.id,
             ProgramEditStatus.CREATION.name());
 
@@ -119,7 +118,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateDescription(
-                    addCSRFToken(fakeRequestBuilder().method("POST")).build(),
+                    fakeRequestBuilder().method("POST").build(),
                     program.id,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -130,7 +129,7 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 controller.updateDescription(
-                    addCSRFToken(fakeRequestBuilder().method("POST")).build(),
+                    fakeRequestBuilder().method("POST").build(),
                     Long.MAX_VALUE,
                     ProgramEditStatus.CREATION.name()))
         .isInstanceOf(NotChangeableException.class);
@@ -143,10 +142,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description"))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -169,10 +167,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "second description")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "second description"))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -201,10 +198,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "new US description")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "new US description"))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -231,10 +227,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", ""))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -256,10 +251,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", ""))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -283,10 +277,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "    ")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "    "))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -309,10 +302,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "    ")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "    "))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -339,10 +331,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", ""))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -358,10 +349,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description"))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -380,10 +370,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", ""))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -403,10 +392,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", ""))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -422,10 +410,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateDescription(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description")))
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("summaryImageDescription", "fake description"))
                 .build(),
             program.id,
             ProgramEditStatus.EDIT.name());
@@ -442,10 +429,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newActiveProgram().build();
 
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey")))
+        fakeRequestBuilder()
+            .method("POST")
+            .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey"))
             .build();
 
     assertThatExceptionOfType(NotChangeableException.class)
@@ -456,10 +442,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   @Test
   public void updateFileKey_missingProgram_throws() {
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey")))
+        fakeRequestBuilder()
+            .method("POST")
+            .bodyForm(ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "fakeFileKey"))
             .build();
 
     assertThatExceptionOfType(NotChangeableException.class)
@@ -474,10 +459,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(createUriWithQueryString(ImmutableMap.of("key", "fakeFileKey"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(createUriWithQueryString(ImmutableMap.of("key", "fakeFileKey")))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -491,10 +475,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME)))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -508,12 +491,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(
-                        createUriWithQueryString(
-                            ImmutableMap.of("bucket", FAKE_BUCKET_NAME + "abc"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(createUriWithQueryString(ImmutableMap.of("bucket", FAKE_BUCKET_NAME + "abc")))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -527,13 +507,11 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(
-                        createUriWithQueryString(
-                            ImmutableMap.of(
-                                "bucket", FAKE_BUCKET_NAME, "key", "applicant-10/myFile"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(
+                createUriWithQueryString(
+                    ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", "applicant-10/myFile")))
             .build();
 
     assertThatExceptionOfType(IllegalArgumentException.class)
@@ -547,16 +525,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     controller.updateFileKey(
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(
-                        createUriWithQueryString(
-                            ImmutableMap.of(
-                                "bucket",
-                                FAKE_BUCKET_NAME,
-                                "key",
-                                "program-summary-image/program-15/myImage.png"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(
+                createUriWithQueryString(
+                    ImmutableMap.of(
+                        "bucket",
+                        FAKE_BUCKET_NAME,
+                        "key",
+                        "program-summary-image/program-15/myImage.png")))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -582,16 +559,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
 
     controller.updateFileKey(
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(
-                        createUriWithQueryString(
-                            ImmutableMap.of(
-                                "bucket",
-                                FAKE_BUCKET_NAME,
-                                "key",
-                                "program-summary-image/program-15/oldImage.png"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(
+                createUriWithQueryString(
+                    ImmutableMap.of(
+                        "bucket",
+                        FAKE_BUCKET_NAME,
+                        "key",
+                        "program-summary-image/program-15/oldImage.png")))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -603,16 +579,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     // WHEN the key is updated
     controller.updateFileKey(
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .method("POST")
-                    .uri(
-                        createUriWithQueryString(
-                            ImmutableMap.of(
-                                "bucket",
-                                FAKE_BUCKET_NAME,
-                                "key",
-                                "program-summary-image/program-15/newImage.png"))))
+        fakeRequestBuilder()
+            .method("POST")
+            .uri(
+                createUriWithQueryString(
+                    ImmutableMap.of(
+                        "bucket",
+                        FAKE_BUCKET_NAME,
+                        "key",
+                        "program-summary-image/program-15/newImage.png")))
             .build(),
         program.id,
         ProgramEditStatus.CREATION.name());
@@ -630,16 +605,15 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
 
     Result result =
         controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .uri(
-                            createUriWithQueryString(
-                                ImmutableMap.of(
-                                    "bucket",
-                                    FAKE_BUCKET_NAME,
-                                    "key",
-                                    "program-summary-image/program-15/newImage.png"))))
+            fakeRequestBuilder()
+                .method("POST")
+                .uri(
+                    createUriWithQueryString(
+                        ImmutableMap.of(
+                            "bucket",
+                            FAKE_BUCKET_NAME,
+                            "key",
+                            "program-summary-image/program-15/newImage.png")))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());
@@ -731,13 +705,11 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   private Result setValidFileKeyOnProgram(ProgramModel program) throws ProgramNotFoundException {
     Result result =
         controller.updateFileKey(
-            addCSRFToken(
-                    fakeRequestBuilder()
-                        .method("POST")
-                        .uri(
-                            createUriWithQueryString(
-                                ImmutableMap.of(
-                                    "bucket", FAKE_BUCKET_NAME, "key", VALID_FILE_KEY))))
+            fakeRequestBuilder()
+                .method("POST")
+                .uri(
+                    createUriWithQueryString(
+                        ImmutableMap.of("bucket", FAKE_BUCKET_NAME, "key", VALID_FILE_KEY)))
                 .build(),
             program.id,
             ProgramEditStatus.CREATION.name());

--- a/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -85,8 +84,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   public void index_ok_get() throws ProgramNotFoundException {
     ProgramModel program = ProgramBuilder.newDraftProgram("test name", "test description").build();
 
-    Result result =
-        controller.index(addCSRFToken(fakeRequestBuilder().method("GET")).build(), program.id);
+    Result result = controller.index(fakeRequestBuilder().method("GET").build(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("No statuses have been created yet");
@@ -107,8 +105,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
                             .build())))
             .build();
 
-    Result result =
-        controller.index(addCSRFToken(fakeRequestBuilder().method("GET")).build(), program.id);
+    Result result = controller.index(fakeRequestBuilder().method("GET").build(), program.id);
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Status with no email");
@@ -533,9 +530,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   @Parameters({"GET", "POST"})
   public void index_missingProgram(String httpMethod) {
     assertThatThrownBy(
-            () ->
-                controller.index(
-                    addCSRFToken(fakeRequestBuilder().method(httpMethod)).build(), Long.MAX_VALUE))
+            () -> controller.index(fakeRequestBuilder().method(httpMethod).build(), Long.MAX_VALUE))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -545,9 +540,7 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
     ProgramModel program = ProgramBuilder.newActiveProgram("test name", "test description").build();
 
     assertThatThrownBy(
-            () ->
-                controller.index(
-                    addCSRFToken(fakeRequestBuilder().method(httpMethod)).build(), program.id))
+            () -> controller.index(fakeRequestBuilder().method(httpMethod).build(), program.id))
         .isInstanceOf(NotChangeableException.class);
   }
 
@@ -626,12 +619,12 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   private Result makeCreateOrUpdateRequest(Long programId, ImmutableMap<String, String> formData)
       throws ProgramNotFoundException {
     return controller.createOrUpdate(
-        addCSRFToken(fakeRequestBuilder().method("POST").bodyForm(formData)).build(), programId);
+        fakeRequestBuilder().method("POST").bodyForm(formData).build(), programId);
   }
 
   private Result makeDeleteRequest(Long programId, ImmutableMap<String, String> formData)
       throws ProgramNotFoundException {
     return controller.delete(
-        addCSRFToken(fakeRequestBuilder().method("POST").bodyForm(formData)).build(), programId);
+        fakeRequestBuilder().method("POST").bodyForm(formData).build(), programId);
   }
 }

--- a/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramTranslationsControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -153,9 +152,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            program.getProgramDefinition().adminName(),
-            "es-US");
+            requestBuilder.build(), program.getProgramDefinition().adminName(), "es-US");
     assertThat(result.status()).isEqualTo(OK);
 
     ProgramDefinition updatedProgram =
@@ -236,9 +233,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            program.getProgramDefinition().adminName(),
-            "es-US");
+            requestBuilder.build(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
@@ -276,9 +271,7 @@ public class AdminProgramTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            program.getProgramDefinition().adminName(),
-            "es-US");
+            requestBuilder.build(), program.getProgramDefinition().adminName(), "es-US");
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation().orElse(""))

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -152,7 +151,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   public void create_failsWithErrorMessageAndPopulatedFields() {
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionName", "name");
-    Request request = addCSRFToken(fakeRequestBuilder().bodyForm(formData.build())).build();
+    Request request = fakeRequestBuilder().addCSRFToken().bodyForm(formData.build()).build();
 
     ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
     Result result = controller.create(request, "text");
@@ -180,7 +179,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_invalidIDReturnsBadRequest() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.edit(request, 9999L).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
@@ -195,7 +194,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     // sanity check that the new question has different id.
     assertThat(publishedQuestion.id).isNotEqualTo(draftQuestion.id);
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.edit(request, publishedQuestion.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -206,7 +205,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   @Test
   public void edit_returnsPopulatedForm() {
     QuestionModel question = testQuestionBank.applicantName();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().addCSRFToken().build();
     Result result = controller.edit(request, question.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Edit name question");
@@ -217,7 +216,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   @Test
   public void edit_repeatedQuestion_hasEnumeratorName() {
     QuestionModel repeatedQuestion = testQuestionBank.applicantHouseholdMemberName();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().addCSRFToken().build();
     Result result = controller.edit(request, repeatedQuestion.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Edit name question");
@@ -235,7 +234,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     QuestionDefinition updatedQuestion =
         new QuestionDefinitionBuilder(nameQuestion).clearId().build();
     testQuestionBank.maybeSave(updatedQuestion, LifecycleStage.DRAFT);
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.index(request).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
@@ -265,7 +264,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void index_withNoQuestions() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.index(request).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
@@ -276,7 +275,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void index_showsMessageFlash() {
-    Request request = addCSRFToken(fakeRequestBuilder().flash("success", "has message")).build();
+    Request request = fakeRequestBuilder().flash("success", "has message").build();
     Result result = controller.index(request).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
@@ -286,7 +285,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void newOne_returnsExpectedForm() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().addCSRFToken().build();
     Result result = controller.newOne(request, "text", "/some/redirect/url");
 
     assertThat(result.status()).isEqualTo(OK);
@@ -298,14 +297,14 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void newOne_returnsFailureForInvalidQuestionType() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result = controller.newOne(request, "nope", "/some/redirect/url");
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
   public void newOne_absoluteRedirectUrl_throws() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     assertThatThrownBy(() -> controller.newOne(request, "text", "https://www.example.com"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContainingAll("Invalid absolute URL.");
@@ -328,7 +327,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
         .put("questionText", "question text updated")
         .put("questionHelpText", "a new help text")
         .put("questionExportState", "DEMOGRAPHIC_PII");
-    RequestBuilder requestBuilder = addCSRFToken(fakeRequestBuilder().bodyForm(formData.build()));
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData.build());
 
     Result result =
         controller.update(
@@ -459,7 +458,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("questionExportState", "NON_DEMOGRAPHIC")
             // Has one fewer than the original question
             .build();
-    RequestBuilder requestBuilder = addCSRFToken(fakeRequestBuilder().bodyForm(formData));
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
 
     Result result =
         controller.update(
@@ -549,7 +548,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("nextAvailableId", "3")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             .build();
-    RequestBuilder requestBuilder = addCSRFToken(fakeRequestBuilder().bodyForm(formData));
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
     QuestionModel found =
@@ -616,7 +615,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("nextAvailableId", "3")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             .build();
-    RequestBuilder requestBuilder = addCSRFToken(fakeRequestBuilder().bodyForm(formData));
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
     QuestionModel found =
@@ -684,7 +683,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("newOptionAdminNames[0]", "lavender_admin")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             .build();
-    RequestBuilder requestBuilder = addCSRFToken(fakeRequestBuilder().bodyForm(formData));
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
 
     controller.update(requestBuilder.build(), question.id, definition.getQuestionType().toString());
     QuestionModel found =
@@ -714,7 +713,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
         .put("questionName", "favorite_color")
         .put("questionDescription", "")
         .put("questionText", "question text updated!");
-    Request request = addCSRFToken(fakeRequestBuilder().bodyForm(formData.build())).build();
+    Request request = fakeRequestBuilder().addCSRFToken().bodyForm(formData.build()).build();
 
     Result result = controller.update(request, question.id, "text");
 

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -105,9 +104,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            question.getQuestionDefinition().getName(),
-            "es-US");
+            requestBuilder.build(), question.getQuestionDefinition().getName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
 
@@ -139,9 +136,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            question.getQuestionDefinition().getName(),
-            "es-US");
+            requestBuilder.build(), question.getQuestionDefinition().getName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
 
@@ -175,9 +170,7 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
 
     Result result =
         controller.update(
-            addCSRFToken(requestBuilder).build(),
-            question.getQuestionDefinition().getName(),
-            "es-US");
+            requestBuilder.build(), question.getQuestionDefinition().getName(), "es-US");
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))

--- a/server/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.stubMessagesApi;
@@ -45,12 +44,9 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   @Test
   public void setLangFromBrowser_updatesLanguageCode_usingRequestHeaders() {
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantInformationController.setLangFromBrowser(
-                            currentApplicant.id))
-                    .header("Accept-Language", "es-US"))
+        fakeRequestBuilder()
+            .call(routes.ApplicantInformationController.setLangFromBrowser(currentApplicant.id))
+            .header("Accept-Language", "es-US")
             .build();
 
     Result result =
@@ -77,12 +73,9 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   @Test
   public void setLangFromSwitcher_redirectsToProgramIndex_withNonEnglishLocale() {
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantInformationController.setLangFromSwitcher(
-                            currentApplicant.id))
-                    .bodyForm(ImmutableMap.of("locale", "es-US")))
+        fakeRequestBuilder()
+            .call(routes.ApplicantInformationController.setLangFromSwitcher(currentApplicant.id))
+            .bodyForm(ImmutableMap.of("locale", "es-US"))
             .build();
 
     Result result =
@@ -99,12 +92,9 @@ public class ApplicantInformationControllerTest extends WithMockedProfiles {
   @Test
   public void setLangFromSwitcher_ignoresExistingLangCookie() {
     Http.Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantInformationController.setLangFromSwitcher(
-                            currentApplicant.id))
-                    .bodyForm(ImmutableMap.of("locale", "es-US")))
+        fakeRequestBuilder()
+            .call(routes.ApplicantInformationController.setLangFromSwitcher(currentApplicant.id))
+            .bodyForm(ImmutableMap.of("locale", "es-US"))
             .langCookie(Locale.US, stubMessagesApi())
             .build();
 

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -6,7 +6,6 @@ import static controllers.applicant.ApplicantRequestedAction.PREVIOUS_BLOCK;
 import static controllers.applicant.ApplicantRequestedAction.REVIEW_PAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -98,11 +97,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
     Result result =
         subject
@@ -125,11 +123,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
     Result result =
         subject
@@ -146,11 +143,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
     Result result =
         subject
@@ -169,14 +165,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void edit_toAProgramThatDoesNotExist_returns404() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id,
-                            program.id + 1000,
-                            "1",
-                            /* questionName= */ Optional.empty())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id + 1000, "1", /* questionName= */ Optional.empty()))
             .build();
 
     Result result =
@@ -192,11 +184,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void edit_toAnExistingBlock_rendersTheBlock() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id, program.id, "1", /* questionName= */ Optional.empty())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
             .build();
 
     Result result =
@@ -231,12 +222,11 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void edit_withMessages_returnsCorrectButtonText() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.editWithApplicantId(
-                            applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
-                    .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.editWithApplicantId(
+                    applicant.id, program.id, "1", /* questionName= */ Optional.empty()))
+            .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .build();
 
     Result result =
@@ -253,11 +243,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void previous_toAnExistingBlock_rendersTheBlock() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                            applicant.id, program.id, 0, true)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                    applicant.id, program.id, 0, true))
             .build();
 
     Result result =
@@ -278,11 +267,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                            applicant.id, draftProgram.id, 0, true)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                    applicant.id, draftProgram.id, 0, true))
             .build();
     Result result =
         subject
@@ -304,11 +292,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                            applicant.id, draftProgram.id, 0, true)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                    applicant.id, draftProgram.id, 0, true))
             .build();
     Result result =
         subject
@@ -324,11 +311,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram = ProgramBuilder.newObsoleteProgram("program").build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.previousWithApplicantId(
-                            applicant.id, obsoleteProgram.id, 0, true)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.previousWithApplicantId(
+                    applicant.id, obsoleteProgram.id, 0, true))
             .build();
     Result result =
         subject
@@ -377,15 +363,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            draftProgram.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    draftProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .build();
     Result result =
         subject
@@ -413,15 +398,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            draftProgram.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    draftProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .build();
     Result result =
         subject
@@ -447,15 +431,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            obsoleteProgram.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    obsoleteProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .build();
     Result result =
         subject
@@ -592,25 +575,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_withValidationErrors_isOK() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "FirstName",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "FirstName",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -633,26 +611,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_withValidationErrors_requestedActionReview_staysOnBlockAndShowsErrors() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(
-                                ApplicantRequestedAction.REVIEW_PAGE)))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "FirstName",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(ApplicantRequestedAction.REVIEW_PAGE)))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "FirstName",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -675,26 +647,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void update_withValidationErrors_requestedActionPrevious_staysOnBlockAndShowsErrors() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(
-                                ApplicantRequestedAction.PREVIOUS_BLOCK)))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "FirstName",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(ApplicantRequestedAction.PREVIOUS_BLOCK)))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "FirstName",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -725,25 +691,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -777,25 +738,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "2",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -830,25 +786,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -880,25 +831,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withOptionalQuestion(testQuestionBank().applicantName())
             .build();
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     subject
@@ -932,25 +878,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
     Request requestWithAnswer =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "InitialFirstName",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "InitialLastName")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "InitialFirstName",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    "InitialLastName"))
             .build();
     subject
         .updateWithApplicantId(
@@ -965,25 +906,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // Then, try to delete the answer
     Request requestWithoutAnswer =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     Result result =
@@ -1017,25 +953,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withOptionalQuestion(testQuestionBank().applicantName())
             .build();
     Request requestWithAnswer =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "InitialFirstName",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "InitialLastName")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "InitialFirstName",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    "InitialLastName"))
             .build();
     subject
         .updateWithApplicantId(
@@ -1050,25 +981,20 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // Then, delete the answer
     Request requestWithoutAnswer =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            requestedAction))
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.FIRST_NAME)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_name")
-                                .join(Scalar.LAST_NAME)
-                                .toString(),
-                            "")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    requestedAction))
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
+                    "",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
+                    ""))
             .build();
 
     subject
@@ -1399,34 +1325,23 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
             .build();
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            "1",
-                            false,
-                            new ApplicantRequestedActionWrapper()))
-                    .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STREET)
-                                .toString(),
-                            "Address In Area",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.LINE2)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
-                            "Redlands",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STATE)
-                                .toString(),
-                            "CA",
-                            Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
-                            "92373")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id, program.id, "1", false, new ApplicantRequestedActionWrapper()))
+            .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_address").join(Scalar.STREET).toString(),
+                    "Address In Area",
+                    Path.create("applicant.applicant_address").join(Scalar.LINE2).toString(),
+                    "",
+                    Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
+                    "Redlands",
+                    Path.create("applicant.applicant_address").join(Scalar.STATE).toString(),
+                    "CA",
+                    Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
+                    "92373"))
             .build();
     Result result =
         subject
@@ -1533,15 +1448,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                            applicant.id,
-                            draftProgram.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(NEXT_BLOCK))))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    draftProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)))
             .build();
 
     Result result =
@@ -1570,15 +1484,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                        applicant.id,
-                        draftProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    draftProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -1606,15 +1519,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
-                        applicant.id,
-                        obsoleteProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false,
-                        new ApplicantRequestedActionWrapper(NEXT_BLOCK))));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateFileWithApplicantId(
+                    applicant.id,
+                    obsoleteProgram.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -1998,14 +1910,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                            applicant.id,
-                            draftProgram.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false))
             .build();
     Result result =
         subject
@@ -2028,11 +1936,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, draftProgram.id, /* blockId= */ "1", /* inReview= */ false));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -2059,14 +1966,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id,
-                        obsoleteProgram.id,
-                        /* blockId= */ "1",
-                        /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, obsoleteProgram.id, /* blockId= */ "1", /* inReview= */ false));
 
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
@@ -2180,11 +2083,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantAddress())
             .build();
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     Result result =
@@ -2214,11 +2116,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .build();
     RequestBuilder requestOne =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(requestOne, ImmutableMap.of("key", "keyOne", "bucket", "fake-bucket"));
 
     subject
@@ -2228,11 +2129,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         .join();
 
     RequestBuilder requestTwo =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(requestTwo, ImmutableMap.of("key", "keyTwo", "bucket", "fake-bucket"));
 
     subject
@@ -2265,11 +2165,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantFile())
             .build();
     RequestBuilder request =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .call(
-                    routes.ApplicantProgramBlocksController.addFileWithApplicantId(
-                        applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false)));
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.addFileWithApplicantId(
+                    applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
     addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
 
     var result =
@@ -2353,15 +2252,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2390,15 +2288,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2425,15 +2322,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
     Result result =
@@ -2456,15 +2352,14 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     long badProgramId = Long.MAX_VALUE;
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            badProgramId,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper())))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    badProgramId,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
             .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
 
@@ -2486,20 +2381,19 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   @Test
   public void confirmAddress_noAddressJson_throws() {
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    // Don't set the ADDRESS_JSON_SESSION_KEY on the session
-                    .bodyForm(
-                        ImmutableMap.of(
-                            AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
-                            "123 Main St, Boston, Massachusetts, 02111")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            // Don't set the ADDRESS_JSON_SESSION_KEY on the session
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
+                    "123 Main St, Boston, Massachusetts, 02111"))
             .build();
 
     assertThatThrownBy(
@@ -2529,34 +2423,27 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // First, answer the address question
     Request answerAddressQuestionRequest =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STREET)
-                                .toString(),
-                            "Legit Address",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.LINE2)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
-                            "Boston",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STATE)
-                                .toString(),
-                            "MA",
-                            Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
-                            "02111")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_address").join(Scalar.STREET).toString(),
+                    "Legit Address",
+                    Path.create("applicant.applicant_address").join(Scalar.LINE2).toString(),
+                    "",
+                    Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
+                    "Boston",
+                    Path.create("applicant.applicant_address").join(Scalar.STATE).toString(),
+                    "MA",
+                    Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
+                    "02111"))
             .build();
     Result result =
         subject
@@ -2575,16 +2462,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // Then, send a confirmAddress request but don't fill in SELECTED_ADDRESS_NAME in the form body
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson()))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .build();
 
     Result confirmAddressResult =
@@ -2657,18 +2543,16 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // one of the address
     // suggestions (set in the session with the key ADDRESS_JSON_SESSION_KEY).
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(NEXT_BLOCK)))
-                    .session(ADDRESS_JSON_SESSION_KEY, addressSuggestionString)
-                    .bodyForm(
-                        ImmutableMap.of(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, address)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(NEXT_BLOCK)))
+            .session(ADDRESS_JSON_SESSION_KEY, addressSuggestionString)
+            .bodyForm(ImmutableMap.of(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, address))
             .build();
     Result result =
         subject
@@ -2713,20 +2597,18 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(
-                                ApplicantRequestedAction.REVIEW_PAGE)))
-                    .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
-                    .bodyForm(
-                        ImmutableMap.of(
-                            AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(ApplicantRequestedAction.REVIEW_PAGE)))
+            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS))
             .build();
     Result result =
         subject
@@ -2766,20 +2648,18 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .build();
 
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "2",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper(
-                                ApplicantRequestedAction.PREVIOUS_BLOCK)))
-                    .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
-                    .bodyForm(
-                        ImmutableMap.of(
-                            AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "2",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper(ApplicantRequestedAction.PREVIOUS_BLOCK)))
+            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS))
             .build();
     Result result =
         subject
@@ -2821,34 +2701,27 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // First, answer the address question
     Request answerAddressQuestionRequest =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.updateWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
-                    .bodyForm(
-                        ImmutableMap.of(
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STREET)
-                                .toString(),
-                            "Legit Address",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.LINE2)
-                                .toString(),
-                            "",
-                            Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
-                            "Boston",
-                            Path.create("applicant.applicant_address")
-                                .join(Scalar.STATE)
-                                .toString(),
-                            "MA",
-                            Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
-                            "02111")))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.updateWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            .session("ESRI_ADDRESS_CORRECTION_ENABLED", "true")
+            .bodyForm(
+                ImmutableMap.of(
+                    Path.create("applicant.applicant_address").join(Scalar.STREET).toString(),
+                    "Legit Address",
+                    Path.create("applicant.applicant_address").join(Scalar.LINE2).toString(),
+                    "",
+                    Path.create("applicant.applicant_address").join(Scalar.CITY).toString(),
+                    "Boston",
+                    Path.create("applicant.applicant_address").join(Scalar.STATE).toString(),
+                    "MA",
+                    Path.create("applicant.applicant_address").join(Scalar.ZIP).toString(),
+                    "02111"))
             .build();
     subject
         .updateWithApplicantId(
@@ -2863,20 +2736,19 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     // Then, choose the original address during address correction
     Request confirmAddressRequest =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
-                            applicant.id,
-                            program.id,
-                            /* blockId= */ "1",
-                            /* inReview= */ false,
-                            new ApplicantRequestedActionWrapper()))
-                    .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
-                    .bodyForm(
-                        ImmutableMap.of(
-                            AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
-                            AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE)))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.confirmAddressWithApplicantId(
+                    applicant.id,
+                    program.id,
+                    /* blockId= */ "1",
+                    /* inReview= */ false,
+                    new ApplicantRequestedActionWrapper()))
+            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
+                    AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE))
             .build();
 
     Result confirmAddressResult =

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -413,12 +412,11 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   public Result review(long applicantId, long programId) {
     Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                            applicantId, programId))
-                    .header(skipUserProfile, shouldSkipUserProfile.toString()))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramReviewController.reviewWithApplicantId(
+                    applicantId, programId))
+            .header(skipUserProfile, shouldSkipUserProfile.toString())
             .build();
     return subject
         .reviewWithApplicantId(request, applicantId, programId)
@@ -429,12 +427,11 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   public Result submit(long applicantId, long programId) {
     Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
-        addCSRFToken(
-                fakeRequestBuilder()
-                    .call(
-                        routes.ApplicantProgramReviewController.submitWithApplicantId(
-                            applicantId, programId))
-                    .header(skipUserProfile, shouldSkipUserProfile.toString()))
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramReviewController.submitWithApplicantId(
+                    applicantId, programId))
+            .header(skipUserProfile, shouldSkipUserProfile.toString())
             .build();
     return subject
         .submitWithApplicantId(request, applicantId, programId)

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -2,7 +2,6 @@ package controllers.applicant;
 
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
@@ -55,7 +54,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_differentApplicant_redirectsToHome() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .indexWithApplicantId(request, currentApplicant.id + 1)
@@ -67,7 +66,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_applicantWithoutProfile_redirectsToHome() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .indexWithApplicantId(request, applicantWithoutProfile.id)
@@ -79,7 +78,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_withNoPrograms_returnsEmptyResult() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -95,7 +94,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     resourceCreator().insertActiveProgram("two");
     resourceCreator().insertDraftProgram("three");
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -107,8 +106,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_clearsRedirectToSessionKey() {
-    Request request =
-        addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect")).build();
+    Request request = fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect").build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
     assertThat(result.session().get(REDIRECT_TO_SESSION_KEY)).isEmpty();
@@ -126,7 +124,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     resourceCreator().insertDraftProgram(programName);
     this.versionRepository.publishNewSynchronizedVersion();
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -152,7 +150,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_withProgram_includesApplyButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -165,7 +163,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_withCommonIntakeform_includesStartHereButtonWithRedirect() {
     ProgramModel program = resourceCreator().insertActiveCommonIntakeForm("benefits");
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -178,9 +176,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void indexWithApplicantId_usesMessagesForUserPreferredLocale() {
     // Set the PLAY_LANG cookie
     Http.Request request =
-        addCSRFToken(fakeRequestBuilder())
-            .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
-            .build();
+        fakeRequestBuilder().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
@@ -196,9 +192,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     // Set the PLAY_LANG cookie
     Http.Request request =
-        addCSRFToken(fakeRequestBuilder())
-            .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
-            .build();
+        fakeRequestBuilder().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result =
         controller.indexWithApplicantId(request, currentApplicant.id).toCompletableFuture().join();
@@ -212,7 +206,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void showWithApplicantId_includesApplyButton() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .showWithApplicantId(request, currentApplicant.id, program.id)
@@ -246,7 +240,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     currentApplicant.getApplicantData().setPreferredLocale(Locale.US);
     currentApplicant.save();
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
 
     String alphaNumProgramParam = program.getSlug();
     Result result = controller.show(request, alphaNumProgramParam).toCompletableFuture().join();
@@ -262,7 +256,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
     Map<String, String> flashData = new HashMap<>();
     flashData.put("redirected-from-program-slug", "disabledProgram");
-    Request request = addCSRFToken(fakeRequestBuilder()).flash(flashData).build();
+    Request request = fakeRequestBuilder().flash(flashData).build();
 
     Result result =
         controller.showInfoDisabledProgram(request, "disabledProgram").toCompletableFuture().join();
@@ -271,7 +265,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void edit_differentApplicant_redirectsToHome() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id + 1, 1L)
@@ -283,7 +277,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void edit_applicantWithoutProfile_redirectsToHome() {
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, applicantWithoutProfile.id, 1L)
@@ -296,7 +290,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_applicantAccessToDraftProgram_redirectsToHome() {
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, draftProgram.id)
@@ -312,7 +306,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     long adminApplicantId = adminAccount.newestApplicant().orElseThrow().id;
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram().build();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, adminApplicantId, draftProgram.id)
@@ -336,7 +330,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_applicantAccessToObsoleteProgram_isOk() {
     ProgramModel obsoleteProgram = ProgramBuilder.newObsoleteProgram("name").build();
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, obsoleteProgram.id)
@@ -354,7 +348,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().applicantName())
             .build();
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)
@@ -387,7 +381,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     QuestionAnswerer.addMetadata(currentApplicant.getApplicantData(), colorPath, 456L, 12345L);
     currentApplicant.save();
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)
@@ -408,7 +402,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   public void edit_whenNoMoreIncompleteBlocks_redirectsToListOfPrograms() {
     ProgramModel program = resourceCreator().insertActiveProgram("My Program");
 
-    Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Request request = fakeRequestBuilder().build();
     Result result =
         controller
             .editWithApplicantId(request, currentApplicant.id, program.id)

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -3,7 +3,6 @@ package controllers.applicant;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileUtils;
@@ -63,9 +62,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(
-                        fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "false"))
-                    .build(),
+                fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "false").build(),
                 programDefinition.slug())
             .toCompletableFuture()
             .join();
@@ -102,8 +99,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "true"))
-                    .build(),
+                fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "true").build(),
                 programDefinition.slug())
             .toCompletableFuture()
             .join();
@@ -131,8 +127,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
-                    .build(),
+                fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url").build(),
                 programDefinition.slug())
             .toCompletableFuture()
             .join();
@@ -152,8 +147,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
         instanceOf(ProgramSlugHandler.class)
             .showProgram(
                 controller,
-                addCSRFToken(fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url"))
-                    .build(),
+                fakeRequestBuilder().session(REDIRECT_TO_SESSION_KEY, "redirect-url").build(),
                 "non-existing-program-slug")
             .toCompletableFuture()
             .join();
@@ -172,8 +166,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
 
     Result result =
         handler
-            .showProgram(
-                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
+            .showProgram(controller, fakeRequestBuilder().build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
 
@@ -211,8 +204,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             applicantRoutes);
     Result result =
         handler
-            .showProgram(
-                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
+            .showProgram(controller, fakeRequestBuilder().build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())
@@ -249,8 +241,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             applicantRoutes);
     Result result =
         handler
-            .showProgram(
-                controller, addCSRFToken(fakeRequestBuilder()).build(), programDefinition.slug())
+            .showProgram(controller, fakeRequestBuilder().build(), programDefinition.slug())
             .toCompletableFuture()
             .join();
     assertThat(result.redirectLocation())

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.UNAUTHORIZED;
@@ -50,7 +49,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(fakeRequestBuilder()).build(),
+                fakeRequestBuilder().build(),
                 applicant.id,
                 programDefinition.id(),
                 application.id,
@@ -106,7 +105,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(fakeRequestBuilder()).build(),
+                fakeRequestBuilder().build(),
                 applicant.id,
                 commonIntakeForm.id(),
                 application.id,
@@ -164,7 +163,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     Result result =
         instanceOf(UpsellController.class)
             .considerRegister(
-                addCSRFToken(fakeRequestBuilder()).build(),
+                fakeRequestBuilder().build(),
                 applicant.id,
                 commonIntakeForm.id(),
                 application.id,
@@ -189,7 +188,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(addCSRFToken(fakeRequestBuilder()).build(), application.id, applicant.id)
+              .download(fakeRequestBuilder().build(), application.id, applicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -213,8 +212,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(
-                  addCSRFToken(fakeRequestBuilder()).build(), application.id, managedApplicant.id)
+              .download(fakeRequestBuilder().build(), application.id, managedApplicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -239,8 +237,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(
-                  addCSRFToken(fakeRequestBuilder()).build(), application.id, unmanagedApplicant.id)
+              .download(fakeRequestBuilder().build(), application.id, unmanagedApplicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -261,7 +258,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(addCSRFToken(fakeRequestBuilder()).build(), application.id, 0)
+              .download(fakeRequestBuilder().build(), application.id, 0)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {
@@ -281,7 +278,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     try {
       result =
           instanceOf(UpsellController.class)
-              .download(addCSRFToken(fakeRequestBuilder()).build(), 0, applicant.id)
+              .download(fakeRequestBuilder().build(), 0, applicant.id)
               .toCompletableFuture()
               .join();
     } catch (ProgramNotFoundException e) {

--- a/server/test/controllers/dev/ProfileControllerTest.java
+++ b/server/test/controllers/dev/ProfileControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
@@ -26,8 +25,7 @@ public class ProfileControllerTest extends WithMockedProfiles {
 
   @Test
   public void testIndexWithNoProfile() {
-    Http.Request request =
-        addCSRFToken(fakeRequestBuilder().header(skipUserProfile, "true")).build();
+    Http.Request request = fakeRequestBuilder().header(skipUserProfile, "true").build();
     Result result = controller.index(request);
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).isEqualTo("No profile present");
@@ -35,8 +33,7 @@ public class ProfileControllerTest extends WithMockedProfiles {
 
   @Test
   public void testIndexWithProfile() {
-    Http.Request request =
-        addCSRFToken(fakeRequestBuilder().header(skipUserProfile, "false")).build();
+    Http.Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
     Result result = controller.index(request);
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -2,7 +2,6 @@ package controllers.ti;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
@@ -44,24 +43,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   public void testUpdateClientInfo_ThrowsApplicantNotFoundException()
       throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-18",
-                        "emailAddress",
-                        "sample3@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-18",
+                    "emailAddress",
+                    "sample3@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
@@ -80,24 +78,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     assertThat(testApplicant.get().getApplicantData().getDateOfBirth().get().toString())
         .isEqualTo("2022-07-18");
     Http.RequestBuilder requestBuilder2 =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "emailControllerSam",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "emailControllerSam",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Http.Request request2 = requestBuilder2.build();
     assertThatThrownBy(() -> tiController.editClient(account.id, request2))
         .isInstanceOf(ApplicantNotFoundException.class)
@@ -111,20 +108,19 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     account.setEmailAddress("test@ReturnsNotfound");
     account.save();
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "first",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "last",
-                        "emailAddress",
-                        "sample1@fake.com",
-                        "dob",
-                        "")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "first",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "last",
+                    "emailAddress",
+                    "sample1@fake.com",
+                    "dob",
+                    ""));
     Http.Request request = requestBuilder.build();
     Result result = tiController.showAddClientForm(account.id, request);
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -133,24 +129,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   @Test
   public void testEditClient_AllFieldsUpdated() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "2022-07-18",
-                        "emailAddress",
-                        "testUpdate@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "2022-07-18",
+                    "emailAddress",
+                    "testUpdate@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
@@ -166,24 +161,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     assertThat(testApplicant.get().getApplicantData().getDateOfBirth().get().toString())
         .isEqualTo("2022-07-18");
     Http.RequestBuilder requestBuilder2 =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "emailControllerSam",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "emailControllerSam",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Http.Request request2 = requestBuilder2.build();
     Result result2 = tiController.editClient(account.id, request2);
 
@@ -212,7 +206,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   @Test
   public void testShowEditClientFormCall() {
     AccountModel account = setupForEditClient("test33@test.com");
-    Http.Request request = addCSRFToken(fakeRequestBuilder()).build();
+    Http.Request request = fakeRequestBuilder().build();
     Result result = tiController.showEditClientForm(account.id, request);
     assertThat(result.status()).isEqualTo(OK);
   }
@@ -222,24 +216,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
     ApplicantModel managedApplicant = createApplicantWithMockedProfile();
     createTIWithMockedProfile(managedApplicant);
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "",
-                        "emailAddress",
-                        "sam2@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "",
+                    "emailAddress",
+                    "sam2@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
@@ -254,24 +247,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
   @Test
   public void addClient_WithAllInformation() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "2022-07-18",
-                        "emailAddress",
-                        "sample2@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "2022-07-18",
+                    "emailAddress",
+                    "sample2@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
@@ -287,24 +279,23 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
   private AccountModel setupForEditClient(String email) {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "clientMiddle",
-                        "lastName",
-                        "clientLast",
-                        "dob",
-                        "2022-07-18",
-                        "emailAddress",
-                        email,
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "clientMiddle",
+                    "lastName",
+                    "clientLast",
+                    "dob",
+                    "2022-07-18",
+                    "emailAddress",
+                    email,
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -3,7 +3,7 @@ package services.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfile;
@@ -41,7 +41,6 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
-import play.test.Helpers;
 import repository.AccountRepository;
 import repository.ApplicationRepository;
 import repository.ResetPostgres;
@@ -808,11 +807,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -916,10 +914,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
-            .submitApplication(applicant.id, progDef.id(), trustedIntermediaryProfile, request)
+            .submitApplication(
+                applicant.id, progDef.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -986,9 +984,8 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     var storedFile = new StoredFileModel().setName(fileKey);
     storedFile.save();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     subject
-        .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, request)
+        .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, fakeRequest())
         .toCompletableFuture()
         .join();
 
@@ -997,7 +994,8 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .containsOnly(firstProgram.getProgramDefinition().adminName());
 
     subject
-        .submitApplication(applicant.id, secondProgram.id, trustedIntermediaryProfile, request)
+        .submitApplication(
+            applicant.id, secondProgram.id, trustedIntermediaryProfile, fakeRequest())
         .toCompletableFuture()
         .join();
 
@@ -1020,11 +1018,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel oldApplication =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -1037,7 +1034,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicationModel newApplication =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -1068,11 +1065,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1102,11 +1098,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1182,11 +1177,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1257,11 +1251,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1317,10 +1310,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
-            .submitApplication(applicant.id, programDefinition.id(), applicantProfile, request)
+            .submitApplication(
+                applicant.id, programDefinition.id(), applicantProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1357,11 +1350,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
     application.refresh();
@@ -1372,14 +1364,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
 
   @Test
   public void submitApplication_failsWithApplicationSubmissionException() {
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), request)
+                        9999L, 9999L, /* tiSubmitterEmail= */ Optional.empty(), fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationSubmissionException.class)
@@ -1406,13 +1396,15 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                        applicant.id,
+                        programDefinition.id(),
+                        trustedIntermediaryProfile,
+                        fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationNotEligibleException.class)
@@ -1440,11 +1432,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .toCompletableFuture()
         .join();
 
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
     ApplicationModel application =
         subject
             .submitApplication(
-                applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
             .toCompletableFuture()
             .join();
 
@@ -1574,14 +1565,15 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
-
     assertThatExceptionOfType(CompletionException.class)
         .isThrownBy(
             () ->
                 subject
                     .submitApplication(
-                        applicant.id, programDefinition.id(), trustedIntermediaryProfile, request)
+                        applicant.id,
+                        programDefinition.id(),
+                        trustedIntermediaryProfile,
+                        fakeRequest())
                     .toCompletableFuture()
                     .join())
         .withCauseInstanceOf(ApplicationOutOfDateException.class)
@@ -3859,7 +3851,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates, false)
         .toCompletableFuture()
         .join();
-    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Request request = fakeRequest();
 
     ApplicationModel ineligibleApplication =
         subject

--- a/server/test/services/ti/TrustedIntermediaryServiceTest.java
+++ b/server/test/services/ti/TrustedIntermediaryServiceTest.java
@@ -2,7 +2,6 @@ package services.ti;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProfileFactory;
@@ -79,24 +78,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_withMissingDob() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm =
@@ -109,24 +107,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_withInvalidDob() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "1850-07-07",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "1850-07-07",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm =
@@ -140,24 +137,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_withUnformattedDob() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "20-20-20",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "20-20-20",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm =
@@ -171,24 +167,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_withInvalidLastName() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm =
@@ -201,24 +196,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_WithInvalidFirstName() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm =
@@ -231,24 +225,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_WithEmailAddressExistsError() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "sample@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "sample@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnedForm1 =
@@ -270,24 +263,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_WithEmptyEmailAddress() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "No",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "Email",
-                        "dob",
-                        "2011-11-11",
-                        "emailAddress",
-                        "",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "No",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "Email",
+                    "dob",
+                    "2011-11-11",
+                    "emailAddress",
+                    "",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     AddNewApplicantReturnObject returnObject =
@@ -311,24 +303,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void addClient_WithAllInformation() {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "add1@fake.com",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "add1@fake.com",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     AddNewApplicantReturnObject returnObject =
@@ -464,24 +455,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     AccountModel account = setupTiClientAccount("emailOld", tiGroup);
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "emailAllPassEditClient",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "emailAllPassEditClient",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -508,24 +498,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_PhoneLengthValidationFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "42598790")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "42598790"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -539,24 +528,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   public void editTiClientInfo_PhoneNumberNonDigitValidationFail()
       throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "42598790UI")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "42598790UI"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -569,24 +557,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_PhoneNumberValidationFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "0000000000")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "0000000000"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -599,24 +586,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_EmptyPhoneNumberDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    ""));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -628,24 +614,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_EmptyEmailDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259870989")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259870989"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -657,24 +642,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_EmptyTiNotesDoesNotFail() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "checkEmail",
-                        "tiNote",
-                        "",
-                        "phoneNumber",
-                        "4259870989")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "checkEmail",
+                    "tiNote",
+                    "",
+                    "phoneNumber",
+                    "4259870989"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -688,24 +672,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     AccountModel account = setupTiClientAccount("email1123", tiGroup);
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2040-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "42598790")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2040-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "42598790"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -721,24 +704,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     AccountModel account = setupTiClientAccount("email121", tiGroup);
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2040-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "42598790")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2040-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "42598790"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -753,24 +735,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     AccountModel account = setupTiClientAccount("email121", tiGroup);
     ApplicantModel applicant = setTiClientApplicant(account, "clientFirst", "2021-12-12");
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "first",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "",
-                        "dob",
-                        "2040-07-07",
-                        "emailAddress",
-                        "email2123",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "42598790")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "first",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "",
+                    "dob",
+                    "2040-07-07",
+                    "emailAddress",
+                    "email2123",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "42598790"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     Form<TiClientInfoForm> returnForm =
@@ -783,24 +764,23 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
   @Test
   public void editTiClientInfo_throwsException() throws ApplicantNotFoundException {
     Http.RequestBuilder requestBuilder =
-        addCSRFToken(
-            fakeRequestBuilder()
-                .bodyForm(
-                    ImmutableMap.of(
-                        "firstName",
-                        "clientFirst",
-                        "middleName",
-                        "middle",
-                        "lastName",
-                        "ClientLast",
-                        "dob",
-                        "2022-07-07",
-                        "emailAddress",
-                        "email21",
-                        "tiNote",
-                        "unitTest",
-                        "phoneNumber",
-                        "4259879090")));
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "firstName",
+                    "clientFirst",
+                    "middleName",
+                    "middle",
+                    "lastName",
+                    "ClientLast",
+                    "dob",
+                    "2022-07-07",
+                    "emailAddress",
+                    "email21",
+                    "tiNote",
+                    "unitTest",
+                    "phoneNumber",
+                    "4259879090"));
     Form<TiClientInfoForm> form =
         formFactory.form(TiClientInfoForm.class).bindFromRequest(requestBuilder.build());
     assertThatThrownBy(

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -1,6 +1,5 @@
 package support;
 
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static services.settings.SettingsService.CIVIFORM_SETTINGS_ATTRIBUTE_KEY;
 
 import auth.ClientIpResolver;
@@ -27,12 +26,17 @@ public final class FakeRequestBuilder extends RequestBuilder {
   }
 
   private FakeRequestBuilder() {
-    addCSRFToken(this);
+    addCSRFToken();
   }
 
   public FakeRequestBuilder call(Call call) {
     method(call.method());
     uri(call.url());
+    return this;
+  }
+
+  public FakeRequestBuilder addCSRFToken() {
+    play.api.test.CSRFTokenHelper.addCSRFToken(this);
     return this;
   }
 


### PR DESCRIPTION
### Description

Remove calls to addCSRFToken in unit tests, except where the test is explicitly testing CSRF, because FakeRequestBuilder does it automatically since #8049.

This supports #8046.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
