### PR TITLE
Fail browser tests on any CSP error

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -600,38 +600,39 @@ test.describe('file upload applicant flow', () => {
         })
       })
 
-      test('File too large error', async ({
-        applicantFileQuestion,
-        applicantQuestions,
-      }) => {
-        await test.step('Initially no error is shown', async () => {
-          await applicantQuestions.applyProgram(programName)
-          await applicantFileQuestion.expectFileTooLargeErrorHidden()
-        })
+      // TODO remove ".fixme" once https://github.com/civiform/civiform/issues/8143 is fixed
+      test.fixme(
+        'File too large error',
+        async ({applicantFileQuestion, applicantQuestions}) => {
+          await test.step('Initially no error is shown', async () => {
+            await applicantQuestions.applyProgram(programName)
+            await applicantFileQuestion.expectFileTooLargeErrorHidden()
+          })
 
-        await test.step('Shows error when file size is too large', async () => {
-          await applicantQuestions.answerFileUploadQuestionWithMbSize(101)
+          await test.step('Shows error when file size is too large', async () => {
+            await applicantQuestions.answerFileUploadQuestionWithMbSize(101)
 
-          await applicantFileQuestion.expectFileTooLargeErrorShown()
-          // Don't perform a screenshot here because it shows a spinner that doesn't become stable
-          // while the file is uploading.
-        })
+            await applicantFileQuestion.expectFileTooLargeErrorShown()
+            // Don't perform a screenshot here because it shows a spinner that doesn't become stable
+            // while the file is uploading.
+          })
 
-        await test.step('Cannot save file if too large', async () => {
-          await applicantQuestions.clickNext()
+          await test.step('Cannot save file if too large', async () => {
+            await applicantQuestions.clickNext()
 
-          // Verify the file isn't saved and we're still on the file upload question block
-          await applicantQuestions.validateQuestionIsOnPage(
-            fileUploadQuestionText,
-          )
-        })
+            // Verify the file isn't saved and we're still on the file upload question block
+            await applicantQuestions.validateQuestionIsOnPage(
+              fileUploadQuestionText,
+            )
+          })
 
-        await test.step('Hides error when smaller file is uploaded', async () => {
-          await applicantQuestions.answerFileUploadQuestionWithMbSize(100)
+          await test.step('Hides error when smaller file is uploaded', async () => {
+            await applicantQuestions.answerFileUploadQuestionWithMbSize(100)
 
-          await applicantFileQuestion.expectFileTooLargeErrorHidden()
-        })
-      })
+            await applicantFileQuestion.expectFileTooLargeErrorHidden()
+          })
+        },
+      )
 
       test('form is correctly formatted', async ({
         page,
@@ -668,46 +669,47 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.expectNoSkipButton()
       })
 
-      test('can upload file', async ({
-        page,
-        applicantQuestions,
-        applicantFileQuestion,
-      }) => {
-        await applicantQuestions.applyProgram(programName)
+      // TODO remove ".fixme" once https://github.com/civiform/civiform/issues/8143 is fixed
+      test.fixme(
+        'can upload file',
+        async ({page, applicantQuestions, applicantFileQuestion}) => {
+          await applicantQuestions.applyProgram(programName)
 
-        await applicantQuestions.answerFileUploadQuestion(
-          'some file',
-          'file.txt',
-        )
+          await applicantQuestions.answerFileUploadQuestion(
+            'some file',
+            'file.txt',
+          )
 
-        await applicantFileQuestion.expectFileNameDisplayed('file.txt')
-        await validateScreenshot(
-          page,
-          'file-uploaded-north-star',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-      })
+          await applicantFileQuestion.expectFileNameDisplayed('file.txt')
+          await validateScreenshot(
+            page,
+            'file-uploaded-north-star',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+        },
+      )
 
       /** Regression test for https://github.com/civiform/civiform/issues/6221. */
-      test('can replace file', async ({
-        applicantQuestions,
-        applicantFileQuestion,
-      }) => {
-        await applicantQuestions.applyProgram(programName)
+      // TODO remove ".fixme" once https://github.com/civiform/civiform/issues/8143 is fixed
+      test.fixme(
+        'can replace file',
+        async ({applicantQuestions, applicantFileQuestion}) => {
+          await applicantQuestions.applyProgram(programName)
 
-        await applicantQuestions.answerFileUploadQuestion(
-          'some file',
-          'file1.txt',
-        )
-        await applicantFileQuestion.expectFileNameDisplayed('file1.txt')
+          await applicantQuestions.answerFileUploadQuestion(
+            'some file',
+            'file1.txt',
+          )
+          await applicantFileQuestion.expectFileNameDisplayed('file1.txt')
 
-        await applicantQuestions.answerFileUploadQuestion(
-          'some file',
-          'file2.txt',
-        )
-        await applicantFileQuestion.expectFileNameDisplayed('file2.txt')
-      })
+          await applicantQuestions.answerFileUploadQuestion(
+            'some file',
+            'file2.txt',
+          )
+          await applicantFileQuestion.expectFileNameDisplayed('file2.txt')
+        },
+      )
 
       test('has no accessiblity violations', async ({
         page,

--- a/browser-test/src/support/civiform_fixtures.ts
+++ b/browser-test/src/support/civiform_fixtures.ts
@@ -86,6 +86,12 @@ export const test = base.extend<CiviformFixtures>({
   },
 
   page: async ({page, request}, use) => {
+    page.on('console', (msg) => {
+      if (msg.text().includes('Content Security Policy')) {
+        throw new Error(msg.text())
+      }
+    })
+
     // BeforeEach
     await test.step('Clear database', async () => {
       await request.post('/dev/seed/clear')


### PR DESCRIPTION
### Description

Update the Playwright browser test page fixture to fail any test that records a CSP (content security policy) violation in the browser console.

Also disable the three file upload tests in the Northstar UI that violate CSP due to #8143.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)