### PR TITLE
Enable CSP enforcement by default

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -352,7 +352,7 @@ play.filters {
   enabled += filters.DevRoutesFilter
 
   csp {
-    reportOnly = true
+    reportOnly = false
     reportOnly = ${?CSP_REPORT_ONLY}
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -18,8 +18,6 @@ play.http {
 }
 
 play.filters {
-  # TODO(https://github.com/civiform/civiform/issues/7574) remove this once CSP is enforced by default
-  csp.reportOnly = false
   csrf {
     cookie.secure = false
   }


### PR DESCRIPTION
### Description

Change the reportOnly setting for CSP from true to false by default. The setting can still be overridden with the [CSP_REPORT_ONLY](https://github.com/civiform/civiform/blob/fb32344e118fc977609de00fd1deb34e44e7082f/server/conf/env-var-docs.json#L629) configuration variable.

Also remove the override in application.dev.conf since false is now the default.

This is for #7574.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)