### PR TITLE
Add question type to TestQuestionBank method names

### DIFF
--- a/server/test/actions/ApplicantAuthorizationActionTest.java
+++ b/server/test/actions/ApplicantAuthorizationActionTest.java
@@ -43,7 +43,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     // Setup fakeRequest and configure it to use the specified route pattern
@@ -76,7 +76,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     // Setup fakeRequest and configure it to use the specified route pattern

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -25,13 +25,13 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
     programWithThreeBlocks =
         ProgramBuilder.newDraftProgram("first program")
             .withBlock("Screen 1")
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .withBlock("Screen 2")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
-            .withRequiredQuestion(testQuestionBank.applicantIceCream())
-            .withRequiredQuestion(testQuestionBank.applicantKitchenTools())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
+            .withRequiredQuestion(testQuestionBank.dropdownApplicantIceCream())
+            .withRequiredQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .withBlock("Screen 3")
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
   }
 

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -39,7 +39,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void create_addOldRevisionAddsLatestRevision() throws UnsupportedQuestionTypeException {
     // Setup.
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     Long activeId = nameQuestion.getId();
     Long draftId = activeId + 100000;
     QuestionDefinition toUpdate =
@@ -101,9 +101,9 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void move_changesOrderOfQuestions() throws Exception {
     // Setup.
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     ProgramBuilder programBuilder = ProgramBuilder.newDraftProgram();
     ProgramModel program =
         programBuilder
@@ -140,7 +140,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void move_invalidPositionInput() throws Exception {
     // Setup.
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     ProgramBuilder programBuilder = ProgramBuilder.newDraftProgram();
     ProgramModel program =
         programBuilder.withBlock("block1").withOptionalQuestion(nameQuestion).build();

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -97,9 +97,9 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     Request request = fakeRequestBuilder().bodyForm(ImmutableMap.of("enumeratorId", "1")).build();
     Result result = controller.create(request, program.id);
@@ -149,7 +149,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .withName("Admin name")
             .withDescription("Admin description")
             .build();
-    QuestionModel applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.nameApplicantName();
     applicantName.save();
     Result result = controller.show(fakeRequest(), program.id, /* blockId= */ 1L);
 
@@ -191,7 +191,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .withName("Admin name")
             .withDescription("Admin description")
             .build();
-    QuestionModel applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.nameApplicantName();
     applicantName.save();
     Result result = controller.edit(fakeRequest(), program.id, /* blockId= */ 1L);
 

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -117,7 +117,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void create_repeatedQuestion_redirectsOnSuccess() {
-    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.enumeratorApplicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "name")
@@ -186,7 +186,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsRedirectWhenEditingQuestionWithExistingDraft() {
-    QuestionModel publishedQuestion = testQuestionBank.applicantName();
+    QuestionModel publishedQuestion = testQuestionBank.nameApplicantName();
     QuestionModel draftQuestion =
         testQuestionBank.maybeSave(
             this.createNameQuestionDuplicate(publishedQuestion), LifecycleStage.DRAFT);
@@ -204,7 +204,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsPopulatedForm() {
-    QuestionModel question = testQuestionBank.applicantName();
+    QuestionModel question = testQuestionBank.nameApplicantName();
     Request request = fakeRequestBuilder().addCSRFToken().build();
     Result result = controller.edit(request, question.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
@@ -215,7 +215,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_repeatedQuestion_hasEnumeratorName() {
-    QuestionModel repeatedQuestion = testQuestionBank.applicantHouseholdMemberName();
+    QuestionModel repeatedQuestion = testQuestionBank.nameRepeatedApplicantHouseholdMemberName();
     Request request = fakeRequestBuilder().addCSRFToken().build();
     Result result = controller.edit(request, repeatedQuestion.id).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(OK);
@@ -227,8 +227,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void index_returnsQuestions() throws Exception {
-    testQuestionBank.applicantAddress();
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    testQuestionBank.addressApplicantAddress();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     // Create a draft version of an already published question and ensure that it isn't
     // double-counted in the rendered total number of questions.
     QuestionDefinition updatedQuestion =
@@ -312,7 +312,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     // We can only update draft questions, so save this in the DRAFT version.
     QuestionModel originalNameQuestion =
         testQuestionBank.maybeSave(
-            this.createNameQuestionDuplicate(testQuestionBank.applicantName()),
+            this.createNameQuestionDuplicate(testQuestionBank.nameApplicantName()),
             LifecycleStage.DRAFT);
     assertThat(originalNameQuestion.getQuestionTags()).isEmpty();
 
@@ -704,7 +704,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
-    QuestionModel question = testQuestionBank.applicantFavoriteColor();
+    QuestionModel question = testQuestionBank.textApplicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "favorite_color")
@@ -722,7 +722,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void update_failsWithInvalidQuestionType() {
-    QuestionModel question = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel question = testQuestionBank.enumeratorApplicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionType", "INVALID_TYPE").put("questionText", "question text updated!");
     RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData.build());

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -70,9 +70,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
     applicant = createApplicantWithMockedProfile();
   }
@@ -102,7 +102,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -128,7 +128,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -272,7 +272,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -297,7 +297,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -368,7 +368,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -403,7 +403,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -436,7 +436,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -697,7 +697,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -742,9 +742,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -792,7 +792,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -837,7 +837,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withOptionalQuestion(testQuestionBank().applicantName())
+            .withOptionalQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -884,7 +884,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request requestWithAnswer =
         fakeRequestBuilder()
@@ -959,7 +959,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withOptionalQuestion(testQuestionBank().applicantName())
+            .withOptionalQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request requestWithAnswer =
         fakeRequestBuilder()
@@ -1030,9 +1030,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1076,9 +1076,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1119,7 +1119,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1159,13 +1159,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank().textApplicantFavoriteColor())
             .withBlock("block 3")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .withBlock("block 4")
-            .withRequiredQuestion(testQuestionBank().applicantEmail())
+            .withRequiredQuestion(testQuestionBank().emailApplicantEmail())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1209,7 +1209,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1250,7 +1250,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1290,11 +1290,11 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank().textApplicantFavoriteColor())
             .withBlock("block 3")
-            .withRequiredQuestion(testQuestionBank().applicantEmail())
+            .withRequiredQuestion(testQuestionBank().emailApplicantEmail())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1331,7 +1331,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     Request request =
         fakeRequestBuilder()
@@ -1380,7 +1380,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -1453,7 +1453,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     Request request =
@@ -1489,7 +1489,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -1524,7 +1524,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -1673,9 +1673,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -1717,9 +1717,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -1763,9 +1763,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -1804,7 +1804,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -1849,7 +1849,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     var fileKey = "fake-key";
@@ -1915,7 +1915,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     Request request =
@@ -1941,7 +1941,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -1971,7 +1971,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -2087,9 +2087,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -2140,7 +2140,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(
                 testQuestionBank().maybeSave(fileUploadWithMaxDefinition, LifecycleStage.ACTIVE))
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -2193,7 +2193,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
     RequestBuilder requestOne =
         fakeRequestBuilder()
@@ -2242,7 +2242,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
     RequestBuilder request =
         fakeRequestBuilder()
@@ -2297,7 +2297,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     long badApplicantId = applicant.id + 1000;
@@ -2331,7 +2331,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Request request =
@@ -2364,7 +2364,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     Request request =
@@ -2397,7 +2397,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     Request request =
@@ -2454,7 +2454,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     String badBlockId = "1000";
@@ -2483,7 +2483,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantDate())
+            .withRequiredQuestion(testQuestionBank().dateApplicantBirthdate())
             .build();
 
     String dateQuestionBlockId = "1";
@@ -2516,7 +2516,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     RequestBuilder request =
@@ -2549,25 +2549,34 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         0,
         "file-key-1");
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         1,
         "key-to-remove");
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         2,
         "file-key-2");
     applicant.save();
@@ -2605,13 +2614,16 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         1,
         "key-to-remove");
     applicant.save();
@@ -2647,19 +2659,25 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
             .build();
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         0,
         "file-key-1");
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicant.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank().applicantFile().getQuestionDefinition().getQuestionPathSegment()),
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
         2,
         "file-key-2");
 
@@ -2729,7 +2747,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .build();
 
     Request request =
@@ -2765,7 +2783,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .build();
 
     Request request =
@@ -2799,7 +2817,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .build();
 
     Request request =
@@ -2897,9 +2915,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .build();
 
     // First, answer the address question
@@ -2992,9 +3010,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .build();
 
     String address = "456 Suggested Ave, Seattle, Washington, 99999";
@@ -3072,9 +3090,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .build();
 
     Request request =
@@ -3121,11 +3139,11 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredQuestion(testQuestionBank().applicantEmail())
+            .withRequiredQuestion(testQuestionBank().emailApplicantEmail())
             .withBlock("block 2")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 3")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .build();
 
     Request request =
@@ -3175,9 +3193,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newActiveProgram()
             .withBlock("block 1")
-            .withRequiredCorrectedAddressQuestion(testQuestionBank().applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank().addressApplicantAddress())
             .withBlock("block 2")
-            .withRequiredQuestion(testQuestionBank().applicantIceCream())
+            .withRequiredQuestion(testQuestionBank().dropdownApplicantIceCream())
             .build();
 
     // First, answer the address question

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -47,7 +47,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     activeProgram =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     applicant = createApplicantWithMockedProfile();
     applicantWithoutProfile = createApplicant();
@@ -73,7 +73,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Result result = this.review(applicant.id, draftProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -87,7 +87,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Result result = this.review(applicant.id, draftProgram.id);
     assertThat(result.status()).isEqualTo(OK);
@@ -133,7 +133,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel draftProgram =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     Result result = this.submit(applicant.id, draftProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -147,12 +147,12 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
 
     ProgramBuilder.newActiveProgram("test program", "desc")
         .withBlock()
-        .withRequiredQuestion(testQuestionBank().applicantName())
+        .withRequiredQuestion(testQuestionBank().nameApplicantName())
         .buildDefinition();
     ProgramDefinition draftProgramDefinition =
         ProgramBuilder.newDraftProgram("test program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .buildDefinition();
     answer(draftProgramDefinition.id());
 
@@ -181,7 +181,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .buildDefinition();
     resourceCreator().insertDraftProgram(programDefinition.adminName());
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
@@ -208,7 +208,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .buildDefinition();
     ProgramModel newProgramModel =
         resourceCreator().insertDraftProgram(programDefinition.adminName());
@@ -258,7 +258,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .buildDefinition();
     ProgramModel newProgramModel =
         resourceCreator().insertDraftProgram(programDefinition.adminName());
@@ -304,7 +304,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock()
             .withRequiredQuestion(testQuestionBank().staticContent())
             .build();
@@ -329,7 +329,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     // The questions haven't been answered.
     Result result = this.submit(applicant.id, activeProgram.id);
@@ -344,7 +344,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     ProgramModel activeProgram =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .withBlock()
             .withRequiredQuestion(testQuestionBank().staticContent())
             .build();

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -346,7 +346,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     ProgramModel program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantName())
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
 
     Result result =
@@ -366,13 +366,13 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   @Test
   public void edit_redirectsToFirstIncompleteBlock() {
     QuestionDefinition colorQuestion =
-        testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank().textApplicantFavoriteColor().getQuestionDefinition();
     ProgramModel program =
         ProgramBuilder.newActiveProgram()
             .withBlock()
             .withRequiredQuestionDefinition(colorQuestion)
             .withBlock()
-            .withRequiredQuestion(testQuestionBank().applicantAddress())
+            .withRequiredQuestion(testQuestionBank().addressApplicantAddress())
             .build();
     // Answer the color question
     Path colorPath = ApplicantData.APPLICANT_PATH.join("applicant_favorite_color");

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -64,7 +64,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
   @Test
   public void
       considerRegister_redirectsToUpsellViewForCommonIntakeWithNoRecommendedProgramsFound() {
-    QuestionModel predicateQuestion = testQuestionBank().applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank().textApplicantFavoriteColor();
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -122,7 +122,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
 
   @Test
   public void considerRegister_redirectsToUpsellViewForCommonIntakeWithRecommendedPrograms() {
-    QuestionModel predicateQuestion = testQuestionBank().applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank().textApplicantFavoriteColor();
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
             .setPredicate(

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -18,7 +18,7 @@ public class QuestionTranslationFormTest {
 
   @Test
   public void builder_updatesExistingTextTranslations() throws Exception {
-    QuestionDefinition question = questionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition question = questionBank.nameApplicantName().getQuestionDefinition();
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();
     form.setQuestionText("new text");
@@ -33,7 +33,7 @@ public class QuestionTranslationFormTest {
 
   @Test
   public void builder_addsTranslationsForNewLocale() throws Exception {
-    QuestionDefinition question = questionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition question = questionBank.nameApplicantName().getQuestionDefinition();
 
     QuestionTranslationForm form = new QuestionTranslationFormImpl();
     form.setQuestionText("new locale");

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -264,7 +264,9 @@ public class ProgramModelTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                            testQuestionBank
+                                .enumeratorApplicantHouseholdMembers()
+                                .getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
             .add(
@@ -276,7 +278,7 @@ public class ProgramModelTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantEmail().getQuestionDefinition(),
+                            testQuestionBank.emailApplicantEmail().getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
             .add(
@@ -289,7 +291,9 @@ public class ProgramModelTest extends ResetPostgres {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                            testQuestionBank
+                                .enumeratorNestedApplicantHouseholdMemberJobs()
+                                .getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
             .add(
@@ -302,7 +306,9 @@ public class ProgramModelTest extends ResetPostgres {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
+                            testQuestionBank
+                                .nameRepeatedApplicantHouseholdMemberName()
+                                .getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
             .add(
@@ -316,7 +322,7 @@ public class ProgramModelTest extends ResetPostgres {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank
-                                .applicantHouseholdMemberDaysWorked()
+                                .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
                                 .getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
@@ -329,7 +335,7 @@ public class ProgramModelTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantName().getQuestionDefinition(),
+                            testQuestionBank.nameApplicantName().getQuestionDefinition(),
                             Optional.of(programDefinitionId)))
                     .build())
             .build();

--- a/server/test/repository/ExportServiceRepositoryTest.java
+++ b/server/test/repository/ExportServiceRepositoryTest.java
@@ -32,7 +32,7 @@ public class ExportServiceRepositoryTest extends ResetPostgres {
   @Test
   public void getMultiSelectedHeaders_NoPreviousQuestionVersion() {
     QuestionDefinition questionDefinition =
-        testQuestionBank.applicantKitchenTools().getQuestionDefinition();
+        testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition();
     ImmutableList<String> multiSelectHeaders =
         repo.getAllHistoricMultiOptionAdminNames(questionDefinition);
     assertThat(multiSelectHeaders.size()).isEqualTo(3);
@@ -115,7 +115,7 @@ public class ExportServiceRepositoryTest extends ResetPostgres {
   @Test
   public void getMultiSelectedHeaders_ThrowsExceptionOnWrongQuestionType() {
     QuestionDefinition questionDefinition =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     assertThatThrownBy(() -> repo.getAllHistoricMultiOptionAdminNames(questionDefinition))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("The Question Type is not a multi-option type");

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -67,7 +67,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void findConflictingQuestion_noConflicts_ok() throws Exception {
     QuestionDefinition applicantAddress =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress)
             .clearId()
@@ -81,7 +81,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void findConflictingQuestion_sameName_hasConflict() throws Exception {
-    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
@@ -95,7 +95,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void findConflictingQuestion_sameQuestionPathSegment_hasConflict() throws Exception {
-    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
@@ -110,7 +110,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void findConflictingQuestion_sameQuestionPathSegmentButDifferentEnumeratorId_ok()
       throws Exception {
-    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
@@ -125,7 +125,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void findConflictingQuestion_sameQuestion_hasConflict() {
-    QuestionModel applicantAddress = testQuestionBank.applicantAddress();
+    QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     Optional<QuestionModel> maybeConflict =
         repo.findConflictingQuestion(applicantAddress.getQuestionDefinition());
 
@@ -134,7 +134,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void findConflictingQuestion_differentVersion_hasConflict() throws Exception {
-    QuestionModel applicantName = testQuestionBank.applicantName();
+    QuestionModel applicantName = testQuestionBank.nameApplicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).setId(123123L).build();
 
@@ -148,7 +148,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void insertingDuplicateDraftQuestions_raisesDatabaseException() throws Exception {
     var versionRepo = instanceOf(VersionRepository.class);
     var draftVersion = versionRepo.getDraftVersionOrCreate();
-    QuestionModel activeQuestion = testQuestionBank.applicantName();
+    QuestionModel activeQuestion = testQuestionBank.nameApplicantName();
     assertThat(activeQuestion.id).isNotNull();
 
     var draftOne =
@@ -251,7 +251,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
   public void createOrUpdateDraft_managesUniversalTagCorrectly()
       throws UnsupportedQuestionTypeException {
     // Question will be published in an ACTIVE version
-    QuestionModel question = testQuestionBank.applicantName();
+    QuestionModel question = testQuestionBank.nameApplicantName();
     QuestionDefinition nextQuestionDefinition;
 
     // Create new draft, ensure tags are correct
@@ -281,10 +281,10 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void createOrUpdateDraft_managesPrimaryApplicantInfoTagsCorrectl()
       throws UnsupportedQuestionTypeException {
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
-    QuestionModel dateQuestion = testQuestionBank.applicantDate();
-    QuestionModel emailQuestion = testQuestionBank.applicantEmail();
-    QuestionModel phoneQuestion = testQuestionBank.applicantPhone();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
+    QuestionModel dateQuestion = testQuestionBank.dateApplicantBirthdate();
+    QuestionModel emailQuestion = testQuestionBank.emailApplicantEmail();
+    QuestionModel phoneQuestion = testQuestionBank.phoneApplicantPhone();
 
     // Create new draft, ensure tags are correct
     QuestionDefinition nameQuestionDefinition = addTagToDefinition(nameQuestion);

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -67,9 +67,9 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   @Test
   public void canAddQuestions_cantAddQuestionNotInActiveDraftState() throws Exception {
     QuestionDefinition householdMemberQuestion =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition householdMemberNameQuestion =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
@@ -97,7 +97,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void canAddQuestion_duplicate() throws Exception {
-    QuestionDefinition question = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition question = testQuestionBank.nameApplicantName().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
@@ -111,8 +111,9 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void canAddQuestion_blockIsSingleQuestion() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition fileQuestion = testQuestionBank.applicantFile().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition fileQuestion =
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
@@ -126,8 +127,9 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void canAddQuestion_cantAddSingleQuestionBlock() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition fileQuestion = testQuestionBank.applicantFile().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition fileQuestion =
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
@@ -142,7 +144,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   @Test
   public void canAddQuestion_cantAddEmuratorQuestionToNonEnumeratorBlock() throws Exception {
     QuestionDefinition question =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1").withBlock().buildDefinition();
     assertThat(
@@ -153,9 +155,9 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void canAddQuestion_cantAddNonEmuratorQuestionToEnumeratorBlock() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition householdMemberQuestion =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -238,7 +238,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   public void stageAndUpdateIfValid_withEmptyUpdatesForMultiSelect_deletesMultiSelectJsonData() {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
-        testQuestionBank.applicantKitchenTools().getQuestionDefinition());
+        testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition());
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path questionPath = Path.create("applicant.kitchen_tools");
 
@@ -278,9 +278,9 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_unansweringRequiredQuestionFailsAtomically() {
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
-    QuestionModel dropdownQuestion = testQuestionBank.applicantIceCream();
+    QuestionModel dropdownQuestion = testQuestionBank.dropdownApplicantIceCream();
     Path dropdownPath = applicantPathForQuestion(dropdownQuestion).join(Scalar.SELECTION);
 
     createProgram(numberQuestion.getQuestionDefinition(), dropdownQuestion.getQuestionDefinition());
@@ -320,7 +320,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_forceUpdate() {
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
     createProgram(numberQuestion.getQuestionDefinition());
     ImmutableMap<String, String> updates =
@@ -352,13 +352,13 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfvalid_invalidInputsForQuestionTypes() {
-    QuestionModel dateQuestion = testQuestionBank.applicantDate();
+    QuestionModel dateQuestion = testQuestionBank.dateApplicantBirthdate();
     Path datePath = applicantPathForQuestion(dateQuestion).join(Scalar.DATE);
-    QuestionModel currencyQuestion = testQuestionBank.applicantMonthlyIncome();
+    QuestionModel currencyQuestion = testQuestionBank.currencyApplicantMonthlyIncome();
     Path currencyPath = applicantPathForQuestion(currencyQuestion).join(Scalar.CURRENCY_CENTS);
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
-    QuestionModel phoneQuestion = testQuestionBank.applicantPhone();
+    QuestionModel phoneQuestion = testQuestionBank.phoneApplicantPhone();
     Path phonePath = applicantPathForQuestion(phoneQuestion).join(Scalar.PHONE_NUMBER);
     createProgram(
         dateQuestion.getQuestionDefinition(),
@@ -416,12 +416,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
       stageAndUpdateIfValid_forEnumeratorBlock_putsMetadataWithEmptyUpdate_andCanPutRealRepeatedEntitiesInAfter() {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
 
@@ -484,13 +484,13 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .buildDefinition();
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
 
@@ -673,7 +673,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_withEnumeratorChangesAndDeletes_isOk() {
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     createProgram(enumeratorQuestionDefinition);
 
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
@@ -703,7 +703,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_enumeratorNotAnswered_stillWritesPathToApplicantData() {
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
 
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(enumeratorQuestionDefinition);
@@ -1530,7 +1530,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_with_correctedAddess_and_esriServiceAreaValidation() {
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -1543,7 +1543,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
 
@@ -1586,7 +1586,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   public void
       stageAndUpdateIfValid_with_correctedAddess_and_esriServiceAreaValidation_with_existing_service_areas() {
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -1599,7 +1599,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
 
@@ -1837,17 +1837,17 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel commonIntakeForm =
         ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -1902,12 +1902,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -1959,7 +1959,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel commonIntakeForm =
         ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
 
     // No CIF application started.
@@ -2031,7 +2031,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForSubmitted =
         ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newDraftProgram("program_for_unapplied").withBlock().build();
@@ -2090,7 +2090,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForSubmitted =
         ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newDraftProgram("program_for_unapplied")
@@ -2232,12 +2232,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -2281,7 +2281,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgramForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraft.id)
@@ -2292,7 +2292,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgramForSubmit =
         ProgramBuilder.newActiveProgram("program_for_submit")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .submitApplication(applicant.id, originalProgramForSubmit.id, Optional.empty())
@@ -2302,12 +2302,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     // Create new program versions.
     ProgramBuilder.newDraftProgram("program_for_draft")
         .withBlock()
-        .withRequiredQuestion(testQuestionBank.applicantName())
+        .withRequiredQuestion(testQuestionBank.nameApplicantName())
         .build();
     ProgramModel updatedProgramForSubmit =
         ProgramBuilder.newDraftProgram("program_for_submit")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     versionRepository.publishNewSynchronizedVersion();
 
@@ -2342,12 +2342,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2362,7 +2362,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.HIDDEN_IN_INDEX)
@@ -2372,7 +2372,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.HIDDEN_IN_INDEX)
@@ -2417,12 +2417,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2436,7 +2436,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.TI_ONLY)
@@ -2446,7 +2446,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.TI_ONLY)
@@ -2495,12 +2495,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2516,7 +2516,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.SELECT_TI)
@@ -2527,7 +2527,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.SELECT_TI)
@@ -2580,12 +2580,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     Optional<ApplicationModel> firstApp =
         applicationRepository
@@ -2645,12 +2645,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
 
     // Create multiple submitted applications and ensure the most recently submitted
@@ -2694,7 +2694,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgramForDraft =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     versionRepository.publishNewSynchronizedVersion();
     applicationRepository
@@ -2737,7 +2737,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     applicationStatusesRepository.createOrUpdateStatusDefinitions(
         program.getProgramDefinition().adminName(),
@@ -2774,7 +2774,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel originalProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     applicationStatusesRepository.createOrUpdateStatusDefinitions(
         originalProgram.getProgramDefinition().adminName(),
@@ -2782,7 +2782,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     originalProgram.getVersions().stream()
         .findAny()
         .orElseThrow()
-        .addQuestion(testQuestionBank.applicantFavoriteColor())
+        .addQuestion(testQuestionBank.textApplicantFavoriteColor())
         .save();
 
     AccountModel adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
@@ -2805,7 +2805,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ProgramModel updatedProgram =
         ProgramBuilder.newActiveProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     applicationStatusesRepository.createOrUpdateStatusDefinitions(
         updatedProgram.getProgramDefinition().adminName(),
@@ -3420,7 +3420,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3532,7 +3532,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3626,7 +3626,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3734,7 +3734,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3773,7 +3773,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3810,7 +3810,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -238,7 +238,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   public void stageAndUpdateIfValid_withEmptyUpdatesForMultiSelect_deletesMultiSelectJsonData() {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
-        testQuestionBank.applicantKitchenTools().getQuestionDefinition());
+        testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition());
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path questionPath = Path.create("applicant.kitchen_tools");
 
@@ -278,9 +278,9 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_unansweringRequiredQuestionFailsAtomically() {
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
-    QuestionModel dropdownQuestion = testQuestionBank.applicantIceCream();
+    QuestionModel dropdownQuestion = testQuestionBank.dropdownApplicantIceCream();
     Path dropdownPath = applicantPathForQuestion(dropdownQuestion).join(Scalar.SELECTION);
 
     createProgram(numberQuestion.getQuestionDefinition(), dropdownQuestion.getQuestionDefinition());
@@ -320,7 +320,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_forceUpdate() {
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
     createProgram(numberQuestion.getQuestionDefinition());
     ImmutableMap<String, String> updates =
@@ -352,13 +352,13 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfvalid_invalidInputsForQuestionTypes() {
-    QuestionModel dateQuestion = testQuestionBank.applicantDate();
+    QuestionModel dateQuestion = testQuestionBank.dateApplicantBirthdate();
     Path datePath = applicantPathForQuestion(dateQuestion).join(Scalar.DATE);
-    QuestionModel currencyQuestion = testQuestionBank.applicantMonthlyIncome();
+    QuestionModel currencyQuestion = testQuestionBank.currencyApplicantMonthlyIncome();
     Path currencyPath = applicantPathForQuestion(currencyQuestion).join(Scalar.CURRENCY_CENTS);
-    QuestionModel numberQuestion = testQuestionBank.applicantJugglingNumber();
+    QuestionModel numberQuestion = testQuestionBank.numberApplicantJugglingNumber();
     Path numberPath = applicantPathForQuestion(numberQuestion).join(Scalar.NUMBER);
-    QuestionModel phoneQuestion = testQuestionBank.applicantPhone();
+    QuestionModel phoneQuestion = testQuestionBank.phoneApplicantPhone();
     Path phonePath = applicantPathForQuestion(phoneQuestion).join(Scalar.PHONE_NUMBER);
     createProgram(
         dateQuestion.getQuestionDefinition(),
@@ -416,12 +416,12 @@ public class ApplicantServiceTest extends ResetPostgres {
       stageAndUpdateIfValid_forEnumeratorBlock_putsMetadataWithEmptyUpdate_andCanPutRealRepeatedEntitiesInAfter() {
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
 
@@ -484,13 +484,13 @@ public class ApplicantServiceTest extends ResetPostgres {
     programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .buildDefinition();
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
 
@@ -673,7 +673,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_withEnumeratorChangesAndDeletes_isOk() {
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     createProgram(enumeratorQuestionDefinition);
 
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
@@ -703,7 +703,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_enumeratorNotAnswered_stillWritesPathToApplicantData() {
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
 
     // We make the question optional since it's not valid to stage empty updates
     createProgramWithOptionalQuestion(enumeratorQuestionDefinition);
@@ -1532,7 +1532,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_with_correctedAddess_and_esriServiceAreaValidation() {
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -1545,7 +1545,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
 
@@ -1588,7 +1588,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   public void
       stageAndUpdateIfValid_with_correctedAddess_and_esriServiceAreaValidation_with_existing_service_areas() {
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -1601,7 +1601,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
             .withEligibilityDefinition(eligibilityDef)
             .buildDefinition();
 
@@ -1839,17 +1839,17 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel commonIntakeForm =
         ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -1904,12 +1904,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -1961,7 +1961,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel commonIntakeForm =
         ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
 
     // No CIF application started.
@@ -2033,7 +2033,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForSubmitted =
         ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newDraftProgram("program_for_unapplied").withBlock().build();
@@ -2092,7 +2092,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForSubmitted =
         ProgramBuilder.newDraftProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newDraftProgram("program_for_unapplied")
@@ -2234,12 +2234,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     ProgramModel programForUnapplied =
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
@@ -2283,7 +2283,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgramForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraft.id)
@@ -2294,7 +2294,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgramForSubmit =
         ProgramBuilder.newActiveProgram("program_for_submit")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .submitApplication(applicant.id, originalProgramForSubmit.id, Optional.empty())
@@ -2304,12 +2304,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     // Create new program versions.
     ProgramBuilder.newDraftProgram("program_for_draft")
         .withBlock()
-        .withRequiredQuestion(testQuestionBank.applicantName())
+        .withRequiredQuestion(testQuestionBank.nameApplicantName())
         .build();
     ProgramModel updatedProgramForSubmit =
         ProgramBuilder.newDraftProgram("program_for_submit")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     versionRepository.publishNewSynchronizedVersion();
 
@@ -2346,12 +2346,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2366,7 +2366,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.HIDDEN_IN_INDEX)
@@ -2376,7 +2376,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.HIDDEN_IN_INDEX)
@@ -2421,12 +2421,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2440,7 +2440,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.TI_ONLY)
@@ -2450,7 +2450,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.TI_ONLY)
@@ -2499,12 +2499,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgramForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel originalProgramForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     applicationRepository
         .createOrUpdateDraft(applicant.id, originalProgramForDraftApp.id)
@@ -2520,7 +2520,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForDraftApp =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForDraftApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.SELECT_TI)
@@ -2531,7 +2531,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForSubmittedApp =
         ProgramBuilder.newDraftProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     updatedProgramForSubmittedApp.getProgramDefinition().toBuilder()
         .setDisplayMode(DisplayMode.SELECT_TI)
@@ -2584,12 +2584,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForDraftApp =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmittedApp =
         ProgramBuilder.newActiveProgram("program_for_application")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     Optional<ApplicationModel> firstApp =
         applicationRepository
@@ -2649,12 +2649,12 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     ProgramModel programForSubmitted =
         ProgramBuilder.newActiveProgram("program_for_submitted")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
 
     // Create multiple submitted applications and ensure the most recently submitted
@@ -2698,7 +2698,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgramForDraft =
         ProgramBuilder.newDraftProgram("program_for_draft")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .build();
     versionRepository.publishNewSynchronizedVersion();
     applicationRepository
@@ -2741,7 +2741,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     repo.createOrUpdateStatusDefinitions(
         program.getProgramDefinition().adminName(),
@@ -2778,7 +2778,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel originalProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     repo.createOrUpdateStatusDefinitions(
         originalProgram.getProgramDefinition().adminName(),
@@ -2786,7 +2786,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     originalProgram.getVersions().stream()
         .findAny()
         .orElseThrow()
-        .addQuestion(testQuestionBank.applicantFavoriteColor())
+        .addQuestion(testQuestionBank.textApplicantFavoriteColor())
         .save();
 
     AccountModel adminAccount = resourceCreator.insertAccountWithEmail("admin@example.com");
@@ -2809,7 +2809,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ProgramModel updatedProgram =
         ProgramBuilder.newActiveProgram("program")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     repo.createOrUpdateStatusDefinitions(
         updatedProgram.getProgramDefinition().adminName(),
@@ -3422,7 +3422,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3534,7 +3534,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3628,7 +3628,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3736,7 +3736,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")
@@ -3775,7 +3775,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newActiveProgram("program")
@@ -3812,7 +3812,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     ApplicantData applicantData =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("program")

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -38,9 +38,10 @@ public class BlockTest {
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   private static final NameQuestionDefinition NAME_QUESTION =
-      (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
+      (NameQuestionDefinition) testQuestionBank.nameApplicantName().getQuestionDefinition();
   private static final TextQuestionDefinition COLOR_QUESTION =
-      (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+      (TextQuestionDefinition)
+          testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
   private static final StaticContentQuestionDefinition STATIC_QUESTION =
       new StaticContentQuestionDefinition(
           QuestionDefinitionConfig.builder()
@@ -467,7 +468,7 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                    testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
                     Optional.empty()))
             .build();
 
@@ -490,7 +491,7 @@ public class BlockTest {
   public void getEnumeratorQuestion() {
     ApplicantData applicantData = new ApplicantData();
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     BlockDefinition definition =
         BlockDefinition.builder()
             .setId(1L)
@@ -520,7 +521,8 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition(), Optional.empty()))
+                    testQuestionBank.fileUploadApplicantFile().getQuestionDefinition(),
+                    Optional.empty()))
             .build();
 
     Block block = new Block("1", definition, applicantData, Optional.empty());
@@ -550,11 +552,11 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                     Optional.of(programId)))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                     Optional.of(programId)))
             .build();
     ApplicantData applicantData = new ApplicantData();
@@ -591,11 +593,11 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                     Optional.of(programId)))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                     Optional.of(programId)))
             .build();
     ApplicantData applicantData = new ApplicantData();
@@ -615,13 +617,13 @@ public class BlockTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     BlockDefinition blockDefinition =
@@ -651,12 +653,12 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                        testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                         Optional.of(programId))
                     .setOptional(true))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                        testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                         Optional.of(programId))
                     .setOptional(true))
             .build();
@@ -678,11 +680,11 @@ public class BlockTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue(""))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                     Optional.of(programId)))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                     Optional.of(programId)))
             .build();
     ApplicantData applicantData = new ApplicantData();
@@ -704,13 +706,13 @@ public class BlockTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId + 1, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     BlockDefinition blockDefinition =
@@ -735,13 +737,13 @@ public class BlockTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             Optional.of(programId));
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
@@ -763,12 +765,12 @@ public class BlockTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd1 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(false);
     ProgramQuestionDefinition pqd2 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(false);
     BlockDefinition blockDefinition =
@@ -792,12 +794,12 @@ public class BlockTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd1 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     ProgramQuestionDefinition pqd2 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(false);
     BlockDefinition blockDefinition =
@@ -821,12 +823,12 @@ public class BlockTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd1 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     ProgramQuestionDefinition pqd2 =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     BlockDefinition blockDefinition =
@@ -851,10 +853,11 @@ public class BlockTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId))
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+                Optional.of(programId))
             .setOptional(true);
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -889,7 +892,8 @@ public class BlockTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId))
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+                Optional.of(programId))
             .setAddressCorrectionEnabled(true);
     BlockDefinition blockDefinition =
         BlockDefinition.builder()

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -51,9 +51,9 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void setUp() {
     jsonPathPredicateGeneratorFactory = instanceOf(JsonPathPredicateGeneratorFactory.class);
     applicantData = new ApplicantData();
-    nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
-    colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
-    addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
+    nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    colorQuestion = testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
+    addressQuestion = testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     staticQuestion = testQuestionBank.staticContent().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program setup")
@@ -88,7 +88,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   @Test
   public void getStoredFileKeys_includesAnsweredFileQuestions() {
     QuestionDefinition fileQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -112,7 +112,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   @Test
   public void getStoredFileKeys_worksForMultipleFileUploads() {
     QuestionDefinition fileQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -143,7 +143,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   @Test
   public void getStoredFileKeys_doesNotReturnOldKeyWhenMultipleFileEnabled() {
     QuestionDefinition fileQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -179,7 +179,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   @Test
   public void getStoredFileKeys_doesNotIncludeUnansweredFileQuestions() {
     QuestionDefinition fileQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -340,13 +340,14 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             .withRequiredQuestionDefinition(colorQuestion)
             .withBlock("enumeration - household members")
             .withVisibilityPredicate(predicate)
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock("repeated - household members name")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberName())
+            .withRequiredQuestion(testQuestionBank.nameRepeatedApplicantHouseholdMemberName())
             .withAnotherRepeatedBlock("repeated - household members jobs")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withRepeatedBlock("deeply repeated - household members number days worked")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberDaysWorked())
+            .withRequiredQuestion(
+                testQuestionBank.numberNestedRepeatedApplicantHouseholdMemberDaysWorked())
             .buildDefinition();
 
     // Answer predicate question so that the block should be visible
@@ -356,7 +357,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     Path enumerationPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     applicantData.putString(enumerationPath.atIndex(0).join(Scalar.ENTITY_NAME), "first entity");
@@ -367,7 +368,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             .atIndex(2)
             .join(
                 testQuestionBank
-                    .applicantHouseholdMemberJobs()
+                    .enumeratorNestedApplicantHouseholdMemberJobs()
                     .getQuestionDefinition()
                     .getQuestionPathSegment());
     applicantData.putString(
@@ -429,24 +430,25 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock("name")
-            .withRequiredQuestion(testQuestionBank.applicantName())
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
             .withBlock("address")
-            .withRequiredQuestion(testQuestionBank.applicantAddress())
+            .withRequiredQuestion(testQuestionBank.addressApplicantAddress())
             .withBlock("enumeration - household members")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock("repeated - household members name")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberName())
+            .withRequiredQuestion(testQuestionBank.nameRepeatedApplicantHouseholdMemberName())
             .withAnotherRepeatedBlock("repeated - household members jobs")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withRepeatedBlock("deeply repeated - household members number days worked")
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberDaysWorked())
+            .withRequiredQuestion(
+                testQuestionBank.numberNestedRepeatedApplicantHouseholdMemberDaysWorked())
             .buildDefinition();
 
     // Add repeated entities to applicant data
     Path enumerationPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     applicantData.putString(enumerationPath.atIndex(0).join(Scalar.ENTITY_NAME), "first entity");
@@ -457,7 +459,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             .atIndex(2)
             .join(
                 testQuestionBank
-                    .applicantHouseholdMemberJobs()
+                    .enumeratorNestedApplicantHouseholdMemberJobs()
                     .getQuestionDefinition()
                     .getQuestionPathSegment());
     applicantData.putString(
@@ -743,7 +745,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getIneligibleQuestionsForProgram_doesNotIncludeUnansweredQuestions() {
     // Create an eligibility condition with number question == 5.
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition numberPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -778,7 +780,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getIneligibleQuestionsForProgram_includesQuestionsWithIneligibleAnswers() {
     // Create an eligibility condition with number question == 5.
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition numberPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -815,14 +817,14 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     // the applicant not eligible.
     assertThat(eligibilityQuestions).hasSize(1);
     assertThat(eligibilityQuestions.stream().findFirst().get().getQuestionDefinition())
-        .isEqualTo(testQuestionBank.applicantJugglingNumber().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition());
   }
 
   @Test
   public void getIneligibleQuestionsForProgram_doesNotIncludeQuestionsWithEligibleAnswers() {
     // Create an eligibility condition with number question == 5.
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition numberPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1051,15 +1053,15 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getSummaryDataOnlyActive_returnsCompletedData() {
     // Create a program with lots of questions
     QuestionDefinition singleSelectQuestionDefinition =
-        testQuestionBank.applicantSeason().getQuestionDefinition();
+        testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition();
     QuestionDefinition multiSelectQuestionDefinition =
-        testQuestionBank.applicantKitchenTools().getQuestionDefinition();
+        testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition();
     QuestionDefinition fileQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition repeatedQuestionDefinition =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -1213,7 +1215,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getSummaryDataOnlyActive_returnsKeysForUploadedFileForSingleFile() {
     // Create a program with a fileupload question and a non-fileupload question
     QuestionDefinition fileUploadQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withBlock("Block one")
@@ -1244,7 +1246,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getSummaryDataOnlyActive_returnsKeysForUploadedFiles() {
     // Create a program with a fileupload question and a non-fileupload question
     QuestionDefinition fileUploadQuestionDefinition =
-        testQuestionBank.applicantFile().getQuestionDefinition();
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withBlock("Block one")
@@ -1281,7 +1283,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getSummaryDataOnlyActive_isEligible(long answer, boolean expectedResult) {
     // Create a program with an eligibility condition == 5 and answer it with different values.
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1348,7 +1350,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
   public void getIsApplicationEligible(long answer, boolean expectedResult) {
     // Create a program with an eligibility condition == 5 and answer it with different values.
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1390,7 +1392,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     // and another with eligibility condition == "blue" answer it with different values.
 
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition numberPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1402,7 +1404,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             PredicateAction.SHOW_BLOCK);
 
     QuestionDefinition colorQuestionDefinition =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
     PredicateDefinition colorPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1454,7 +1456,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     // block with different values.
 
     QuestionDefinition numberQuestionDefinition =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateDefinition numberPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1466,7 +1468,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
             PredicateAction.SHOW_BLOCK);
 
     QuestionDefinition colorQuestionDefinition =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
     PredicateDefinition colorPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(

--- a/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
+++ b/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
@@ -43,9 +43,10 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
     applicantData = new ApplicantData();
     pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId))
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+                Optional.of(programId))
             .setAddressCorrectionEnabled(true);
-    addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
+    addressQuestion = testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -131,9 +132,10 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
     ApplicantData applicantData = new ApplicantData();
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId));
+            testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+            Optional.of(programId));
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(
@@ -177,10 +179,11 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
     ApplicantData applicantData = new ApplicantData();
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId))
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+                Optional.of(programId))
             .setAddressCorrectionEnabled(true);
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     EligibilityDefinition eligibilityDef =
         EligibilityDefinition.builder()
             .setPredicate(

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -40,10 +40,10 @@ public class JsonPathPredicateGeneratorTest {
 
   @Before
   public void setupGenerator() {
-    question = questionBank.applicantAddress().getQuestionDefinition();
-    dateQuestion = questionBank.applicantDate().getQuestionDefinition();
-    numberQuestion = questionBank.applicantJugglingNumber().getQuestionDefinition();
-    currencyQuestion = questionBank.applicantIceCream().getQuestionDefinition();
+    question = questionBank.addressApplicantAddress().getQuestionDefinition();
+    dateQuestion = questionBank.dateApplicantBirthdate().getQuestionDefinition();
+    numberQuestion = questionBank.numberApplicantJugglingNumber().getQuestionDefinition();
+    currencyQuestion = questionBank.dropdownApplicantIceCream().getQuestionDefinition();
     generator =
         new JsonPathPredicateGenerator(
             new DateConverter(clock),
@@ -319,10 +319,10 @@ public class JsonPathPredicateGeneratorTest {
     ApplicantData applicantData = new ApplicantData();
     EnumeratorQuestionDefinition enumerator =
         (EnumeratorQuestionDefinition)
-            questionBank.applicantHouseholdMembers().getQuestionDefinition();
+            questionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition repeatedQuestion =
         new QuestionDefinitionBuilder(
-                questionBank.applicantHouseholdMemberName().getQuestionDefinition())
+                questionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition())
             .setEnumeratorId(Optional.of(enumerator.getId()))
             .build();
 
@@ -363,10 +363,10 @@ public class JsonPathPredicateGeneratorTest {
     ApplicantData applicantData = new ApplicantData();
     EnumeratorQuestionDefinition enumerator =
         (EnumeratorQuestionDefinition)
-            questionBank.applicantHouseholdMembers().getQuestionDefinition();
+            questionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition siblingQuestion =
         new QuestionDefinitionBuilder(
-                questionBank.applicantHouseholdMemberName().getQuestionDefinition())
+                questionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition())
             .setEnumeratorId(Optional.of(enumerator.getId()))
             .build();
 
@@ -408,13 +408,15 @@ public class JsonPathPredicateGeneratorTest {
     //  \_ name (target), jobs
     //                      \_ days worked (current block)
     QuestionDefinition topLevelEnumerator =
-        questionBank.applicantHouseholdMembers().getQuestionDefinition();
+        questionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition targetQuestion =
-        questionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        questionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     QuestionDefinition nestedEnumerator =
-        questionBank.applicantHouseholdMemberJobs().getQuestionDefinition();
+        questionBank.enumeratorNestedApplicantHouseholdMemberJobs().getQuestionDefinition();
     QuestionDefinition currentQuestion =
-        questionBank.applicantHouseholdMemberDaysWorked().getQuestionDefinition();
+        questionBank
+            .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
+            .getQuestionDefinition();
 
     // Put an entity at the enumerator path so we can generate repeated contexts.
     ApplicantQuestion applicantEnumerator =
@@ -467,14 +469,14 @@ public class JsonPathPredicateGeneratorTest {
       throws Exception {
     ApplicantData applicantData = new ApplicantData();
     QuestionDefinition topLevelEnumerator =
-        questionBank.applicantHouseholdMembers().getQuestionDefinition();
+        questionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition targetQuestion =
         new QuestionDefinitionBuilder(
-                questionBank.applicantHouseholdMemberName().getQuestionDefinition())
+                questionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition())
             .setEnumeratorId(Optional.of(12345L))
             .build();
     QuestionDefinition currentQuestion =
-        questionBank.applicantHouseholdMemberJobs().getQuestionDefinition();
+        questionBank.enumeratorNestedApplicantHouseholdMemberJobs().getQuestionDefinition();
 
     // Put an entity at the enumerator path so we can generate repeated contexts.
     ApplicantQuestion applicantEnumerator =

--- a/server/test/services/applicant/predicate/PredicateEvaluatorTest.java
+++ b/server/test/services/applicant/predicate/PredicateEvaluatorTest.java
@@ -24,7 +24,7 @@ public class PredicateEvaluatorTest {
 
   private final TestQuestionBank questionBank = new TestQuestionBank(false);
   private final QuestionDefinition addressQuestion =
-      questionBank.applicantAddress().getQuestionDefinition();
+      questionBank.addressApplicantAddress().getQuestionDefinition();
 
   private ApplicantData applicantData;
   private ApplicantQuestion applicantQuestion;

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -32,7 +32,7 @@ public class ApplicantQuestionTest {
   public void getContextualizedScalars_returnsContextualizedScalarsAndMetadataForType() {
     ApplicantQuestion testApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+            testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
 
@@ -53,7 +53,7 @@ public class ApplicantQuestionTest {
   public void getContextualizedScalars_forEnumerationQuestion_throwsInvalidQuestionTypeException() {
     ApplicantQuestion enumerationApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+            testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
 
@@ -86,7 +86,7 @@ public class ApplicantQuestionTest {
   public void getsExpectedQuestionType() {
     ApplicantQuestion addressApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantAddress().getQuestionDefinition(),
+            testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(addressApplicantQuestion.createAddressQuestion())
@@ -94,7 +94,7 @@ public class ApplicantQuestionTest {
 
     ApplicantQuestion checkboxApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantKitchenTools().getQuestionDefinition(),
+            testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(checkboxApplicantQuestion.createMultiSelectQuestion())
@@ -102,7 +102,7 @@ public class ApplicantQuestionTest {
 
     ApplicantQuestion dropdownApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantIceCream().getQuestionDefinition(),
+            testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(dropdownApplicantQuestion.createSingleSelectQuestion())
@@ -110,7 +110,7 @@ public class ApplicantQuestionTest {
 
     ApplicantQuestion enumeratorApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+            testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(enumeratorApplicantQuestion.createEnumeratorQuestion())
@@ -118,21 +118,21 @@ public class ApplicantQuestionTest {
 
     ApplicantQuestion nameApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantName().getQuestionDefinition(),
+            testQuestionBank.nameApplicantName().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(nameApplicantQuestion.createNameQuestion()).isInstanceOf(NameQuestion.class);
 
     ApplicantQuestion numberApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(numberApplicantQuestion.createNumberQuestion()).isInstanceOf(NumberQuestion.class);
 
     ApplicantQuestion radioApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantSeason().getQuestionDefinition(),
+            testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(radioApplicantQuestion.createSingleSelectQuestion())
@@ -140,14 +140,14 @@ public class ApplicantQuestionTest {
 
     ApplicantQuestion textApplicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+            testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(textApplicantQuestion.createTextQuestion()).isInstanceOf(TextQuestion.class);
 
     ApplicantQuestion phoneQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantPhone().getQuestionDefinition(),
+            testQuestionBank.phoneApplicantPhone().getQuestionDefinition(),
             new ApplicantData(),
             Optional.empty());
     assertThat(phoneQuestion.createPhoneQuestion()).isInstanceOf(PhoneQuestion.class);
@@ -162,91 +162,91 @@ public class ApplicantQuestionTest {
         .addEqualityGroup(
             // Address
             new ApplicantQuestion(
-                testQuestionBank.applicantAddress().getQuestionDefinition(),
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantAddress().getQuestionDefinition(),
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Address
             new ApplicantQuestion(
-                testQuestionBank.applicantPhone().getQuestionDefinition(),
+                testQuestionBank.phoneApplicantPhone().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantPhone().getQuestionDefinition(),
+                testQuestionBank.phoneApplicantPhone().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Checkbox
             new ApplicantQuestion(
-                testQuestionBank.applicantKitchenTools().getQuestionDefinition(),
+                testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantKitchenTools().getQuestionDefinition(),
+                testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Dropdown
             new ApplicantQuestion(
-                testQuestionBank.applicantIceCream().getQuestionDefinition(),
+                testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantIceCream().getQuestionDefinition(),
+                testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Name
             new ApplicantQuestion(
-                testQuestionBank.applicantName().getQuestionDefinition(),
+                testQuestionBank.nameApplicantName().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantName().getQuestionDefinition(),
+                testQuestionBank.nameApplicantName().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Number
             new ApplicantQuestion(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Radio button
             new ApplicantQuestion(
-                testQuestionBank.applicantSeason().getQuestionDefinition(),
+                testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantSeason().getQuestionDefinition(),
+                testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Text
             new ApplicantQuestion(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 new ApplicantData(),
                 Optional.empty()))
         .addEqualityGroup(
             // Text with answered data
             new ApplicantQuestion(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 dataWithAnswers,
                 Optional.empty()),
             new ApplicantQuestion(
-                testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition(),
                 dataWithAnswers,
                 Optional.empty()))
         .testEquals();
@@ -258,7 +258,7 @@ public class ApplicantQuestionTest {
     Path householdMembersPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantHouseholdMembers()
+                .enumeratorApplicantHouseholdMembers()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.answerEnumeratorQuestion(
@@ -268,7 +268,7 @@ public class ApplicantQuestionTest {
             .atIndex(0)
             .join(
                 testQuestionBank
-                    .applicantHouseholdMemberJobs()
+                    .enumeratorNestedApplicantHouseholdMemberJobs()
                     .getQuestionDefinition()
                     .getQuestionPathSegment());
     QuestionAnswerer.answerEnumeratorQuestion(
@@ -276,7 +276,7 @@ public class ApplicantQuestionTest {
     RepeatedEntity jonathan =
         RepeatedEntity.createRepeatedEntities(
                 (EnumeratorQuestionDefinition)
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                    testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
                 Optional.empty(),
                 applicantData)
             .get(0);
@@ -284,14 +284,18 @@ public class ApplicantQuestionTest {
         jonathan
             .createNestedRepeatedEntities(
                 (EnumeratorQuestionDefinition)
-                    testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                    testQuestionBank
+                        .enumeratorNestedApplicantHouseholdMemberJobs()
+                        .getQuestionDefinition(),
                 Optional.empty(),
                 applicantData)
             .get(0);
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantHouseholdMemberDaysWorked().getQuestionDefinition(),
+            testQuestionBank
+                .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
+                .getQuestionDefinition(),
             applicantData,
             Optional.of(jonCo));
 
@@ -308,7 +312,7 @@ public class ApplicantQuestionTest {
     ApplicantData applicantData = new ApplicantData();
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(
-            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+            testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
             applicantData,
             Optional.empty());
     QuestionAnswerer.addMetadata(
@@ -324,7 +328,7 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             Optional.of(programId));
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, applicantData, Optional.empty());
@@ -340,7 +344,7 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             Optional.of(programId));
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, applicantData, Optional.empty());
@@ -356,7 +360,7 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             Optional.of(programId));
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, applicantData, Optional.empty());
@@ -374,7 +378,7 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
     ApplicantQuestion applicantQuestion =
@@ -392,13 +396,13 @@ public class ApplicantQuestionTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
 
@@ -415,13 +419,13 @@ public class ApplicantQuestionTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId + 1, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
                 Optional.of(programId))
             .setOptional(true);
 
@@ -438,13 +442,13 @@ public class ApplicantQuestionTest {
     Path questionPath =
         ApplicantData.APPLICANT_PATH.join(
             testQuestionBank
-                .applicantJugglingNumber()
+                .numberApplicantJugglingNumber()
                 .getQuestionDefinition()
                 .getQuestionPathSegment());
     QuestionAnswerer.addMetadata(applicantData, questionPath, programId, 0L);
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
             Optional.of(programId));
 
     ApplicantQuestion applicantQuestion =
@@ -459,7 +463,8 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-                testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId))
+                testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+                Optional.of(programId))
             .setAddressCorrectionEnabled(true);
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, applicantData, Optional.empty());
@@ -475,7 +480,8 @@ public class ApplicantQuestionTest {
     long programId = 5L;
     ProgramQuestionDefinition pqd =
         ProgramQuestionDefinition.create(
-            testQuestionBank.applicantAddress().getQuestionDefinition(), Optional.of(programId));
+            testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+            Optional.of(programId));
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, applicantData, Optional.empty());
     QuestionAnswerer.addMetadata(

--- a/server/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/server/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -202,7 +202,7 @@ public class EnumeratorQuestionTest extends ResetPostgres {
   public void getMetadata_forEnumeratorQuestion() {
     ApplicantData applicantData = new ApplicantData();
     QuestionDefinition enumeratorQuestionDefinition =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     Path enumeratorPath =
         ApplicantData.APPLICANT_PATH.join(enumeratorQuestionDefinition.getQuestionPathSegment());
     applicantData.putLong(enumeratorPath.atIndex(0).join(Scalar.UPDATED_AT), 123L);

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -257,7 +257,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
   }
 
   protected void createFakeProgramWithOptionalQuestion(QuestionModel optionalQuestion) {
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
 
     ProgramModel fakeProgramWithOptionalQuestion =
         ProgramBuilder.newActiveProgram()
@@ -293,8 +293,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
    * applications have submission times one month apart starting on 2023-01-01.
    */
   protected void createFakeProgramWithVisibilityPredicate() {
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
-    QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
+    QuestionModel colorQuestion = testQuestionBank.textApplicantFavoriteColor();
 
     PredicateDefinition colorPredicate =
         PredicateDefinition.create(
@@ -340,8 +340,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
    * The applications have submission times one month apart starting on 2022-01-01.
    */
   protected void createFakeProgramWithEligibilityPredicate() {
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
-    QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
+    QuestionModel colorQuestion = testQuestionBank.textApplicantFavoriteColor();
 
     PredicateDefinition colorPredicate =
         PredicateDefinition.create(
@@ -418,13 +418,14 @@ public abstract class AbstractExporterTest extends ResetPostgres {
    * applications. The applications have submission times one month apart starting on 2022-01-01.
    */
   protected void createFakeProgramWithEnumeratorAndAnswerQuestions() {
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
-    QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
-    QuestionModel monthlyIncomeQuestion = testQuestionBank.applicantMonthlyIncome();
-    QuestionModel householdMembersQuestion = testQuestionBank.applicantHouseholdMembers();
-    QuestionModel hmNameQuestion = testQuestionBank.applicantHouseholdMemberName();
-    QuestionModel hmJobsQuestion = testQuestionBank.applicantHouseholdMemberJobs();
-    QuestionModel hmNumberDaysWorksQuestion = testQuestionBank.applicantHouseholdMemberDaysWorked();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
+    QuestionModel colorQuestion = testQuestionBank.textApplicantFavoriteColor();
+    QuestionModel monthlyIncomeQuestion = testQuestionBank.currencyApplicantMonthlyIncome();
+    QuestionModel householdMembersQuestion = testQuestionBank.enumeratorApplicantHouseholdMembers();
+    QuestionModel hmNameQuestion = testQuestionBank.nameRepeatedApplicantHouseholdMemberName();
+    QuestionModel hmJobsQuestion = testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs();
+    QuestionModel hmNumberDaysWorksQuestion =
+        testQuestionBank.numberNestedRepeatedApplicantHouseholdMemberDaysWorked();
     fakeProgramWithEnumerator =
         ProgramBuilder.newActiveProgram()
             .withName("Fake Program With Enumerator")
@@ -619,8 +620,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
      * @return the fake {@link ProgramBuilder}
      */
     FakeProgramBuilder withDateQuestionWithVisibilityPredicateOnTextQuestion() {
-      QuestionModel dateQuestion = testQuestionBank.applicantDate();
-      QuestionModel colorQuestion = testQuestionBank.applicantFavoriteColor();
+      QuestionModel dateQuestion = testQuestionBank.dateApplicantBirthdate();
+      QuestionModel colorQuestion = testQuestionBank.textApplicantFavoriteColor();
 
       PredicateDefinition colorPredicate =
           PredicateDefinition.create(
@@ -654,20 +655,23 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       if (addEnumeratorQuestion && addNestedEnumeratorQuestion) {
         fakeProgramBuilder
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberFavoriteShape())
+            .withRequiredQuestion(
+                testQuestionBank.textRepeatedApplicantHouseholdMemberFavoriteShape())
             .withAnotherRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberDaysWorked())
+            .withRequiredQuestion(
+                testQuestionBank.numberNestedRepeatedApplicantHouseholdMemberDaysWorked())
             .build();
       } else if (addEnumeratorQuestion) {
         fakeProgramBuilder
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberFavoriteShape())
+            .withRequiredQuestion(
+                testQuestionBank.textRepeatedApplicantHouseholdMemberFavoriteShape())
             .build();
       }
 
@@ -708,7 +712,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
         String street, String line2, String city, String state, String zip) {
       Path answerPath =
           testQuestionBank
-              .applicantAddress()
+              .addressApplicantAddress()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -731,7 +735,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
         String serviceArea) {
       Path answerPath =
           testQuestionBank
-              .applicantAddress()
+              .addressApplicantAddress()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -755,7 +759,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerCheckboxQuestion(ImmutableList<Long> optionIds) {
       Path answerPath =
           testQuestionBank
-              .applicantKitchenTools()
+              .checkboxApplicantKitchenTools()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -770,7 +774,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerCurrencyQuestion(String answer) {
       Path answerPath =
           testQuestionBank
-              .applicantMonthlyIncome()
+              .currencyApplicantMonthlyIncome()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -782,7 +786,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerDateQuestion(String answer) {
       Path answerPath =
           testQuestionBank
-              .applicantDate()
+              .dateApplicantBirthdate()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -794,7 +798,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerDropdownQuestion(Long optionId) {
       Path answerPath =
           testQuestionBank
-              .applicantIceCream()
+              .dropdownApplicantIceCream()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -807,7 +811,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerEmailQuestion(String answer) {
       Path answerPath =
           testQuestionBank
-              .applicantEmail()
+              .emailApplicantEmail()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -819,7 +823,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerFileUploadQuestion(String fileKey) {
       Path answerPath =
           testQuestionBank
-              .applicantFile()
+              .fileUploadApplicantFile()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -832,7 +836,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerIdQuestion(String answer) {
       Path answerPath =
           testQuestionBank
-              .applicantId()
+              .IdApplicantId()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -845,7 +849,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerNameQuestion(String firstName, String middleName, String lastName) {
       Path answerPath =
           testQuestionBank
-              .applicantName()
+              .nameApplicantName()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -858,7 +862,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerNumberQuestion(long answer) {
       Path answerPath =
           testQuestionBank
-              .applicantJugglingNumber()
+              .numberApplicantJugglingNumber()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -870,7 +874,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerPhoneQuestion(String countryCode, String phoneNumber) {
       Path answerPath =
           testQuestionBank
-              .applicantPhone()
+              .phoneApplicantPhone()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -883,7 +887,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerRadioButtonQuestion(Long optionId) {
       Path answerPath =
           testQuestionBank
-              .applicantSeason()
+              .radioApplicantFavoriteSeason()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -896,7 +900,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerTextQuestion(String answer) {
       Path answerPath =
           testQuestionBank
-              .applicantFavoriteColor()
+              .textApplicantFavoriteColor()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -908,7 +912,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     FakeApplicationFiller answerEnumeratorQuestion(ImmutableList<String> householdMembers) {
       Path answerPath =
           testQuestionBank
-              .applicantHouseholdMembers()
+              .enumeratorApplicantHouseholdMembers()
               .getQuestionDefinition()
               .getContextualizedPath(
                   /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
@@ -923,7 +927,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
               (EnumeratorQuestionDefinition)
-                  testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                  testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
               /* visibility= */ Optional.empty(),
               applicant.getApplicantData());
       var parentRepeatedEntity =
@@ -932,7 +936,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .findFirst();
       Path answerPath =
           testQuestionBank
-              .applicantHouseholdMemberJobs()
+              .enumeratorNestedApplicantHouseholdMemberJobs()
               .getQuestionDefinition()
               .getContextualizedPath(parentRepeatedEntity, ApplicantData.APPLICANT_PATH);
       QuestionAnswerer.answerEnumeratorQuestion(applicant.getApplicantData(), answerPath, jobNames);
@@ -944,14 +948,14 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
               (EnumeratorQuestionDefinition)
-                  testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                  testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
               /* visibility= */ Optional.empty(),
               applicant.getApplicantData());
       var repeatedEntity =
           repeatedEntities.stream().filter(e -> e.entityName().equals(entityName)).findFirst();
       Path answerPath =
           testQuestionBank
-              .applicantHouseholdMemberFavoriteShape()
+              .textRepeatedApplicantHouseholdMemberFavoriteShape()
               .getQuestionDefinition()
               .getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
       QuestionAnswerer.answerTextQuestion(applicant.getApplicantData(), answerPath, answer);
@@ -964,7 +968,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       var repeatedEntities =
           RepeatedEntity.createRepeatedEntities(
               (EnumeratorQuestionDefinition)
-                  testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                  testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
               /* visibility= */ Optional.empty(),
               applicant.getApplicantData());
       var nestedRepeatedEntities =
@@ -974,7 +978,9 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .get()
               .createNestedRepeatedEntities(
                   (EnumeratorQuestionDefinition)
-                      testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                      testQuestionBank
+                          .enumeratorNestedApplicantHouseholdMemberJobs()
+                          .getQuestionDefinition(),
                   /* visibility= */ Optional.empty(),
                   applicant.getApplicantData());
 
@@ -984,7 +990,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .findFirst();
       Path answerPath =
           testQuestionBank
-              .applicantHouseholdMemberDaysWorked()
+              .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
               .getQuestionDefinition()
               .getContextualizedPath(nestedRepeatedEntity, ApplicantData.APPLICANT_PATH);
       QuestionAnswerer.answerNumberQuestion(applicant.getApplicantData(), answerPath, answer);

--- a/server/test/services/export/CsvExporterServiceTest.java
+++ b/server/test/services/export/CsvExporterServiceTest.java
@@ -70,7 +70,7 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .withQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerCheckboxQuestion(
@@ -85,7 +85,7 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
         QuestionOption.create(4L, 4L, "stand_mixer", LocalizedStrings.of(Locale.US, "stand_mixer"));
     MultiOptionQuestionDefinition questionDefinition =
         (MultiOptionQuestionDefinition)
-            testQuestionBank.applicantKitchenTools().getQuestionDefinition();
+            testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition();
     ImmutableList<QuestionOption> currentOptions = questionDefinition.getOptions();
     ImmutableList<QuestionOption> newOptionList =
         ImmutableList.<QuestionOption>builder().addAll(currentOptions).add(newOption).build();
@@ -178,7 +178,7 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "Admin Note");
 
     NameQuestion nameApplicantQuestion =
-        getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
+        getApplicantQuestion(testQuestionBank.nameApplicantName().getQuestionDefinition())
             .createNameQuestion();
     String firstNameHeader =
         CsvExporterService.formatHeader(nameApplicantQuestion.getFirstNamePath());
@@ -264,7 +264,7 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "Admin Note");
 
     NameQuestion nameApplicantQuestion =
-        getApplicantQuestion(testQuestionBank.applicantName().getQuestionDefinition())
+        getApplicantQuestion(testQuestionBank.nameApplicantName().getQuestionDefinition())
             .createNameQuestion();
     String firstNameHeader =
         CsvExporterService.formatHeader(nameApplicantQuestion.getFirstNamePath());

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -259,7 +259,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantAddress())
+            .withQuestion(testQuestionBank.addressApplicantAddress())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerCorrectedAddressQuestion(
@@ -307,7 +307,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantAddress())
+            .withQuestion(testQuestionBank.addressApplicantAddress())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerAddressQuestion("12345 E South St", "", "CityVille Township", "OR", "97403")
@@ -345,7 +345,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantAddress())
+            .withQuestion(testQuestionBank.addressApplicantAddress())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -381,7 +381,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .withQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerCheckboxQuestion(
@@ -414,7 +414,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantKitchenTools())
+            .withQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -441,7 +441,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantMonthlyIncome())
+            .withQuestion(testQuestionBank.currencyApplicantMonthlyIncome())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerCurrencyQuestion("5,444.33").submit();
 
@@ -468,7 +468,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantMonthlyIncome())
+            .withQuestion(testQuestionBank.currencyApplicantMonthlyIncome())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -495,7 +495,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantDate())
+            .withQuestion(testQuestionBank.dateApplicantBirthdate())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerDateQuestion("2015-10-21").submit();
 
@@ -522,7 +522,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantDate())
+            .withQuestion(testQuestionBank.dateApplicantBirthdate())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -549,7 +549,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantIceCream())
+            .withQuestion(testQuestionBank.dropdownApplicantIceCream())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerDropdownQuestion(2L /* strawberry */)
@@ -578,7 +578,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantIceCream())
+            .withQuestion(testQuestionBank.dropdownApplicantIceCream())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -605,7 +605,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantEmail())
+            .withQuestion(testQuestionBank.emailApplicantEmail())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerEmailQuestion("chell@aperturescience.com")
@@ -634,7 +634,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantEmail())
+            .withQuestion(testQuestionBank.emailApplicantEmail())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -661,7 +661,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantFile())
+            .withQuestion(testQuestionBank.fileUploadApplicantFile())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerFileUploadQuestion("test-file-key")
@@ -691,7 +691,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantFile())
+            .withQuestion(testQuestionBank.fileUploadApplicantFile())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -717,7 +717,9 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenIdQuestionIsAnswered_valueIsInResponse() {
     createFakeQuestions();
     var fakeProgram =
-        FakeProgramBuilder.newActiveProgram().withQuestion(testQuestionBank.applicantId()).build();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.IdApplicantId())
+            .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerIdQuestion("011235813").submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
@@ -742,7 +744,9 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
   public void export_whenIdQuestionIsNotAnswered_valueInResponseIsNull() {
     createFakeQuestions();
     var fakeProgram =
-        FakeProgramBuilder.newActiveProgram().withQuestion(testQuestionBank.applicantId()).build();
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.IdApplicantId())
+            .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
@@ -768,7 +772,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantName())
+            .withQuestion(testQuestionBank.nameApplicantName())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerNameQuestion("Taylor", "Allison", "Swift")
@@ -799,7 +803,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantName())
+            .withQuestion(testQuestionBank.nameApplicantName())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerNameQuestion("Taylor", "", "Swift")
@@ -830,7 +834,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantName())
+            .withQuestion(testQuestionBank.nameApplicantName())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -859,7 +863,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerNumberQuestion(42).submit();
 
@@ -886,7 +890,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -913,7 +917,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantPhone())
+            .withQuestion(testQuestionBank.phoneApplicantPhone())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerPhoneQuestion("US", "(555) 867-5309")
@@ -942,7 +946,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantPhone())
+            .withQuestion(testQuestionBank.phoneApplicantPhone())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -969,7 +973,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantSeason())
+            .withQuestion(testQuestionBank.radioApplicantFavoriteSeason())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerRadioButtonQuestion(3L /* summer */)
@@ -998,7 +1002,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantSeason())
+            .withQuestion(testQuestionBank.radioApplicantFavoriteSeason())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -1025,7 +1029,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .withQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerTextQuestion("circle 💖").submit();
 
@@ -1052,7 +1056,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .withQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).submit();
 
@@ -1468,13 +1472,13 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     createFakeQuestions();
     ProgramModel fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram).answerNumberQuestion(3).submit();
 
     ProgramModel updatedFakeProgram =
         FakeProgramBuilder.newDraftOf(fakeProgram)
-            .withQuestion(testQuestionBank.applicantEmail())
+            .withQuestion(testQuestionBank.emailApplicantEmail())
             .build();
     FakeApplicationFiller.newFillerFor(updatedFakeProgram)
         .answerNumberQuestion(4)
@@ -1537,8 +1541,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     ProgramModel fakeProgram =
         FakeProgramBuilder.newActiveProgram()
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
-            .withQuestion(testQuestionBank.applicantEmail())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
+            .withQuestion(testQuestionBank.emailApplicantEmail())
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerNumberQuestion(3)
@@ -1546,7 +1550,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
         .submit();
 
     ProgramModel updatedProgram =
-        FakeProgramBuilder.removeBlockWithQuestion(fakeProgram, testQuestionBank.applicantEmail())
+        FakeProgramBuilder.removeBlockWithQuestion(
+                fakeProgram, testQuestionBank.emailApplicantEmail())
             .build();
     FakeApplicationFiller.newFillerFor(updatedProgram).answerNumberQuestion(4).submit();
 
@@ -1614,11 +1619,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     // Create programs A and B
     ProgramModel fakeProgramA =
         FakeProgramBuilder.newActiveProgram("fake program A")
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
             .build();
     ProgramModel fakeProgramB =
         FakeProgramBuilder.newActiveProgram("fake program B")
-            .withQuestion(testQuestionBank.applicantEmail())
+            .withQuestion(testQuestionBank.emailApplicantEmail())
             .build();
 
     // Fill out both programs
@@ -1648,7 +1653,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
     // Add question from program A to program B
     ProgramModel updatedFakeProgramB =
         FakeProgramBuilder.newDraftOf(fakeProgramB)
-            .withQuestion(testQuestionBank.applicantJugglingNumber())
+            .withQuestion(testQuestionBank.numberApplicantJugglingNumber())
             .build();
 
     // Without updating the application, re-export it
@@ -1688,12 +1693,12 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     var fakeProgram =
         FakeProgramBuilder.newActiveProgram("test new options")
-            .withQuestion(testQuestionBank.applicantIceCream())
+            .withQuestion(testQuestionBank.dropdownApplicantIceCream())
             .build();
 
     // Add new question option
     QuestionDefinition questionDefinition =
-        testQuestionBank.applicantIceCream().getQuestionDefinition();
+        testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition();
     ImmutableList<QuestionOption> newOptions =
         ImmutableList.<QuestionOption>builder()
             .addAll(((MultiOptionQuestionDefinition) questionDefinition).getOptions())

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -75,7 +75,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   public void exportApplication_optionalFileUploadWithFile_asAdmin_singleFile()
       throws IOException, DocumentException {
 
-    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel fileQuestion = testQuestionBank.fileUploadApplicantFile();
 
     createFakeProgramWithOptionalQuestion(fileQuestion);
 
@@ -127,7 +127,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   public void exportApplication_optionalFileUploadWithFile_asAdmin()
       throws IOException, DocumentException {
 
-    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel fileQuestion = testQuestionBank.fileUploadApplicantFile();
 
     createFakeProgramWithOptionalQuestion(fileQuestion);
 
@@ -184,7 +184,7 @@ public class PdfExporterTest extends AbstractExporterTest {
       exportApplication_optionalFileUploadWithFile_asApplicantUsesDifferentLinkWithSameContent_singleFile()
           throws IOException, DocumentException {
 
-    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel fileQuestion = testQuestionBank.fileUploadApplicantFile();
 
     createFakeProgramWithOptionalQuestion(fileQuestion);
 
@@ -232,7 +232,7 @@ public class PdfExporterTest extends AbstractExporterTest {
       exportApplication_optionalFileUploadWithFile_asApplicantUsesDifferentLinkWithSameContent()
           throws IOException, DocumentException {
 
-    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel fileQuestion = testQuestionBank.fileUploadApplicantFile();
 
     createFakeProgramWithOptionalQuestion(fileQuestion);
 
@@ -285,7 +285,7 @@ public class PdfExporterTest extends AbstractExporterTest {
   public void exportApplication_optionalFileUploadWithoutFile()
       throws IOException, DocumentException {
 
-    QuestionModel fileQuestion = testQuestionBank.applicantFile();
+    QuestionModel fileQuestion = testQuestionBank.fileUploadApplicantFile();
 
     createFakeProgramWithOptionalQuestion(fileQuestion);
 

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -56,11 +56,11 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
             .buildDefinition();
 
     QuestionDefinition addressQuestionDefinition =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition nameQuestionDefinition =
-        testQuestionBank.applicantName().getQuestionDefinition();
+        testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition emailQuestionDefinition =
-        testQuestionBank.applicantEmail().getQuestionDefinition();
+        testQuestionBank.emailApplicantEmail().getQuestionDefinition();
 
     ImmutableList<QuestionDefinition> questions =
         ImmutableList.of(

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -66,7 +66,7 @@ public class BlockDefinitionTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue("Block Description"))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                    testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition(),
                     Optional.empty()))
             .build();
 
@@ -92,7 +92,8 @@ public class BlockDefinitionTest {
             .setLocalizedDescription(LocalizedStrings.withDefaultValue("Block Description"))
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition(), Optional.empty()))
+                    testQuestionBank.fileUploadApplicantFile().getQuestionDefinition(),
+                    Optional.empty()))
             .build();
 
     assertThat(blockDefinition.isFileUpload()).isTrue();
@@ -158,9 +159,10 @@ public class BlockDefinitionTest {
 
   @Test
   public void getAddressCorrectionEnabledOnDifferentQuestion() {
-    QuestionDefinition firstAddress = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition firstAddress =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition secondAddress =
-        testQuestionBank.applicantSecondaryAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantSecondaryAddress().getQuestionDefinition();
     ProgramQuestionDefinition firstQuestion =
         ProgramQuestionDefinition.create(firstAddress, Optional.empty());
     // Second address has correction enabled
@@ -185,11 +187,11 @@ public class BlockDefinitionTest {
   }
 
   private BlockDefinition makeBlockDefinitionWithQuestions() {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition addressQuestion =
-        testQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition colorQuestion =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
 
     BlockDefinition block =
         BlockDefinition.builder()
@@ -224,7 +226,7 @@ public class BlockDefinitionTest {
 
   @Test
   public void hasNullQuestion_isFalse() {
-    QuestionDefinition nullQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nullQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
 
     BlockDefinition blockDefinition =
         BlockDefinition.builder()

--- a/server/test/services/program/EligibilityDefinitionTest.java
+++ b/server/test/services/program/EligibilityDefinitionTest.java
@@ -20,7 +20,7 @@ public class EligibilityDefinitionTest {
 
   @Test
   public void setAndGet() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -123,18 +123,18 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantJugglingNumber())
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
-            .withRequiredQuestion(testQuestionBank.applicantDate())
+            .withRequiredQuestion(testQuestionBank.numberApplicantJugglingNumber())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
+            .withRequiredQuestion(testQuestionBank.dateApplicantBirthdate())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantKitchenTools())
+            .withRequiredQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .buildDefinition();
 
     assertThat(
             programDefinition
-                .getProgramQuestionDefinition(testQuestionBank.applicantJugglingNumber().id)
+                .getProgramQuestionDefinition(testQuestionBank.numberApplicantJugglingNumber().id)
                 .id())
-        .isEqualTo(testQuestionBank.applicantJugglingNumber().id);
+        .isEqualTo(testQuestionBank.numberApplicantJugglingNumber().id);
   }
 
   @Test
@@ -142,16 +142,16 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
-            .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
-            .withRequiredQuestion(testQuestionBank.applicantDate())
+            .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
+            .withRequiredQuestion(testQuestionBank.dateApplicantBirthdate())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantKitchenTools())
+            .withRequiredQuestion(testQuestionBank.checkboxApplicantKitchenTools())
             .buildDefinition();
 
     assertThatThrownBy(
             () ->
                 programDefinition.getProgramQuestionDefinition(
-                    testQuestionBank.applicantJugglingNumber().id))
+                    testQuestionBank.numberApplicantJugglingNumber().id))
         .isInstanceOf(ProgramQuestionDefinitionNotFoundException.class);
   }
 
@@ -166,7 +166,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
                         PredicateDefinition.create(
                             PredicateExpressionNode.create(
                                 LeafAddressServiceAreaExpressionNode.builder()
-                                    .setQuestionId(testQuestionBank.applicantAddress().id)
+                                    .setQuestionId(testQuestionBank.addressApplicantAddress().id)
                                     .setServiceAreaId("seattle")
                                     .build()),
                             PredicateAction.ELIGIBLE_BLOCK))
@@ -175,7 +175,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafOperationExpressionNode.builder()
-                            .setQuestionId(testQuestionBank.applicantDate().id)
+                            .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                             .setScalar(Scalar.DATE)
                             .setOperator(Operator.IS_BEFORE)
                             .setComparedValue(CfTestHelpers.stringToPredicateDate("2023-01-01"))
@@ -183,13 +183,17 @@ public class ProgramDefinitionTest extends ResetPostgres {
                     PredicateAction.HIDE_BLOCK))
             .buildDefinition();
 
-    assertThat(programDefinition.isQuestionUsedInPredicate(testQuestionBank.applicantAddress().id))
-        .isTrue();
-    assertThat(programDefinition.isQuestionUsedInPredicate(testQuestionBank.applicantDate().id))
+    assertThat(
+            programDefinition.isQuestionUsedInPredicate(
+                testQuestionBank.addressApplicantAddress().id))
         .isTrue();
     assertThat(
             programDefinition.isQuestionUsedInPredicate(
-                testQuestionBank.applicantKitchenTools().id))
+                testQuestionBank.dateApplicantBirthdate().id))
+        .isTrue();
+    assertThat(
+            programDefinition.isQuestionUsedInPredicate(
+                testQuestionBank.checkboxApplicantKitchenTools().id))
         .isFalse();
 
     // program has eligibility enabled
@@ -198,10 +202,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void hasQuestion_trueIfTheProgramUsesTheQuestion() {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition questionB =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition questionC =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
 
     long programDefinitionId = 123L;
     BlockDefinition blockA =
@@ -342,10 +347,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void getSupportedLocales_returnsLocalesSupportedByQuestionsAndText() {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition questionB =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition questionC =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
 
     long programDefinitionId = 123L;
     BlockDefinition blockA =
@@ -396,10 +402,13 @@ public class ProgramDefinitionTest extends ResetPostgres {
   @Test
   public void getAvailablePredicateQuestionDefinitions()
       throws ProgramBlockDefinitionNotFoundException {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
-    QuestionDefinition questionC = testQuestionBank.applicantFile().getQuestionDefinition();
-    QuestionDefinition questionD = testQuestionBank.applicantSeason().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition questionB =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
+    QuestionDefinition questionC =
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
+    QuestionDefinition questionD =
+        testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition();
 
     long programDefinitionId = 123L;
     // To aid readability and reduce errors the block names include the questions that are in them.
@@ -484,10 +493,13 @@ public class ProgramDefinitionTest extends ResetPostgres {
   @Test
   public void getAvailablePredicateQuestionDefinitions_doesNotDependOnBlockIdOrder()
       throws ProgramBlockDefinitionNotFoundException {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
-    QuestionDefinition questionC = testQuestionBank.applicantFile().getQuestionDefinition();
-    QuestionDefinition questionD = testQuestionBank.applicantSeason().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition questionB =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
+    QuestionDefinition questionC =
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
+    QuestionDefinition questionD =
+        testQuestionBank.radioApplicantFavoriteSeason().getQuestionDefinition();
 
     long programDefinitionId = 123L;
     // The blocks have their IDs set to non-consecutive numbers. This mimics blocks being re-ordered
@@ -574,15 +586,17 @@ public class ProgramDefinitionTest extends ResetPostgres {
   public void
       getAvailablePredicateQuestionDefinitions_withRepeatedBlocks_onlyIncludesQuestionsWithSameEnumeratorId()
           throws ProgramBlockDefinitionNotFoundException {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition questionBEnum =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition questionC =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     QuestionDefinition questionDEnum =
-        testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition();
+        testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs().getQuestionDefinition();
     QuestionDefinition questionE =
-        testQuestionBank.applicantHouseholdMemberDaysWorked().getQuestionDefinition();
+        testQuestionBank
+            .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
+            .getQuestionDefinition();
 
     long programDefinitionId = 123L;
     BlockDefinition blockA =
@@ -697,9 +711,9 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .build()
             .getProgramDefinition();
 
@@ -712,11 +726,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build()
             .getProgramDefinition();
     BlockDefinition blockDefinition =
@@ -736,12 +750,15 @@ public class ProgramDefinitionTest extends ResetPostgres {
     assertThat(result.getBlockDefinitionByIndex(0).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
     assertThat(result.getBlockDefinitionByIndex(0).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
     assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(1).get().enumeratorId()).contains(1L);
     assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+        .isEqualTo(
+            testQuestionBank
+                .enumeratorNestedApplicantHouseholdMemberJobs()
+                .getQuestionDefinition());
     assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
     assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionCount()).isEqualTo(0);
@@ -753,11 +770,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build()
             .getProgramDefinition();
 
@@ -768,12 +785,15 @@ public class ProgramDefinitionTest extends ResetPostgres {
     assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isFalse();
     assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
     assertThat(result.getBlockDefinitionByIndex(2).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
     assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+        .isEqualTo(
+            testQuestionBank
+                .enumeratorNestedApplicantHouseholdMemberJobs()
+                .getQuestionDefinition());
   }
 
   @Test
@@ -781,11 +801,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build()
             .getProgramDefinition();
 
@@ -796,17 +816,20 @@ public class ProgramDefinitionTest extends ResetPostgres {
     assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isFalse();
     assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
     assertThat(result.getBlockDefinitionByIndex(2).get().isEnumerator()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
     assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
     assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+        .isEqualTo(
+            testQuestionBank
+                .enumeratorNestedApplicantHouseholdMemberJobs()
+                .getQuestionDefinition());
   }
 
   @Test
   public void moveBlock_up_withVisibilityPredicate() throws Exception {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -823,7 +846,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(predicateQuestion)
             .withBlock()
-            .withOptionalQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withOptionalQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withBlock()
             .withVisibilityPredicate(predicate)
             .build()
@@ -837,7 +860,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withVisibilityPredicate_throwsForIllegalMove() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -867,7 +890,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicate() throws Exception {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -887,7 +910,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .withBlock()
             .withRequiredQuestion(predicateQuestion)
             .withBlock()
-            .withOptionalQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withOptionalQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withBlock()
             .withEligibilityDefinition(eligibility)
             .build()
@@ -905,7 +928,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicate_throwsForIllegalMove() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -938,7 +961,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlock_up_withEligibilityPredicateAndQuestionInSameBlock() throws Exception {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block with a predicate before the block it depends on throws.
     EligibilityDefinition eligibility =
         EligibilityDefinition.builder()
@@ -956,7 +979,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
-            .withOptionalQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withOptionalQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withBlock()
             .withRequiredQuestion(predicateQuestion)
             .withEligibilityDefinition(eligibility)
@@ -976,7 +999,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void moveBlockDown_throwsForIllegalMove() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     // Trying to move a block after a block that depends on it throws.
     PredicateDefinition predicate =
         PredicateDefinition.create(
@@ -1006,7 +1029,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void hasValidPredicateOrdering() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1042,7 +1065,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void hasValidPredicateOrdering_returnsFalseIfQuestionsAreInSameBlockAsPredicate() {
-    QuestionModel predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    QuestionModel predicateQuestion = testQuestionBank.textApplicantFavoriteColor();
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -1292,10 +1315,11 @@ public class ProgramDefinitionTest extends ResetPostgres {
 
   @Test
   public void serializeThenDeserialize_allFieldsPresent() throws JsonProcessingException {
-    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition questionB =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     QuestionDefinition questionC =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
 
     long programDefinitionId = 654L;
     BlockDefinition blockA =
@@ -1460,13 +1484,15 @@ public class ProgramDefinitionTest extends ResetPostgres {
     long programDefinitionId = 654L;
 
     QuestionDefinition mainEnumQ =
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition qForMainEnum =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     QuestionDefinition nestedEnumQ =
-        testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition();
+        testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs().getQuestionDefinition();
     QuestionDefinition qForNestedEnum =
-        testQuestionBank.applicantHouseholdMemberDaysWorked().getQuestionDefinition();
+        testQuestionBank
+            .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
+            .getQuestionDefinition();
 
     BlockDefinition blockA =
         BlockDefinition.builder()

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -91,10 +91,11 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
-    secondaryAddressQuestion = testQuestionBank.applicantSecondaryAddress().getQuestionDefinition();
-    colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
-    nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    addressQuestion = testQuestionBank.addressApplicantAddress().getQuestionDefinition();
+    secondaryAddressQuestion =
+        testQuestionBank.addressApplicantSecondaryAddress().getQuestionDefinition();
+    colorQuestion = testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
+    nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
     when(mockSettingsManifest.getDisabledVisibilityConditionEnabled(request)).thenReturn(false);
     categoryRepository = instanceOf(CategoryRepository.class);
@@ -1385,11 +1386,11 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
 
     ErrorAnd<ProgramBlockAdditionResult, CiviFormError> result =
@@ -1407,13 +1408,16 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(found.getBlockDefinitionByIndex(0).get().isEnumerator()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
     assertThat(found.getBlockDefinitionByIndex(0).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
 
     assertThat(found.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(1).get().isRepeated()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(1).get().enumeratorId()).contains(1L);
     assertThat(found.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+        .isEqualTo(
+            testQuestionBank
+                .enumeratorNestedApplicantHouseholdMemberJobs()
+                .getQuestionDefinition());
 
     // The newly added block.
     assertThat(found.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
@@ -1423,7 +1427,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
     assertThat(found.getBlockDefinitionByIndex(3).get().isRepeated()).isFalse();
     assertThat(found.getBlockDefinitionByIndex(3).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantFavoriteColor().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition());
 
     assertThat(found.blockDefinitions())
         .containsExactlyElementsOf(updatedProgramDefinition.blockDefinitions());
@@ -1434,11 +1438,11 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantFavoriteColor())
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .withBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
             .withRepeatedBlock()
-            .withRequiredQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withRequiredQuestion(testQuestionBank.enumeratorNestedApplicantHouseholdMemberJobs())
             .build();
 
     ErrorAnd<ProgramBlockAdditionResult, CiviFormError> result =
@@ -1456,18 +1460,21 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(found.getBlockDefinitionByIndex(0).get().isEnumerator()).isFalse();
     assertThat(found.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
     assertThat(found.getBlockDefinitionByIndex(0).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantFavoriteColor().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition());
 
     assertThat(found.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(1).get().isRepeated()).isFalse();
     assertThat(found.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+        .isEqualTo(testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition());
 
     assertThat(found.getBlockDefinitionByIndex(2).get().isEnumerator()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
     assertThat(found.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(2L);
     assertThat(found.getBlockDefinitionByIndex(2).get().getQuestionDefinition(0))
-        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+        .isEqualTo(
+            testQuestionBank
+                .enumeratorNestedApplicantHouseholdMemberJobs()
+                .getQuestionDefinition());
 
     // The newly added block.
     assertThat(found.getBlockDefinitionByIndex(3).get().isRepeated()).isTrue();
@@ -1721,7 +1728,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setBlockPredicate_updatesBlock() throws Exception {
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
@@ -1834,7 +1841,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setBlockEligibilityDefinition_updatesBlock() throws Exception {
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
@@ -2500,7 +2507,9 @@ public class ProgramServiceTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                            testQuestionBank
+                                .enumeratorApplicantHouseholdMembers()
+                                .getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
             .add(
@@ -2512,7 +2521,7 @@ public class ProgramServiceTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantEmail().getQuestionDefinition(),
+                            testQuestionBank.emailApplicantEmail().getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
             .add(
@@ -2525,7 +2534,9 @@ public class ProgramServiceTest extends ResetPostgres {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                            testQuestionBank
+                                .enumeratorNestedApplicantHouseholdMemberJobs()
+                                .getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
             .add(
@@ -2538,7 +2549,9 @@ public class ProgramServiceTest extends ResetPostgres {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
+                            testQuestionBank
+                                .nameRepeatedApplicantHouseholdMemberName()
+                                .getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
             .add(
@@ -2552,7 +2565,7 @@ public class ProgramServiceTest extends ResetPostgres {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank
-                                .applicantHouseholdMemberDaysWorked()
+                                .numberNestedRepeatedApplicantHouseholdMemberDaysWorked()
                                 .getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
@@ -2565,7 +2578,7 @@ public class ProgramServiceTest extends ResetPostgres {
                     .setLocalizedDescription(LocalizedStrings.withDefaultValue("description"))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantName().getQuestionDefinition(),
+                            testQuestionBank.nameApplicantName().getQuestionDefinition(),
                             Optional.of(programId)))
                     .build())
             .build();

--- a/server/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/server/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -63,7 +63,8 @@ public class PredicateExpressionNodeTest {
 
   @Test
   public void toDisplayString_leafNodeOnly() {
-    QuestionDefinition question = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition question =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     LeafOperationExpressionNode leaf =
         LeafOperationExpressionNode.create(
             question.getId(), Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
@@ -74,7 +75,8 @@ public class PredicateExpressionNodeTest {
 
   @Test
   public void toDisplayString_addressServiceAreaNodeOnly_questionIsPresent() {
-    QuestionDefinition question = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition question =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     LeafAddressServiceAreaExpressionNode leaf =
         LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
 
@@ -84,7 +86,8 @@ public class PredicateExpressionNodeTest {
 
   @Test
   public void toDisplayString_addressServiceAreaNodeOnly_questionIsNotPresent() {
-    QuestionDefinition question = testQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition question =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     LeafAddressServiceAreaExpressionNode leaf =
         LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
 
@@ -95,7 +98,7 @@ public class PredicateExpressionNodeTest {
   @Test
   public void toDisplayString_andNode() {
     QuestionDefinition question =
-        testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     LeafOperationExpressionNode leaf1 =
         LeafOperationExpressionNode.create(
             question.getId(), Scalar.NUMBER, Operator.GREATER_THAN, PredicateValue.of(45));
@@ -119,8 +122,9 @@ public class PredicateExpressionNodeTest {
 
   @Test
   public void toDisplayString_orNode() {
-    QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
-    QuestionDefinition date = testQuestionBank.applicantDate().getQuestionDefinition();
+    QuestionDefinition multiOption =
+        testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition();
+    QuestionDefinition date = testQuestionBank.dateApplicantBirthdate().getQuestionDefinition();
     LeafOperationExpressionNode leaf1 =
         LeafOperationExpressionNode.create(
             multiOption.getId(),

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -29,19 +29,19 @@ public class PredicateGeneratorTest extends ResetPostgres {
   private ProgramDefinition programDefinition =
       ProgramBuilder.newDraftProgram("program1")
           .withBlock()
-          .withRequiredQuestion(testQuestionBank.applicantJugglingNumber())
-          .withRequiredCorrectedAddressQuestion(testQuestionBank.applicantAddress())
-          .withRequiredQuestion(testQuestionBank.applicantDate())
+          .withRequiredQuestion(testQuestionBank.numberApplicantJugglingNumber())
+          .withRequiredCorrectedAddressQuestion(testQuestionBank.addressApplicantAddress())
+          .withRequiredQuestion(testQuestionBank.dateApplicantBirthdate())
           .withBlock()
-          .withRequiredQuestion(testQuestionBank.applicantKitchenTools())
+          .withRequiredQuestion(testQuestionBank.checkboxApplicantKitchenTools())
           .buildDefinition();
   private ReadOnlyQuestionService readOnlyQuestionService =
       new FakeReadOnlyQuestionService(
           ImmutableList.of(
-              testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
-              testQuestionBank.applicantAddress().getQuestionDefinition(),
-              testQuestionBank.applicantDate().getQuestionDefinition(),
-              testQuestionBank.applicantKitchenTools().getQuestionDefinition()));
+              testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
+              testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
+              testQuestionBank.dateApplicantBirthdate().getQuestionDefinition(),
+              testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition()));
 
   @Before
   public void setUp() {
@@ -56,12 +56,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "CURRENCY_CENTS",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "GREATER_THAN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "12.34"));
 
     PredicateDefinition predicateDefinition =
@@ -72,12 +73,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.CURRENCY_CENTS)
                     .setOperator(Operator.GREATER_THAN)
                     .setComparedValue(PredicateValue.of(1234))
@@ -91,16 +92,17 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "CURRENCY_CENTS",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "BETWEEN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "12.34",
                 String.format(
                     "group-1-question-%d-predicateSecondValue",
-                    testQuestionBank.applicantDate().id),
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "56.78"));
 
     PredicateDefinition predicateDefinition =
@@ -111,12 +113,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.CURRENCY_CENTS)
                     .setOperator(Operator.BETWEEN)
                     .setComparedValue(PredicateValue.pairOfLongs(1234, 5678))
@@ -130,16 +132,17 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "BETWEEN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "2020-05-20",
                 String.format(
                     "group-1-question-%d-predicateSecondValue",
-                    testQuestionBank.applicantDate().id),
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "2024-05-20"));
 
     PredicateDefinition predicateDefinition =
@@ -150,12 +153,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.BETWEEN)
                     .setComparedValue(
@@ -171,12 +174,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "IS_AFTER",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "2024-05-20"));
 
     PredicateDefinition predicateDefinition =
@@ -187,12 +191,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.IS_AFTER)
                     .setComparedValue(PredicateValue.of(LocalDate.of(2024, 5, 20)))
@@ -206,16 +210,17 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "AGE_BETWEEN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "14",
                 String.format(
                     "group-1-question-%d-predicateSecondValue",
-                    testQuestionBank.applicantDate().id),
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "18"));
 
     PredicateDefinition predicateDefinition =
@@ -226,12 +231,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.AGE_BETWEEN)
                     .setComparedValue(PredicateValue.pairOfLongs(14, 18))
@@ -245,12 +250,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "AGE_OLDER_THAN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "18"));
 
     PredicateDefinition predicateDefinition =
@@ -261,12 +267,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.AGE_OLDER_THAN)
                     .setComparedValue(PredicateValue.of(18))
@@ -280,12 +286,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "AGE_YOUNGER_THAN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "10.5"));
 
     PredicateDefinition predicateDefinition =
@@ -296,12 +303,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.AGE_YOUNGER_THAN)
                     .setComparedValue(PredicateValue.of(10.5))
@@ -315,12 +322,14 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantAddress().id),
+                String.format("question-%d-scalar", testQuestionBank.addressApplicantAddress().id),
                 "SERVICE_AREA",
-                String.format("question-%d-operator", testQuestionBank.applicantAddress().id),
+                String.format(
+                    "question-%d-operator", testQuestionBank.addressApplicantAddress().id),
                 "IN_SERVICE_AREA",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantAddress().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.addressApplicantAddress().id),
                 "seattle"));
 
     PredicateDefinition predicateDefinition =
@@ -331,12 +340,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantAddress().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.addressApplicantAddress().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafAddressServiceAreaExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantAddress().id)
+                    .setQuestionId(testQuestionBank.addressApplicantAddress().id)
                     .setServiceAreaId("seattle")
                     .build()));
   }
@@ -348,12 +357,14 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantAddress().id),
+                String.format("question-%d-scalar", testQuestionBank.addressApplicantAddress().id),
                 "SERVICE_AREA",
-                String.format("question-%d-operator", testQuestionBank.applicantAddress().id),
+                String.format(
+                    "question-%d-operator", testQuestionBank.addressApplicantAddress().id),
                 "IN_SERVICE_AREA",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantAddress().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.addressApplicantAddress().id),
                 "seattle invalid"));
 
     assertThatThrownBy(
@@ -370,12 +381,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "NUMBER",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "IN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "1,2,3"));
 
     PredicateDefinition predicateDefinition =
@@ -386,12 +398,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.NUMBER)
                     .setOperator(Operator.IN)
                     .setComparedValue(PredicateValue.listOfLongs(ImmutableList.of(1L, 2L, 3L)))
@@ -405,16 +417,17 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "NUMBER",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "BETWEEN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "1234",
                 String.format(
                     "group-1-question-%d-predicateSecondValue",
-                    testQuestionBank.applicantDate().id),
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "5678"));
 
     PredicateDefinition predicateDefinition =
@@ -425,12 +438,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.NUMBER)
                     .setOperator(Operator.BETWEEN)
                     .setComparedValue(PredicateValue.pairOfLongs(1234, 5678))
@@ -444,12 +457,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "NUMBER",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "GREATER_THAN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "1234"));
 
     PredicateDefinition predicateDefinition =
@@ -460,12 +474,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.NUMBER)
                     .setOperator(Operator.GREATER_THAN)
                     .setComparedValue(PredicateValue.of(1234))
@@ -479,12 +493,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "LAST_NAME",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "EQUAL_TO",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "abcdef"));
 
     PredicateDefinition predicateDefinition =
@@ -495,12 +510,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.LAST_NAME)
                     .setOperator(Operator.EQUAL_TO)
                     .setComparedValue(PredicateValue.of("abcdef"))
@@ -514,12 +529,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "FIRST_NAME",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "IN",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "a,b,c"));
 
     PredicateDefinition predicateDefinition =
@@ -530,12 +546,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantDate().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.dateApplicantBirthdate().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.FIRST_NAME)
                     .setOperator(Operator.IN)
                     .setComparedValue(PredicateValue.listOfStrings(ImmutableList.of("a", "b", "c")))
@@ -549,28 +565,31 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "SHOW_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantJugglingNumber().id),
+                String.format(
+                    "question-%d-scalar", testQuestionBank.numberApplicantJugglingNumber().id),
                 "NUMBER",
                 String.format(
-                    "question-%d-operator", testQuestionBank.applicantJugglingNumber().id),
+                    "question-%d-operator", testQuestionBank.numberApplicantJugglingNumber().id),
                 "EQUAL_TO",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "1",
                 String.format(
                     "group-2-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "2",
-                String.format("question-%d-scalar", testQuestionBank.applicantDate().id),
+                String.format("question-%d-scalar", testQuestionBank.dateApplicantBirthdate().id),
                 "DATE",
-                String.format("question-%d-operator", testQuestionBank.applicantDate().id),
+                String.format("question-%d-operator", testQuestionBank.dateApplicantBirthdate().id),
                 "EQUAL_TO",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "2023-01-01",
                 String.format(
-                    "group-2-question-%d-predicateValue", testQuestionBank.applicantDate().id),
+                    "group-2-question-%d-predicateValue",
+                    testQuestionBank.dateApplicantBirthdate().id),
                 "2023-02-02"));
 
     PredicateDefinition predicateDefinition =
@@ -582,7 +601,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.SHOW_BLOCK);
     assertThat(predicateDefinition.getQuestions())
         .containsExactlyInAnyOrder(
-            testQuestionBank.applicantJugglingNumber().id, testQuestionBank.applicantDate().id);
+            testQuestionBank.numberApplicantJugglingNumber().id,
+            testQuestionBank.dateApplicantBirthdate().id);
 
     assertThat(predicateDefinition.rootNode().getType()).isEqualTo(PredicateExpressionNodeType.OR);
     assertThat(predicateDefinition.rootNode().getOrNode().children())
@@ -592,14 +612,14 @@ public class PredicateGeneratorTest extends ResetPostgres {
                     ImmutableList.of(
                         PredicateExpressionNode.create(
                             LeafOperationExpressionNode.builder()
-                                .setQuestionId(testQuestionBank.applicantDate().id)
+                                .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                                 .setScalar(Scalar.DATE)
                                 .setOperator(Operator.EQUAL_TO)
                                 .setComparedValue(CfTestHelpers.stringToPredicateDate("2023-01-01"))
                                 .build()),
                         PredicateExpressionNode.create(
                             LeafOperationExpressionNode.builder()
-                                .setQuestionId(testQuestionBank.applicantJugglingNumber().id)
+                                .setQuestionId(testQuestionBank.numberApplicantJugglingNumber().id)
                                 .setScalar(Scalar.NUMBER)
                                 .setOperator(Operator.EQUAL_TO)
                                 .setComparedValue(PredicateValue.of(1))
@@ -609,14 +629,14 @@ public class PredicateGeneratorTest extends ResetPostgres {
                     ImmutableList.of(
                         PredicateExpressionNode.create(
                             LeafOperationExpressionNode.builder()
-                                .setQuestionId(testQuestionBank.applicantDate().id)
+                                .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                                 .setScalar(Scalar.DATE)
                                 .setOperator(Operator.EQUAL_TO)
                                 .setComparedValue(CfTestHelpers.stringToPredicateDate("2023-02-02"))
                                 .build()),
                         PredicateExpressionNode.create(
                             LeafOperationExpressionNode.builder()
-                                .setQuestionId(testQuestionBank.applicantJugglingNumber().id)
+                                .setQuestionId(testQuestionBank.numberApplicantJugglingNumber().id)
                                 .setScalar(Scalar.NUMBER)
                                 .setOperator(Operator.EQUAL_TO)
                                 .setComparedValue(PredicateValue.of(2))
@@ -630,17 +650,19 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantKitchenTools().id),
+                String.format(
+                    "question-%d-scalar", testQuestionBank.checkboxApplicantKitchenTools().id),
                 "SELECTION",
-                String.format("question-%d-operator", testQuestionBank.applicantKitchenTools().id),
+                String.format(
+                    "question-%d-operator", testQuestionBank.checkboxApplicantKitchenTools().id),
                 "ANY_OF",
                 String.format(
                     "group-1-question-%d-predicateValues[1]",
-                    testQuestionBank.applicantKitchenTools().id),
+                    testQuestionBank.checkboxApplicantKitchenTools().id),
                 "1",
                 String.format(
                     "group-1-question-%d-predicateValues[2]",
-                    testQuestionBank.applicantKitchenTools().id),
+                    testQuestionBank.checkboxApplicantKitchenTools().id),
                 "2"));
 
     PredicateDefinition predicateDefinition =
@@ -651,12 +673,12 @@ public class PredicateGeneratorTest extends ResetPostgres {
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_QUESTION);
     assertThat(predicateDefinition.action()).isEqualTo(PredicateAction.HIDE_BLOCK);
     assertThat(predicateDefinition.getQuestions())
-        .isEqualTo(ImmutableList.of(testQuestionBank.applicantKitchenTools().id));
+        .isEqualTo(ImmutableList.of(testQuestionBank.checkboxApplicantKitchenTools().id));
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantKitchenTools().id)
+                    .setQuestionId(testQuestionBank.checkboxApplicantKitchenTools().id)
                     .setScalar(Scalar.SELECTION)
                     .setOperator(Operator.ANY_OF)
                     .setComparedValue(PredicateValue.listOfStrings(ImmutableList.of("2", "1")))
@@ -670,12 +692,13 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantEmail().id),
+                String.format("question-%d-scalar", testQuestionBank.emailApplicantEmail().id),
                 "EMAIL",
-                String.format("question-%d-operator", testQuestionBank.applicantEmail().id),
+                String.format("question-%d-operator", testQuestionBank.emailApplicantEmail().id),
                 "EQUAL_TO",
                 String.format(
-                    "group-1-question-%d-predicateValue", testQuestionBank.applicantEmail().id),
+                    "group-1-question-%d-predicateValue",
+                    testQuestionBank.emailApplicantEmail().id),
                 "98144"));
 
     assertThatThrownBy(
@@ -692,14 +715,15 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "invalid",
-                String.format("question-%d-scalar", testQuestionBank.applicantJugglingNumber().id),
+                String.format(
+                    "question-%d-scalar", testQuestionBank.numberApplicantJugglingNumber().id),
                 "NUMBER",
                 String.format(
-                    "question-%d-operator", testQuestionBank.applicantJugglingNumber().id),
+                    "question-%d-operator", testQuestionBank.numberApplicantJugglingNumber().id),
                 "EQUAL_TO",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "98144"));
 
     assertThatThrownBy(
@@ -717,11 +741,11 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "predicateAction",
                 "HIDE_BLOCK",
                 String.format(
-                    "question-%d-operator", testQuestionBank.applicantJugglingNumber().id),
+                    "question-%d-operator", testQuestionBank.numberApplicantJugglingNumber().id),
                 "EQUAL_TO",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "1"));
 
     assertThatThrownBy(
@@ -738,14 +762,15 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantJugglingNumber().id),
+                String.format(
+                    "question-%d-scalar", testQuestionBank.numberApplicantJugglingNumber().id),
                 "invalid",
                 String.format(
-                    "question-%d-operator", testQuestionBank.applicantJugglingNumber().id),
+                    "question-%d-operator", testQuestionBank.numberApplicantJugglingNumber().id),
                 "EQUAL_TO",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "1"));
 
     assertThatThrownBy(
@@ -762,11 +787,11 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantAddress().id),
+                String.format("question-%d-scalar", testQuestionBank.addressApplicantAddress().id),
                 "ZIP",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "1"));
 
     assertThatThrownBy(
@@ -783,14 +808,15 @@ public class PredicateGeneratorTest extends ResetPostgres {
             ImmutableMap.of(
                 "predicateAction",
                 "HIDE_BLOCK",
-                String.format("question-%d-scalar", testQuestionBank.applicantJugglingNumber().id),
+                String.format(
+                    "question-%d-scalar", testQuestionBank.numberApplicantJugglingNumber().id),
                 "NUMBER",
                 String.format(
-                    "question-%d-operator", testQuestionBank.applicantJugglingNumber().id),
+                    "question-%d-operator", testQuestionBank.numberApplicantJugglingNumber().id),
                 "invalid",
                 String.format(
                     "group-1-question-%d-predicateValue",
-                    testQuestionBank.applicantJugglingNumber().id),
+                    testQuestionBank.numberApplicantJugglingNumber().id),
                 "98144"));
 
     assertThatThrownBy(

--- a/server/test/services/program/predicate/PredicateValueTest.java
+++ b/server/test/services/program/predicate/PredicateValueTest.java
@@ -64,7 +64,7 @@ public class PredicateValueTest {
   @Test
   public void toDisplayString_currency() {
     QuestionDefinition currencyDef =
-        testQuestionBank.applicantMonthlyIncome().getQuestionDefinition();
+        testQuestionBank.currencyApplicantMonthlyIncome().getQuestionDefinition();
     PredicateValue value = PredicateValue.of(10001);
 
     assertThat(value.value()).isEqualTo("10001");
@@ -74,7 +74,7 @@ public class PredicateValueTest {
   @Test
   public void toDisplayString_currencyPair() {
     QuestionDefinition currencyDef =
-        testQuestionBank.applicantMonthlyIncome().getQuestionDefinition();
+        testQuestionBank.currencyApplicantMonthlyIncome().getQuestionDefinition();
     PredicateValue value = PredicateValue.pairOfLongs(10001, 20002);
 
     assertThat(value.value()).isEqualTo("[10001, 20002]");
@@ -83,7 +83,7 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_date() {
-    QuestionDefinition dateDef = testQuestionBank.applicantDate().getQuestionDefinition();
+    QuestionDefinition dateDef = testQuestionBank.dateApplicantBirthdate().getQuestionDefinition();
     PredicateValue value = PredicateValue.of(LocalDate.ofYearDay(2021, 1));
 
     assertThat(value.value()).isEqualTo("1609459200000");
@@ -92,7 +92,8 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_listOfLongs() {
-    QuestionDefinition longDef = testQuestionBank.applicantJugglingNumber().getQuestionDefinition();
+    QuestionDefinition longDef =
+        testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition();
     PredicateValue value = PredicateValue.listOfLongs(ImmutableList.of(1L, 2L, 3L));
 
     assertThat(value.value()).isEqualTo("[1, 2, 3]");
@@ -102,7 +103,7 @@ public class PredicateValueTest {
   @Test
   public void toDisplayString_simpleList() {
     QuestionDefinition stringDef =
-        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
     PredicateValue value = PredicateValue.listOfStrings(ImmutableList.of("kangaroo", "turtle"));
 
     assertThat(value.toDisplayString(stringDef)).isEqualTo("[\"kangaroo\", \"turtle\"]");
@@ -110,7 +111,8 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_multiOptionList() {
-    QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
+    QuestionDefinition multiOption =
+        testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition();
 
     PredicateValue value = PredicateValue.listOfStrings(ImmutableList.of("1", "2"));
 
@@ -120,7 +122,7 @@ public class PredicateValueTest {
   @Test
   public void toDisplayString_multiOptionSingleValue_convertsIdToString() {
     QuestionDefinition multiOption =
-        testQuestionBank.applicantKitchenTools().getQuestionDefinition();
+        testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition();
 
     PredicateValue value = PredicateValue.of("1");
 
@@ -129,7 +131,8 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_multiOptionList_missingIdDefaultsToObsolete() {
-    QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
+    QuestionDefinition multiOption =
+        testQuestionBank.dropdownApplicantIceCream().getQuestionDefinition();
 
     PredicateValue value =
         PredicateValue.listOfStrings(ImmutableList.of("1", "100")); // 100 is not a valid ID
@@ -139,7 +142,7 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_pairOfDates() {
-    QuestionDefinition dateDef = testQuestionBank.applicantDate().getQuestionDefinition();
+    QuestionDefinition dateDef = testQuestionBank.dateApplicantBirthdate().getQuestionDefinition();
 
     LocalDate date1 = LocalDate.of(2024, 5, 1);
     LocalDate date2 = LocalDate.of(2024, 5, 2);
@@ -150,7 +153,7 @@ public class PredicateValueTest {
 
   @Test
   public void toDisplayString_pairOfLongs() {
-    QuestionDefinition dateDef = testQuestionBank.applicantDate().getQuestionDefinition();
+    QuestionDefinition dateDef = testQuestionBank.dateApplicantBirthdate().getQuestionDefinition();
 
     PredicateValue value = PredicateValue.pairOfLongs(18, 30);
 

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -46,7 +46,7 @@ public class QuestionServiceTest extends ResetPostgres {
   @Test
   public void create_failsWhenQuestionsConflict() throws Exception {
     QuestionDefinition householdMemberName =
-        testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition();
+        testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(householdMemberName)
             .clearId()
@@ -105,7 +105,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void update_returnsQuestionDefinitionWhenSucceeds() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion).setDescription("updated description").build();
 
@@ -134,7 +134,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void update_failsWhenQuestionImmutableMembersChange() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
 
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion)
@@ -166,7 +166,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void discardDraft() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     long draftId = nameQuestion.getId() + 100000;
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion)
@@ -228,7 +228,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_notReferencedSucceeds() throws Exception {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
         .doesNotContain(addressQuestion.getQuestionDefinition().getName());
@@ -239,7 +239,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_referencedFails() {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
     // Create a program that references the question.
     ProgramBuilder.newDraftProgram()
         .withBlock()
@@ -257,7 +257,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_alreadyArchivedFails() throws Exception {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
     questionService.archiveQuestion(addressQuestion.id);
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
@@ -278,7 +278,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void archiveQuestion_createsDraftIfNoneExists() throws Exception {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
 
     assertThat(
             versionRepository.getQuestionNamesForVersion(
@@ -299,7 +299,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void restoreQuestion_pendingDeletionSucceeds() throws Exception {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
     questionService.archiveQuestion(addressQuestion.id);
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames())
@@ -311,7 +311,7 @@ public class QuestionServiceTest extends ResetPostgres {
 
   @Test
   public void restoreQuestion_notArchivedFails() {
-    QuestionModel addressQuestion = testQuestionBank.applicantAddress();
+    QuestionModel addressQuestion = testQuestionBank.addressApplicantAddress();
 
     assertThat(versionRepository.getDraftVersionOrCreate().getTombstonedQuestionNames()).isEmpty();
     assertThatThrownBy(() -> questionService.restoreQuestion(addressQuestion.id))

--- a/server/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
@@ -30,9 +30,9 @@ public class ReadOnlyCurrentQuestionServiceImplTest extends ResetPostgres {
   @Test
   public void getAllQuestions() {
     // The question bank initializes these in the active version.
-    testQuestionBank.applicantName();
-    testQuestionBank.applicantAddress();
-    testQuestionBank.applicantFavoriteColor();
+    testQuestionBank.nameApplicantName();
+    testQuestionBank.addressApplicantAddress();
+    testQuestionBank.textApplicantFavoriteColor();
     var service = new ReadOnlyCurrentQuestionServiceImpl(versionRepository);
     assertThat(service.getAllQuestions().size()).isEqualTo(3);
   }
@@ -40,7 +40,7 @@ public class ReadOnlyCurrentQuestionServiceImplTest extends ResetPostgres {
   @Test
   public void getEnumeratorQuestions() {
     // The question bank initializes this question in the active version.
-    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.enumeratorApplicantHouseholdMembers();
 
     var service = new ReadOnlyCurrentQuestionServiceImpl(versionRepository);
 
@@ -55,7 +55,7 @@ public class ReadOnlyCurrentQuestionServiceImplTest extends ResetPostgres {
   @Test
   public void getQuestionDefinition_byId() throws QuestionNotFoundException {
     // The question bank initializes these in the active version.
-    QuestionModel nameQuestion = testQuestionBank.applicantName();
+    QuestionModel nameQuestion = testQuestionBank.nameApplicantName();
     long questionId = nameQuestion.id;
 
     var service = new ReadOnlyCurrentQuestionServiceImpl(versionRepository);

--- a/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/server/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -28,9 +28,9 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
   public void setupQuestions() {
     testQuestionBank = new TestQuestionBank(true);
     // The question bank initializes these questions in the active version.
-    nameQuestion = testQuestionBank.applicantName();
-    addressQuestion = testQuestionBank.applicantAddress();
-    basicQuestion = testQuestionBank.applicantFavoriteColor();
+    nameQuestion = testQuestionBank.nameApplicantName();
+    addressQuestion = testQuestionBank.addressApplicantAddress();
+    basicQuestion = testQuestionBank.textApplicantFavoriteColor();
     questions = ImmutableList.of(nameQuestion, addressQuestion, basicQuestion);
     versionRepository = instanceOf(VersionRepository.class);
     VersionModel version = new VersionModel(LifecycleStage.OBSOLETE);
@@ -76,7 +76,7 @@ public class ReadOnlyVersionedQuestionServiceImplTest extends ResetPostgres {
 
   @Test
   public void getEnumeratorQuestions() {
-    QuestionModel enumeratorQuestion = testQuestionBank.applicantHouseholdMembers();
+    QuestionModel enumeratorQuestion = testQuestionBank.enumeratorApplicantHouseholdMembers();
 
     VersionModel version = new VersionModel(LifecycleStage.OBSOLETE);
     addQuestionsToVersion(version, questions);

--- a/server/test/services/question/types/QuestionDefinitionBuilderTest.java
+++ b/server/test/services/question/types/QuestionDefinitionBuilderTest.java
@@ -26,7 +26,7 @@ public class QuestionDefinitionBuilderTest {
             .setQuestionText(LocalizedStrings.of())
             .setQuestionHelpText(LocalizedStrings.empty());
     applicantNameBuilder =
-        new QuestionDefinitionBuilder(QUESTION_BANK.applicantName().getQuestionDefinition());
+        new QuestionDefinitionBuilder(QUESTION_BANK.nameApplicantName().getQuestionDefinition());
   }
 
   @Test

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -76,146 +76,173 @@ public class TestQuestionBank {
    */
   public ImmutableMap<QuestionType, QuestionModel> getSampleQuestionsForAllTypes() {
     return new ImmutableMap.Builder<QuestionType, QuestionModel>()
-        .put(QuestionType.ADDRESS, applicantAddress())
-        .put(QuestionType.CHECKBOX, applicantKitchenTools())
-        .put(QuestionType.CURRENCY, applicantMonthlyIncome())
-        .put(QuestionType.DATE, applicantDate())
-        .put(QuestionType.DROPDOWN, applicantIceCream())
-        .put(QuestionType.EMAIL, applicantEmail())
-        .put(QuestionType.ENUMERATOR, applicantHouseholdMembers())
-        .put(QuestionType.FILEUPLOAD, applicantFile())
-        .put(QuestionType.ID, applicantId())
-        .put(QuestionType.NAME, applicantName())
-        .put(QuestionType.NUMBER, applicantJugglingNumber())
-        .put(QuestionType.PHONE, applicantPhone())
-        .put(QuestionType.RADIO_BUTTON, applicantSeason())
+        .put(QuestionType.ADDRESS, addressApplicantAddress())
+        .put(QuestionType.CHECKBOX, checkboxApplicantKitchenTools())
+        .put(QuestionType.CURRENCY, currencyApplicantMonthlyIncome())
+        .put(QuestionType.DATE, dateApplicantBirthdate())
+        .put(QuestionType.DROPDOWN, dropdownApplicantIceCream())
+        .put(QuestionType.EMAIL, emailApplicantEmail())
+        .put(QuestionType.ENUMERATOR, enumeratorApplicantHouseholdMembers())
+        .put(QuestionType.FILEUPLOAD, fileUploadApplicantFile())
+        .put(QuestionType.ID, IdApplicantId())
+        .put(QuestionType.NAME, nameApplicantName())
+        .put(QuestionType.NUMBER, numberApplicantJugglingNumber())
+        .put(QuestionType.PHONE, phoneApplicantPhone())
+        .put(QuestionType.RADIO_BUTTON, radioApplicantFavoriteSeason())
         .put(QuestionType.STATIC, staticContent())
-        .put(QuestionType.TEXT, applicantFavoriteColor())
+        .put(QuestionType.TEXT, textApplicantFavoriteColor())
         .build();
   }
 
-  public QuestionModel applicantPhone() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_PHONE, this::applicantPhone);
-  }
-
-  // Address
-  public QuestionModel applicantAddress() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ADDRESS, this::applicantAddress);
-  }
-
-  // Address
-  public QuestionModel applicantSecondaryAddress() {
+  /** Returns a sample PHONE question. */
+  public QuestionModel phoneApplicantPhone() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_SECONDARY_ADDRESS, this::applicantSecondaryAddress);
+        QuestionEnum.PHONE_APPLICANT_PHONE, this::phoneApplicantPhone);
   }
 
-  // Checkbox
-  public QuestionModel applicantKitchenTools() {
+  /** Returns a sample ADDRESS question. */
+  public QuestionModel addressApplicantAddress() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_KITCHEN_TOOLS, this::applicantKitchenTools);
+        QuestionEnum.ADDRESS_APPLICANT_ADDRESS, this::addressApplicantAddress);
   }
 
-  // Date
-  public QuestionModel applicantDate() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_BIRTHDATE, this::applicantDate);
-  }
-
-  // Dropdown
-  public QuestionModel applicantIceCream() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ICE_CREAM, this::applicantIceCream);
-  }
-
-  // Email
-  public QuestionModel applicantEmail() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_EMAIL, this::applicantEmail);
-  }
-
-  // Enumerator
-  public QuestionModel applicantHouseholdMembers() {
+  /** Returns a sample ADDRESS question for the applicant's secondary address. */
+  public QuestionModel addressApplicantSecondaryAddress() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, this::applicantHouseholdMembers);
+        QuestionEnum.ADDRESS_APPLICANT_SECONDARY_ADDRESS, this::addressAapplicantSecondaryAddress);
   }
 
-  // Nested Enumerator
-  public QuestionModel applicantHouseholdMemberJobs() {
+  /** Returns a sample CHECKBOX question about kitchen tools the applicant owns. */
+  public QuestionModel checkboxApplicantKitchenTools() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOBS, this::applicantHouseholdMemberJobs);
+        QuestionEnum.CHECKBOX_APPLICANT_KITCHEN_TOOLS, this::checkboxApplicantKitchenTools);
   }
 
-  // File upload
-  public QuestionModel applicantFile() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_FILE, this::applicantFile);
-  }
-
-  // Currency
-  public QuestionModel applicantMonthlyIncome() {
+  /** Returns a sample DATE question for the applicant's birthday. */
+  public QuestionModel dateApplicantBirthdate() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_MONTHLY_INCOME, this::applicantMonthlyIncome);
+        QuestionEnum.DATE_APPLICANT_BIRTHDATE, this::DateApplicantBirthdate);
   }
 
-  // Id
-  public QuestionModel applicantId() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ID, this::applicantId);
+  /** Returns a sample DROPDOWN question about the applicant's favorite ice cream flavor. */
+  public QuestionModel dropdownApplicantIceCream() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.DROPDOWN_APPLICANT_ICE_CREAM, this::dropdownApplicantIceCream);
   }
 
-  // Name
-  public QuestionModel applicantName() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_NAME, this::applicantName);
+  /** Returns a sample EMAIL question about the applicant's email. */
+  public QuestionModel emailApplicantEmail() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.EMAIL_APPLICANT_EMAIL, this::emailApplicantEmail);
   }
 
-  // Name
+  /**
+   * Returns a sample ENUMERATOR question listing the applicant's household members.
+   *
+   * <p>This enumerator question is used as the parent of many sample repeated questions.
+   */
+  public QuestionModel enumeratorApplicantHouseholdMembers() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS,
+        this::enumeratorApplicantHouseholdMembers);
+  }
+
+  /**
+   * Returns a nested sample ENUMERATOR question listing the jobs each of the applicant's household
+   * members holds.
+   *
+   * <p>This enumerator is nested under the household members enumerator, and is the parent of many
+   * sample nested repeated questions.
+   */
+  public QuestionModel enumeratorNestedApplicantHouseholdMemberJobs() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.ENUMERATOR_NESTED_APPLICANT_HOUSEHOLD_MEMBER_JOBS,
+        this::enumeratorNestedApplicantHouseholdMemberJobs);
+  }
+
+  /** Returns a sample FILE_UPLOAD question. */
+  public QuestionModel fileUploadApplicantFile() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.FILE_UPLOAD_APPLICANT_FILE, this::fileUploadApplicantFile);
+  }
+
+  /** Returns a sample CURRENCY question about the applicant's monthly income. */
+  public QuestionModel currencyApplicantMonthlyIncome() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.CURRENCY_APPLICANT_MONTHLY_INCOME, this::currencyApplicantMonthlyIncome);
+  }
+
+  /** Returns a sample ID question. */
+  public QuestionModel IdApplicantId() {
+    return questionCache.computeIfAbsent(QuestionEnum.ID_APPLICANT_ID, this::IdApplicantId);
+  }
+
+  /** Returns a sample NAME question. */
+  public QuestionModel nameApplicantName() {
+    return questionCache.computeIfAbsent(QuestionEnum.NAME_APPLICANT_NAME, this::nameApplicantName);
+  }
+
+  /** Returns a sample NULL question. */
   public QuestionModel nullQuestion() {
     return questionCache.computeIfAbsent(QuestionEnum.NULL_QUESTION, this::nullQuestion);
   }
 
-  // Repeated name
-  public QuestionModel applicantHouseholdMemberName() {
+  /** Returns a sample repeated NAME question about the applicant's household members' names. */
+  public QuestionModel nameRepeatedApplicantHouseholdMemberName() {
     // Make sure the next call will have the question ready
-    applicantHouseholdMembers();
+    enumeratorApplicantHouseholdMembers();
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME, this::applicantHouseholdMemberName);
+        QuestionEnum.NAME_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_NAME,
+        this::nameRepeatedApplicantHouseholdMemberName);
   }
 
-  // Repeated test
-  public QuestionModel applicantHouseholdMemberFavoriteShape() {
+  /**
+   * Returns a sample repeated TEXT question about the applicant's household members' favorite
+   * shapes.
+   */
+  public QuestionModel textRepeatedApplicantHouseholdMemberFavoriteShape() {
     // Make sure the next call will have the question ready
-    applicantHouseholdMembers();
+    enumeratorApplicantHouseholdMembers();
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE,
-        this::applicantHouseholdMemberFavoriteShape);
+        QuestionEnum.TEXT_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE,
+        this::textRepeatedApplicantHouseholdMemberFavoriteShape);
   }
 
-  // Number
-  public QuestionModel applicantJugglingNumber() {
+  /** Returns a sample NUMBER question about the number of items the applicant can juggle. */
+  public QuestionModel numberApplicantJugglingNumber() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_JUGGLING_NUMBER, this::applicantJugglingNumber);
+        QuestionEnum.NUMBER_APPLICANT_JUGGLING_NUMBER, this::numberApplicantJugglingNumber);
   }
 
-  // Deeply nested Number
-  public QuestionModel applicantHouseholdMemberDaysWorked() {
+  /**
+   * Returns a nested repeated sample NUMBER question about the number of days worked at each of the
+   * jobs of each of the applicant's household numbers.
+   */
+  public QuestionModel numberNestedRepeatedApplicantHouseholdMemberDaysWorked() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
-        this::applicantHouseholdMemberDaysWorked);
+        QuestionEnum.NUMBER_NESTED_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
+        this::numberNestedRepeatedApplicantHouseholdMemberDaysWorked);
   }
 
-  // Radio button
-  public QuestionModel applicantSeason() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_SEASON, this::applicantSeason);
-  }
-
-  // Text
-  public QuestionModel applicantFavoriteColor() {
+  /** Returns a sample RADIO question about the applicant's favorite season. */
+  public QuestionModel radioApplicantFavoriteSeason() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_FAVORITE_COLOR, this::applicantFavoriteColor);
+        QuestionEnum.RADIO_APPLICANT_FAVORITE_SEASON, this::radioApplicantFavoriteSeason);
   }
 
-  // Text
+  /** Returns a sample TEXT question about the applicant's favorite color. */
+  public QuestionModel textApplicantFavoriteColor() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.TEXT_APPLICANT_FAVORITE_COLOR, this::textApplicantFavoriteColor);
+  }
+
+  /** Returns a sample STATIC_CONTENT question */
   public QuestionModel staticContent() {
     return questionCache.computeIfAbsent(QuestionEnum.STATIC_CONTENT, this::staticContent);
   }
 
   // Address
-  private QuestionModel applicantAddress(QuestionEnum ignore) {
+  private QuestionModel addressApplicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -227,7 +254,7 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private QuestionModel applicantPhone(QuestionEnum ignore) {
+  private QuestionModel phoneApplicantPhone(QuestionEnum ignore) {
     QuestionDefinition definition =
         new PhoneQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -240,7 +267,7 @@ public class TestQuestionBank {
   }
 
   // Address
-  private QuestionModel applicantSecondaryAddress(QuestionEnum ignore) {
+  private QuestionModel addressAapplicantSecondaryAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -253,7 +280,7 @@ public class TestQuestionBank {
   }
 
   // Checkbox
-  private QuestionModel applicantKitchenTools(QuestionEnum ignore) {
+  private QuestionModel checkboxApplicantKitchenTools(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("kitchen tools")
@@ -277,7 +304,7 @@ public class TestQuestionBank {
   }
 
   // Dropdown
-  private QuestionModel applicantIceCream(QuestionEnum ignore) {
+  private QuestionModel dropdownApplicantIceCream(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("applicant ice cream")
@@ -301,7 +328,7 @@ public class TestQuestionBank {
   }
 
   // Enumerator
-  private QuestionModel applicantHouseholdMembers(QuestionEnum ignore) {
+  private QuestionModel enumeratorApplicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -315,8 +342,8 @@ public class TestQuestionBank {
   }
 
   // Nested Enumerator
-  private QuestionModel applicantHouseholdMemberJobs(QuestionEnum ignore) {
-    QuestionModel householdMembers = applicantHouseholdMembers();
+  private QuestionModel enumeratorNestedApplicantHouseholdMemberJobs(QuestionEnum ignore) {
+    QuestionModel householdMembers = enumeratorApplicantHouseholdMembers();
     QuestionDefinition definition =
         new EnumeratorQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -331,7 +358,7 @@ public class TestQuestionBank {
   }
 
   // File upload
-  private QuestionModel applicantFile(QuestionEnum ignore) {
+  private QuestionModel fileUploadApplicantFile(QuestionEnum ignore) {
     QuestionDefinition definition =
         new FileUploadQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -345,7 +372,7 @@ public class TestQuestionBank {
   }
 
   // Currency
-  private QuestionModel applicantMonthlyIncome(QuestionEnum ignore) {
+  private QuestionModel currencyApplicantMonthlyIncome(QuestionEnum ignore) {
     QuestionDefinition definition =
         new CurrencyQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -358,7 +385,7 @@ public class TestQuestionBank {
   }
 
   // Id
-  private QuestionModel applicantId(QuestionEnum ignore) {
+  private QuestionModel IdApplicantId(QuestionEnum ignore) {
     QuestionDefinition definition =
         new IdQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -371,7 +398,7 @@ public class TestQuestionBank {
   }
 
   // Name
-  private QuestionModel applicantName(QuestionEnum ignore) {
+  private QuestionModel nameApplicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -389,8 +416,8 @@ public class TestQuestionBank {
   }
 
   // Repeated name
-  private QuestionModel applicantHouseholdMemberName(QuestionEnum ignore) {
-    QuestionModel householdMembers = applicantHouseholdMembers();
+  private QuestionModel nameRepeatedApplicantHouseholdMemberName(QuestionEnum ignore) {
+    QuestionModel householdMembers = enumeratorApplicantHouseholdMembers();
     QuestionDefinition definition =
         new NameQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -406,8 +433,8 @@ public class TestQuestionBank {
   }
 
   // Repeated text
-  private QuestionModel applicantHouseholdMemberFavoriteShape(QuestionEnum ignore) {
-    QuestionModel householdMembers = applicantHouseholdMembers();
+  private QuestionModel textRepeatedApplicantHouseholdMemberFavoriteShape(QuestionEnum ignore) {
+    QuestionModel householdMembers = enumeratorApplicantHouseholdMembers();
     QuestionDefinition definition =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -421,7 +448,7 @@ public class TestQuestionBank {
   }
 
   // Number
-  private QuestionModel applicantJugglingNumber(QuestionEnum ignore) {
+  private QuestionModel numberApplicantJugglingNumber(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -435,7 +462,7 @@ public class TestQuestionBank {
   }
 
   // Date
-  private QuestionModel applicantDate(QuestionEnum ignore) {
+  private QuestionModel DateApplicantBirthdate(QuestionEnum ignore) {
     QuestionDefinition definition =
         new DateQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -448,7 +475,7 @@ public class TestQuestionBank {
   }
 
   // Email
-  private QuestionModel applicantEmail(QuestionEnum ignore) {
+  private QuestionModel emailApplicantEmail(QuestionEnum ignore) {
     QuestionDefinition definition =
         new EmailQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -461,8 +488,9 @@ public class TestQuestionBank {
   }
 
   // Deeply Nested Number
-  private QuestionModel applicantHouseholdMemberDaysWorked(QuestionEnum ignore) {
-    QuestionModel householdMemberJobs = applicantHouseholdMemberJobs();
+  private QuestionModel numberNestedRepeatedApplicantHouseholdMemberDaysWorked(
+      QuestionEnum ignore) {
+    QuestionModel householdMemberJobs = enumeratorNestedApplicantHouseholdMemberJobs();
     QuestionDefinition definition =
         new NumberQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -481,7 +509,7 @@ public class TestQuestionBank {
   }
 
   // Radio button
-  private QuestionModel applicantSeason(QuestionEnum ignore) {
+  private QuestionModel radioApplicantFavoriteSeason(QuestionEnum ignore) {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()
             .setName("applicant favorite season")
@@ -515,7 +543,7 @@ public class TestQuestionBank {
   }
 
   // Text
-  private QuestionModel applicantFavoriteColor(QuestionEnum ignore) {
+  private QuestionModel textApplicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -568,26 +596,26 @@ public class TestQuestionBank {
   }
 
   private enum QuestionEnum {
-    APPLICANT_ADDRESS,
-    APPLICANT_SECONDARY_ADDRESS,
-    APPLICANT_FAVORITE_COLOR,
-    APPLICANT_FILE,
-    APPLICANT_ID,
-    APPLICANT_HOUSEHOLD_MEMBERS,
-    APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
-    APPLICANT_HOUSEHOLD_MEMBER_NAME,
-    APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE,
-    APPLICANT_HOUSEHOLD_MEMBER_JOBS,
-    APPLICANT_MONTHLY_INCOME,
-    APPLICANT_ICE_CREAM,
-    APPLICANT_JUGGLING_NUMBER,
-    APPLICANT_KITCHEN_TOOLS,
-    APPLICANT_NAME,
-    APPLICANT_BIRTHDATE,
-    APPLICANT_SEASON,
-    APPLICANT_EMAIL,
+    ADDRESS_APPLICANT_ADDRESS,
+    ADDRESS_APPLICANT_SECONDARY_ADDRESS,
+    CHECKBOX_APPLICANT_KITCHEN_TOOLS,
+    CURRENCY_APPLICANT_MONTHLY_INCOME,
+    DATE_APPLICANT_BIRTHDATE,
+    DROPDOWN_APPLICANT_ICE_CREAM,
+    EMAIL_APPLICANT_EMAIL,
+    ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS,
+    ENUMERATOR_NESTED_APPLICANT_HOUSEHOLD_MEMBER_JOBS,
+    FILE_UPLOAD_APPLICANT_FILE,
+    ID_APPLICANT_ID,
+    NAME_APPLICANT_NAME,
+    NAME_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_NAME,
+    NULL_QUESTION,
+    NUMBER_APPLICANT_JUGGLING_NUMBER,
+    NUMBER_NESTED_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_DAYS_WORKED,
+    PHONE_APPLICANT_PHONE,
+    RADIO_APPLICANT_FAVORITE_SEASON,
     STATIC_CONTENT,
-    APPLICANT_PHONE,
-    NULL_QUESTION
+    TEXT_APPLICANT_FAVORITE_COLOR,
+    TEXT_REPEATED_APPLICANT_HOUSEHOLD_MEMBER_FAVORITE_SHAPE
   }
 }

--- a/server/test/support/TestQuestionBankTest.java
+++ b/server/test/support/TestQuestionBankTest.java
@@ -22,15 +22,15 @@ public class TestQuestionBankTest {
 
   @Test
   public void withoutDatabase_canGetQuestion() {
-    QuestionModel question = testQuestionBank.applicantAddress();
+    QuestionModel question = testQuestionBank.addressApplicantAddress();
 
     assertThat(question.id).isEqualTo(1L);
   }
 
   @Test
   public void withoutDatabase_setsId() {
-    testQuestionBank.applicantAddress();
-    QuestionModel question = testQuestionBank.applicantName();
+    testQuestionBank.addressApplicantAddress();
+    QuestionModel question = testQuestionBank.nameApplicantName();
 
     assertThat(question.id).isEqualTo(2L);
   }

--- a/server/test/views/admin/programs/ProgramBaseViewTest.java
+++ b/server/test/views/admin/programs/ProgramBaseViewTest.java
@@ -32,8 +32,8 @@ public class ProgramBaseViewTest {
   private SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
   private ImmutableList<QuestionDefinition> questionDefinitions =
       ImmutableList.of(
-          testQuestionBank.applicantDate().getQuestionDefinition(),
-          testQuestionBank.applicantEmail().getQuestionDefinition());
+          testQuestionBank.dateApplicantBirthdate().getQuestionDefinition(),
+          testQuestionBank.emailApplicantEmail().getQuestionDefinition());
 
   @Test
   public void renderExistingPredicate_singleQuestion() {
@@ -41,7 +41,7 @@ public class ProgramBaseViewTest {
         PredicateDefinition.create(
             PredicateExpressionNode.create(
                 LeafOperationExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.applicantDate().id)
+                    .setQuestionId(testQuestionBank.dateApplicantBirthdate().id)
                     .setScalar(Scalar.DATE)
                     .setOperator(Operator.EQUAL_TO)
                     .setComparedValue(CfTestHelpers.stringToPredicateDate("2023-01-01"))
@@ -70,7 +70,8 @@ public class ProgramBaseViewTest {
                                 ImmutableList.of(
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantDate().id)
+                                            .setQuestionId(
+                                                testQuestionBank.dateApplicantBirthdate().id)
                                             .setScalar(Scalar.DATE)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(
@@ -78,7 +79,8 @@ public class ProgramBaseViewTest {
                                             .build()),
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantEmail().id)
+                                            .setQuestionId(
+                                                testQuestionBank.emailApplicantEmail().id)
                                             .setScalar(Scalar.EMAIL)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(PredicateValue.of("test@example.com"))
@@ -108,7 +110,8 @@ public class ProgramBaseViewTest {
                                 ImmutableList.of(
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantDate().id)
+                                            .setQuestionId(
+                                                testQuestionBank.dateApplicantBirthdate().id)
                                             .setScalar(Scalar.DATE)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(
@@ -116,7 +119,8 @@ public class ProgramBaseViewTest {
                                             .build()),
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantEmail().id)
+                                            .setQuestionId(
+                                                testQuestionBank.emailApplicantEmail().id)
                                             .setScalar(Scalar.EMAIL)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(PredicateValue.of("test@example.com"))
@@ -126,7 +130,8 @@ public class ProgramBaseViewTest {
                                 ImmutableList.of(
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantDate().id)
+                                            .setQuestionId(
+                                                testQuestionBank.dateApplicantBirthdate().id)
                                             .setScalar(Scalar.DATE)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(
@@ -134,7 +139,8 @@ public class ProgramBaseViewTest {
                                             .build()),
                                     PredicateExpressionNode.create(
                                         LeafOperationExpressionNode.builder()
-                                            .setQuestionId(testQuestionBank.applicantEmail().id)
+                                            .setQuestionId(
+                                                testQuestionBank.emailApplicantEmail().id)
                                             .setScalar(Scalar.EMAIL)
                                             .setOperator(Operator.EQUAL_TO)
                                             .setComparedValue(

--- a/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
+++ b/server/test/views/applicant/ApplicantProgramBlockEditViewTest.java
@@ -17,7 +17,7 @@ import views.questiontypes.ApplicantQuestionRendererParams;
 public class ApplicantProgramBlockEditViewTest extends ResetPostgres {
 
   private static QuestionDefinition ADDRESS_QD =
-      testQuestionBank.applicantAddress().getQuestionDefinition();
+      testQuestionBank.addressApplicantAddress().getQuestionDefinition();
   private static ApplicantRoutes applicantRoutes = new ApplicantRoutes();
 
   private static ApplicantProgramBlockEditView EMPTY_VIEW =


### PR DESCRIPTION
### Description

Adds the question type to the names of the TestQuestionBank methods.

No new functionality is added, this is just a renaming PR. The interesting changes are in TestQuestionBank.java, everything else is auto-refactored from changing the symbol names.

## Release notes

n/a

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Part of #5257
