### PR TITLE
Add test for APPLICANT_PORTAL_NAME use on index page

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -51,6 +51,30 @@ test.describe('applicant program index page', () => {
     await logout(page)
   })
 
+  test('shows value of APPLICANT_PORTAL_NAME in welcome text', async ({
+    page,
+    adminSettings,
+  }) => {
+    await loginAsAdmin(page)
+    await adminSettings.gotoAdminSettings()
+    await adminSettings.setStringSetting(
+      'APPLICANT_PORTAL_NAME',
+      'Awesome Sauce',
+    )
+    await adminSettings.expectStringSetting(
+      'APPLICANT_PORTAL_NAME',
+      'Awesome Sauce',
+    )
+    await adminSettings.saveChanges()
+    await logout(page)
+
+    expect(
+      await page
+        .getByText(/Log in to your (\w|\s)+ account or create/)
+        .textContent(),
+    ).toContain('Awesome Sauce')
+  })
+
   test('shows log in button for guest users', async ({
     page,
     applicantQuestions,

--- a/browser-test/src/support/admin_settings.ts
+++ b/browser-test/src/support/admin_settings.ts
@@ -34,6 +34,22 @@ export class AdminSettings {
     ).toBeChecked()
   }
 
+  async setStringSetting(settingName: string, value: string) {
+    await this.page
+      .getByTestId(`string-${settingName}`)
+      .locator('input')
+      .fill(value)
+  }
+
+  async expectStringSetting(settingName: string, value: string) {
+    expect(
+      await this.page
+        .getByTestId(`string-${settingName}`)
+        .locator('input')
+        .inputValue(),
+    ).toBe(value)
+  }
+
   async saveChanges(expectUpdated = true) {
     await this.page.click('button:text("Save changes")')
 

--- a/server/app/views/admin/settings/AdminSettingsIndexView.java
+++ b/server/app/views/admin/settings/AdminSettingsIndexView.java
@@ -239,7 +239,10 @@ public final class AdminSettingsIndexView extends BaseHtmlView {
 
     value.ifPresent((val) -> field.setValue(OptionalInt.of(Integer.parseInt(val))));
 
-    return div(field.getNumberTag().condWith(settingDescription.isReadOnly(), READ_ONLY_TEXT))
+    return div(field
+            .getNumberTag()
+            .withData("testid", String.format("int-%s", settingDescription.variableName()))
+            .condWith(settingDescription.isReadOnly(), READ_ONLY_TEXT))
         .withClasses("mt-2");
   }
 
@@ -264,6 +267,7 @@ public final class AdminSettingsIndexView extends BaseHtmlView {
             .setDisabled(settingDescription.isReadOnly())
             .setReadOnly(settingDescription.isReadOnly())
             .getInputTag()
+            .withData("testid", String.format("string-%s", settingDescription.variableName()))
             .condWith(settingDescription.isReadOnly(), READ_ONLY_TEXT)
             .with(errors.orElse(null)))
         .withClasses("mt-2");
@@ -291,6 +295,7 @@ public final class AdminSettingsIndexView extends BaseHtmlView {
 
     return div(selectWithLabel
             .getSelectTag()
+            .withData("testid", String.format("enum-%s", settingDescription.variableName()))
             .condWith(settingDescription.isReadOnly(), READ_ONLY_TEXT))
         .withClasses("mt-2");
   }


### PR DESCRIPTION
### Description

Following on from https://github.com/civiform/civiform/pull/8054, this adds a test to verify the text on the index page is using the APPLICANT_PORTAL_NAME text.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
