### PR TITLE
Add list method for answering multi-file upload questions

### DIFF
--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -331,9 +331,9 @@ public interface QuestionJsonSampler<Q extends Question> {
         boolean multipleFileUploadEnabled) {
       if (multipleFileUploadEnabled) {
         QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-            applicantData, applicantQuestion.getContextualizedPath(), 0, "my-file-key-1");
-        QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-            applicantData, applicantQuestion.getContextualizedPath(), 1, "my-file-key-2");
+            applicantData,
+            applicantQuestion.getContextualizedPath(),
+            ImmutableList.of("my-file-key-1", "my-file-key-2"));
       } else {
         QuestionAnswerer.answerFileQuestion(
             applicantData, applicantQuestion.getContextualizedPath(), "my-file-key");

--- a/server/app/services/question/QuestionAnswerer.java
+++ b/server/app/services/question/QuestionAnswerer.java
@@ -77,6 +77,15 @@ public final class QuestionAnswerer {
         contextualizedPath.join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX).atIndex(index), fileKey);
   }
 
+  public static void answerFileQuestionWithMultipleUpload(
+      ApplicantData applicantData, Path contextualizedPath, ImmutableList<String> fileKeys) {
+    for (int i = 0; i < fileKeys.size(); i++) {
+      applicantData.putString(
+          contextualizedPath.join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX).atIndex(i),
+          fileKeys.get(i));
+    }
+  }
+
   public static void answerMultiSelectQuestion(
       ApplicantData applicantData, Path contextualizedPath, int index, long value) {
     applicantData.putLong(

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -2559,26 +2559,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 .fileUploadApplicantFile()
                 .getQuestionDefinition()
                 .getQuestionPathSegment()),
-        0,
-        "file-key-1");
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicant.getApplicantData(),
-        ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank()
-                .fileUploadApplicantFile()
-                .getQuestionDefinition()
-                .getQuestionPathSegment()),
-        1,
-        "key-to-remove");
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicant.getApplicantData(),
-        ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank()
-                .fileUploadApplicantFile()
-                .getQuestionDefinition()
-                .getQuestionPathSegment()),
-        2,
-        "file-key-2");
+        ImmutableList.of("file-key-1", "key-to-remove", "file-key-2"));
+
     applicant.save();
 
     RequestBuilder request =
@@ -2624,8 +2606,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 .fileUploadApplicantFile()
                 .getQuestionDefinition()
                 .getQuestionPathSegment()),
-        1,
-        "key-to-remove");
+        ImmutableList.of("key-to-remove"));
     applicant.save();
 
     RequestBuilder request =
@@ -2669,17 +2650,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                 .fileUploadApplicantFile()
                 .getQuestionDefinition()
                 .getQuestionPathSegment()),
-        0,
-        "file-key-1");
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicant.getApplicantData(),
-        ApplicantData.APPLICANT_PATH.join(
-            testQuestionBank()
-                .fileUploadApplicantFile()
-                .getQuestionDefinition()
-                .getQuestionPathSegment()),
-        2,
-        "file-key-2");
+        ImmutableList.of("file-key-1", "file-key-2"));
 
     applicant.save();
 

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -124,14 +124,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicantData,
         ApplicantData.APPLICANT_PATH.join(fileQuestionDefinition.getQuestionPathSegment()),
-        0,
-        "file-key");
-
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantData,
-        ApplicantData.APPLICANT_PATH.join(fileQuestionDefinition.getQuestionPathSegment()),
-        1,
-        "file-key-2");
+        ImmutableList.of("file-key", "file-key-2"));
 
     ReadOnlyApplicantProgramService service =
         new ReadOnlyApplicantProgramServiceImpl(
@@ -160,14 +153,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicantData,
         ApplicantData.APPLICANT_PATH.join(fileQuestionDefinition.getQuestionPathSegment()),
-        0,
-        "file-key");
-
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantData,
-        ApplicantData.APPLICANT_PATH.join(fileQuestionDefinition.getQuestionPathSegment()),
-        1,
-        "file-key-2");
+        ImmutableList.of("file-key", "file-key-2"));
 
     ReadOnlyApplicantProgramService service =
         new ReadOnlyApplicantProgramServiceImpl(
@@ -1275,14 +1261,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends ResetPostgres {
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
         applicantData,
         ApplicantData.APPLICANT_PATH.join(fileUploadQuestionDefinition.getQuestionPathSegment()),
-        0,
-        "file-key-1");
-
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantData,
-        ApplicantData.APPLICANT_PATH.join(fileUploadQuestionDefinition.getQuestionPathSegment()),
-        1,
-        "file-key-2");
+        ImmutableList.of("file-key-1", "file-key-2"));
 
     // Test the summary data
     ReadOnlyApplicantProgramService subject =

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -2,6 +2,7 @@ package services.applicant.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -156,7 +157,7 @@ public class FileUploadQuestionTest extends ResetPostgres {
     assertThat(fileUploadQuestion.canUploadFile()).isTrue();
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantData, applicantQuestion.getContextualizedPath(), 0, "filekey1");
+        applicantData, applicantQuestion.getContextualizedPath(), ImmutableList.of("filekey1"));
 
     assertThat(fileUploadQuestion.canUploadFile()).isTrue();
   }

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -968,12 +968,12 @@ public abstract class AbstractExporterTest extends ResetPostgres {
     }
 
     FakeApplicationFiller answerFileQuestionWithMultipleUpload(
-        QuestionModel question, String fileKey, int index) {
-      return answerFileQuestionWithMultipleUpload(question, null, fileKey, index);
+        QuestionModel question, ImmutableList<String> fileKeys) {
+      return answerFileQuestionWithMultipleUpload(question, null, fileKeys);
     }
 
     FakeApplicationFiller answerFileQuestionWithMultipleUpload(
-        QuestionModel question, String repeatedEntityName, String fileKey, int index) {
+        QuestionModel question, String repeatedEntityName, ImmutableList<String> fileKeys) {
       var repeatedEntity =
           Optional.ofNullable(repeatedEntityName).flatMap(name -> getHouseholdMemberEntity(name));
       Path answerPath =
@@ -982,7 +982,7 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
 
       QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-          applicant.getApplicantData(), answerPath, index, fileKey);
+          applicant.getApplicantData(), answerPath, fileKeys);
       applicant.save();
       return this;
     }

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -906,9 +906,8 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
             .build();
     FakeApplicationFiller.newFillerFor(fakeProgram)
         .answerFileQuestionWithMultipleUpload(
-            testQuestionBank.fileUploadApplicantFile(), "test-file-key-1", 0)
-        .answerFileQuestionWithMultipleUpload(
-            testQuestionBank.fileUploadApplicantFile(), "test-file-key-2", 1)
+            testQuestionBank.fileUploadApplicantFile(),
+            ImmutableList.of("test-file-key-1", "test-file-key-2"))
         .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);
@@ -974,13 +973,7 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
         .answerFileQuestionWithMultipleUpload(
             testQuestionBank.fileUploadRepeatedHouseholdMemberFile(),
             "taylor",
-            "test-file-key-1",
-            0)
-        .answerFileQuestionWithMultipleUpload(
-            testQuestionBank.fileUploadRepeatedHouseholdMemberFile(),
-            "taylor",
-            "test-file-key-2",
-            1)
+            ImmutableList.of("test-file-key-1", "test-file-key-2"))
         .submit();
 
     JsonExporterService exporter = instanceOf(JsonExporterService.class);

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -3,6 +3,7 @@ package services.export;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.pdf.PdfArray;
 import com.itextpdf.text.pdf.PdfDictionary;
@@ -137,9 +138,9 @@ public class PdfExporterTest extends AbstractExporterTest {
             .getContextualizedPath(Optional.empty(), ApplicantData.APPLICANT_PATH);
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantFive.getApplicantData(), answerPath, 0, "my-file-key-1");
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantFive.getApplicantData(), answerPath, 0, "my-file-key-2");
+        applicantFive.getApplicantData(),
+        answerPath,
+        ImmutableList.of("my-file-key-1", "my-file-key-2"));
 
     applicantFive.save();
     applicationFive.setApplicantData(applicantFive.getApplicantData());
@@ -242,9 +243,9 @@ public class PdfExporterTest extends AbstractExporterTest {
             .getContextualizedPath(Optional.empty(), ApplicantData.APPLICANT_PATH);
 
     QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantFive.getApplicantData(), answerPath, 0, "my-file-key-1");
-    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
-        applicantFive.getApplicantData(), answerPath, 0, "my-file-key-2");
+        applicantFive.getApplicantData(),
+        answerPath,
+        ImmutableList.of("my-file-key-1", "my-file-key-2"));
 
     applicantFive.save();
     applicationFive.setApplicantData(applicantFive.getApplicantData());


### PR DESCRIPTION
### Description

Following up from previous PR. Adding option to answer file uploads with a list, instead of index by index. 

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
