### PR TITLE
Only set the cache after the program association sync is complete

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -161,7 +161,15 @@ public final class ProgramRepository {
         && getFullProgramDefinitionFromCache(programId).isEmpty()) {
       // We should never set the cache for draft programs.
       if (!versionRepository.get().isDraftProgram(programId)) {
-        programDefCache.set(String.valueOf(programId), programDefinition);
+        if (!programDefinition.hasOrderedBlockDefinitions()) {
+          logger.warn(
+              "Program {} with ID {} does not have ordered block definitions, so we won't set it"
+                  + " into the cache.",
+              programDefinition.slug(),
+              programDefinition.id());
+        } else {
+          programDefCache.set(String.valueOf(programId), programDefinition);
+        }
       }
     }
   }

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -161,6 +161,11 @@ public final class ProgramRepository {
         && getFullProgramDefinitionFromCache(programId).isEmpty()) {
       // We should never set the cache for draft programs.
       if (!versionRepository.get().isDraftProgram(programId)) {
+        // Every program definition should have the block definitions ordered, since the cache is
+        // only set
+        // after syncing program associations and ordering the block definitions. We want to log
+        // when this doesn't happen to troubleshoot
+        // https://github.com/civiform/civiform/issues/8360.
         if (!programDefinition.hasOrderedBlockDefinitions()) {
           logger.warn(
               "Program {} with ID {} does not have ordered block definitions, so we won't set it"

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -161,20 +161,7 @@ public final class ProgramRepository {
         && getFullProgramDefinitionFromCache(programId).isEmpty()) {
       // We should never set the cache for draft programs.
       if (!versionRepository.get().isDraftProgram(programId)) {
-        // Every program definition should have the block definitions ordered, since the cache is
-        // only set
-        // after syncing program associations and ordering the block definitions. We want to log
-        // when this doesn't happen to troubleshoot
-        // https://github.com/civiform/civiform/issues/8360.
-        if (!programDefinition.hasOrderedBlockDefinitions()) {
-          logger.warn(
-              "Program {} with ID {} does not have ordered block definitions, so we won't set it"
-                  + " into the cache.",
-              programDefinition.slug(),
-              programDefinition.id());
-        } else {
-          programDefCache.set(String.valueOf(programId), programDefinition);
-        }
+        programDefCache.set(String.valueOf(programId), programDefinition);
       }
     }
   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -295,12 +295,12 @@ public final class ProgramService {
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(
-            programRepository.getShallowProgramDefinition(program), maxVersionForProgram).thenApply(ProgramDefinition::orderBlockDefinitions);
+                programRepository.getShallowProgramDefinition(program), maxVersionForProgram)
+            .thenApply(ProgramDefinition::orderBlockDefinitions);
 
     // It is safe to set the program definition cache, since we have already checked that it is
     // not a draft program.
-    programRepository.setFullProgramDefinitionCache(
-        program.id, programDefinition);
+    programRepository.setFullProgramDefinitionCache(program.id, programDefinition);
 
     return CompletableFuture.completedStage(programDefinition);
   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -295,7 +295,8 @@ public final class ProgramService {
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(
-                programRepository.getShallowProgramDefinition(program), maxVersionForProgram).orderBlockDefinitions();
+                programRepository.getShallowProgramDefinition(program), maxVersionForProgram)
+            .orderBlockDefinitions();
 
     // It is safe to set the program definition cache, since we have already checked that it is
     // not a draft program.

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -295,8 +295,7 @@ public final class ProgramService {
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(
-                programRepository.getShallowProgramDefinition(program), maxVersionForProgram)
-            .thenApply(ProgramDefinition::orderBlockDefinitions);
+                programRepository.getShallowProgramDefinition(program), maxVersionForProgram).orderBlockDefinitions();
 
     // It is safe to set the program definition cache, since we have already checked that it is
     // not a draft program.

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -295,14 +295,14 @@ public final class ProgramService {
 
     ProgramDefinition programDefinition =
         syncProgramDefinitionQuestions(
-            programRepository.getShallowProgramDefinition(program), maxVersionForProgram);
+            programRepository.getShallowProgramDefinition(program), maxVersionForProgram).thenApply(ProgramDefinition::orderBlockDefinitions);
 
     // It is safe to set the program definition cache, since we have already checked that it is
     // not a draft program.
     programRepository.setFullProgramDefinitionCache(
-        program.id, programDefinition.orderBlockDefinitions());
+        program.id, programDefinition);
 
-    return CompletableFuture.completedStage(programDefinition.orderBlockDefinitions());
+    return CompletableFuture.completedStage(programDefinition);
   }
 
   /**


### PR DESCRIPTION
### Description

It seems that there is a race condition where the cache is getting set when not all questions are added to the full program definition in certain cases. I've made the call async to see if that fixes the issue. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8360
