### PR TITLE
Replace inline javascript for language selector

### DIFF
--- a/server/app/assets/javascripts/applicant_entry_point.ts
+++ b/server/app/assets/javascripts/applicant_entry_point.ts
@@ -4,6 +4,7 @@
  */
 
 import * as main from './main'
+import * as languageSelector from './language_selector'
 import * as enumerator from './enumerator'
 import * as radio from './radio'
 import * as toast from './toast'
@@ -18,6 +19,7 @@ import * as trustedIntermediary from './trusted_intermediary'
 
 window.addEventListener('load', () => {
   main.init()
+  languageSelector.init()
   enumerator.init()
   radio.init()
   toast.init()

--- a/server/app/assets/javascripts/language_selector.ts
+++ b/server/app/assets/javascripts/language_selector.ts
@@ -1,0 +1,11 @@
+// Javascript handling for the applicant language selector
+import {addEventListenerToElements} from './util'
+
+function onLanguageChange(event: Event) {
+  const languageSelector = event.target as HTMLSelectElement
+  languageSelector.form!.submit()
+}
+
+export function init() {
+  addEventListenerToElements('#select-language', 'change', onLanguageChange)
+}

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -262,7 +262,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
     SelectTag languageDropdown =
         languageSelector
             .renderDropdown(preferredLanguage)
-            .attr("onchange", "this.form.submit()")
             .attr("aria-label", messages.at(MessageKey.LANGUAGE_LABEL_SR.getKeyName()));
     languageFormDiv =
         languageFormDiv.with(

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -195,7 +195,6 @@
 
     <select
       name="locale"
-      onchange="this.form.submit()"
       th:aria-label="#{label.languageSr}"
       class="usa-button"
       id="select-language"


### PR DESCRIPTION
### Description

Replace the inline onchange listener for the language selector dropdown with a static javascript listener in a new language_selector.ts file. This is necessary to enforce a content security policy (https://github.com/civiform/civiform/issues/7574), which disallows inline javascript.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
