### PR TITLE
Add CSP nonce to Northstar views

### DIFF
--- a/server/app/views/CspUtil.java
+++ b/server/app/views/CspUtil.java
@@ -6,10 +6,14 @@ import play.mvc.Http.RequestHeader;
 import views.html.helper.CSPNonce;
 
 public final class CspUtil {
+  /** Get the CSP nonce from the given request */
+  public static String getNonce(RequestHeader request) {
+    return CSPNonce.apply(request.asScala());
+  }
+
   /** Apply the CSP nonce from the given request to the given scriptTag */
   public static ScriptTag applyCsp(RequestHeader request, ScriptTag scriptTag) {
-    String nonce = CSPNonce.apply(request.asScala());
-    return scriptTag.attr("nonce", nonce);
+    return scriptTag.attr("nonce", getNonce(request));
   }
 
   /** Apply the CSP nonce from the given request to the given scriptTags */

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -62,6 +62,7 @@ public abstract class NorthStarBaseView {
     context.setVariable("applicantJsBundle", assetsFinder.path("dist/applicant.bundle.js"));
     context.setVariable("uswdsJsInit", assetsFinder.path("javascripts/uswds/uswds-init.min.js"));
     context.setVariable("uswdsJsBundle", assetsFinder.path("dist/uswds.bundle.js"));
+    context.setVariable("cspNonce", CspUtil.getNonce(request));
     context.setVariable("csrfToken", CSRF.getToken(request.asScala()).value());
     context.setVariable(
         "smallLogoUrl",

--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -5,12 +5,24 @@
 
   <link th:href="${tailwindStylesheet}" type="text/css" rel="stylesheet" />
   <link th:href="${northStarStylesheet}" type="text/css" rel="stylesheet" />
-  <script th:src="${uswdsJsInit}" type="text/javascript"></script>
+  <script
+    th:nonce="${cspNonce}"
+    th:src="${uswdsJsInit}"
+    type="text/javascript"
+  ></script>
 </head>
 
 <th:block th:fragment="pageFooterScripts">
-  <script th:src="${applicantJsBundle}" type="text/javascript"></script>
-  <script th:src="${uswdsJsBundle}" type="text/javascript"></script>
+  <script
+    th:nonce="${cspNonce}"
+    th:src="${applicantJsBundle}"
+    type="text/javascript"
+  ></script>
+  <script
+    th:nonce="${cspNonce}"
+    th:src="${uswdsJsBundle}"
+    type="text/javascript"
+  ></script>
 </th:block>
 
 <div th:fragment="requiredFieldsExplanation">

--- a/server/test/views/CspUtilTest.java
+++ b/server/test/views/CspUtilTest.java
@@ -16,6 +16,17 @@ import play.test.Helpers;
 
 @RunWith(JUnitParamsRunner.class)
 public class CspUtilTest {
+
+  @Test
+  public void testGetNonce() {
+    RequestImpl request =
+        Helpers.fakeRequest().attr(RequestAttrKey.CSPNonce().asJava(), "nonce-value").build();
+
+    String result = CspUtil.getNonce(request);
+
+    assertThat(result).isEqualTo("nonce-value");
+  }
+
   /** This covers both overloads of applyCsp because the List one calls the singular one */
   @Test
   public void testApplyCsp() {


### PR DESCRIPTION
### Description

Add the CSP nonce to all thymeleaf templates so that the browser knows they are approved to load. This is for https://github.com/civiform/civiform/issues/7574.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)