### PR TITLE
Remove INTAKE_FORM_ENABLED feature flag

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -29,7 +29,6 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.program.ProgramType;
 import services.question.QuestionService;
-import services.settings.SettingsManifest;
 import views.admin.programs.ProgramEditStatus;
 import views.admin.programs.ProgramIndexView;
 import views.admin.programs.ProgramMetaDataEditView;
@@ -46,7 +45,6 @@ public final class AdminProgramController extends CiviFormController {
   private final ProgramMetaDataEditView editView;
   private final FormFactory formFactory;
   private final RequestChecker requestChecker;
-  private final SettingsManifest settingsManifest;
 
   @Inject
   public AdminProgramController(
@@ -58,8 +56,7 @@ public final class AdminProgramController extends CiviFormController {
       VersionRepository versionRepository,
       ProfileUtils profileUtils,
       FormFactory formFactory,
-      RequestChecker requestChecker,
-      SettingsManifest settingsManifest) {
+      RequestChecker requestChecker) {
     super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
@@ -68,7 +65,6 @@ public final class AdminProgramController extends CiviFormController {
     this.editView = checkNotNull(editView);
     this.formFactory = checkNotNull(formFactory);
     this.requestChecker = checkNotNull(requestChecker);
-    this.settingsManifest = settingsManifest;
   }
 
   /**
@@ -134,9 +130,7 @@ public final class AdminProgramController extends CiviFormController {
 
     // If the user needs to confirm that they want to change the common intake form from a different
     // program to this one, show the confirmation dialog.
-    if (settingsManifest.getIntakeFormEnabled()
-        && programData.getIsCommonIntakeForm()
-        && !programData.getConfirmedChangeCommonIntakeForm()) {
+    if (programData.getIsCommonIntakeForm() && !programData.getConfirmedChangeCommonIntakeForm()) {
       Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()) {
         return ok(
@@ -158,7 +152,6 @@ public final class AdminProgramController extends CiviFormController {
             programData.getIsCommonIntakeForm()
                 ? ProgramType.COMMON_INTAKE_FORM
                 : ProgramType.DEFAULT,
-            settingsManifest.getIntakeFormEnabled(),
             ImmutableList.copyOf(programData.getTiGroups()),
             ImmutableList.copyOf(programData.getCategories()));
     // There shouldn't be any errors since we already validated the program, but check for errors
@@ -269,9 +262,7 @@ public final class AdminProgramController extends CiviFormController {
 
     // If the user needs to confirm that they want to change the common intake form from a different
     // program to this one, show the confirmation dialog.
-    if (settingsManifest.getIntakeFormEnabled()
-        && programData.getIsCommonIntakeForm()
-        && !programData.getConfirmedChangeCommonIntakeForm()) {
+    if (programData.getIsCommonIntakeForm() && !programData.getConfirmedChangeCommonIntakeForm()) {
       Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()
           && !maybeCommonIntakeForm.get().adminName().equals(programDefinition.adminName())) {
@@ -296,7 +287,6 @@ public final class AdminProgramController extends CiviFormController {
         programData.getDisplayMode(),
         programData.getEligibilityIsGating(),
         programData.getIsCommonIntakeForm() ? ProgramType.COMMON_INTAKE_FORM : ProgramType.DEFAULT,
-        settingsManifest.getIntakeFormEnabled(),
         ImmutableList.copyOf(programData.getTiGroups()),
         ImmutableList.copyOf(programData.getCategories()));
     return getSaveProgramDetailsRedirect(programId, programEditStatus);

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -176,7 +176,6 @@ public final class DevDatabaseSeedTask {
               DisplayMode.PUBLIC.getValue(),
               /* eligibilityIsGating= */ true,
               /* programType= */ ProgramType.DEFAULT,
-              /* isIntakeFormFeatureEnabled= */ false,
               ImmutableList.copyOf(new ArrayList<>()),
               /* categoryIds= */ ImmutableList.of());
       if (programDefinitionResult.isError()) {
@@ -219,7 +218,6 @@ public final class DevDatabaseSeedTask {
               DisplayMode.PUBLIC.getValue(),
               /* eligibilityIsGating= */ true,
               /* programType= */ ProgramType.DEFAULT,
-              /* isIntakeFormFeatureEnabled= */ false,
               ImmutableList.copyOf(new ArrayList<>()),
               /* categoryIds= */ ImmutableList.of());
       if (programDefinitionResult.isError()) {

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -315,15 +315,14 @@ public final class ProgramService {
    *     the applicant submits their application
    * @param externalLink A link to an external page containing additional program details
    * @param displayMode The display mode for the program
+   * @param eligibilityIsGating true if an applicant must meet all eligibility criteria in order to
+   *     submit an application, and false if an application can submit an application even if they
+   *     don't meet some/all of the eligibility criteria.
    * @param programType ProgramType for this Program. If this is set to COMMON_INTAKE_FORM and there
    *     is already another active or draft program with {@link
    *     services.program.ProgramType#COMMON_INTAKE_FORM}, that program's ProgramType will be
    *     changed to {@link services.program.ProgramType#DEFAULT}, creating a new draft of it if
    *     necessary.
-   * @param isIntakeFormFeatureEnabled whether or not the common intake form feature is enabled.
-   * @param eligibilityIsGating true if an applicant must meet all eligibility criteria in order to
-   *     submit an application, and false if an application can submit an application even if they
-   *     don't meet some/all of the eligibility criteria.
    * @param tiGroups The List of TiOrgs who have visibility to program in SELECT_TI display mode
    * @return the {@link ProgramDefinition} that was created if succeeded, or a set of errors if
    *     failed
@@ -338,7 +337,6 @@ public final class ProgramService {
       String displayMode,
       boolean eligibilityIsGating,
       ProgramType programType,
-      Boolean isIntakeFormFeatureEnabled,
       ImmutableList<Long> tiGroups,
       ImmutableList<Long> categoryIds) {
     ImmutableSet<CiviFormError> errors =
@@ -360,9 +358,6 @@ public final class ProgramService {
       return ErrorAnd.error(maybeEmptyBlock.getErrors());
     }
 
-    if (!isIntakeFormFeatureEnabled) {
-      programType = ProgramType.DEFAULT;
-    }
     if (programType.equals(ProgramType.COMMON_INTAKE_FORM) && getCommonIntakeForm().isPresent()) {
       clearCommonIntakeForm();
     }
@@ -461,7 +456,6 @@ public final class ProgramService {
    *     is already another active or draft program with {@link ProgramType#COMMON_INTAKE_FORM},
    *     that program's ProgramType will be changed to {@link ProgramType#DEFAULT}, creating a new
    *     draft of it if necessary.
-   * @param isIntakeFormFeatureEnabled whether or not the common intake for feature is enabled.
    * @param tiGroups the TI Orgs having visibility to the program for SELECT_TI display_mode
    * @return the {@link ProgramDefinition} that was updated if succeeded, or a set of errors if
    *     failed
@@ -478,7 +472,6 @@ public final class ProgramService {
       String displayMode,
       boolean eligibilityIsGating,
       ProgramType programType,
-      Boolean isIntakeFormFeatureEnabled,
       ImmutableList<Long> tiGroups,
       ImmutableList<Long> categoryIds)
       throws ProgramNotFoundException {
@@ -490,9 +483,6 @@ public final class ProgramService {
       return ErrorAnd.error(errors);
     }
 
-    if (!isIntakeFormFeatureEnabled) {
-      programType = ProgramType.DEFAULT;
-    }
     if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
       Optional<ProgramDefinition> maybeCommonIntakeForm = getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -858,11 +858,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE", request);
   }
 
-  /** Enables the Common Intake Form feature. */
-  public boolean getIntakeFormEnabled() {
-    return getBool("INTAKE_FORM_ENABLED");
-  }
-
   /**
    * If this is a staging deployment and this variable is set to true, a [robots
    * noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) metadata
@@ -1886,12 +1881,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
-                  SettingDescription.create(
-                      "INTAKE_FORM_ENABLED",
-                      "Enables the Common Intake Form feature.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
-                      SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "STAGING_ADD_NOINDEX_META_TAG",
                       "If this is a staging deployment and this variable is set to true, a [robots"

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -18,7 +18,6 @@ import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramDefinition;
-import services.settings.SettingsManifest;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -35,18 +34,13 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
   private final AdminLayout layout;
   private final String baseUrl;
   private final ProgramCardFactory programCardFactory;
-  private final SettingsManifest settingsManifest;
 
   @Inject
   public ProgramAdministratorProgramListView(
-      AdminLayoutFactory layoutFactory,
-      Config config,
-      ProgramCardFactory programCardFactory,
-      SettingsManifest settingsManifest) {
+      AdminLayoutFactory layoutFactory, Config config, ProgramCardFactory programCardFactory) {
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
     this.baseUrl = checkNotNull(config).getString("base_url");
     this.programCardFactory = checkNotNull(programCardFactory);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   public Content render(
@@ -104,10 +98,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                 /* selectedApplicationUri= */ Optional.empty())
             .url();
 
-    String buttonText =
-        settingsManifest.getIntakeFormEnabled() && activeProgram.isCommonIntakeForm()
-            ? "Forms"
-            : "Applications";
+    String buttonText = activeProgram.isCommonIntakeForm() ? "Forms" : "Applications";
     ButtonTag button =
         makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, viewApplicationsLink);

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -201,7 +201,6 @@ public final class ProgramBlocksView extends ProgramBaseView {
                                     csrfTag,
                                     blockDescriptionEditModal.getButton(),
                                     blockDeleteScreenModal.getButton(),
-                                    settingsManifest.getIntakeFormEnabled(),
                                     request))));
 
     // Add top level UI that is only visible in the editable version.
@@ -433,7 +432,6 @@ public final class ProgramBlocksView extends ProgramBaseView {
       InputTag csrfTag,
       ButtonTag blockDescriptionModalButton,
       ButtonTag blockDeleteModalButton,
-      boolean isIntakeFormFeatureEnabled,
       Request request) {
     // A block can only be deleted when it has no repeated blocks. Same is true for
     // removing the enumerator question from the block.
@@ -457,8 +455,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
             allQuestions);
 
     Optional<DivTag> maybeEligibilityPredicateDisplay = Optional.empty();
-    if (!(isIntakeFormFeatureEnabled
-        && program.programType().equals(ProgramType.COMMON_INTAKE_FORM))) {
+    if (!program.programType().equals(ProgramType.COMMON_INTAKE_FORM)) {
       maybeEligibilityPredicateDisplay =
           Optional.of(
               renderEligibilityPredicate(

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -222,9 +222,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                 legend("Program eligibility gating")
                     .withClass(BaseStyles.INPUT_LABEL)
                     .with(ViewUtils.requiredQuestionIndicator())
-                    .condWith(
-                        settingsManifest.getIntakeFormEnabled(),
-                        p("(Not applicable if this program is the pre-screener)")),
+                    .with(p("(Not applicable if this program is the pre-screener)")),
                 FieldWithLabel.radio()
                     .setFieldName(ELIGIBILITY_IS_GATING_FIELD_NAME)
                     .setAriaRequired(true)
@@ -244,44 +242,41 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                     .setChecked(!eligibilityIsGating)
                     .getRadioTag()));
 
-    formTag.with(
-        FieldWithLabel.textArea()
-            .setId("program-description-textarea")
-            .setFieldName("adminDescription")
-            .setLabelText("Program note for administrative use only")
-            .setValue(adminDescription)
-            .getTextareaTag());
-    if (settingsManifest.getIntakeFormEnabled()) {
-      formTag
-          .with(
-              FieldWithLabel.checkbox()
-                  .setId("common-intake-checkbox")
-                  .setFieldName("isCommonIntakeForm")
-                  .setLabelText("Set program as pre-screener")
-                  .addStyleClass("border-none")
-                  .setValue("true")
-                  .setChecked(isCommonIntakeForm)
-                  .getCheckboxTag()
-                  .with(
-                      span(ViewUtils.makeSvgToolTip(
-                              "You can set one program as the ‘pre-screener’. This will pin the"
-                                  + " program card to the top of the programs and services page"
-                                  + " while moving other program cards below it.",
-                              Icons.INFO))
-                          .withClass("ml-2")))
-          .with(
-              // Hidden checkbox used to signal whether or not the user has confirmed they want to
-              // change which program is marked as the common intake form.
-              FieldWithLabel.checkbox()
-                  .setId("confirmed-change-common-intake-checkbox")
-                  .setFieldName("confirmedChangeCommonIntakeForm")
-                  .setValue("false")
-                  .setChecked(false)
-                  .addStyleClass("hidden")
-                  .getCheckboxTag());
-    }
-
-    formTag.with(createSubmitButton(programEditStatus));
+    formTag
+        .with(
+            FieldWithLabel.textArea()
+                .setId("program-description-textarea")
+                .setFieldName("adminDescription")
+                .setLabelText("Program note for administrative use only")
+                .setValue(adminDescription)
+                .getTextareaTag())
+        .with(
+            FieldWithLabel.checkbox()
+                .setId("common-intake-checkbox")
+                .setFieldName("isCommonIntakeForm")
+                .setLabelText("Set program as pre-screener")
+                .addStyleClass("border-none")
+                .setValue("true")
+                .setChecked(isCommonIntakeForm)
+                .getCheckboxTag()
+                .with(
+                    span(ViewUtils.makeSvgToolTip(
+                            "You can set one program as the ‘pre-screener’. This will pin the"
+                                + " program card to the top of the programs and services page"
+                                + " while moving other program cards below it.",
+                            Icons.INFO))
+                        .withClass("ml-2")))
+        .with(
+            // Hidden checkbox used to signal whether or not the user has confirmed they want to
+            // change which program is marked as the common intake form.
+            FieldWithLabel.checkbox()
+                .setId("confirmed-change-common-intake-checkbox")
+                .setFieldName("confirmedChangeCommonIntakeForm")
+                .setValue("false")
+                .setChecked(false)
+                .addStyleClass("hidden")
+                .getCheckboxTag())
+        .with(createSubmitButton(programEditStatus));
     return formTag;
   }
 

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -646,10 +646,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                   /* selectedApplicationUri= */ Optional.empty())
               .url();
 
-      String buttonText =
-          settingsManifest.getIntakeFormEnabled() && activeProgram.isCommonIntakeForm()
-              ? "Forms"
-              : "Applications";
+      String buttonText = activeProgram.isCommonIntakeForm() ? "Forms" : "Applications";
       ButtonTag button =
           makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
       return Optional.of(asRedirectElement(button, editLink));

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -29,7 +29,6 @@ import services.applicant.ApplicantPersonalInfo;
 import services.applicant.RepeatedEntity;
 import services.program.ProgramType;
 import services.question.types.QuestionDefinition;
-import services.settings.SettingsManifest;
 import views.AlertComponent;
 import views.ApplicationBaseView;
 import views.BaseHtmlView;
@@ -50,18 +49,13 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
   private final ApplicantLayout layout;
   private final DateConverter dateConverter;
-  private final SettingsManifest settingsManifest;
   private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ApplicantProgramSummaryView(
-      ApplicantLayout layout,
-      DateConverter dateConverter,
-      SettingsManifest settingsManifest,
-      ApplicantRoutes applicantRoutes) {
+      ApplicantLayout layout, DateConverter dateConverter, ApplicantRoutes applicantRoutes) {
     this.layout = checkNotNull(layout);
     this.dateConverter = checkNotNull(dateConverter);
-    this.settingsManifest = checkNotNull(settingsManifest);
     this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
@@ -142,8 +136,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
         .ifPresent(bundle::addToastMessages);
 
     String pageTitle =
-        settingsManifest.getIntakeFormEnabled()
-                && params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
+        params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
             ? messages.at(MessageKey.TITLE_COMMON_INTAKE_SUMMARY.getKeyName())
             : messages.at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());
     bundle.setTitle(String.format("%s — %s", pageTitle, params.programTitle()));

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -66,8 +66,7 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
 
     Optional<ProgramSectionParams> intakeSection = Optional.empty();
 
-    if (settingsManifest.getIntakeFormEnabled()
-        && applicationPrograms.commonIntakeForm().isPresent()) {
+    if (applicationPrograms.commonIntakeForm().isPresent()) {
       intakeSection =
           Optional.of(
               getCommonIntakeFormSection(

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -192,8 +192,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                 Math.max(relevantPrograms.unapplied().size(), relevantPrograms.submitted().size()),
                 relevantPrograms.inProgress().size()));
 
-    if (settingsManifest.getIntakeFormEnabled()
-        && relevantPrograms.commonIntakeForm().isPresent()) {
+    if (relevantPrograms.commonIntakeForm().isPresent()) {
       content.with(
           findServicesSection(
               request,

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
-import services.settings.SettingsManifest;
 import views.ProgramImageUtils;
 import views.ViewUtils;
 import views.ViewUtils.ProgramDisplayType;
@@ -28,17 +27,13 @@ import views.style.StyleUtils;
 
 /** Responsible for generating a program card for view by CiviForm admins / program admins. */
 public final class ProgramCardFactory {
-
   private final ViewUtils viewUtils;
   private final ProgramImageUtils programImageUtils;
-  private final SettingsManifest settingsManifest;
 
   @Inject
-  public ProgramCardFactory(
-      ViewUtils viewUtils, ProgramImageUtils programImageUtils, SettingsManifest settingsManifest) {
+  public ProgramCardFactory(ViewUtils viewUtils, ProgramImageUtils programImageUtils) {
     this.viewUtils = checkNotNull(viewUtils);
     this.programImageUtils = checkNotNull(programImageUtils);
-    this.settingsManifest = settingsManifest;
   }
 
   public DivTag renderCard(ProgramCardData cardData) {
@@ -192,8 +187,7 @@ public final class ProgramCardFactory {
   }
 
   private boolean shouldShowCommonIntakeFormIndicator(ProgramDefinition displayProgram) {
-    return settingsManifest.getIntakeFormEnabled()
-        && displayProgram.programType().equals(ProgramType.COMMON_INTAKE_FORM);
+    return displayProgram.programType().equals(ProgramType.COMMON_INTAKE_FORM);
   }
 
   private static ProgramDefinition getDisplayProgram(ProgramCardData cardData) {

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -719,11 +719,6 @@
         "description": "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login screen. Is disabled by default.",
         "type": "bool"
       },
-      "INTAKE_FORM_ENABLED": {
-        "mode": "ADMIN_READABLE",
-        "description": "Enables the Common Intake Form feature.",
-        "type": "bool"
-      },
       "STAGING_ADD_NOINDEX_META_TAG": {
         "mode": "HIDDEN",
         "description": "If this is a staging deployment and this variable is set to true, a [robots noindex](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) metadata tag is added to the CiviForm pages. This causes the staging site to not be listed on search engines.",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -23,10 +23,6 @@ staging_disable_demo_mode_logins = ${?STAGING_DISABLE_DEMO_MODE_LOGINS}
 
 # In development features.
 
-# Common Intake Form flags
-intake_form_enabled = true
-intake_form_enabled = ${?INTAKE_FORM_ENABLED}
-
 # api generated docs tab
 api_generated_docs_enabled = false
 api_generated_docs_enabled = ${?API_GENERATED_DOCS_ENABLED}

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -2,7 +2,6 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -16,7 +15,6 @@ import models.DisplayMode;
 import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import play.data.FormFactory;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
@@ -27,7 +25,6 @@ import repository.VersionRepository;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionService;
-import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 import views.admin.programs.ProgramEditStatus;
 import views.admin.programs.ProgramIndexView;
@@ -40,14 +37,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
   private AdminProgramController controller;
   private ProgramRepository programRepository;
   private VersionRepository versionRepository;
-  private SettingsManifest mockSettingsManifest;
 
   @Before
   public void setup() {
     programRepository = instanceOf(ProgramRepository.class);
     versionRepository = instanceOf(VersionRepository.class);
-    mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-    when(mockSettingsManifest.getIntakeFormEnabled()).thenReturn(true);
 
     controller =
         new AdminProgramController(
@@ -59,8 +53,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
             versionRepository,
             instanceOf(ProfileUtils.class),
             instanceOf(FormFactory.class),
-            instanceOf(RequestChecker.class),
-            mockSettingsManifest);
+            instanceOf(RequestChecker.class));
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -247,7 +247,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -268,7 +267,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -293,7 +291,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -319,7 +316,6 @@ public class ProgramServiceTest extends ResetPostgres {
             "",
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             /* tiGroup */ ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -341,7 +337,6 @@ public class ProgramServiceTest extends ResetPostgres {
         DisplayMode.PUBLIC.getValue(),
         /* eligibilityIsGating= */ true,
         ProgramType.DEFAULT,
-        /* isIntakeFormFeatureEnabled= */ false,
         ImmutableList.copyOf(new ArrayList<>()),
         /* categoryIds= */ ImmutableList.of());
 
@@ -356,7 +351,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -380,7 +374,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -408,7 +401,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 DisplayMode.PUBLIC.getValue(),
                 /* eligibilityIsGating= */ true,
                 ProgramType.DEFAULT,
-                /* isIntakeFormFeatureEnabled= */ false,
                 ImmutableList.copyOf(new ArrayList<>()),
                 /* categoryIds= */ ImmutableList.of())
             .getResult();
@@ -431,7 +423,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
     assertThat(result.hasResult()).isFalse();
@@ -453,7 +444,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -475,34 +465,12 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ false,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().eligibilityIsGating()).isFalse();
-  }
-
-  @Test
-  public void createProgram_intakeFormDisabled() {
-    ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.createProgramDefinition(
-            "name-one",
-            "description",
-            "display name",
-            "display description",
-            "",
-            "https://usa.gov",
-            DisplayMode.PUBLIC.getValue(),
-            /* eligibilityIsGating= */ true,
-            ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ false,
-            ImmutableList.copyOf(new ArrayList<>()),
-            /* categoryIds= */ ImmutableList.of());
-    assertThat(result.hasResult()).isTrue();
-    assertThat(result.isError()).isFalse();
-    assertThat(result.getResult().programType()).isEqualTo(ProgramType.DEFAULT);
   }
 
   @Test
@@ -517,7 +485,6 @@ public class ProgramServiceTest extends ResetPostgres {
         DisplayMode.PUBLIC.getValue(),
         /* eligibilityIsGating= */ true,
         ProgramType.COMMON_INTAKE_FORM,
-        /* isIntakeFormFeatureEnabled= */ true,
         ImmutableList.copyOf(new ArrayList<>()),
         /* categoryIds= */ ImmutableList.of());
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -531,7 +498,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -552,7 +518,6 @@ public class ProgramServiceTest extends ResetPostgres {
         DisplayMode.PUBLIC.getValue(),
         /* eligibilityIsGating= */ true,
         ProgramType.COMMON_INTAKE_FORM,
-        /* isIntakeFormFeatureEnabled= */ true,
         ImmutableList.copyOf(new ArrayList<>()),
         /* categoryIds= */ ImmutableList.of());
 
@@ -571,7 +536,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
     assertThat(result.hasResult()).isTrue();
@@ -698,7 +662,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 DisplayMode.PUBLIC.getValue(),
                 /* eligibilityIsGating= */ true,
                 ProgramType.DEFAULT,
-                /* isIntakeFormFeatureEnabled= */ false,
                 ImmutableList.copyOf(new ArrayList<>()),
                 /* categoryIds= */ ImmutableList.of())
             .getResult();
@@ -768,7 +731,6 @@ public class ProgramServiceTest extends ResetPostgres {
                     DisplayMode.PUBLIC.getValue(),
                     /* eligibilityIsGating= */ true,
                     ProgramType.DEFAULT,
-                    /* isIntakeFormFeatureEnabled= */ false,
                     ImmutableList.copyOf(new ArrayList<>()),
                     /* categories= */ ImmutableList.of()))
         .isInstanceOf(ProgramNotFoundException.class)
@@ -791,7 +753,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -827,7 +788,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 DisplayMode.PUBLIC.getValue(),
                 /* eligibilityIsGating= */ true,
                 ProgramType.DEFAULT,
-                /* isIntakeFormFeatureEnabled= */ false,
                 ImmutableList.copyOf(new ArrayList<>()),
                 /* categories= */ ImmutableList.of())
             .getResult();
@@ -853,7 +813,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -881,7 +840,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -904,7 +862,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
     ProgramDefinition secondProgramUpdate = resultTwo.getResult();
@@ -926,7 +883,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            false,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
     ProgramDefinition thirdProgramUpdate = resultThree.getResult();
@@ -943,31 +899,6 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void updateProgram_intakeFormDisabled() throws Exception {
-    ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
-
-    ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.updateProgramDefinition(
-            program.id(),
-            Locale.US,
-            "a",
-            "a",
-            "a",
-            "",
-            "https://usa.gov",
-            DisplayMode.PUBLIC.getValue(),
-            /* eligibilityIsGating= */ true,
-            ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ false,
-            ImmutableList.copyOf(new ArrayList<>()),
-            /* categories= */ ImmutableList.of());
-
-    assertThat(result.hasResult()).isTrue();
-    assertThat(result.isError()).isFalse();
-    assertThat(result.getResult().programType()).isEqualTo(ProgramType.DEFAULT);
-  }
-
-  @Test
   public void updateProgram_clearsExistingCommonIntakeForm() throws Exception {
     ps.createProgramDefinition(
         "name-one",
@@ -979,7 +910,6 @@ public class ProgramServiceTest extends ResetPostgres {
         DisplayMode.PUBLIC.getValue(),
         /* eligibilityIsGating= */ true,
         ProgramType.COMMON_INTAKE_FORM,
-        /* isIntakeFormFeatureEnabled= */ true,
         ImmutableList.copyOf(new ArrayList<>()),
         /* categoryIds= */ ImmutableList.of());
 
@@ -1000,7 +930,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -1029,7 +958,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -1045,7 +973,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -1066,7 +993,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categoryIds= */ ImmutableList.of());
 
@@ -1082,7 +1008,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -1127,7 +1052,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.COMMON_INTAKE_FORM,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -1174,7 +1098,6 @@ public class ProgramServiceTest extends ResetPostgres {
             DisplayMode.PUBLIC.getValue(),
             /* eligibilityIsGating= */ true,
             ProgramType.DEFAULT,
-            /* isIntakeFormFeatureEnabled= */ true,
             ImmutableList.copyOf(new ArrayList<>()),
             /* categories= */ ImmutableList.of());
 
@@ -1595,7 +1518,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 DisplayMode.PUBLIC.getValue(),
                 /* eligibilityIsGating= */ true,
                 ProgramType.DEFAULT,
-                false,
                 ImmutableList.copyOf(new ArrayList<>()),
                 /* categoryIds= */ ImmutableList.of())
             .getResult();


### PR DESCRIPTION
### Description

Fully remove the INTAKE_FORM_ENABLED feature flag, now that it has been enabled in prod for a month.

## Release notes

Removed the INTAKE_FORM_ENABLED feature flag, so the pre-screener form feature is always available. Note that this does automatically create a pre-screener program, just makes the feature available to admins.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Fixes #7865
