### PR TITLE
Align vscode extension lists

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,6 +49,7 @@
         "bradlc.vscode-tailwindcss",
         "dbaeumer.vscode-eslint",
         "github.vscode-pull-request-github",
+        "graphite.gti-vscode",
         "ms-azuretools.vscode-docker",
         "ms-ossdata.vscode-postgresql",
         "ms-playwright.playwright",
@@ -58,8 +59,7 @@
         "scala-lang.scala",
         "scalameta.metals",
         "vscjava.vscode-java-pack",
-        "vscode-icons-team.vscode-icons",
-        "Graphite.gti-vscode"
+        "vscode-icons-team.vscode-icons"
       ]
     }
   },

--- a/civiform.code-workspace
+++ b/civiform.code-workspace
@@ -21,17 +21,20 @@
   },
   "extensions": {
     "recommendations": [
-      "vscjava.vscode-java-pack",
-      "github.vscode-pull-request-github",
-      "knisterpeter.vscode-github",
-      "ms-azuretools.vscode-docker",
-      "hashicorp.terraform",
-      "ms-ossdata.vscode-postgresql",
       "bradlc.vscode-tailwindcss",
-      "scala-lang.scala",
-      "redhat.vscode-yaml",
       "dbaeumer.vscode-eslint",
-      "rvest.vs-code-prettier-eslint"
+      "github.vscode-pull-request-github",
+      "graphite.gti-vscode",
+      "ms-azuretools.vscode-docker",
+      "ms-ossdata.vscode-postgresql",
+      "ms-playwright.playwright",
+      "ms-vscode-remote.remote-containers",
+      "redhat.vscode-yaml",
+      "rvest.vs-code-prettier-eslint",
+      "scala-lang.scala",
+      "scalameta.metals",
+      "vscjava.vscode-java-pack",
+      "vscode-icons-team.vscode-icons"
     ]
   },
   "launch": {


### PR DESCRIPTION
### Description

Bringing (recommended) extension lists into sync

- Remove obsolete extension; we already have the recommended replacement in the list
`knisterpeter.vscode-github`  ➡️  `github.vscode-pull-request-github`

- Remove `hashicorp.terraform` since it's not used in this repo

- Adding `graphite`, `playwright`, and `remote containers` as recommended extensions

- Sorting



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
