### PR TITLE
Clarify the description of the APPLICANT_OIDC_PROVIDER_LOGOUT config variable

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -148,7 +148,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
 
   /**
    * Enables [central
-   * logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2).
+   * logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2) for both
+   * admin and applicant auth providers (despite the name).
    */
   public boolean getApplicantOidcProviderLogout() {
     return getBool("APPLICANT_OIDC_PROVIDER_LOGOUT");
@@ -1113,7 +1114,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                                   SettingDescription.create(
                                       "APPLICANT_OIDC_PROVIDER_LOGOUT",
                                       "Enables [central"
-                                          + " logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2).",
+                                          + " logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2)"
+                                          + " for both admin and applicant auth providers (despite"
+                                          + " the name).",
                                       /* isRequired= */ false,
                                       SettingType.BOOLEAN,
                                       SettingMode.HIDDEN),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -124,7 +124,7 @@
             "members": {
               "APPLICANT_OIDC_PROVIDER_LOGOUT": {
                 "mode": "HIDDEN",
-                "description": "Enables [central logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2).",
+                "description": "Enables [central logout](https://github.com/civiform/civiform/wiki/Authentication-Providers#logout-2) for both admin and applicant auth providers (despite the name).",
                 "type": "bool"
               },
               "APPLICANT_OIDC_OVERRIDE_LOGOUT_URL": {


### PR DESCRIPTION
### Description

Update the description for the APPLICANT_OIDC_PROVIDER_LOGOUT config variable to clarify that it applies to both admin and applicant auth, despite the name.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)