### PR TITLE
Link to troubleshooting page in authority ID error message

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -158,7 +158,8 @@ public class CiviFormProfile {
                             + " new authority ID address %s. If the 'iss' values of the authority"
                             + " ID are different it is likely that the email address was used to"
                             + " create an account using one authentication system (applicant/admin)"
-                            + " and the new authority was created in the other (applicant/admin).",
+                            + " and the new authority was created in the other (applicant/admin)."
+                            + "See https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
                         existingAuthorityId, authorityId));
               }
               a.setAuthorityId(authorityId);

--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -159,7 +159,7 @@ public class CiviFormProfile {
                             + " ID are different it is likely that the email address was used to"
                             + " create an account using one authentication system (applicant/admin)"
                             + " and the new authority was created in the other"
-                            + " (applicant/admin).See"
+                            + " (applicant/admin). See"
                             + " https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
                         existingAuthorityId, authorityId));
               }

--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -158,8 +158,9 @@ public class CiviFormProfile {
                             + " new authority ID address %s. If the 'iss' values of the authority"
                             + " ID are different it is likely that the email address was used to"
                             + " create an account using one authentication system (applicant/admin)"
-                            + " and the new authority was created in the other (applicant/admin)."
-                            + "See https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
+                            + " and the new authority was created in the other"
+                            + " (applicant/admin).See"
+                            + " https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
                         existingAuthorityId, authorityId));
               }
               a.setAuthorityId(authorityId);

--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -158,9 +158,8 @@ public class CiviFormProfile {
                             + " new authority ID address %s. If the 'iss' values of the authority"
                             + " ID are different it is likely that the email address was used to"
                             + " create an account using one authentication system (applicant/admin)"
-                            + " and the new authority was created in the other"
-                            + " (applicant/admin). See"
-                            + " https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
+                            + " and the new authority was created in the other (applicant/admin)."
+                            + " See https://docs.civiform.us/it-manual/sre-playbook/troubleshooting-production#errors-related-to-authority-id",
                         existingAuthorityId, authorityId));
               }
               a.setAuthorityId(authorityId);


### PR DESCRIPTION
### Description

We can link to the troubleshooting page in the authority ID error message, so people can see more information on what to do to fix the issue.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)

### Issue(s) this completes

#8251
