### PR TITLE
Remove obsolete security workaround

### DIFF
--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -81,13 +81,6 @@ public class SecurityModule extends AbstractModule {
     logoutController.setDefaultUrl(baseUrl + routes.HomeController.index().url());
     logoutController.setLocalLogout(true);
     logoutController.setDestroySession(true);
-    /*
-     * This mitigates a vulnerability in the logout process described here:
-     * https://groups.google.com/g/pac4j-security/c/poWGfZKo-ww/m/S-h4ggaSAgAJ
-     *
-     * <p>Can be removed after upgrading to pac4j v5.6.1
-     */
-    logoutController.setLogoutUrlPattern("^(\\/|\\/[^\\/].*)$");
 
     Boolean shouldPerformAuthProviderLogout = configuration.getBoolean("auth.oidc_provider_logout");
     logoutController.setCentralLogout(shouldPerformAuthProviderLogout);


### PR DESCRIPTION
### Description

This workaround was only necessary until pac4j 5.6.1, and we're [on 5.7.6](https://github.com/civiform/civiform/blob/65a5fea8918d08b6c668d480475a1d0d1dc11f66/server/build.sbt#L76-L84). 


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)