### PR TITLE
Move unit tests from QuestionDefinitionTest to type-specific test classes 

### DIFF
--- a/server/test/services/question/types/EnumeratorQuestionDefinitionTest.java
+++ b/server/test/services/question/types/EnumeratorQuestionDefinitionTest.java
@@ -1,0 +1,25 @@
+package services.question.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.Test;
+import services.CiviFormError;
+import services.LocalizedStrings;
+
+public class EnumeratorQuestionDefinitionTest {
+  @Test
+  public void validate_enumeratorQuestion_withEmptyEntityString_returnsErrors() throws Exception {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+            .build();
+    QuestionDefinition question =
+        new EnumeratorQuestionDefinition(config, LocalizedStrings.withDefaultValue(""));
+
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Enumerator question must have specified entity type"));
+  }
+}

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -4,14 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalInt;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import services.CiviFormError;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionValidationPredicates;
 
+@RunWith(JUnitParamsRunner.class)
 public class MultiOptionQuestionDefinitionTest {
 
   @Test
@@ -174,5 +184,327 @@ public class MultiOptionQuestionDefinitionTest {
     MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
 
     assertThat(multiOption.getOptionAdminNames()).containsExactly("opt1", "opt2");
+  }
+
+  @Test
+  public void validate_withoutOptions_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, /* questionOptions */ ImmutableList.of(), MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option questions must have at least one option"));
+  }
+
+  @Test
+  public void validate_withBlankOption_returnsError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config,
+            ImmutableList.of(
+                QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue(""))),
+            MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option questions cannot have blank options"));
+  }
+
+  @Test
+  public void validate_withBlankOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config,
+            ImmutableList.of(QuestionOption.create(1L, "", LocalizedStrings.withDefaultValue("a"))),
+            MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsExactlyInAnyOrder(
+            CiviFormError.of("Multi-option questions cannot have blank admin names"),
+            CiviFormError.of(
+                "Multi-option admin names can only contain lowercase letters, numbers, underscores,"
+                    + " and dashes"));
+  }
+
+  @Test
+  public void validate_withDuplicateOptions_returnsError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.withDefaultValue("a")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+  }
+
+  @Test
+  public void validate_withDuplicateOptionsWithDifferentCase_returnsError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L, "Parks_and_Recreation", LocalizedStrings.withDefaultValue("a1")),
+            QuestionOption.create(
+                2L, "Parks_and_recreation", LocalizedStrings.withDefaultValue("a2")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .contains(CiviFormError.of("Multi-option question admin names must be unique"));
+  }
+
+  @Test
+  public void validate_withDuplicateOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt1", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option question admin names must be unique"));
+  }
+
+  @Test
+  public void validate_withUniqueOptionAdminNames_doesNotReturnError() {
+    QuestionDefinitionConfig config = makeConfigBuilder().build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a_one-1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_two-2", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate()).isEmpty();
+  }
+
+  @Test
+  public void validate_withInvalidOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(
+            CiviFormError.of(
+                "Multi-option admin names can only contain lowercase letters, numbers, underscores,"
+                    + " and dashes"));
+  }
+
+  @Test
+  public void validate_withCapitalLetterInOptionAdminNames_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "A_invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    assertThat(question.validate())
+        .containsOnly(
+            CiviFormError.of(
+                "Multi-option admin names can only contain lowercase letters, numbers, underscores,"
+                    + " and dashes"));
+  }
+
+  @Test
+  public void validate_withInvalidOptionAdminNameInPreviousDefinition_doesNotReturnError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "c_valid", LocalizedStrings.withDefaultValue("c")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion))).isEmpty();
+  }
+
+  @Test
+  public void validate_withValidOptionAdminNameInPreviousAndDuplicateNameInUpdate_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a_valid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "A_valid", LocalizedStrings.withDefaultValue("c")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
+        .containsOnly(CiviFormError.of("Multi-option question admin names must be unique"));
+  }
+
+  @Test
+  public void validate_withInvalidOptionAdminNameInPreviousAndUpdatedDefinition_returnsError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> previousQuestionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    QuestionDefinition previousQuestion =
+        new MultiOptionQuestionDefinition(
+            config, previousQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableList<QuestionOption> updatedQuestionOptions =
+        ImmutableList.<QuestionOption>builder()
+            .addAll(previousQuestionOptions)
+            .add(QuestionOption.create(2L, "c invalid", LocalizedStrings.withDefaultValue("c")))
+            .build();
+    QuestionDefinition updatedQuestion =
+        new MultiOptionQuestionDefinition(
+            config, updatedQuestionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    assertThat(updatedQuestion.validate(Optional.of(previousQuestion)))
+        .containsOnly(
+            CiviFormError.of(
+                "Multi-option admin names can only contain lowercase letters, numbers, underscores,"
+                    + " and dashes"));
+  }
+
+  @SuppressWarnings("unused") // Is used via reflection by the @Parameters annotation below
+  private static ImmutableList<Object[]> getMultiOptionQuestionValidationTestData() {
+    return ImmutableList.of(
+        // Valid cases.
+        new Object[] {OptionalInt.empty(), OptionalInt.empty(), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.empty(), Optional.<String>empty()},
+        new Object[] {OptionalInt.empty(), OptionalInt.of(1), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
+
+        // Edge cases.
+        new Object[] {
+          OptionalInt.of(-1),
+          OptionalInt.empty(),
+          Optional.of("Minimum number of choices required cannot be negative")
+        },
+        new Object[] {
+          OptionalInt.empty(),
+          OptionalInt.of(-1),
+          Optional.of("Maximum number of choices allowed cannot be negative")
+        },
+        new Object[] {
+          OptionalInt.of(2),
+          OptionalInt.of(1),
+          Optional.of(
+              "Minimum number of choices required must be less than or equal to the maximum"
+                  + " choices allowed")
+        },
+        new Object[] {
+          OptionalInt.of(0), OptionalInt.of(0), Optional.of("Cannot require exactly 0 choices")
+        },
+        // Note: In the test code, we configure two options.
+        new Object[] {
+          OptionalInt.empty(),
+          OptionalInt.of(3),
+          Optional.of("Maximum number of choices allowed cannot exceed the number of options")
+        },
+        new Object[] {
+          OptionalInt.of(3),
+          OptionalInt.empty(),
+          Optional.of("Minimum number of choices required cannot exceed the number of options")
+        });
+  }
+
+  @Test
+  @Parameters(method = "getMultiOptionQuestionValidationTestData")
+  public void validate_multiOptionQuestion_validationConstraints(
+      OptionalInt minChoicesRequired,
+      OptionalInt maxChoicesAllowed,
+      Optional<String> wantErrorMessage) {
+    QuestionDefinitionConfig config =
+        makeConfigBuilder()
+            .setValidationPredicates(
+                MultiOptionValidationPredicates.builder()
+                    .setMinChoicesRequired(minChoicesRequired)
+                    .setMaxChoicesAllowed(maxChoicesAllowed)
+                    .build())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "opt1", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "opt2", LocalizedStrings.withDefaultValue("b")));
+
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+
+    ImmutableSet<CiviFormError> errors = question.validate();
+    if (wantErrorMessage.isEmpty()) {
+      assertThat(errors).isEmpty();
+    } else {
+      assertThat(question.validate()).containsOnly(CiviFormError.of(wantErrorMessage.get()));
+    }
+  }
+
+  private QuestionDefinitionConfig.Builder makeConfigBuilder() {
+    return QuestionDefinitionConfig.builder()
+        .setName("name")
+        .setDescription("description")
+        .setQuestionText(LocalizedStrings.of(Locale.US, "question?"));
   }
 }


### PR DESCRIPTION
### Description

Move unit tests that test specific question functionality from QuestionDefinitionTest to test classes specific to those question types.

This moves code without making any changes.

This is for #7919.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
