### PR TITLE
Example forcing js to rebuild for uswds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ ENTRYPOINT ["/bin/bash"]
 # Save build results to anonymous volumes for reuse
 # We do this first, so they don't get shadowed by the
 # local server directory when running locally.
-VOLUME [ "/usr/src/server/target","/usr/src/server/project/project", "/usr/src/server/project/target", "/usr/src/server/node_modules", "/usr/src/server/.bsp/","/usr/src/server/public/stylesheets/" ]
+VOLUME [ "/usr/src/server/project/project", "/usr/src/server/project/target", "/usr/src/server/.bsp/","/usr/src/server/public/stylesheets/" ]
 # Then map the server code to a volume, which can be shadowed
 # locally.
 VOLUME ["/usr/src/server"]

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -4,9 +4,7 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   stats: 'errors-only',
-  cache: {
-    type: 'filesystem'
-  },
+  cache: false,
   module: {
     rules: [
       {
@@ -36,7 +34,7 @@ module.exports = {
       {
         test: /\.tsx?$/,
         use: 'ts-loader',
-        exclude: /node_modules\/(?!(@uswds)\/).*/,
+        //exclude: /node_modules\/(?!(@uswds)\/).*/,
       },
     ],
   },


### PR DESCRIPTION
## One time

- make the changes to the `Dockerfile` and the `webpack.config.js`
- remove existing docker containers `docker rm -f $(docker ps --filter=name=civiform --quiet)`
- start application `bin/run-dev`


## After changes when you want to refresh

- make any change to the `server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss` (really any scss file should work)
- reload the page
- find and open the *-uswds.bundle.js file the web page loaded. Check for expected changes. If it does you probably don't need to keep checking each time. Just make sure the file name prefix changes
