### PR TITLE
Adding a missing '/' to the ses email link in devtools

### DIFF
--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -212,7 +212,8 @@ public class DatabaseSeedView extends BaseHtmlView {
         .with(p("Open S3 or SES endpoints on localstack"))
         .withClasses("flex", "flex-col", "gap-4", "border", "border-black", "p-4")
         .with(
-            createLink("✉\uFE0F View SES Emails", "http://localhost.localstack.cloud:4566/_aws/ses/")
+            createLink(
+                    "✉\uFE0F View SES Emails", "http://localhost.localstack.cloud:4566/_aws/ses/")
                 .withTarget("_blank"),
             createLink(
                     "\uD83D\uDCC1 S3 Private Bucket",

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -212,7 +212,7 @@ public class DatabaseSeedView extends BaseHtmlView {
         .with(p("Open S3 or SES endpoints on localstack"))
         .withClasses("flex", "flex-col", "gap-4", "border", "border-black", "p-4")
         .with(
-            createLink("✉\uFE0F View SES Emails", "http://localhost.localstack.cloud:4566/_aws/ses")
+            createLink("✉\uFE0F View SES Emails", "http://localhost.localstack.cloud:4566/_aws/ses/")
                 .withTarget("_blank"),
             createLink(
                     "\uD83D\uDCC1 S3 Private Bucket",


### PR DESCRIPTION
### Description

Adding a missing '/' to the ses email link in devtools


### Issue(s) this completes

Fixes #8307
