### PR TITLE
Only run address test locally

### DIFF
--- a/browser-test/src/dev/address_checker.test.ts
+++ b/browser-test/src/dev/address_checker.test.ts
@@ -2,75 +2,78 @@ import {test, expect} from '../support/civiform_fixtures'
 import {
   disableFeatureFlag,
   enableFeatureFlag,
+  isLocalDevEnvironment,
   validateAccessibility,
   validateScreenshot,
 } from '../support'
 import {waitForPageJsLoad, waitForHtmxReady} from '../support/wait'
 
 test.describe('Address checker', () => {
-  test('All features run when correction and validation are enabled', async ({
-    page,
-  }) => {
-    await enableFeatureFlag(page, 'ESRI_ADDRESS_CORRECTION_ENABLED')
-    await enableFeatureFlag(
+  if (isLocalDevEnvironment()) {
+    test('All features run when correction and validation are enabled', async ({
       page,
-      'ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED',
-    )
+    }) => {
+      await enableFeatureFlag(page, 'ESRI_ADDRESS_CORRECTION_ENABLED')
+      await enableFeatureFlag(
+        page,
+        'ESRI_ADDRESS_SERVICE_AREA_VALIDATION_ENABLED',
+      )
 
-    await test.step('Navigate to address tools', async () => {
-      await page.click('#debug-content-modal-button')
-      await page.click('#additional-tools')
-      await waitForPageJsLoad(page)
-      await page.getByRole('heading', {name: 'Address Checker'}).isVisible()
-      await page.getByRole('link', {name: 'Go to address tools'}).click()
-      await waitForPageJsLoad(page)
+      await test.step('Navigate to address tools', async () => {
+        await page.click('#debug-content-modal-button')
+        await page.click('#additional-tools')
+        await waitForPageJsLoad(page)
+        await page.getByRole('heading', {name: 'Address Checker'}).isVisible()
+        await page.getByRole('link', {name: 'Go to address tools'}).click()
+        await waitForPageJsLoad(page)
+      })
+
+      await test.step('Address correction runs and loads results', async () => {
+        await page
+          .getByRole('textbox', {name: 'Address 1'})
+          .fill('Address In Area')
+
+        await page.getByRole('button', {name: 'Correct Address'}).click()
+
+        await waitForHtmxReady(page)
+        await expect(
+          page.getByRole('heading', {name: 'Address Correction Results'}),
+        ).toBeVisible()
+      })
+
+      await test.step('Address correction result runs and loads service area validation', async () => {
+        await page.getByRole('textbox', {name: 'Latitude/Y'}).fill('100')
+        await page.getByRole('textbox', {name: 'Longitude/X'}).fill('-100')
+        await page.getByRole('textbox', {name: 'WellKnownId'}).fill('4326')
+
+        await page
+          .getByTestId('address-correction-results')
+          .getByRole('button', {name: 'Check Service Area'})
+          .last()
+          .click()
+
+        await waitForHtmxReady(page)
+        await expect(
+          page.getByRole('heading', {name: 'Validation Result: Failed'}),
+        ).toBeVisible()
+      })
+
+      await test.step('Service area validation runs and loads results', async () => {
+        await page
+          .getByRole('form', {name: 'Search Service Area'})
+          .getByRole('button', {name: 'Check Service Area'})
+          .click()
+
+        await waitForHtmxReady(page)
+        await expect(
+          page.getByRole('heading', {name: 'Validation Result: InArea'}),
+        ).toBeVisible()
+      })
+
+      await validateAccessibility(page)
+      await validateScreenshot(page, 'address-checker-enabled')
     })
-
-    await test.step('Address correction runs and loads results', async () => {
-      await page
-        .getByRole('textbox', {name: 'Address 1'})
-        .fill('Address In Area')
-
-      await page.getByRole('button', {name: 'Correct Address'}).click()
-
-      await waitForHtmxReady(page)
-      await expect(
-        page.getByRole('heading', {name: 'Address Correction Results'}),
-      ).toBeVisible()
-    })
-
-    await test.step('Address correction result runs and loads service area validation', async () => {
-      await page.getByRole('textbox', {name: 'Latitude/Y'}).fill('100')
-      await page.getByRole('textbox', {name: 'Longitude/X'}).fill('-100')
-      await page.getByRole('textbox', {name: 'WellKnownId'}).fill('4326')
-
-      await page
-        .getByTestId('address-correction-results')
-        .getByRole('button', {name: 'Check Service Area'})
-        .last()
-        .click()
-
-      await waitForHtmxReady(page)
-      await expect(
-        page.getByRole('heading', {name: 'Validation Result: Failed'}),
-      ).toBeVisible()
-    })
-
-    await test.step('Service area validation runs and loads results', async () => {
-      await page
-        .getByRole('form', {name: 'Search Service Area'})
-        .getByRole('button', {name: 'Check Service Area'})
-        .click()
-
-      await waitForHtmxReady(page)
-      await expect(
-        page.getByRole('heading', {name: 'Validation Result: InArea'}),
-      ).toBeVisible()
-    })
-
-    await validateAccessibility(page)
-    await validateScreenshot(page, 'address-checker-enabled')
-  })
+  }
 
   test('All features run when correction and validation are disabled', async ({
     page,


### PR DESCRIPTION
### Description

This address test expects the esri endpoint (or mock version) to be online. Making it only run locally, similarly to some other address tests.

Ignore whitespace for easier diff
<img width="266" alt="image" src="https://github.com/user-attachments/assets/b37c9b27-1974-48c0-b6fa-a221f0e790e2">


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
