### PR TITLE
Add Additional Program Disabled Check

### DIFF
--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -1380,9 +1380,7 @@ test.describe('Application Version Fast-Forward Flow', () => {
     // Applicant submits application for program v1; it does not change to program v3
     await test.step('As applicant - active program v3', async () => {
       await applicantActor.getPage().reload()
-      await applicantActor
-        .getPage()
-        .waitForURL('**/programs/program-fastforward-example/disabled')
+      await applicantActor.waitForDisabledPage()
     })
   })
 })

--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -1491,7 +1491,7 @@ class FastForwardCiviformAdminActor {
    */
   async publish() {
     await test.step('publish', async () => {
-      await this.adminPrograms.publishAllDrafts() // (this.programName)
+      await this.adminPrograms.publishAllDrafts()
     })
   }
 

--- a/server/app/actions/ProgramDisabledAction.java
+++ b/server/app/actions/ProgramDisabledAction.java
@@ -11,8 +11,11 @@ import models.DisplayMode;
 import play.mvc.Action;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import play.routing.Router;
 import services.program.ProgramDefinition;
+import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
+import services.settings.SettingsManifest;
 
 /**
  * Action that ensures the program the user is trying to access is not disabled.
@@ -23,10 +26,12 @@ import services.program.ProgramService;
  */
 public class ProgramDisabledAction extends Action.Simple {
   private final ProgramService programService;
+  private final SettingsManifest settingsManifest;
 
   @Inject
-  public ProgramDisabledAction(ProgramService programService) {
+  public ProgramDisabledAction(ProgramService programService, SettingsManifest settingsManifest) {
     this.programService = checkNotNull(programService);
+    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   private boolean programIsDisabled(String programSlug) {
@@ -38,9 +43,18 @@ public class ProgramDisabledAction extends Action.Simple {
     return programDefiniton.displayMode() == DisplayMode.DISABLED;
   }
 
+  private ProgramDefinition getProgram(long programId) {
+    try {
+      return programService.getFullProgramDefinition(programId);
+    } catch (ProgramNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public CompletionStage<Result> call(Request req) {
-    Optional<String> programSlugOptional = req.flash().get(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG);
+
+    Optional<String> programSlugOptional = getProgramSlug(req);
 
     if (programSlugOptional.isPresent() && programIsDisabled(programSlugOptional.get())) {
       return CompletableFuture.completedFuture(
@@ -50,5 +64,31 @@ public class ProgramDisabledAction extends Action.Simple {
     }
 
     return delegate.call(req); // continute processing next step
+  }
+
+  /** Get the program slug from flash key or from programId */
+  private Optional<String> getProgramSlug(Request request) {
+    Optional<String> programSlugOptional =
+        request.flash().get(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG);
+
+    if (programSlugOptional.isPresent()) {
+      return programSlugOptional;
+    }
+
+    if (!settingsManifest.getFastforwardEnabled(request)
+        || !request.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
+      return Optional.empty();
+    }
+
+    String routePattern = request.attrs().get(Router.Attrs.HANDLER_DEF).path();
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, request.path());
+    Optional<Long> programId = routeExtractor.getParamOptionalLongValue("programId");
+
+    if (programId.isPresent()) {
+      ProgramDefinition program = getProgram(programId.get());
+      return Optional.of(program.slug());
+    }
+
+    return Optional.empty();
   }
 }

--- a/server/app/actions/RouteExtractor.java
+++ b/server/app/actions/RouteExtractor.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import play.mvc.Http;
@@ -95,6 +96,25 @@ public final class RouteExtractor {
 
     try {
       return Long.parseLong(routeParameters.get(key));
+    } catch (NumberFormatException ex) {
+      throw new RuntimeException(
+          String.format("Could not parse value from '%s' in route '%s'", key, path), ex);
+    }
+  }
+
+  /**
+   * The given key's value converted into a long format or an empty optional.
+   *
+   * @param key Path parameter key name as defined in the routes file.
+   * @return the given key's value converted into a long format or an empty optional.
+   */
+  public Optional<Long> getParamOptionalLongValue(String key) {
+    if (!routeParameters.containsKey(key)) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(Long.parseLong(routeParameters.get(key)));
     } catch (NumberFormatException ex) {
       throw new RuntimeException(
           String.format("Could not parse value from '%s' in route '%s'", key, path), ex);

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -1,44 +1,76 @@
 package actions;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static support.FakeRequestBuilder.fakeRequest;
+import static support.FakeRequestBuilder.createHandlerDef;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
-import java.util.HashMap;
+import controllers.FlashKey;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import models.DisplayMode;
 import models.ProgramModel;
 import org.junit.Test;
+import org.mockito.Mockito;
 import play.mvc.Action;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import play.routing.Router;
 import play.test.WithApplication;
 import repository.VersionRepository;
 import services.LocalizedStrings;
 import services.program.BlockDefinition;
 import services.program.ProgramService;
 import services.program.ProgramType;
+import services.settings.SettingsManifest;
 
 public class ProgramDisabledActionTest extends WithApplication {
-  private static final BlockDefinition EMPTY_FIRST_BLOCK =
-      BlockDefinition.builder()
-          .setId(1)
-          .setName("Screen 1")
-          .setDescription("Screen 1 description")
-          .setLocalizedName(LocalizedStrings.withDefaultValue("Screen 1"))
-          .setLocalizedDescription(LocalizedStrings.withDefaultValue("Screen 1 description"))
-          .build();
+  private ProgramModel createProgram(DisplayMode displayMode) {
+    BlockDefinition emptyFirstBlock =
+        BlockDefinition.builder()
+            .setId(1)
+            .setName("Screen 1")
+            .setDescription("Screen 1 description")
+            .setLocalizedName(LocalizedStrings.withDefaultValue("Screen 1"))
+            .setLocalizedDescription(LocalizedStrings.withDefaultValue("Screen 1 description"))
+            .build();
 
+    VersionRepository versionRepository = instanceOf(VersionRepository.class);
+
+    ProgramModel program =
+        new ProgramModel(
+            /* adminName */ String.format("%s-program1", displayMode),
+            /* adminDescription */ "admin-description",
+            /* defaultDisplayName */ "admin-name",
+            /* defaultDisplayDescription */ "description",
+            /* defaultConfirmationMessage */ "",
+            /* externalLink */ "",
+            /* displayMode */ displayMode.getValue(),
+            /* blockDefinitions */ ImmutableList.of(emptyFirstBlock),
+            /* associatedVersion */ versionRepository.getActiveVersion(),
+            /* programType */ ProgramType.DEFAULT,
+            /* eligibilityIsGating= */ true,
+            /* ProgramAcls */ new ProgramAcls(),
+            /* categories */ ImmutableList.of());
+    program.save();
+
+    return program;
+  }
+
+  // Fast Forward Disabled
   @Test
-  public void testProgramSlugIsNotAvailable() {
+  public void testProgramSlugIsNotAvailable_whenFastForwardIsDisabled() {
+    Request request = fakeRequestBuilder().build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(false);
+
     ProgramService programService = instanceOf(ProgramService.class);
-    ProgramDisabledAction action = new ProgramDisabledAction(programService);
-    Request request = fakeRequest();
+    ProgramDisabledAction action = new ProgramDisabledAction(programService, mockSettingsManifest);
 
     // Set up a mock for the delegate action
     Action.Simple delegateMock = mock(Action.Simple.class);
@@ -47,73 +79,182 @@ public class ProgramDisabledActionTest extends WithApplication {
     Result result = action.call(request).toCompletableFuture().join();
 
     // Verify that the delegate action was called
-    assertEquals(null, result);
+    assertNull(result);
   }
 
   @Test
-  public void testDisabledProgram() {
-    ProgramService programService = instanceOf(ProgramService.class);
-    VersionRepository versionRepository = instanceOf(VersionRepository.class);
-    ProgramDisabledAction action = new ProgramDisabledAction(programService);
+  public void testDisabledProgramFromFlashKey_whenFastForwardIsDisabled() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED);
 
-    Map<String, String> flashData = new HashMap<>();
-    flashData.put("redirected-from-program-slug", "disabledprogram1");
-    Request request = fakeRequestBuilder().flash(flashData).build();
-    ProgramModel program =
-        new ProgramModel(
-            /* adminName */ "disabledprogram1",
-            /* adminDescription */ "description for a disabled program ",
-            /* defaultDisplayName */ "disabled program",
-            /* defaultDisplayDescription */ "description",
-            /* defaultConfirmationMessage */ "",
-            /* externalLink */ "",
-            /* displayMode */ DisplayMode.DISABLED.getValue(),
-            /* blockDefinitions */ ImmutableList.of(EMPTY_FIRST_BLOCK),
-            /* associatedVersion */ versionRepository.getActiveVersion(),
-            /* programType */ ProgramType.DEFAULT,
-            /* eligibilityIsGating= */ true,
-            /* ProgramAcls */ new ProgramAcls(),
-            /* categories */ ImmutableList.of());
-    program.save();
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(false);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
 
     Result result = action.call(request).toCompletableFuture().join();
     assertEquals(
         result.redirectLocation().get(),
         controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
-                "disabledprogram1")
+                program.getSlug())
             .url());
   }
 
   @Test
-  public void testNonDisabledProgram() {
-    ProgramService programService = instanceOf(ProgramService.class);
-    VersionRepository versionRepository = instanceOf(VersionRepository.class);
-    ProgramDisabledAction action = new ProgramDisabledAction(programService);
-    Map<String, String> flashData = new HashMap<>();
-    flashData.put("redirected-from-program-slug", "publicprogram1");
-    Request request = fakeRequestBuilder().flash(flashData).build();
-    ProgramModel program =
-        new ProgramModel(
-            /* adminName */ "publicprogram1",
-            /* adminDescription */ "description for a public visibile program",
-            /* defaultDisplayName */ "public program",
-            /* defaultDisplayDescription */ "description",
-            /* defaultConfirmationMessage */ "",
-            /* externalLink */ "",
-            /* displayMode */ DisplayMode.PUBLIC.getValue(),
-            /* blockDefinitions */ ImmutableList.of(EMPTY_FIRST_BLOCK),
-            /* associatedVersion */ versionRepository.getActiveVersion(),
-            /* programType */ ProgramType.DEFAULT,
-            /* eligibilityIsGating= */ true,
-            /* ProgramAcls */ new ProgramAcls(),
-            /* categories */ ImmutableList.of());
-    program.save();
+  public void testDisabledProgramFromUriPathProgramId_whenFastForwardIsDisabled() {
+    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+
+    var routePattern =
+        "/programs/$programId<[^/]+>/applicant/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit";
+    var path = String.format("/programs/%d/applicant/a/blocks/2/edit", program.id);
+
+    Request request =
+        fakeRequestBuilder()
+            .location("GET", path)
+            .build()
+            .addAttr(
+                Router.Attrs.HANDLER_DEF,
+                createHandlerDef(getClass().getClassLoader(), routePattern));
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(false);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
 
     Action.Simple delegateMock = mock(Action.Simple.class);
     when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
     action.delegate = delegateMock;
 
     Result result = action.call(request).toCompletableFuture().join();
-    assertEquals(null, result);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testNonDisabledProgram_whenFastForwardIsDisabled() {
+    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(false);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+
+    Result result = action.call(request).toCompletableFuture().join();
+
+    assertNull(result);
+  }
+
+  // Fast Forward Enabled
+  @Test
+  public void testProgramSlugIsNotAvailable_whenFastForwardIsEnabled() {
+    Request request = fakeRequestBuilder().build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(true);
+
+    ProgramService programService = instanceOf(ProgramService.class);
+    ProgramDisabledAction action = new ProgramDisabledAction(programService, mockSettingsManifest);
+
+    // Set up a mock for the delegate action
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // Verify that the delegate action was called
+    assertNull(result);
+  }
+
+  @Test
+  public void testDisabledProgramFromFlashKey_whenFastForwardIsEnabled() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED);
+
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(true);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    Result result = action.call(request).toCompletableFuture().join();
+    assertEquals(
+        result.redirectLocation().get(),
+        controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
+                program.getSlug())
+            .url());
+  }
+
+  @Test
+  public void testDisabledProgramFromUriPathProgramId_whenFastForwardIsEnabled() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED);
+
+    var routePattern =
+        "/programs/$programId<[^/]+>/applicant/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit";
+    var path = String.format("/programs/%d/applicant/a/blocks/2/edit", program.id);
+
+    Request request =
+        fakeRequestBuilder()
+            .location("GET", path)
+            .build()
+            .addAttr(
+                Router.Attrs.HANDLER_DEF,
+                createHandlerDef(getClass().getClassLoader(), routePattern));
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(true);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    Result result = action.call(request).toCompletableFuture().join();
+    assertEquals(
+        result.redirectLocation().get(),
+        controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
+                program.getSlug())
+            .url());
+  }
+
+  @Test
+  public void testNonDisabledProgramFromFlashKey_whenFastForwardIsEnabled() {
+    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(true);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+
+    Result result = action.call(request).toCompletableFuture().join();
+
+    assertNull(result);
   }
 }

--- a/server/test/actions/RouteExtractorTest.java
+++ b/server/test/actions/RouteExtractorTest.java
@@ -3,6 +3,7 @@ package actions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
 import org.junit.Test;
 
 public final class RouteExtractorTest {
@@ -27,11 +28,21 @@ public final class RouteExtractorTest {
   }
 
   @Test
-  public void asking_for_route_parameter_that_does_not_exist() {
+  public void asking_for_route_parameter_that_does_not_exist_throws() {
     String routePattern = "/programs/$programId<[^/]+>/blocks/$blockId<[^/]+>/edit";
     String path = "/programs/1/blocks/2/edit";
     RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
 
     assertThatThrownBy(() -> routeExtractor.getParamLongValue("unexpectedId"));
+  }
+
+  @Test
+  public void asking_for_route_parameter_that_does_not_exist_returns_empty() {
+    String routePattern = "/programs/$programId<[^/]+>/blocks/$blockId<[^/]+>/edit";
+    String path = "/programs/1/blocks/2/edit";
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, path);
+
+    assertThat(routeExtractor.getParamOptionalLongValue("unexpectedId"))
+        .isEqualTo(Optional.empty());
   }
 }

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -7,12 +7,15 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import play.api.mvc.request.RequestAttrKey;
+import play.api.routing.HandlerDef;
 import play.mvc.Call;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
 import play.mvc.Http.RequestImpl;
+import scala.jdk.javaapi.CollectionConverters;
 
 public final class FakeRequestBuilder extends RequestBuilder {
   private List<String> xForwardedFor = new ArrayList<>();
@@ -31,6 +34,12 @@ public final class FakeRequestBuilder extends RequestBuilder {
   public FakeRequestBuilder call(Call call) {
     method(call.method());
     uri(call.url());
+    return this;
+  }
+
+  public FakeRequestBuilder location(String httpVerb, String path) {
+    method(httpVerb);
+    uri(path);
     return this;
   }
 
@@ -75,5 +84,27 @@ public final class FakeRequestBuilder extends RequestBuilder {
       attr(CIVIFORM_SETTINGS_ATTRIBUTE_KEY, settings);
     }
     return super.build();
+  }
+
+  /**
+   * Create a {@link HandlerDef} object with customized route information
+   *
+   * @param routePattern is the pattern for the routes
+   * @return {@link HandlerDef}
+   */
+  public static HandlerDef createHandlerDef(ClassLoader classLoader, String routePattern) {
+    HandlerDef handlerDef =
+        new HandlerDef(
+            classLoader,
+            "router",
+            "controllers.MyFakeController", // This can be anything
+            "index",
+            CollectionConverters.asScala(Collections.<Class<?>>emptyList()).toSeq(),
+            "GET",
+            routePattern,
+            "",
+            CollectionConverters.asScala(Collections.<String>emptyList()).toSeq());
+
+    return handlerDef;
   }
 }


### PR DESCRIPTION
### Description

When fastforward is enabled, adds an additional check to have the `ProgramDisabledAction` see if the url path has a programId. If it does load the program and get the slug, then continue running following the existing rules.

## Release notes

Fixes a bug that occurs when the ProgramDisabled and FastForward features are both enabled.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #8290
