### PR TITLE
[Suffix] Add suffix to applicant service

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -525,6 +525,11 @@ public final class ApplicantService {
                                           applicantData
                                               .readString(path.join(Scalar.LAST_NAME))
                                               .orElseThrow());
+                                      // Name suffix is optional
+                                      applicant.setSuffix(
+                                          applicantData
+                                              .readString(path.join(Scalar.NAME_SUFFIX))
+                                              .orElse(""));
                                       break;
                                     case APPLICANT_EMAIL:
                                       applicant.setEmailAddress(

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -31,7 +31,6 @@ public enum Scalar {
   LINE2("address line 2", ScalarType.STRING),
   LONGITUDE("longitude", ScalarType.DOUBLE),
   MIDDLE_NAME("middle name", ScalarType.STRING),
-  NAME_SUFFIX("name suffix", ScalarType.STRING),
   NUMBER("number", ScalarType.LONG),
   ORIGINAL_FILE_NAME("original file name", ScalarType.STRING),
   SELECTION("selection", ScalarType.STRING),
@@ -122,7 +121,7 @@ public enum Scalar {
       case ID:
         return ImmutableSet.of(ID);
       case NAME:
-        return ImmutableSet.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME, NAME_SUFFIX);
+        return ImmutableSet.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME);
       case NUMBER:
         return ImmutableSet.of(NUMBER);
       case TEXT:

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -121,7 +121,7 @@ public enum Scalar {
       case ID:
         return ImmutableSet.of(ID);
       case NAME:
-        return ImmutableSet.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME);
+        return ImmutableSet.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME, NAME_SUFFIX);
       case NUMBER:
         return ImmutableSet.of(NUMBER);
       case TEXT:

--- a/server/app/services/applicant/question/Scalar.java
+++ b/server/app/services/applicant/question/Scalar.java
@@ -31,6 +31,7 @@ public enum Scalar {
   LINE2("address line 2", ScalarType.STRING),
   LONGITUDE("longitude", ScalarType.DOUBLE),
   MIDDLE_NAME("middle name", ScalarType.STRING),
+  NAME_SUFFIX("name suffix", ScalarType.STRING),
   NUMBER("number", ScalarType.LONG),
   ORIGINAL_FILE_NAME("original file name", ScalarType.STRING),
   SELECTION("selection", ScalarType.STRING),

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -213,9 +213,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantData applicantDataMiddle =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
     assertThat(applicantDataMiddle.asJsonString()).contains("Alice", "Doe");
-    ApplicantData applicantDataSuffix =
-        accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
-    assertThat(applicantDataSuffix.asJsonString()).contains("Alice", "Doe");
 
     // Now put empty updates
     updates =

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -213,6 +213,9 @@ public class ApplicantServiceTest extends ResetPostgres {
     ApplicantData applicantDataMiddle =
         accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
     assertThat(applicantDataMiddle.asJsonString()).contains("Alice", "Doe");
+    ApplicantData applicantDataSuffix =
+        accountRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
+    assertThat(applicantDataSuffix.asJsonString()).contains("Alice", "Doe");
 
     // Now put empty updates
     updates =
@@ -977,6 +980,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .put(Path.create("applicant.nameplz").join(Scalar.FIRST_NAME).toString(), "Jean")
             .put(Path.create("applicant.nameplz").join(Scalar.MIDDLE_NAME).toString(), "Luc")
             .put(Path.create("applicant.nameplz").join(Scalar.LAST_NAME).toString(), "Picard")
+            .put(Path.create("applicant.nameplz").join(Scalar.NAME_SUFFIX).toString(), "Sr.")
             .put(Path.create("applicant.dateplz").join(Scalar.DATE).toString(), "1999-01-07")
             .put(
                 Path.create("applicant.emailplz").join(Scalar.EMAIL).toString(),
@@ -1006,6 +1010,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(applicant.getFirstName().get()).isEqualTo("Jean");
     assertThat(applicant.getMiddleName().get()).isEqualTo("Luc");
     assertThat(applicant.getLastName().get()).isEqualTo("Picard");
+    assertThat(applicant.getSuffix().get()).isEqualTo("Sr.");
     assertThat(applicant.getDateOfBirth().get()).isEqualTo("1999-01-07");
     assertThat(applicant.getEmailAddress().get()).isEqualTo("picard@starfleet.com");
     assertThat(applicant.getPhoneNumber().get()).isEqualTo("5032161111");
@@ -2895,6 +2900,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Taylor",
         "Allison",
         "Swift",
+        "I",
         programForAnsweringQuestions
             .getProgramDefinition()
             .getBlockDefinitionByIndex(0)
@@ -2964,6 +2970,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Taylor",
         "Allison",
         "Swift",
+        "I",
         programWithEligibleAndIneligibleAnswers
             .getProgramDefinition()
             .getBlockDefinitionByIndex(0)
@@ -2976,6 +2983,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Solána",
         "Imani",
         "Rowe",
+        "Jr.",
         programWithEligibleAndIneligibleAnswers
             .getProgramDefinition()
             .getBlockDefinitionByIndex(1)
@@ -3048,6 +3056,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Taylor",
         "Allison",
         "Swift",
+        "I",
         programWithEligibleAndIneligibleAnswers
             .getProgramDefinition()
             .getBlockDefinitionByIndex(0)
@@ -3060,6 +3069,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Solána",
         "Imani",
         "Rowe",
+        "Jr.",
         programWithEligibleAndIneligibleAnswers
             .getProgramDefinition()
             .getBlockDefinitionByIndex(1)
@@ -3118,6 +3128,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Taylor",
         "Allison",
         "Swift",
+        "I",
         commonIntakeForm.getProgramDefinition().getBlockDefinitionByIndex(0).orElseThrow().id(),
         applicant.id,
         commonIntakeForm.id);
@@ -3162,6 +3173,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Taylor",
         "Allison",
         "Swift",
+        "I",
         testProgramWithNoEligibilityConditions
             .getProgramDefinition()
             .getBlockDefinitionByIndex(0)
@@ -3250,6 +3262,7 @@ public class ApplicantServiceTest extends ResetPostgres {
       String firstName,
       String middleName,
       String lastName,
+      String nameSuffix,
       Long blockId,
       long applicantId,
       long programId) {
@@ -3260,6 +3273,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .put(questionPath.join(Scalar.FIRST_NAME).toString(), firstName)
             .put(questionPath.join(Scalar.MIDDLE_NAME).toString(), middleName)
             .put(questionPath.join(Scalar.LAST_NAME).toString(), lastName)
+            .put(questionPath.join(Scalar.NAME_SUFFIX).toString(), nameSuffix)
             .build();
     subject
         .stageAndUpdateIfValid(


### PR DESCRIPTION
### Description

Modified ApplicantService. It now takes nameSuffix as part of the answers to the applicantion's Primary Applicant Info questions into the Primary Applicant Info columns in the applicants table. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

part of #8267
