### PR TITLE
Make the dev grafana require no auth

### DIFF
--- a/bin/dev-grafana
+++ b/bin/dev-grafana
@@ -16,5 +16,3 @@ docker::compose_dev \
   -d
 
 echo "Running grafana at http://localhost:8013"
-echo "Default username: admin"
-echo "Default password: admin"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -89,6 +89,8 @@ services:
     restart: unless-stopped
     ports:
       - 8013:3000
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: true
     volumes:
       - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources


### PR DESCRIPTION
### Description

I already got tired have having to login to the local instance all the time. Fixed it!

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
