### PR TITLE
Delete code-coverage folder contents when running sbt clean

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -179,6 +179,10 @@ lazy val root = (project in file("."))
     // since running in non-forked mode causes javaOptions to not be propagated, which
     // causes the configuration override above not to have an effect.
     // Test / fork := false,
+
+    // Add the code-coverage folder to the list of things that will be cleaned when running `sbt clean`
+    cleanFiles += baseDirectory.value / "code-coverage",
+
     // Turn off scaladoc link warnings
     Compile / doc / scalacOptions += "-no-link-warnings",
     // Turn off scaladoc


### PR DESCRIPTION
### Description

This adds the `code-coverage` folder to the list of things automatically clean with running `sbt clean`. It won't necessarily solve the problem, but will make it less manual to clean up. If people are in the habit of running `clean` already it'll probably lower the likelihood of it occurring.

[History on the problem](https://civiform.slack.com/archives/C01QKN2UNMA/p1700618715682069) from Slack.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
