### PR TITLE
Use Play Environment to get program category translation directory

### DIFF
--- a/server/app/controllers/dev/seeding/CategoryTranslationFileParser.java
+++ b/server/app/controllers/dev/seeding/CategoryTranslationFileParser.java
@@ -19,6 +19,7 @@ import models.CategoryModel;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.Environment;
 import play.i18n.Lang;
 
 /**
@@ -28,6 +29,7 @@ import play.i18n.Lang;
 public final class CategoryTranslationFileParser {
 
   public static final String CATEGORY_TRANSLATIONS_DIRECTORY = "conf/i18n/categories/";
+  private final Environment environment;
   private Map<String, String> childcareMap = new HashMap<>();
   private Map<String, String> economicMap = new HashMap<>();
   private Map<String, String> educationMap = new HashMap<>();
@@ -39,6 +41,10 @@ public final class CategoryTranslationFileParser {
   private Map<String, String> transportationMap = new HashMap<>();
   private Map<String, String> utilitiesMap = new HashMap<>();
   private static final Logger logger = LoggerFactory.getLogger(CategoryTranslationFileParser.class);
+
+  public CategoryTranslationFileParser(Environment environment) {
+    this.environment = environment;
+  }
 
   public List<CategoryModel> createCategoryModelList() {
     parseCategoryTranslationFiles();
@@ -58,7 +64,7 @@ public final class CategoryTranslationFileParser {
   }
 
   private void parseCategoryTranslationFiles() {
-    File directory = new File(CATEGORY_TRANSLATIONS_DIRECTORY);
+    File directory = environment.getFile(CATEGORY_TRANSLATIONS_DIRECTORY);
     if (!directory.exists()) {
       logger.error("Directory does not exist: " + CATEGORY_TRANSLATIONS_DIRECTORY);
       return;

--- a/server/app/controllers/dev/seeding/CategoryTranslationFileParser.java
+++ b/server/app/controllers/dev/seeding/CategoryTranslationFileParser.java
@@ -1,5 +1,6 @@
 package controllers.dev.seeding;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableMap;
@@ -43,7 +44,7 @@ public final class CategoryTranslationFileParser {
   private static final Logger logger = LoggerFactory.getLogger(CategoryTranslationFileParser.class);
 
   public CategoryTranslationFileParser(Environment environment) {
-    this.environment = environment;
+    this.environment = checkNotNull(environment);
   }
 
   public List<CategoryModel> createCategoryModelList() {
@@ -67,6 +68,10 @@ public final class CategoryTranslationFileParser {
     File directory = environment.getFile(CATEGORY_TRANSLATIONS_DIRECTORY);
     if (!directory.exists()) {
       logger.error("Directory does not exist: " + CATEGORY_TRANSLATIONS_DIRECTORY);
+      return;
+    }
+    if (!directory.isDirectory()) {
+      logger.error("File is not a directory: " + CATEGORY_TRANSLATIONS_DIRECTORY);
       return;
     }
     File[] files = directory.listFiles();

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -41,6 +41,7 @@ import models.CategoryModel;
 import models.DisplayMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.Environment;
 import repository.CategoryRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
@@ -85,7 +86,7 @@ public final class DevDatabaseSeedTask {
   private static final int MAX_RETRIES = 10;
   private final QuestionService questionService;
   private final ProgramService programService;
-
+  private final Environment environment;
   private final VersionRepository versionRepository;
   private final CategoryRepository categoryRepository;
   private final Database database;
@@ -95,12 +96,14 @@ public final class DevDatabaseSeedTask {
       QuestionService questionService,
       ProgramService programService,
       VersionRepository versionRepository,
-      CategoryRepository categoryRepository) {
+      CategoryRepository categoryRepository,
+      Environment environment) {
     this.questionService = checkNotNull(questionService);
     this.versionRepository = checkNotNull(versionRepository);
     this.categoryRepository = checkNotNull(categoryRepository);
     this.programService = checkNotNull(programService);
     this.database = DB.getDefault();
+    this.environment = checkNotNull(environment);
   }
 
   /**
@@ -352,7 +355,7 @@ public final class DevDatabaseSeedTask {
 
   /** Seeds the predefined program categories from the category translation files. */
   public List<CategoryModel> seedProgramCategories() {
-    CategoryTranslationFileParser parser = new CategoryTranslationFileParser();
+    CategoryTranslationFileParser parser = new CategoryTranslationFileParser(environment);
     List<CategoryModel> categories = parser.createCategoryModelList();
 
     List<CategoryModel> dbCategories = new ArrayList<>();


### PR DESCRIPTION
### Description

The `DevDatabaseSeedTask` was failing to seed categories because it couldn't resolve the path to the category translation files.  Using Play `Environment.getFile(<relative path>)` solves this problem.


