### PR TITLE
PDF Download of a form should include information about "required" or "optional" questions

### DIFF
--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -379,7 +379,9 @@ public final class PdfExporter {
       if (programQuestionDefinition.isPresent()) {
         document.add(
             text(
-                "isOptional: " + programQuestionDefinition.get().optional(),
+                programQuestionDefinition.get().optional()
+                    ? "Optional Question"
+                    : "Required Question",
                 PARAGRAPH_FONT,
                 indentationLevel));
       }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -382,7 +382,7 @@ public final class PdfExporter {
                 programQuestionDefinition.get().optional()
                     ? "Required Question"
                     : "Optional Question",
-                PARAGRAPH_FONT,
+                SMALL_GRAY_FONT,
                 indentationLevel));
       }
 

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -380,8 +380,8 @@ public final class PdfExporter {
         document.add(
             text(
                 programQuestionDefinition.get().optional()
-                    ? "Optional Question"
-                    : "Required Question",
+                    ? "Required Question"
+                    : "Optional Question",
                 PARAGRAPH_FONT,
                 indentationLevel));
       }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -380,8 +380,8 @@ public final class PdfExporter {
         document.add(
             text(
                 programQuestionDefinition.get().optional()
-                    ? "Required Question"
-                    : "Optional Question",
+                    ? "Optional Question"
+                    : "Required Question",
                 SMALL_GRAY_FONT,
                 indentationLevel));
       }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -40,6 +40,7 @@ import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
+import services.program.ProgramQuestionDefinition;
 import services.program.predicate.PredicateDefinition;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -369,6 +370,20 @@ public final class PdfExporter {
         document.add(
             text(question.getQuestionHelpText().getDefault(), PARAGRAPH_FONT, indentationLevel));
       }
+
+      // Adds a line describing whether the question is optional or not
+      Optional<ProgramQuestionDefinition> programQuestionDefinition =
+          block.programQuestionDefinitions().stream()
+              .filter(pqd -> pqd.id() == question.getId())
+              .findFirst();
+      if (programQuestionDefinition.isPresent()) {
+        document.add(
+            text(
+                "isOptional: " + programQuestionDefinition.get().optional(),
+                PARAGRAPH_FONT,
+                indentationLevel));
+      }
+
       document.add(text("Admin name: " + question.getName(), SMALL_GRAY_FONT, indentationLevel));
       document.add(
           text(

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -290,12 +290,13 @@ public class PdfExporterTest extends AbstractExporterTest {
       pdfText =
           assertContainsThenCrop(
               pdfText,
-              "isOptional: "
-                  + block.programQuestionDefinitions().stream()
+              block.programQuestionDefinitions().stream()
                       .filter(pqd -> pqd.id() == questionDefinition.getId())
                       .findFirst()
                       .get()
-                      .optional());
+                      .optional()
+                  ? "Optional Question"
+                  : "Required Question");
       pdfText = assertContainsThenCrop(pdfText, "Admin name: " + questionDefinition.getName());
       pdfText =
           assertContainsThenCrop(

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import services.applications.PdfExporterService;
+import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
 
@@ -278,6 +279,7 @@ public class PdfExporterTest extends AbstractExporterTest {
     // question): Verify the PDF has the block name, question text, question help text, admin name,
     // admin description, and question type.
     for (int i = 0; i < fakeQuestions.size(); i++) {
+      BlockDefinition block = programDef.blockDefinitions().get(i);
       QuestionDefinition questionDefinition = fakeQuestions.get(i).getQuestionDefinition();
       pdfText = assertContainsThenCrop(pdfText, "Screen " + (i + 1));
       pdfText = assertContainsThenCrop(pdfText, questionDefinition.getQuestionText().getDefault());
@@ -285,6 +287,15 @@ public class PdfExporterTest extends AbstractExporterTest {
         pdfText =
             assertContainsThenCrop(pdfText, questionDefinition.getQuestionHelpText().getDefault());
       }
+      pdfText =
+          assertContainsThenCrop(
+              pdfText,
+              "isOptional: "
+                  + block.programQuestionDefinitions().stream()
+                      .filter(pqd -> pqd.id() == questionDefinition.getId())
+                      .findFirst()
+                      .get()
+                      .optional());
       pdfText = assertContainsThenCrop(pdfText, "Admin name: " + questionDefinition.getName());
       pdfText =
           assertContainsThenCrop(

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -295,8 +295,8 @@ public class PdfExporterTest extends AbstractExporterTest {
                       .findFirst()
                       .get()
                       .optional()
-                  ? "Required Question"
-                  : "Optional Question");
+                  ? "Optional Question"
+                  : "Required Question");
       pdfText = assertContainsThenCrop(pdfText, "Admin name: " + questionDefinition.getName());
       pdfText =
           assertContainsThenCrop(

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -295,8 +295,8 @@ public class PdfExporterTest extends AbstractExporterTest {
                       .findFirst()
                       .get()
                       .optional()
-                  ? "Optional Question"
-                  : "Required Question");
+                  ? "Required Question"
+                  : "Optional Question");
       pdfText = assertContainsThenCrop(pdfText, "Admin name: " + questionDefinition.getName());
       pdfText =
           assertContainsThenCrop(


### PR DESCRIPTION
### Description

Added a line that describes whether the question is optional or not in the program preview pdf.
If the question is required, it should display "Required Question". Otherwise, it will display "Optional Question".

## Release notes

Added a line that describes whether the question is optional or not in the program preview pdf.
If the question is required, it should display "Required Question". Otherwise, it will display "Optional Question".

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Issue(s) this completes

Fixes #7365 
