### PR TITLE
Only set submitter email if TI is submitting for someone else

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -434,11 +434,16 @@ public final class ApplicantService {
           .thenComposeAsync(
               v -> submitterProfile.getAccount(), classLoaderExecutionContext.current())
           .thenComposeAsync(
-              account ->
+              tiAccount ->
                   submitApplication(
                       applicantId,
                       programId,
-                      /* tiSubmitterEmail= */ Optional.of(account.getEmailAddress()),
+                      // /* tiSubmitterEmail= */
+                      // If the TI is submitting for themselves, don't set the tiSubmitterEmail. See
+                      // #5325 for more.
+                      tiAccount.ownedApplicantIds().contains(applicantId)
+                          ? Optional.empty()
+                          : Optional.of(tiAccount.getEmailAddress()),
                       request),
               classLoaderExecutionContext.current());
     }

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -110,6 +110,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   private ApplicationRepository applicationRepository;
   private VersionRepository versionRepository;
   private CiviFormProfile trustedIntermediaryProfile;
+  private ApplicantModel tiApplicant;
   private ProgramService programService;
   private String baseUrl;
   private SimpleEmail amazonSESClient;
@@ -134,13 +135,12 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
 
     trustedIntermediaryProfile = Mockito.mock(CiviFormProfile.class);
     applicantProfile = Mockito.mock(CiviFormProfile.class);
-    AccountModel account = new AccountModel();
-    account.setEmailAddress("test@example.com");
+    tiApplicant = resourceCreator.insertApplicantWithAccount(Optional.of("ti@tis.com"));
     Mockito.when(trustedIntermediaryProfile.isTrustedIntermediary()).thenReturn(true);
     Mockito.when(trustedIntermediaryProfile.getAccount())
-        .thenReturn(CompletableFuture.completedFuture(account));
+        .thenReturn(CompletableFuture.completedFuture(tiApplicant.getAccount()));
     Mockito.when(trustedIntermediaryProfile.getEmailAddress())
-        .thenReturn(CompletableFuture.completedFuture("test@example.com"));
+        .thenReturn(CompletableFuture.completedFuture("ti@tis.com"));
     Mockito.when(applicantProfile.isTrustedIntermediary()).thenReturn(false);
     AccountModel applicantAccount = new AccountModel();
     applicantAccount.setEmailAddress("applicant@example.com");
@@ -899,6 +899,48 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
   }
 
   @Test
+  public void submitApplication_savesTiEmailAsSubmitterEmail() {
+    ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
+    applicant.setAccount(resourceCreator.insertAccount());
+    applicant.save();
+
+    subject
+        .stageAndUpdateIfValid(
+            applicant.id, programDefinition.id(), "1", applicationUpdates(), false, false)
+        .toCompletableFuture()
+        .join();
+
+    ApplicationModel application =
+        subject
+            .submitApplication(
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(application.getSubmitterEmail()).isPresent();
+    assertThat(application.getSubmitterEmail().get()).isEqualTo("ti@tis.com");
+  }
+
+  @Test
+  public void
+      submitApplication_whenTiIsSubmittingForThemsleves_doesNotSaveTiEmailAsSubmitterEmail() {
+    subject
+        .stageAndUpdateIfValid(
+            tiApplicant.id, programDefinition.id(), "1", applicationUpdates(), false, false)
+        .toCompletableFuture()
+        .join();
+
+    ApplicationModel application =
+        subject
+            .submitApplication(
+                tiApplicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(application.getSubmitterEmail()).isEmpty();
+  }
+
+  @Test
   public void submitApplication_savesPrimaryApplicantInfoAnswers() {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
@@ -1210,7 +1252,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     // TI email
     Mockito.verify(amazonSESClient)
         .send(
-            "test@example.com",
+            "ti@tis.com",
             messages.at(
                 MessageKey.EMAIL_TI_APPLICATION_SUBMITTED_SUBJECT.getKeyName(),
                 programName,
@@ -1289,7 +1331,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     // TI email
     Mockito.verify(amazonSESClient)
         .send(
-            "test@example.com",
+            "ti@tis.com",
             messages.at(
                 MessageKey.EMAIL_TI_APPLICATION_SUBMITTED_SUBJECT.getKeyName(),
                 programName,
@@ -1321,6 +1363,8 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     tiApplicant.setAccount(tiAccount);
     tiApplicant.getApplicantData().setPreferredLocale(Locale.KOREA);
     tiApplicant.save();
+    tiAccount.setApplicants(ImmutableList.of(tiApplicant));
+    tiAccount.save();
     Mockito.when(trustedIntermediaryProfile.getAccount())
         .thenReturn(CompletableFuture.completedFuture(tiAccount));
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -110,6 +110,7 @@ public class ApplicantServiceTest extends ResetPostgres {
   private ApplicationRepository applicationRepository;
   private VersionRepository versionRepository;
   private CiviFormProfile trustedIntermediaryProfile;
+  private ApplicantModel tiApplicant;
   private ProgramService programService;
   private String baseUrl;
   private SimpleEmail amazonSESClient;
@@ -134,13 +135,12 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     trustedIntermediaryProfile = Mockito.mock(CiviFormProfile.class);
     applicantProfile = Mockito.mock(CiviFormProfile.class);
-    AccountModel account = new AccountModel();
-    account.setEmailAddress("test@example.com");
+    tiApplicant = resourceCreator.insertApplicantWithAccount(Optional.of("ti@tis.com"));
     Mockito.when(trustedIntermediaryProfile.isTrustedIntermediary()).thenReturn(true);
     Mockito.when(trustedIntermediaryProfile.getAccount())
-        .thenReturn(CompletableFuture.completedFuture(account));
+        .thenReturn(CompletableFuture.completedFuture(tiApplicant.getAccount()));
     Mockito.when(trustedIntermediaryProfile.getEmailAddress())
-        .thenReturn(CompletableFuture.completedFuture("test@example.com"));
+        .thenReturn(CompletableFuture.completedFuture("ti@tis.com"));
     Mockito.when(applicantProfile.isTrustedIntermediary()).thenReturn(false);
     AccountModel applicantAccount = new AccountModel();
     applicantAccount.setEmailAddress("applicant@example.com");
@@ -899,6 +899,48 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void submitApplication_savesTiEmailAsSubmitterEmail() {
+    ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
+    applicant.setAccount(resourceCreator.insertAccount());
+    applicant.save();
+
+    subject
+        .stageAndUpdateIfValid(
+            applicant.id, programDefinition.id(), "1", applicationUpdates(), false, false)
+        .toCompletableFuture()
+        .join();
+
+    ApplicationModel application =
+        subject
+            .submitApplication(
+                applicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(application.getSubmitterEmail()).isPresent();
+    assertThat(application.getSubmitterEmail().get()).isEqualTo("ti@tis.com");
+  }
+
+  @Test
+  public void
+      submitApplication_whenTiIsSubmittingForThemsleves_doesNotSaveTiEmailAsSubmitterEmail() {
+    subject
+        .stageAndUpdateIfValid(
+            tiApplicant.id, programDefinition.id(), "1", applicationUpdates(), false, false)
+        .toCompletableFuture()
+        .join();
+
+    ApplicationModel application =
+        subject
+            .submitApplication(
+                tiApplicant.id, programDefinition.id(), trustedIntermediaryProfile, fakeRequest())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(application.getSubmitterEmail()).isEmpty();
+  }
+
+  @Test
   public void submitApplication_savesPrimaryApplicantInfoAnswers() {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
@@ -1213,7 +1255,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // TI email
     Mockito.verify(amazonSESClient)
         .send(
-            "test@example.com",
+            "ti@tis.com",
             messages.at(
                 MessageKey.EMAIL_TI_APPLICATION_SUBMITTED_SUBJECT.getKeyName(),
                 programName,
@@ -1292,7 +1334,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     // TI email
     Mockito.verify(amazonSESClient)
         .send(
-            "test@example.com",
+            "ti@tis.com",
             messages.at(
                 MessageKey.EMAIL_TI_APPLICATION_SUBMITTED_SUBJECT.getKeyName(),
                 programName,
@@ -1324,6 +1366,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     tiApplicant.setAccount(tiAccount);
     tiApplicant.getApplicantData().setPreferredLocale(Locale.KOREA);
     tiApplicant.save();
+    tiAccount.setApplicants(ImmutableList.of(tiApplicant));
+    tiAccount.save();
     Mockito.when(trustedIntermediaryProfile.getAccount())
         .thenReturn(CompletableFuture.completedFuture(tiAccount));
 

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -1,5 +1,6 @@
 package support;
 
+import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
 import io.ebean.Database;
 import java.time.Instant;
@@ -195,6 +196,8 @@ public class ResourceCreator {
     account.save();
     applicant.setAccount(account);
     applicant.save();
+    account.setApplicants(ImmutableList.of(applicant));
+    account.save();
 
     return applicant;
   }


### PR DESCRIPTION
### Description

Only set the submitter email if TI is submitting for someone else. 

Details:
- When exporting we use the submitter_email field to determine if the application was submitted by an applicant or a TI, but this field is set even when the TI is submitting an application for themselves. (https://github.com/civiform/civiform/issues/5325 would fix this as well)
- Now, we check if the applicant's applicant ID is the same as the TI's applicant ID, and if they are, we don't set the `submitter_email` field
- This also requires fixing the mocks that don't fully set up the relationship between Accounts and Applicants.

## Release notes

When exporting applications that are submitted by a TI, for themselves, the `submitter_type` field will now say `APPLICANT`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Instructions for manual testing

- Fill out an application, as a TI, for the TI (you may need to use the deep link to get to the program screen as the TI account)
- Export the application and confirm that the `submitter_type` is `APPLICANT`.

### Issue(s) this completes

Fixes #6908
