### PR TITLE
Add a config variable to override CSP report only config

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -747,6 +747,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * Overrides the default configuration for the content security policy. If set to true, the
+   * browser reports content security policy violations but does not enforce the policy. If set to
+   * false, the browser enforces the policy.
+   */
+  public boolean getCspReportOnly() {
+    return getBool("CSP_REPORT_ONLY");
+  }
+
+  /**
    * If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If
    * disabled, '/metrics' returns a 404.
    */
@@ -2096,5 +2105,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " deployments, this value is 1.",
                       /* isRequired= */ false,
                       SettingType.INT,
-                      SettingMode.ADMIN_READABLE))));
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "CSP_REPORT_ONLY",
+                      "Overrides the default configuration for the content security policy. If set"
+                          + " to true, the browser reports content security policy violations but"
+                          + " does not enforce the policy. If set to false, the browser enforces"
+                          + " the policy.",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.HIDDEN))));
 }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -351,6 +351,7 @@ play.filters {
 
   csp {
     reportOnly = true
+    reportOnly = ${?CSP_REPORT_ONLY}
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
   }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -626,6 +626,11 @@
     "description": "The count of reverse proxies between the internet and the server. In typical deployments, this value is 1.",
     "type": "int"
   },
+  "CSP_REPORT_ONLY": {
+    "mode": "HIDDEN",
+    "description": "Overrides the default configuration for the content security policy. If set to true, the browser reports content security policy violations but does not enforce the policy. If set to false, the browser enforces the policy.",
+    "type": "bool"
+  },
   "Observability": {
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {


### PR DESCRIPTION
### Description

Add a config variable to override CSP (content security policy) enforcement per environment. This allows us to execute an incremental rollout per instance without the additional work of implementing a feature flag. This is for #7574.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
