### PR TITLE
Update renovate to look for java 17

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,7 +53,7 @@
         "bellsoft/liberica-openjdk-alpine",
         "eclipse-temurin"
       ],
-      "allowedVersions": "<12.0.0"
+      "allowedVersions": "<18.0.0"
     },
     {
       "groupName": "jupiter",


### PR DESCRIPTION
### Description

Forgot to update the renovate config to allow for java 17.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
