### PR TITLE
Add thymeleaf step to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@ Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#wr
   - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
   - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
 - [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
+- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
 - [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
 - [ ] Manually tested at 200% size
 - [ ] Manually evaluated tab order


### PR DESCRIPTION
### Description

Add step to PR template to remind SWEs to either make changes to the Thymeleaf version of a feature, or open an issue so we don't forget.