### PR TITLE
Have data accessing modules wait for evolutions to complete

### DIFF
--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -3,6 +3,8 @@ package modules;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import javax.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.api.db.evolutions.ApplicationEvolutions;
 import services.seeding.DatabaseSeedTask;
 
@@ -11,9 +13,11 @@ import services.seeding.DatabaseSeedTask;
  * start time.
  */
 public final class DatabaseSeedModule extends AbstractModule {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSeedModule.class);
 
   @Override
   protected void configure() {
+    LOGGER.trace("Module Started");
     bind(DatabaseSeedScheduler.class).asEagerSingleton();
   }
 
@@ -23,9 +27,14 @@ public final class DatabaseSeedModule extends AbstractModule {
     public DatabaseSeedScheduler(
         ApplicationEvolutions applicationEvolutions,
         Provider<DatabaseSeedTask> databaseSeedTaskProvider) {
+      LOGGER.trace("DatabaseSeedScheduler - Started");
 
       if (applicationEvolutions.upToDate()) {
+        LOGGER.trace("DatabaseSeedScheduler - Task Start");
         databaseSeedTaskProvider.get().run();
+        LOGGER.trace("DatabaseSeedScheduler - Task End");
+      } else {
+        LOGGER.trace("Evolutions Not Ready");
       }
     }
   }

--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -21,6 +21,13 @@ public final class DatabaseSeedModule extends AbstractModule {
     bind(DatabaseSeedScheduler.class).asEagerSingleton();
   }
 
+  /**
+   * This class injects ApplicationEvolutions and checks the `upToDate` method to prevent this
+   * module from running until after the evolutions are completed.
+   *
+   * <p>See <a href="https://github.com/civiform/civiform/pull/8253">PR 8253</a> for more extensive
+   * details.
+   */
   public static final class DatabaseSeedScheduler {
 
     @Inject

--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -46,7 +46,16 @@ public final class DurableJobModule extends AbstractModule {
     bind(DurableJobRunnerScheduler.class).asEagerSingleton();
   }
 
-  /** Schedules the job runner to run on an interval using the akka scheduling system. */
+  /**
+   * This class injects ApplicationEvolutions and checks the `upToDate` method to prevent this
+   * module from running until after the evolutions are completed.
+   *
+   * <p>See <a href="https://github.com/civiform/civiform/pull/8253">PR 8253</a> for more extensive
+   * details.
+   *
+   * <p>Additionally this uses The Akka scheduling system to schedules the job runner to run on an
+   * interval.
+   */
   public static final class DurableJobRunnerScheduler {
 
     @Inject

--- a/server/app/modules/SettingsMigrationModule.java
+++ b/server/app/modules/SettingsMigrationModule.java
@@ -3,6 +3,8 @@ package modules;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import javax.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.api.db.evolutions.ApplicationEvolutions;
 import services.settings.SettingsService;
 
@@ -11,9 +13,11 @@ import services.settings.SettingsService;
  * settings. Runs each time the server is started.
  */
 public class SettingsMigrationModule extends AbstractModule {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SettingsMigrationModule.class);
 
   @Override
   protected void configure() {
+    LOGGER.trace("Module Started");
     bind(SettingsMigrator.class).asEagerSingleton();
   }
 
@@ -23,9 +27,14 @@ public class SettingsMigrationModule extends AbstractModule {
     public SettingsMigrator(
         ApplicationEvolutions applicationEvolutions,
         Provider<SettingsService> settingsServiceProvider) {
+      LOGGER.trace("SettingsMigrator - Started");
 
       if (applicationEvolutions.upToDate()) {
+        LOGGER.trace("SettingsMigrator - Task Start");
         settingsServiceProvider.get().migrateConfigValuesToSettingsGroup();
+        LOGGER.trace("SettingsMigrator - Task End");
+      } else {
+        LOGGER.trace("Evolutions Not Ready");
       }
     }
   }

--- a/server/app/modules/SettingsMigrationModule.java
+++ b/server/app/modules/SettingsMigrationModule.java
@@ -21,6 +21,13 @@ public class SettingsMigrationModule extends AbstractModule {
     bind(SettingsMigrator.class).asEagerSingleton();
   }
 
+  /**
+   * This class injects ApplicationEvolutions and checks the `upToDate` method to prevent this
+   * module from running until after the evolutions are completed.
+   *
+   * <p>See <a href="https://github.com/civiform/civiform/pull/8253">PR 8253</a> for more extensive
+   * details.
+   */
   public static final class SettingsMigrator {
 
     @Inject


### PR DESCRIPTION
### Description

#### TL;DR
Make custom modules that edit the database wait for evolutions to complete and also finish running before the app starts servicing clients.

#### More
Custom modules making changes to the database that are expected to be done before the app is live relied on Akka's ActorSystem, but this would result in work being completed after the app is live. The change checks that the evolutions have completed before moving on.

I've been told this didn't work back in the early days of the project which is why Akka was used. Later the delay was added to avoid a race condition. This was [considered hacky at the time](https://github.com/civiform/civiform/pull/3663).

> [!NOTE]
>The [recommended approach from Play](https://www.playframework.com/documentation/3.0.x/Migration27#Application-starts-when-evolutions-scripts-need-to-be-applied-in-DEV-mode) is to inject `ApplicationEvolutions` and check that `upToDate` is true before doing anything. This is true both in the 2.7 migration guide and what you find Play contributors say in their repo. 
> > That’s why we added [ApplicationEvolutions.upToDate](https://www.playframework.com/documentation/3.0.x/api/scala/play/api/db/evolutions/ApplicationEvolutions.html#upToDate:Boolean) which indicates if the process of applying evolutions is finished or not. Only if that method returns true you can be sure that all evolutions scripts were executed successfully. upToDate will return true at some point eventually, because each time you apply or resolve evolutions scripts in DEV mode an application automatically restarts, re-initializing all it’s modules.

This is in the migration guide, but hasn't made it into the [docs](https://github.com/playframework/playframework/issues/9910) yet. There was a backport a while ago [changing the DEV mode part](https://github.com/playframework/playframework/pull/10030), but the checking upToDate remains true.

Additional notes can be found in the [Slack convo](https://civiform.slack.com/archives/C01QKN2UNMA/p1722902344358089).

#### Log output of start the app now (trimmed, logging was added for testing and is not in the final changes)
```
INFO  p.a.h.HttpErrorHandlerExceptions - Registering exception handler: guice-provision-exception-handler
INFO  m.EsriModule - Using services.geo.esri.RealEsriClient class for Esri client
WARN  m.SettingsMigrationModule - SettingsMigrationModule - ctor
INFO  m.SecurityModule - Using ADFS for admin auth provider
INFO  m.SecurityModule - Using generic OIDC for applicant auth provider
WARN  m.DatabaseSeedModule - DatabaseSeedModule - ctor
WARN  m.DurableJobModule - DurableJobModule - ctor
INFO  p.a.d.DefaultDBApi - Database [default] initialized
INFO  p.a.d.HikariCPConnectionPool - Creating Pool for datasource 'default'
INFO  io.ebean - ebean version: unknown
INFO  io.ebean.core - Started database[default] platform[POSTGRES] in 232ms

DEBUG p.a.d.e.DefaultEvolutionsApi - Execute
DEBUG p.a.d.e.DefaultEvolutionsApi - Finished in 4ms
      ... lots more evolutions ...
DEBUG p.a.d.e.DefaultEvolutionsApi - Execute
DEBUG p.a.d.e.DefaultEvolutionsApi - Finished in 0ms

WARN  m.SettingsMigrationModule - SettingsMigrationModule.SettingsMigrator - ctor
TRACE m.SettingsMigrationModule - SettingsMigrationModule.SettingsMigrator - scheduleOnce - start
DEBUG io.ebean.SQL - txn[]
INFO  s.s.SettingsService - Migrated 24 settings from config to database.
TRACE m.SettingsMigrationModule - SettingsMigrationModule.SettingsMigrator - scheduleOnce - end

WARN  m.DatabaseSeedModule - DatabaseSeedModule.DatabaseSeedScheduler - ctor
TRACE m.DatabaseSeedModule - DatabaseSeedModule.DatabaseSeedScheduler - scheduleOnce - start
INFO  s.s.DatabaseSeedTask - DatabaseSeekTask - run
DEBUG io.ebean.SQL - txn[]
INFO  s.s.DatabaseSeedTask - Created canonical question "Name"
DEBUG io.ebean.SQL - txn[]
INFO  s.s.DatabaseSeedTask - Created canonical question "Applicant Date of Birth"

WARN  m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - ctor
TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - beforeStartup - start
TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - work.....
TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - beforeStartup - end

INFO  play.api.Play - Application started (Dev) (no global state)
INFO  loggingfilter - GET       /       15ms    303 -> /callback?client_name=GuestClient

TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - scheduleAtFixedRate - start
DEBUG io.ebean.SQL - txn[]
INFO  d.DurableJobRunner - JobRunner_Start thread ID=446
DEBUG io.ebean.SQL - txn[]
INFO  d.DurableJobRunner - JobRunner_Stop thread_ID=446
TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - scheduleAtFixedRate - end

TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - scheduleAtFixedRate - start
DEBUG io.ebean.SQL - txn[]
INFO  d.DurableJobRunner - JobRunner_Start thread ID=446
DEBUG io.ebean.SQL - txn[]
INFO  d.DurableJobRunner - JobRunner_Stop thread_ID=446
TRACE m.DurableJobModule - DurableJobModule.DurableJobRunnerScheduler - scheduleAtFixedRate - end
```

### Release Notes

Optimizing application startup

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Related to #3663