### PR TITLE
Use a custom regex for matching docker java in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,7 +53,13 @@
         "bellsoft/liberica-openjdk-alpine",
         "eclipse-temurin"
       ],
-      "allowedVersions": "<18.0.0"
+      // Allow for version 17.*
+      // 
+      // Examples of what this should match are:
+      //   17.0.12_7-jdk-alpine
+      //   17.0.12_7-jre-alpine
+      //   17.0.12-10
+      "allowedVersions": "/^17\\.([0-9]*)\\.([0-9]*)([-_]?)([0-9]*)(-?.*)$/",
     },
     {
       "groupName": "jupiter",


### PR DESCRIPTION
### Description

Renovate's built in pattern for matching the bellsoft/liberica-open-jdk-alpine version we use doesn't match correctly. This pattern should work for both bellsoft and eclipse temurin.

Running the renovate cli in local mode I'm able to get it to see updates for both bellsoft and temurin 17.0.12 against a test dockerfile with the previous 17.0.11 version in it.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
