### PR TITLE
Make Program Blocks Optional for Translations (temporary)

### DIFF
--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -13,7 +13,6 @@ import com.google.inject.Inject;
 import controllers.BadRequestException;
 import controllers.admin.ImageDescriptionNotRemovableException;
 import forms.BlockForm;
-import forms.translation.ProgramTranslationForm;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -826,6 +825,9 @@ public final class ProgramService {
                 errorsBuilder.add(
                     CiviFormError.of("Found invalid block id " + screenUpdate.blockIdToUpdate()));
               }
+
+              /*
+              //  TODO: Issue 8109, re-enabled after transition period
               validateProgramText(
                   errorsBuilder,
                   ProgramTranslationForm.localizedScreenName(screenUpdate.blockIdToUpdate()),
@@ -834,6 +836,7 @@ public final class ProgramService {
                   errorsBuilder,
                   ProgramTranslationForm.localizedScreenDescription(screenUpdate.blockIdToUpdate()),
                   screenUpdate.localizedDescription());
+               */
             });
   }
 

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2464,46 +2464,47 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.getErrors()).containsExactly(CiviFormError.of("Found invalid block id 3"));
   }
 
-  @Test
-  public void updateLocalizations_blockTranslationsEmpty() throws Exception {
-    ProgramModel program =
-        ProgramBuilder.newDraftProgram("English name", "English description")
-            .withLocalizedName(Locale.FRENCH, "existing French name")
-            .withLocalizedDescription(Locale.FRENCH, "existing French description")
-            .withLocalizedConfirmationMessage(Locale.FRENCH, "")
-            .setLocalizedSummaryImageDescription(
-                LocalizedStrings.of(
-                    Locale.US,
-                    "English image description",
-                    Locale.FRENCH,
-                    "existing French image description"))
-            .withBlock("first block", "a description")
-            .build();
-
-    LocalizationUpdate updateData =
-        LocalizationUpdate.builder()
-            .setLocalizedDisplayName("new French name")
-            .setLocalizedDisplayDescription("new French description")
-            .setLocalizedSummaryImageDescription("new French image description")
-            .setLocalizedConfirmationMessage("")
-            .setStatuses(ImmutableList.of())
-            .setScreens(
-                ImmutableList.of(
-                    LocalizationUpdate.ScreenUpdate.builder()
-                        .setBlockIdToUpdate(1L)
-                        .setLocalizedName("")
-                        .setLocalizedDescription("")
-                        .build()))
-            .build();
-    ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.updateLocalization(program.id, Locale.FRENCH, updateData);
-
-    assertThat(result.isError()).isTrue();
-    assertThat(result.getErrors())
-        .containsExactly(
-            CiviFormError.of("program screen-name-1 cannot be blank"),
-            CiviFormError.of("program screen-description-1 cannot be blank"));
-  }
+  //  TODO: Issue 8109, re-enabled after transition period
+  //  @Test
+  //  public void updateLocalizations_blockTranslationsEmpty() throws Exception {
+  //    ProgramModel program =
+  //        ProgramBuilder.newDraftProgram("English name", "English description")
+  //            .withLocalizedName(Locale.FRENCH, "existing French name")
+  //            .withLocalizedDescription(Locale.FRENCH, "existing French description")
+  //            .withLocalizedConfirmationMessage(Locale.FRENCH, "")
+  //            .setLocalizedSummaryImageDescription(
+  //                LocalizedStrings.of(
+  //                    Locale.US,
+  //                    "English image description",
+  //                    Locale.FRENCH,
+  //                    "existing French image description"))
+  //            .withBlock("first block", "a description")
+  //            .build();
+  //
+  //    LocalizationUpdate updateData =
+  //        LocalizationUpdate.builder()
+  //            .setLocalizedDisplayName("new French name")
+  //            .setLocalizedDisplayDescription("new French description")
+  //            .setLocalizedSummaryImageDescription("new French image description")
+  //            .setLocalizedConfirmationMessage("")
+  //            .setStatuses(ImmutableList.of())
+  //            .setScreens(
+  //                ImmutableList.of(
+  //                    LocalizationUpdate.ScreenUpdate.builder()
+  //                        .setBlockIdToUpdate(1L)
+  //                        .setLocalizedName("")
+  //                        .setLocalizedDescription("")
+  //                        .build()))
+  //            .build();
+  //    ErrorAnd<ProgramDefinition, CiviFormError> result =
+  //        ps.updateLocalization(program.id, Locale.FRENCH, updateData);
+  //
+  //    assertThat(result.isError()).isTrue();
+  //    assertThat(result.getErrors())
+  //        .containsExactly(
+  //            CiviFormError.of("program screen-name-1 cannot be blank"),
+  //            CiviFormError.of("program screen-description-1 cannot be blank"));
+  //  }
 
   @Test
   public void updateLocalizations_returnsErrorMessages() throws Exception {


### PR DESCRIPTION
### Description

Make the block name and block description fields on the Program translations page optional. This is a transitional step to give Civiform Admins time to get translations and update them, but not to block immediate changes to program name (and related fields).

Opened #8109 to track re-enabling them as required


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)

Fixes #8107 
