### PR TITLE
Replace inline javascript for entity delete button

### DIFF
--- a/server/app/assets/javascripts/enumerator.ts
+++ b/server/app/assets/javascripts/enumerator.ts
@@ -99,9 +99,14 @@ function addNewEnumeratorField() {
  * @param {Event} event The event that triggered this action.
  */
 function removeEnumeratorField(event: Event) {
+  const removeButton = event.currentTarget as HTMLElement
+  if (!confirm(removeButton.dataset.confirmationMessage)) {
+    return false
+  }
+
   // Get the parent div, which contains the input field and remove button, and remove it.
   const enumeratorFieldDiv = assertNotNull(
-    (event.currentTarget as HTMLElement).parentNode,
+    removeButton.parentNode,
   ) as HTMLElement
   enumeratorFieldDiv.remove()
 
@@ -119,6 +124,10 @@ function removeEnumeratorField(event: Event) {
 function removeExistingEnumeratorField(event: Event) {
   // Get the button that was clicked
   const removeButton = event.currentTarget as HTMLElement
+
+  if (!confirm(removeButton.dataset.confirmationMessage)) {
+    return false
+  }
 
   // Hide the field that was removed. We cannot remove it completely, as we need to
   // submit the input to maintain entity ordering.

--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -95,9 +95,9 @@
     <button
       type="button"
       class="cf-enumerator-delete-button usa-button--unstyled"
+      th:data-confirmation-message="#{dialog.confirmDeleteAllButtonsSave(${enumeratorQuestion.getEntityType()})}"
       th:id="${deleteButtonId}"
       th:text="#{button.removeEntity(${enumeratorQuestion.getEntityType()})} + ${indexString}"
-      th:attr="onclick='if(confirm(\'' + #{dialog.confirmDeleteAllButtonsSave(${enumeratorQuestion.getEntityType()})} + '\')){ return true; } else { var e = arguments[0] || window.event; e.stopImmediatePropagation(); return false; }'"
     ></button>
   </div>
 </div>

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -190,12 +190,7 @@ public final class EnumeratorQuestionRenderer extends ApplicantCompositeQuestion
         TagCreator.button()
             .withType("button")
             .withCondId(existingIndex.isPresent(), existingIndex.map(String::valueOf).orElse(""))
-            .attr(
-                "onclick",
-                String.format(
-                    "if(confirm('%s')){ return true; } else { var e = arguments[0] ||"
-                        + " window.event; e.stopImmediatePropagation(); return false; }",
-                    confirmationMessage))
+            .withData("confirmation-message", confirmationMessage)
             .withClasses(
                 ReferenceClasses.ENUMERATOR_EXISTING_DELETE_BUTTON,
                 StyleUtils.removeStyles(ButtonStyles.OUTLINED_TRANSPARENT, "px-8"),


### PR DESCRIPTION
### Description

Replace the "onclick" inline javascript for the enumerator entity delete button with static javascript. It requires a localized string, which is now plumbed in a data attribute on the button.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #8097
