### PR TITLE
Replace inline javascript for retire api key form

### DIFF
--- a/browser-test/src/support/admin_api_keys.ts
+++ b/browser-test/src/support/admin_api_keys.ts
@@ -90,7 +90,7 @@ export class AdminApiKeys {
           `#${keyNameSlugified}-call-count`,
           {timeout: 100},
         )
-      } catch (e) {
+      } catch {
         console.log(`failed to find #${keyNameSlugified}-call-count`)
       }
 
@@ -118,7 +118,7 @@ export class AdminApiKeys {
           `#${keyNameSlugified}-last-call-ip`,
           {timeout: 100},
         )
-      } catch (e) {
+      } catch {
         console.log(`failed to find #${keyNameSlugified}-last-call-ip`)
       }
 
@@ -133,8 +133,13 @@ export class AdminApiKeys {
 
   async retireApiKey(keyNameSlugified: string) {
     await this.gotoApiKeyIndexPage()
-    this.page.on('dialog', (dialog) => void dialog.accept())
+    let isDialogHandled = false
+    this.page.on('dialog', (dialog) => {
+      void dialog.accept()
+      isDialogHandled = true
+    })
     await this.page.click(`#retire-${keyNameSlugified} button`)
+    expect(isDialogHandled).toBe(true)
   }
 
   async expectApiKeyIsActive(keyName: string) {

--- a/server/app/assets/javascripts/admin_api_keys.ts
+++ b/server/app/assets/javascripts/admin_api_keys.ts
@@ -1,0 +1,21 @@
+// Javascript handling for the admin API keys page (ApiKeyIndexView)
+import {addEventListenerToElements} from './util'
+
+function onRetireKeyFormSubmit(event: Event) {
+  const keyName = (event.target as HTMLFormElement).dataset.apiKeyName
+  const message =
+    'Retiring the API key is permanent and will prevent anyone from being able to call the API with the key. Are you sure you want to retire ' +
+    keyName +
+    '?'
+  if (!confirm(message)) {
+    event.preventDefault()
+  }
+}
+
+export function init() {
+  addEventListenerToElements(
+    '.retire-key-form',
+    'submit',
+    onRetireKeyFormSubmit,
+  )
+}

--- a/server/app/assets/javascripts/admin_entry_point.ts
+++ b/server/app/assets/javascripts/admin_entry_point.ts
@@ -7,6 +7,7 @@ import * as main from './main'
 import * as radio from './radio'
 import * as toast from './toast'
 import * as toggle from './toggle'
+import * as adminApiKeys from './admin_api_keys'
 import * as adminApplicationView from './admin_application_view'
 import * as adminApplications from './admin_applications'
 import * as adminPredicates from './admin_predicate_configuration'
@@ -50,6 +51,7 @@ function initializeEverything(): void {
   radio.init()
   toast.init()
   toggle.init()
+  adminApiKeys.init()
   adminApplicationView.init()
   adminApplications.init()
   adminPredicates.init()

--- a/server/app/views/admin/apikeys/ApiKeyIndexView.java
+++ b/server/app/views/admin/apikeys/ApiKeyIndexView.java
@@ -148,19 +148,13 @@ public final class ApiKeyIndexView extends BaseHtmlView {
     if (apiKey.isRetired()) {
       statsDiv.with(p("Retired " + dateConverter.formatRfc1123(apiKey.getRetiredTime().get())));
     } else {
-
-      String onSubmitJs =
-          "return confirm('Retiring the API key is permanent and will prevent"
-              + " anyone from being able to call the API with the key. Are you"
-              + " sure you want to retire "
-              + apiKey.getName()
-              + "?')";
       linksDiv.with(
           form(makeCsrfTokenInputTag(request))
               .withAction(controllers.admin.routes.AdminApiKeysController.retire(apiKey.id).url())
               .withMethod("POST")
-              .withOnsubmit(onSubmitJs)
               .withId(String.format("retire-%s", keyNameSlugified))
+              .withData("api-key-name", apiKey.getName())
+              .withClasses("retire-key-form")
               .with(
                   makeSvgTextButton("Retire key", Icons.DELETE)
                       .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON)));


### PR DESCRIPTION
### Description

Replace the "onsubmit" inline javascript for the "retire key" button on the admin API keys page with static javascript. The message requires the key name, which is now plumbed in a data attribute on the form.

This is necessary to enforce a content security policy (https://github.com/civiform/civiform/issues/7574), which disallows inline javascript.

Also:

- Update the retireApiKey helper so that admin_api_keys.test.ts validates that the dialog actually appears
- Fix unused variable warnings that randomly popped up in admin_api_keys.ts

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
