### PR TITLE
Prepare new ineligible alert strings for North Star

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -1416,6 +1416,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             request,
             profileUtils.currentUserProfile(request).get().isTrustedIntermediary(),
             !roApplicantProgramService.isApplicationNotEligible(),
+            settingsManifest.getNorthStarApplicantUi(request),
+            false,
             programId);
 
     return ApplicationBaseViewParams.builder()

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -150,6 +150,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
                       request,
                       profileUtils.currentUserProfile(request).get().isTrustedIntermediary(),
                       !roApplicantProgramService.isApplicationNotEligible(),
+                      settingsManifest.getNorthStarApplicantUi(request),
+                      false,
                       programId);
 
               ApplicantProgramSummaryView.Params.Builder params =

--- a/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
+++ b/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
@@ -37,7 +37,12 @@ public final class EligibilityAlertSettingsCalculator {
   }
 
   public AlertSettings calculate(
-      Http.Request request, boolean isTI, boolean isApplicationEligible, long programId) {
+      Http.Request request,
+      boolean isTI,
+      boolean isApplicationEligible,
+      boolean isNorthStarEnabled,
+      boolean pageHasSupplementalInformation,
+      long programId) {
     Messages messages = messagesApi.preferred(request);
 
     boolean isEligibilityGating = isEligibilityGating(programId);
@@ -51,8 +56,16 @@ public final class EligibilityAlertSettingsCalculator {
 
     Triple triple =
         isTI
-            ? getTi(isApplicationFastForwarded, isApplicationEligible)
-            : getApplicant(isApplicationFastForwarded, isApplicationEligible);
+            ? getTi(
+                isApplicationFastForwarded,
+                isApplicationEligible,
+                isNorthStarEnabled,
+                pageHasSupplementalInformation)
+            : getApplicant(
+                isApplicationFastForwarded,
+                isApplicationEligible,
+                isNorthStarEnabled,
+                pageHasSupplementalInformation);
 
     return new AlertSettings(
         isEligibilityGating,
@@ -61,7 +74,11 @@ public final class EligibilityAlertSettingsCalculator {
         triple.alertType);
   }
 
-  private Triple getTi(Boolean isApplicationFastForwarded, Boolean isApplicationEligible) {
+  private Triple getTi(
+      boolean isApplicationFastForwarded,
+      boolean isApplicationEligible,
+      boolean isNorthStarEnabled,
+      boolean pageHasSupplementalInformation) {
     if (isApplicationFastForwarded == true && isApplicationEligible == true) {
       return new Triple(
           AlertType.SUCCESS,
@@ -83,6 +100,13 @@ public final class EligibilityAlertSettingsCalculator {
           MessageKey.ALERT_ELIGIBILITY_TI_ELIGIBLE_TEXT);
     }
 
+    if (isNorthStarEnabled == true && pageHasSupplementalInformation == true) {
+      return new Triple(
+          AlertType.WARNING,
+          MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TITLE,
+          MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT_SHORT);
+    }
+
     // The default case: isApplicationFastForwarded == false && isApplicationEligible == false
     return new Triple(
         AlertType.WARNING,
@@ -90,7 +114,11 @@ public final class EligibilityAlertSettingsCalculator {
         MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT);
   }
 
-  private Triple getApplicant(Boolean isApplicationFastForwarded, Boolean isApplicationEligible) {
+  private Triple getApplicant(
+      boolean isApplicationFastForwarded,
+      boolean isApplicationEligible,
+      boolean isNorthStarEnabled,
+      boolean pageHasSupplementalInformation) {
     if (isApplicationFastForwarded == true && isApplicationEligible == true) {
       return new Triple(
           AlertType.SUCCESS,
@@ -110,6 +138,13 @@ public final class EligibilityAlertSettingsCalculator {
           AlertType.SUCCESS,
           MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TITLE,
           MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TEXT);
+    }
+
+    if (pageHasSupplementalInformation == true && isNorthStarEnabled == true) {
+      return new Triple(
+          AlertType.WARNING,
+          MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TITLE,
+          MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT_SHORT);
     }
 
     // The default case: isApplicationFastForwarded == false && isApplicationEligible == false

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -26,6 +26,8 @@ public enum MessageKey {
   ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TEXT("alert.eligibility_applicant_eligible_text"),
   ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TITLE("alert.eligibility_applicant_not_eligible_title"),
   ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT("alert.eligibility_applicant_not_eligible_text"),
+  ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT_SHORT(
+      "alert.eligibilityApplicantNotEligibleTextShort"), // North Star only
   ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_ELIGIBLE_TITLE(
       "alert.eligibility_applicant_fastforwarded_eligible_title"),
   ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_ELIGIBLE_TEXT(
@@ -38,6 +40,8 @@ public enum MessageKey {
   ALERT_ELIGIBILITY_TI_ELIGIBLE_TEXT("alert.eligibility_ti_eligible_text"),
   ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TITLE("alert.eligibility_ti_not_eligible_title"),
   ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT("alert.eligibility_ti_not_eligible_text"),
+  ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT_SHORT(
+      "alert.eligibilityTiNotEligibleTextShort"), // North Star only
   ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TITLE(
       "alert.eligibility_ti_fastforwarded_eligible_title"),
   ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TEXT(
@@ -125,6 +129,8 @@ public enum MessageKey {
   CONTENT_FILE_UPLOAD_BLOCK_PROGRESS_FULL("content.fileUploadBlockProgressFull"),
   CONTENT_SAVE_TIME("content.saveTimeServices"),
   CONTENT_CHANGE_ELIGIBILITY_ANSWERS("content.changeAnswersForEligibility"),
+  CONTENT_CHANGE_ELIGIBILITY_ANSWERS_V2(
+      "content.changeAnswersForEligibility.v2"), // North Star only
   CONTENT_CIVIFORM_DESCRIPTION("content.findProgramsDescription"),
   CONTENT_CLIENT_CREATED("content.clientCreated"),
   CONTENT_CONFIRMED("content.confirmed"),
@@ -138,6 +144,7 @@ public enum MessageKey {
       "content.commonIntakeNoMatchingProgramsNextStep"),
   CONTENT_OTHER_PROGRAMS_TO_APPLY_FOR("content.otherProgramsToApplyFor"),
   CONTENT_ELIGIBILITY_CRITERIA("content.eligibilityCriteria"),
+  CONTENT_ELIGIBILITY_CRITERIA_V2("content.eligibilityCriteria.v2"), // North Star only
   CONTENT_EMAIL_TOOLTIP("content.emailTooltip"),
   CONTENT_FIND_PROGRAMS("content.findPrograms"),
   CONTENT_GUEST_DESCRIPTION("content.guestDescription"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -324,7 +324,11 @@ title.programSummary=Program application summary
 title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
 title.applicantNotEligibleTi=Based on your responses to the following questions, your client may not qualify for the {0}.
 content.eligibilityCriteria=For eligibility criteria please refer to {0}
+# Describes how to learn more about eligibility criteria for a program. The variable text is "program details", which will become a hyperlink to another webpage.
+content.eligibilityCriteria.v2=For eligibility criteria, please refer to {0}.
 content.changeAnswersForEligibility=You can return to the previous page to edit your answers. Or apply to another program.
+# Text shown on a webpage when the applicant is ineligible for a program.
+content.changeAnswersForEligibility.v2=If you think there is a mistake, you can return to the previous page to edit your answers. You can also apply to other programs.
 button.goBackAndEdit=Go back and edit
 toast.mayQualifyTi=Based on your responses, your client may qualify for the {0}. To proceed, continue filling out the application.
 toast.mayQualify=Based on your responses, you may qualify for the {0}. To proceed, continue filling out the application.
@@ -332,10 +336,9 @@ tag.mayQualify=You may qualify
 tag.mayQualifyTi=Your client may qualify
 tag.mayNotQualify=You may not qualify
 tag.mayNotQualifyTi=Your client may not qualify
-
 toast.mayNotQualify=Based on your responses, you may not qualify for the {0}. If your information has changed you can edit your answers and then proceed with the application.
-
 toast.mayNotQualifyTi=Based on your responses, your client may not qualify for the {0}. If your client''s information has changed you can edit your answers and then proceed with the application.
+
 banner.errorSavingApplication=Error saving application
 
 # Alert title when applicant may be eligible for a program
@@ -347,6 +350,8 @@ alert.eligibility_applicant_eligible_text=Based on your responses, you are likel
 alert.eligibility_applicant_not_eligible_title=You may not be eligible for this program
 # Alert text when applicant may not be eligible for a program
 alert.eligibility_applicant_not_eligible_text=Based on your responses, you may not be eligible for this program. If your information has changed, you can edit your answer and proceed with the application.
+# Alert text when applicant may not be eligible for a program (new version for North Star)
+alert.eligibilityApplicantNotEligibleTextShort=Based on your responses to the following questions, you may not be eligible for this program.
 
 # Alert title when applicant may be eligible for a program after the application gets updated to using a newer program version
 alert.eligibility_applicant_fastforwarded_eligible_title=You may be eligible for this program
@@ -367,6 +372,8 @@ alert.eligibility_ti_eligible_text=Based on your responses, your client is likel
 alert.eligibility_ti_not_eligible_title=Your client may not be eligible for this program
 # Alert text when TI client may not be eligible for a program
 alert.eligibility_ti_not_eligible_text=Based on your responses, your client may not be eligible for this program. If your client''s information has changed, you can edit your answer and proceed with the application.
+# Alert text when TI client may not be eligible for a program (new version for North Star)
+alert.eligibilityTiNotEligibleTextShort=Based on your responses to the following questions, your client may not be eligible for this program.
 
 # Alert title when TI client may be eligible for a program after the application gets updated to using a newer program version
 alert.eligibility_ti_fastforwarded_eligible_title=Your client may be eligible for this program

--- a/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
+++ b/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableMap;
 import controllers.FlashKey;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.DisplayMode;
@@ -41,32 +40,55 @@ public class EligibilityAlertSettingsCalculatorTest {
         ImmutableMap.<String, String>builder()
             .put(
                 MessageKey.ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_ELIGIBLE_TITLE.getKeyName(),
-                "A11")
+                "APPLICANT_FASTFORWARDED_ELIGIBLE_TITLE")
             .put(
                 MessageKey.ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_ELIGIBLE_TEXT.getKeyName(),
-                "A12")
+                "APPLICANT_FASTFORWARDED_ELIGIBLE_TEXT")
             .put(
                 MessageKey.ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TITLE
                     .getKeyName(),
-                "A21")
+                "APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TITLE")
             .put(
                 MessageKey.ALERT_ELIGIBILITY_APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TEXT.getKeyName(),
-                "A22")
-            .put(MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TITLE.getKeyName(), "A31")
-            .put(MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TEXT.getKeyName(), "A32")
-            .put(MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TITLE.getKeyName(), "A41")
-            .put(MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT.getKeyName(), "A42")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TITLE.getKeyName(), "T11")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TEXT.getKeyName(), "T12")
+                "APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TEXT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TITLE.getKeyName(),
+                "APPLICANT_ELIGIBLE_TITLE")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TEXT.getKeyName(),
+                "APPLICANT_ELIGIBLE_TEXT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TITLE.getKeyName(),
+                "APPLICANT_NOT_ELIGIBLE_TITLE")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT.getKeyName(),
+                "APPLICANT_NOT_ELIGIBLE_TEXT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TEXT_SHORT.getKeyName(),
+                "APPLICANT_NOT_ELIGIBLE_TEXT_SHORT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TITLE.getKeyName(),
+                "TI_FASTFORWARDED_ELIGIBLE_TITLE")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_ELIGIBLE_TEXT.getKeyName(),
+                "TI_FASTFORWARDED_ELIGIBLE_TEXT")
             .put(
                 MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_NOT_ELIGIBLE_TITLE.getKeyName(),
-                "T21")
+                "TI_FASTFORWARDED_NOT_ELIGIBLE_TITLE")
             .put(
-                MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_NOT_ELIGIBLE_TEXT.getKeyName(), "T22")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_ELIGIBLE_TITLE.getKeyName(), "T31")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_ELIGIBLE_TEXT.getKeyName(), "T32")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TITLE.getKeyName(), "T41")
-            .put(MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT.getKeyName(), "T42")
+                MessageKey.ALERT_ELIGIBILITY_TI_FASTFORWARDED_NOT_ELIGIBLE_TEXT.getKeyName(),
+                "TI_FASTFORWARDED_NOT_ELIGIBLE_TEXT")
+            .put(MessageKey.ALERT_ELIGIBILITY_TI_ELIGIBLE_TITLE.getKeyName(), "TI_ELIGIBLE_TITLE")
+            .put(MessageKey.ALERT_ELIGIBILITY_TI_ELIGIBLE_TEXT.getKeyName(), "TI_ELIGIBLE_TEXT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TITLE.getKeyName(),
+                "TI_NOT_ELIGIBLE_TITLE")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT.getKeyName(),
+                "TI_NOT_ELIGIBLE_TEXT")
+            .put(
+                MessageKey.ALERT_ELIGIBILITY_TI_NOT_ELIGIBLE_TEXT_SHORT.getKeyName(),
+                "TI_NOT_ELIGIBLE_TEXT_SHORT")
             .build();
 
     Map<String, Map<String, String>> langMap =
@@ -102,22 +124,129 @@ public class EligibilityAlertSettingsCalculatorTest {
       boolean isTi,
       boolean isFastForwarded,
       boolean isApplicationEligible,
+      boolean isNorthStarEnabled,
+      boolean pageHasSupplementalInformation,
       AlertType expectedAlertType,
+      String expectedTitle,
       String expectedText) {}
 
   public static ImmutableList<ParamValue> getTestData() {
     return ImmutableList.of(
         // Applicant
-        new ParamValue(false, true, true, AlertType.SUCCESS, "A1"),
-        new ParamValue(false, true, false, AlertType.WARNING, "A2"),
-        new ParamValue(false, false, true, AlertType.SUCCESS, "A3"),
-        new ParamValue(false, false, false, AlertType.WARNING, "A4"),
+        new ParamValue(
+            false,
+            true,
+            true,
+            false,
+            false,
+            AlertType.SUCCESS,
+            "APPLICANT_FASTFORWARDED_ELIGIBLE_TITLE",
+            "APPLICANT_FASTFORWARDED_ELIGIBLE_TEXT"),
+        new ParamValue(
+            false,
+            true,
+            false,
+            false,
+            false,
+            AlertType.WARNING,
+            "APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TITLE",
+            "APPLICANT_FASTFORWARDED_NOT_ELIGIBLE_TEXT"),
+        new ParamValue(
+            false,
+            false,
+            true,
+            false,
+            false,
+            AlertType.SUCCESS,
+            "APPLICANT_ELIGIBLE_TITLE",
+            "APPLICANT_ELIGIBLE_TEXT"),
+        new ParamValue(
+            false,
+            false,
+            false,
+            false,
+            false,
+            AlertType.WARNING,
+            "APPLICANT_NOT_ELIGIBLE_TITLE",
+            "APPLICANT_NOT_ELIGIBLE_TEXT"),
 
         // TI
-        new ParamValue(true, true, true, AlertType.SUCCESS, "T1"),
-        new ParamValue(true, true, false, AlertType.WARNING, "T2"),
-        new ParamValue(true, false, true, AlertType.SUCCESS, "T3"),
-        new ParamValue(true, false, false, AlertType.WARNING, "T4"));
+        new ParamValue(
+            true,
+            true,
+            true,
+            false,
+            false,
+            AlertType.SUCCESS,
+            "TI_FASTFORWARDED_ELIGIBLE_TITLE",
+            "TI_FASTFORWARDED_ELIGIBLE_TEXT"),
+        new ParamValue(
+            true,
+            true,
+            false,
+            false,
+            false,
+            AlertType.WARNING,
+            "TI_FASTFORWARDED_NOT_ELIGIBLE_TITLE",
+            "TI_FASTFORWARDED_NOT_ELIGIBLE_TEXT"),
+        new ParamValue(
+            true,
+            false,
+            true,
+            false,
+            false,
+            AlertType.SUCCESS,
+            "TI_ELIGIBLE_TITLE",
+            "TI_ELIGIBLE_TEXT"),
+        new ParamValue(
+            true,
+            false,
+            false,
+            false,
+            false,
+            AlertType.WARNING,
+            "TI_NOT_ELIGIBLE_TITLE",
+            "TI_NOT_ELIGIBLE_TEXT"),
+
+        // North Star, pageHasSupplementalInformation==false
+        new ParamValue(
+            false,
+            false,
+            false,
+            true,
+            false,
+            AlertType.WARNING,
+            "APPLICANT_NOT_ELIGIBLE_TITLE",
+            "APPLICANT_NOT_ELIGIBLE_TEXT"),
+        new ParamValue(
+            true,
+            false,
+            false,
+            true,
+            false,
+            AlertType.WARNING,
+            "TI_NOT_ELIGIBLE_TITLE",
+            "TI_NOT_ELIGIBLE_TEXT"),
+
+        // North Star, , pageHasSupplementalInformation==true
+        new ParamValue(
+            false,
+            false,
+            false,
+            true,
+            true,
+            AlertType.WARNING,
+            "APPLICANT_NOT_ELIGIBLE_TITLE",
+            "APPLICANT_NOT_ELIGIBLE_TEXT_SHORT"),
+        new ParamValue(
+            true,
+            false,
+            false,
+            true,
+            true,
+            AlertType.WARNING,
+            "TI_NOT_ELIGIBLE_TITLE",
+            "TI_NOT_ELIGIBLE_TEXT_SHORT"));
   }
 
   @Test
@@ -138,12 +267,17 @@ public class EligibilityAlertSettingsCalculatorTest {
 
     AlertSettings result =
         eligibilityAlertSettingsCalculator.calculate(
-            request, value.isTi, value.isApplicationEligible, /* programId */ 1L);
+            request,
+            value.isTi,
+            value.isApplicationEligible,
+            value.isNorthStarEnabled, /* programId */
+            value.pageHasSupplementalInformation,
+            1L);
 
     assertThat(result.show()).isEqualTo(isEligibilityGating);
     assertThat(result.alertType()).isEqualTo(value.expectedAlertType);
-    assertThat(result.title()).isEqualTo(Optional.of(String.format("%s1", value.expectedText)));
-    assertThat(result.text()).isEqualTo(String.format("%s2", value.expectedText));
+    assertThat(result.title().get()).isEqualTo(value.expectedTitle);
+    assertThat(result.text()).isEqualTo(value.expectedText);
   }
 
   @Test
@@ -161,7 +295,7 @@ public class EligibilityAlertSettingsCalculatorTest {
 
     AlertSettings result =
         eligibilityAlertSettingsCalculator.calculate(
-            fakeRequest(), false, true, /* programId */ 1L);
+            fakeRequest(), false, true, false, false, /* programId */ 1L);
 
     assertThat(result.show()).isEqualTo(isEligibilityGating);
   }


### PR DESCRIPTION
### Description

Adding new ineligible alert strings for North Star. This change was originally a part of #8104 but I wanted to split it up into smaller chunks for ease of review.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

n/a

### Issue(s) this completes

Part of #7996
