### PR TITLE
Refactor AccountRepository.updateSerializedIdTokens

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -165,7 +165,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
               account -> {
                 accountRepositoryProvider
                     .get()
-                    .updateSerializedIdTokens(account, sessionId, oidcProfile);
+                    .updateSerializedIdTokens(account, sessionId, oidcProfile.getIdTokenString());
               })
           .join();
     }

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import models.AccountModel;
 import models.ApplicantModel;
 import models.TrustedIntermediaryGroupModel;
-import org.pac4j.oidc.profile.OidcProfile;
 import services.CiviFormError;
 import services.applicant.ApplicantData;
 import services.program.ProgramDefinition;
@@ -486,8 +485,7 @@ public final class AccountRepository {
    *
    * <p>Also purges any expired ID tokens as a side effect.
    */
-  public void updateSerializedIdTokens(
-      AccountModel account, String sessionId, OidcProfile oidcProfile) {
+  public void updateSerializedIdTokens(AccountModel account, String sessionId, String idToken) {
     SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
     if (serializedIdTokens == null) {
       serializedIdTokens = new SerializedIdTokens();
@@ -495,7 +493,7 @@ public final class AccountRepository {
     }
     IdTokens idTokens = idTokensFactory.create(serializedIdTokens);
     idTokens.purgeExpiredIdTokens();
-    idTokens.storeIdToken(sessionId, oidcProfile.getIdTokenString());
+    idTokens.storeIdToken(sessionId, idToken);
     account.save();
   }
 }

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -21,7 +21,6 @@ import models.LifecycleStage;
 import models.TrustedIntermediaryGroupModel;
 import org.junit.Before;
 import org.junit.Test;
-import org.pac4j.oidc.profile.OidcProfile;
 import services.CiviFormError;
 import services.WellKnownPaths;
 import services.applicant.ApplicantData;
@@ -418,18 +417,14 @@ public class AccountRepositoryTest extends ResetPostgres {
     LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
     Instant timeInPast = now.minus(1, ChronoUnit.SECONDS).toInstant(ZoneOffset.UTC);
     JWT expiredJwt = getJwtWithExpirationTime(timeInPast);
-    OidcProfile expiredOidcProfile = new OidcProfile();
-    expiredOidcProfile.setIdTokenString(expiredJwt.serialize());
 
-    repo.updateSerializedIdTokens(account, "sessionId1", expiredOidcProfile);
+    repo.updateSerializedIdTokens(account, "sessionId1", expiredJwt.serialize());
 
     // Create a JWT that won't expire for an hour.
     Instant timeInFuture = now.plus(1, ChronoUnit.HOURS).toInstant(ZoneOffset.UTC);
     JWT validJwt = getJwtWithExpirationTime(timeInFuture);
-    OidcProfile validOidcProfile = new OidcProfile();
-    validOidcProfile.setIdTokenString(validJwt.serialize());
 
-    repo.updateSerializedIdTokens(account, "sessionId2", validOidcProfile);
+    repo.updateSerializedIdTokens(account, "sessionId2", validJwt.serialize());
 
     Optional<AccountModel> retrievedAccount = repo.lookupAccount(accountId);
     assertThat(retrievedAccount).isNotEmpty();


### PR DESCRIPTION
### Description

Refactor AccountRepository.updateSerializedIdTokens to take the idToken rather than the whole OidcProfile that it doesn't need. This makes the code easier to read and simplifies the test a bit.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
