### PR TITLE
Adding Operator property to LeafAddressServiceArea

### DIFF
--- a/server/app/durablejobs/DurableJobName.java
+++ b/server/app/durablejobs/DurableJobName.java
@@ -14,6 +14,7 @@ public enum DurableJobName {
   UNUSED_ACCOUNT_CLEANUP("UNUSED_ACCOUNT_CLEANUP"),
   UNUSED_PROGRAM_IMAGES_CLEANUP("UNUSED_PROGRAM_IMAGES_CLEANUP"),
   MIGRATE_PRIMARY_APPLICANT_INFO("MIGRATE_PRIMARY_APPLICANT_INFO"),
+  ADD_OPERATOR_TO_LEAF_ADDRESS_SERVICE_AREA("ADD_OPERATOR_TO_LEAF_ADDRESS_SERVICE_AREA"),
 
   // Jobs below this line are deprecated, but must be kept around so that durableJobRegistry.get
   // does not throw an IllegalArgumentException error

--- a/server/app/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJob.java
+++ b/server/app/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJob.java
@@ -1,0 +1,141 @@
+package durablejobs.jobs;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import durablejobs.DurableJob;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.SqlRow;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
+import java.util.List;
+import java.util.Objects;
+import models.PersistedDurableJobModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import services.program.predicate.Operator;
+
+public final class AddOperatorToLeafAddressServiceAreaJob extends DurableJob {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AddOperatorToLeafAddressServiceAreaJob.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final Database database;
+  private final PersistedDurableJobModel persistedDurableJobModel;
+
+  public AddOperatorToLeafAddressServiceAreaJob(PersistedDurableJobModel persistedDurableJobModel) {
+    this.persistedDurableJobModel = checkNotNull(persistedDurableJobModel);
+    this.database = DB.getDefault();
+  }
+
+  @Override
+  public PersistedDurableJobModel getPersistedDurableJob() {
+    return persistedDurableJobModel;
+  }
+
+  @Override
+  public void run() {
+    LOGGER.debug("Run - Begin");
+
+    String selectSql =
+        """
+SELECT id, block_definitions
+FROM programs
+WHERE jsonb_path_exists(block_definitions, '$.hidePredicate.rootNode.**.node ? (@.type == "leafAddressServiceArea")')
+OR jsonb_path_exists(block_definitions, '$.eligibilityDefinition.predicate.rootNode.**.node ? (@.type == "leafAddressServiceArea")')
+""";
+
+    List<SqlRow> programs = database.sqlQuery(selectSql).findList();
+
+    try (Transaction jobTransaction = database.beginTransaction()) {
+      jobTransaction.setNestedUseSavepoint();
+      int errorCount = 0;
+
+      for (SqlRow program : programs) {
+        LOGGER.debug("id: {}", program.getLong("id"));
+
+        try {
+          JsonNode rootJsonNode = objectMapper.readTree(program.getString("block_definitions"));
+          int startingRootJsonNodeHashCode = rootJsonNode.hashCode();
+
+          if (!rootJsonNode.isArray()) {
+            LOGGER.error("block_definitions is not an array");
+            continue;
+          }
+
+          for (var blockDefinitionJsonNode : rootJsonNode) {
+            JsonNode nodeJsonNode =
+                blockDefinitionJsonNode.at("/eligibilityDefinition/predicate/rootNode/node");
+            if (!nodeJsonNode.isMissingNode()) {
+              addOperatorToLeafAddressServiceAreaNode(nodeJsonNode);
+            }
+          }
+
+          for (var blockDefinitionJsonNode : rootJsonNode) {
+            JsonNode nodeJsonNode = blockDefinitionJsonNode.at("/hidePredicate/rootNode/node");
+            if (!nodeJsonNode.isMissingNode()) {
+              addOperatorToLeafAddressServiceAreaNode(nodeJsonNode);
+            }
+          }
+
+          if (startingRootJsonNodeHashCode == rootJsonNode.hashCode()) {
+            LOGGER.debug("No changes made to JsonNode. No need to update the database.");
+            continue;
+          }
+
+          String updateSql =
+              """
+              update programs
+              set block_definitions = CAST(:block_definitions AS jsonb)
+              where id = :id
+              """;
+
+          try (Transaction stepTransaction = database.beginTransaction(TxScope.mandatory())) {
+            database
+                .sqlUpdate(updateSql)
+                .setParameter("id", program.getLong("id"))
+                .setParameter("block_definitions", rootJsonNode.toString())
+                .execute();
+
+            stepTransaction.commit();
+            LOGGER.debug("JsonNode change. Updated database.");
+          }
+        } catch (Exception e) {
+          LOGGER.error(e.getMessage(), e);
+          errorCount++;
+        }
+      }
+
+      if (errorCount == 0) {
+        LOGGER.debug("Job succeeded.");
+        jobTransaction.commit();
+      } else {
+        LOGGER.error("Job failed to add operator. All changes undone. Error count: {}", errorCount);
+        jobTransaction.rollback();
+      }
+    }
+
+    LOGGER.debug("Run - End");
+  }
+
+  public void addOperatorToLeafAddressServiceAreaNode(JsonNode nodeJsonNode) {
+    if (!nodeJsonNode.isObject()) {
+      return;
+    }
+
+    if (nodeJsonNode.has("children") && nodeJsonNode.get("children").isArray()) {
+      for (JsonNode childNodeJsonNode : nodeJsonNode.get("children")) {
+        if (childNodeJsonNode.has("node")) {
+          addOperatorToLeafAddressServiceAreaNode(childNodeJsonNode.get("node"));
+        }
+      }
+    } else if (nodeJsonNode.has("type")
+        && Objects.equals(nodeJsonNode.get("type").textValue(), "leafAddressServiceArea")
+        && !nodeJsonNode.has("operator")) {
+      ((ObjectNode) nodeJsonNode).put("operator", Operator.IN_SERVICE_AREA.name());
+    }
+  }
+}

--- a/server/app/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJob.java
+++ b/server/app/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJob.java
@@ -18,6 +18,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import services.program.predicate.Operator;
 
+/**
+ * This job searches for {@link services.program.predicate.LeafAddressServiceAreaExpressionNode}s
+ * found in the programs.block_definitions columns of the database. When it finds one it adds a new
+ * property named `operator` with a default value of {@link Operator#IN_SERVICE_AREA}. Casing stored
+ * matches the casing stored on other nodes with `operator` properties.
+ *
+ * <p>Additional notes:
+ * <li>Nodes may have children so this recursively searches the tree
+ * <li>Both hidePredicate and eligibilityDefinition.predicate are checked
+ * <li>Will not modify nodes that already have this property added
+ * <li>Idempotent
+ * <li>Any failure will rollback the entire changeset
+ */
 public final class AddOperatorToLeafAddressServiceAreaJob extends DurableJob {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AddOperatorToLeafAddressServiceAreaJob.class);

--- a/server/app/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJob.java
+++ b/server/app/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJob.java
@@ -16,6 +16,18 @@ import models.PersistedDurableJobModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This job searches for {@link services.program.predicate.LeafAddressServiceAreaExpressionNode}s
+ * found in the programs.block_definitions columns of the database. When it finds one it removes the
+ * property named `operator`.
+ *
+ * <p>Additional notes:
+ * <li>Nodes may have children so this recursively searches the tree
+ * <li>Both hidePredicate and eligibilityDefinition.predicate are checked
+ * <li>Will not modify nodes that do not have this property
+ * <li>Idempotent
+ * <li>Any failure will rollback the entire changeset
+ */
 public final class RemoveOperatorFromLeafAddressServiceAreaJob extends DurableJob {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(RemoveOperatorFromLeafAddressServiceAreaJob.class);

--- a/server/app/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJob.java
+++ b/server/app/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJob.java
@@ -1,0 +1,155 @@
+package durablejobs.jobs;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import durablejobs.DurableJob;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.SqlRow;
+import io.ebean.Transaction;
+import java.util.List;
+import java.util.Objects;
+import models.PersistedDurableJobModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class RemoveOperatorFromLeafAddressServiceAreaJob extends DurableJob {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(RemoveOperatorFromLeafAddressServiceAreaJob.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final Database database;
+  private final PersistedDurableJobModel persistedDurableJobModel;
+
+  /**
+   * @param persistedDurableJobModel Job model for integrating with the durable job system
+   * @param cerberusSafeguard Guarding the gate making sure this doesn't run by accident
+   */
+  public RemoveOperatorFromLeafAddressServiceAreaJob(
+      PersistedDurableJobModel persistedDurableJobModel, String cerberusSafeguard) {
+    if (!Objects.equals(cerberusSafeguard, "Orpheus's lyre")) {
+      throw new IllegalArgumentException(
+          """
+You attempted to use the RemoveOperatorFromLeafAddressServiceAreaJob. This job is here
+only in case of an emergency so great that we need to rollback the
+companion AddOperatorToLeafAddressServiceAreaJob.
+
+Most likely you should NOT use this job.
+""");
+    }
+
+    this.persistedDurableJobModel = checkNotNull(persistedDurableJobModel);
+    this.database = DB.getDefault();
+  }
+
+  @Override
+  public PersistedDurableJobModel getPersistedDurableJob() {
+    return persistedDurableJobModel;
+  }
+
+  @Override
+  public void run() {
+    LOGGER.debug("Run - Begin");
+
+    String selectSql =
+        """
+SELECT id, block_definitions
+FROM programs
+WHERE jsonb_path_exists(block_definitions, '$.hidePredicate.rootNode.**.node ? (@.type == "leafAddressServiceArea")')
+OR jsonb_path_exists(block_definitions, '$.eligibilityDefinition.predicate.rootNode.**.node ? (@.type == "leafAddressServiceArea")')
+""";
+
+    List<SqlRow> programs = database.sqlQuery(selectSql).findList();
+
+    try (Transaction jobTransaction = database.beginTransaction()) {
+      jobTransaction.setNestedUseSavepoint();
+      int errorCount = 0;
+
+      for (SqlRow program : programs) {
+        LOGGER.debug("id: {}", program.getLong("id"));
+
+        try {
+          JsonNode rootJsonNode = objectMapper.readTree(program.getString("block_definitions"));
+          int startingRootJsonNodeHashCode = rootJsonNode.hashCode();
+
+          if (!rootJsonNode.isArray()) {
+            LOGGER.error("block_definitions is not an array");
+            continue;
+          }
+
+          for (var blockDefinitionJsonNode : rootJsonNode) {
+            JsonNode nodeJsonNode =
+                blockDefinitionJsonNode.at("/eligibilityDefinition/predicate/rootNode/node");
+            if (!nodeJsonNode.isMissingNode()) {
+              removeOperatorFromLeafAddressServiceAreaNode(nodeJsonNode);
+            }
+          }
+
+          for (var blockDefinitionJsonNode : rootJsonNode) {
+            JsonNode nodeJsonNode = blockDefinitionJsonNode.at("/hidePredicate/rootNode/node");
+            if (!nodeJsonNode.isMissingNode()) {
+              removeOperatorFromLeafAddressServiceAreaNode(nodeJsonNode);
+            }
+          }
+
+          if (startingRootJsonNodeHashCode == rootJsonNode.hashCode()) {
+            LOGGER.debug("No changes made to JsonNode. No need to update the database.");
+            continue;
+          }
+
+          String updateSql =
+              """
+              update programs
+              set block_definitions = CAST(:block_definitions AS jsonb)
+              where id = :id
+              """;
+
+          try (Transaction stepTransaction = database.beginTransaction()) {
+            database
+                .sqlUpdate(updateSql)
+                .setParameter("id", program.getLong("id"))
+                .setParameter("block_definitions", rootJsonNode.toString())
+                .execute();
+
+            stepTransaction.commit();
+            LOGGER.debug("JsonNode change. Updated database.");
+          }
+
+        } catch (Exception e) {
+          LOGGER.error(e.getMessage(), e);
+          errorCount++;
+        }
+      }
+      if (errorCount == 0) {
+        LOGGER.debug("Job succeeded.");
+        jobTransaction.commit();
+      } else {
+        LOGGER.error("Job failed to add operator. All changes undone. Error count: {}", errorCount);
+        jobTransaction.rollback();
+      }
+    }
+
+    LOGGER.debug("Run - End");
+  }
+
+  public void removeOperatorFromLeafAddressServiceAreaNode(JsonNode nodeJsonNode) {
+    if (!nodeJsonNode.isObject()) {
+      return;
+    }
+
+    if (nodeJsonNode.has("children") && nodeJsonNode.get("children").isArray()) {
+      for (JsonNode childNodeJsonNode : nodeJsonNode.get("children")) {
+        if (childNodeJsonNode.has("node")) {
+          removeOperatorFromLeafAddressServiceAreaNode(childNodeJsonNode.get("node"));
+        }
+      }
+    } else if (nodeJsonNode.has("type")
+        && Objects.equals(nodeJsonNode.get("type").textValue(), "leafAddressServiceArea")
+        && nodeJsonNode.has("operator")) {
+      ((ObjectNode) nodeJsonNode).remove("operator");
+    }
+  }
+}

--- a/server/app/modules/DurableJobModule.java
+++ b/server/app/modules/DurableJobModule.java
@@ -17,6 +17,7 @@ import durablejobs.RecurringJobExecutionTimeResolvers;
 import durablejobs.RecurringJobScheduler;
 import durablejobs.StartupDurableJobRunner;
 import durablejobs.StartupJobScheduler;
+import durablejobs.jobs.AddOperatorToLeafAddressServiceAreaJob;
 import durablejobs.jobs.MigratePrimaryApplicantInfoJob;
 import durablejobs.jobs.OldJobCleanupJob;
 import durablejobs.jobs.ReportingDashboardMonthlyRefreshJob;
@@ -162,19 +163,13 @@ public final class DurableJobModule extends AbstractModule {
   @Provides
   @StartupJobsProviderName
   public DurableJobRegistry provideStartupDurableJobRegistry() {
-    //  PersistedDurableJobRepository persistedDurableJobRepository) {
-    //    var durableJobRegistry = new DurableJobRegistry();
+    var durableJobRegistry = new DurableJobRegistry();
 
-    //    // Sample job. DELETE THIS when adding first real job
-    //
-    //    durableJobRegistry.registerStartupJob(
-    //        DurableJobName.SOME_JOB_NAME,
-    //        JobType.RUN_ONCE,
-    //        persistedDurableJob ->
-    //            new SomeClassThatIsAJob(persistedDurableJob));
+    durableJobRegistry.registerStartupJob(
+        DurableJobName.ADD_OPERATOR_TO_LEAF_ADDRESS_SERVICE_AREA,
+        JobType.RUN_ONCE,
+        persistedDurableJob -> new AddOperatorToLeafAddressServiceAreaJob(persistedDurableJob));
 
-    //    return durableJobRegistry;
-
-    return new DurableJobRegistry();
+    return durableJobRegistry;
   }
 }

--- a/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
+++ b/server/app/services/program/predicate/LeafAddressServiceAreaExpressionNode.java
@@ -19,8 +19,13 @@ public abstract class LeafAddressServiceAreaExpressionNode implements LeafExpres
   @JsonCreator
   public static LeafAddressServiceAreaExpressionNode create(
       @JsonProperty("questionId") long questionId,
-      @JsonProperty("serviceAreaId") String serviceAreaId) {
-    return builder().setQuestionId(questionId).setServiceAreaId(serviceAreaId).build();
+      @JsonProperty("serviceAreaId") String serviceAreaId,
+      @JsonProperty("operator") Operator operator) {
+    return builder()
+        .setQuestionId(questionId)
+        .setServiceAreaId(serviceAreaId)
+        .setOperator(operator)
+        .build();
   }
 
   /** The ID of the address {@link services.question.types.QuestionDefinition} this node checks. */
@@ -31,6 +36,10 @@ public abstract class LeafAddressServiceAreaExpressionNode implements LeafExpres
   /** The string ID of the service area the address should be checked for inclusion in. */
   @JsonProperty("serviceAreaId")
   public abstract String serviceAreaId();
+
+  /** The operator for this expression. */
+  @JsonProperty("operator")
+  public abstract Operator operator();
 
   @Override
   @JsonIgnore
@@ -59,7 +68,9 @@ public abstract class LeafAddressServiceAreaExpressionNode implements LeafExpres
             .map(addressName -> String.format("\"%s\"", addressName))
             .orElse("address");
 
-    return String.format("%s is in service area \"%s\"", addressLabel, serviceAreaId());
+    String operator = operator().toDisplayString();
+
+    return String.format("%s is %s \"%s\"", addressLabel, operator, serviceAreaId());
   }
 
   public static Builder builder() {
@@ -74,6 +85,8 @@ public abstract class LeafAddressServiceAreaExpressionNode implements LeafExpres
     public abstract Builder setQuestionId(long questionId);
 
     public abstract Builder setServiceAreaId(String serviceAreaId);
+
+    public abstract Builder setOperator(Operator operator);
 
     public abstract LeafAddressServiceAreaExpressionNode build();
   }

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -214,10 +214,8 @@ public final class PredicateGenerator {
 
       LeafExpressionNode leafNode =
           scalar.equals(Scalar.SERVICE_AREA)
-              ? LeafAddressServiceAreaExpressionNode.builder()
-                  .setQuestionId(questionId)
-                  .setServiceAreaId(predicateValue.value())
-                  .build()
+              ? LeafAddressServiceAreaExpressionNode.create(
+                  questionId, predicateValue.value(), operator)
               : LeafOperationExpressionNode.builder()
                   .setQuestionId(questionId)
                   .setScalar(scalar)

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -593,8 +593,12 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
     Optional<Operator> maybeSelectedOperator;
 
     if (questionDefinition.isAddress()) {
+      Optional<LeafAddressServiceAreaExpressionNode> maybeLeafAddressServiceAreaExpressionNode =
+          assertLeafAddressServiceAreaNode(maybeLeafNode);
       maybeSelectedScalar = Optional.of(Scalar.SERVICE_AREA);
-      maybeSelectedOperator = Optional.of(Operator.IN_SERVICE_AREA);
+      maybeSelectedOperator =
+          maybeLeafAddressServiceAreaExpressionNode.map(
+              LeafAddressServiceAreaExpressionNode::operator);
     } else {
       try {
         ImmutableSet<Scalar> scalars = Scalar.getScalars(questionDefinition.getQuestionType());

--- a/server/test/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJobTest.java
+++ b/server/test/durablejobs/jobs/AddOperatorToLeafAddressServiceAreaJobTest.java
@@ -1,0 +1,1004 @@
+package durablejobs.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.SqlRow;
+import io.ebean.Transaction;
+import io.ebean.annotation.TxIsolation;
+import java.time.Instant;
+import models.JobType;
+import models.PersistedDurableJobModel;
+import models.ProgramModel;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.program.ProgramBlockDefinitionNotFoundException;
+import services.program.predicate.Operator;
+
+public class AddOperatorToLeafAddressServiceAreaJobTest extends ResetPostgres {
+
+  private final Database database = DB.getDefault();
+
+  @Test
+  public void run_verifyEligibilityDefinitionAddsOperatorPropertyToSingleRootLevelAddressNode()
+      throws ProgramBlockDefinitionNotFoundException, JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the addition to the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "operator": "IN_SERVICE_AREA",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model
+    ProgramModel programModel = findProgramModelById(id);
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(1L)
+                .eligibilityDefinition()
+                .isPresent())
+        .isTrue();
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(1L)
+                .eligibilityDefinition()
+                .get()
+                .predicate()
+                .rootNode()
+                .getLeafAddressNode()
+                .operator())
+        .isEqualTo(Operator.IN_SERVICE_AREA);
+  }
+
+  @Test
+  public void run_verifyEligibilityDefinitionAddsOperatorPropertyToNestedAddressNodes()
+      throws ProgramBlockDefinitionNotFoundException, JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              },
+              {
+                "id": 2349,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2511,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2509,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "or",
+                    "children": [
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"4\\", \\"2\\", \\"5\\", \\"3\\", \\"1\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"14\\", \\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "320716800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"16\\", \\"17\\", \\"15\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "1701388800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the addition to the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              },
+              {
+                "id": 2349,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2511,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2509,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "or",
+                    "children": [
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"4\\", \\"2\\", \\"5\\", \\"3\\", \\"1\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"14\\", \\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "320716800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "operator": "IN_SERVICE_AREA",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"16\\", \\"17\\", \\"15\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "operator": "IN_SERVICE_AREA",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "1701388800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model
+    ProgramModel programModel = findProgramModelById(id);
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(1L)
+                .eligibilityDefinition()
+                .isPresent())
+        .isTrue();
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(1L)
+                .eligibilityDefinition()
+                .get()
+                .predicate()
+                .rootNode()
+                .getOrNode()
+                .children()
+                .get(0)
+                .getAndNode()
+                .children()
+                .get(3)
+                .getLeafAddressNode()
+                .operator())
+        .isEqualTo(Operator.IN_SERVICE_AREA);
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(1L)
+                .eligibilityDefinition()
+                .get()
+                .predicate()
+                .rootNode()
+                .getOrNode()
+                .children()
+                .get(1)
+                .getAndNode()
+                .children()
+                .get(1)
+                .getLeafAddressNode()
+                .operator())
+        .isEqualTo(Operator.IN_SERVICE_AREA);
+  }
+
+  @Test
+  public void run_verifyHidePredicateAddsOperatorPropertyToAddressNode()
+      throws ProgramBlockDefinitionNotFoundException, JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": {
+              "action": "HIDE_BLOCK",
+              "rootNode": {
+                "node": {
+                  "type": "leafAddressServiceArea",
+                  "questionId": 2513,
+                  "serviceAreaId": "Seattle"
+                }
+              }
+            },
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          },
+          {
+            "id": 3,
+            "name": "Screen 3",
+            "repeaterId": null,
+            "description": "Screen 3 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2515,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the addition to the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "operator": "IN_SERVICE_AREA",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": {
+              "action": "HIDE_BLOCK",
+              "rootNode": {
+                "node": {
+                  "type": "leafAddressServiceArea",
+                  "operator": "IN_SERVICE_AREA",
+                  "questionId": 2513,
+                  "serviceAreaId": "Seattle"
+                }
+              }
+            },
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          },
+          {
+            "id": 3,
+            "name": "Screen 3",
+            "repeaterId": null,
+            "description": "Screen 3 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2515,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model
+    ProgramModel programModel = findProgramModelById(id);
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(2L)
+                .visibilityPredicate()
+                .isPresent())
+        .isTrue();
+
+    assertThat(
+            programModel
+                .getProgramDefinition()
+                .getBlockDefinition(2L)
+                .visibilityPredicate()
+                .get()
+                .rootNode()
+                .getLeafAddressNode()
+                .operator())
+        .isEqualTo(Operator.IN_SERVICE_AREA);
+  }
+
+  /**
+   * Directly inserts a record into `public.programs` populated with default values and the provided
+   * json for the `block_definitions` column.
+   *
+   * @param blockDefinitions Json string representing the block definition configuration to store
+   * @return the new Id of the inserted record
+   */
+  private Long insertProgram(String blockDefinitions) {
+    String insertSql =
+        """
+        INSERT INTO public.programs
+        (
+          name,
+          description,
+          block_definitions,
+          slug,
+          localized_name,
+          localized_description,
+          external_link,
+          display_mode,
+          create_time,
+          last_modified_time,
+          program_type,
+          eligibility_is_gating,
+          localized_confirmation_message
+        )
+        VALUES
+        (
+          'program-name',
+          '',
+          CAST(:block_definitions AS jsonb),
+          'program-name',
+          CAST('{ "translations": {} }' AS jsonb),
+          CAST('{ "translations": {} }' AS jsonb),
+          '',
+          'PUBLIC',
+          '2024-06-01',
+          '2024-06-01',
+          'default',
+          true,
+          CAST('{ "translations": {} }' AS jsonb)
+        )
+        RETURNING id;
+        """;
+
+    try (Transaction transaction = database.beginTransaction(TxIsolation.SERIALIZABLE)) {
+      SqlRow sqlRow =
+          database
+              .sqlQuery(insertSql)
+              .setParameter("block_definitions", blockDefinitions)
+              .findOne();
+      transaction.commit();
+
+      assertThat(sqlRow).isNotNull();
+
+      Long id = sqlRow.getLong("id");
+      assertThat(id).isGreaterThan(0);
+
+      return id;
+    }
+  }
+
+  /**
+   * Both strings will be serialized to a Jackson JsonNode and compared against their pretty strings
+   * in order to normalize whitespace, formatting, and property ordering.
+   *
+   * @param expected, a json string value
+   * @param actual, a json string value
+   */
+  private void assertJsonStringsAreTheSame(String expected, String actual)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    assertThat(objectMapper.readTree(expected).toPrettyString())
+        .isEqualTo(objectMapper.readTree(actual).toPrettyString());
+  }
+
+  /** Build and run the job */
+  private void runJob() {
+    AddOperatorToLeafAddressServiceAreaJob job =
+        new AddOperatorToLeafAddressServiceAreaJob(
+            new PersistedDurableJobModel("fake-job", JobType.RUN_ONCE, Instant.now()));
+
+    job.run();
+  }
+
+  /** Load block_definitons from the database for the supplied program id */
+  private String findBlockDefinitionsForProgramId(Long id) {
+    String selectSql =
+        """
+        SELECT block_definitions
+        FROM programs
+        WHERE id = :id
+        """;
+
+    SqlRow sqlRow = database.sqlQuery(selectSql).setParameter("id", id).findOne();
+
+    return sqlRow.getString("block_definitions");
+  }
+
+  /** Find the {@link ProgramModel} from the supplied id */
+  private ProgramModel findProgramModelById(Long id) {
+    ProgramModel programModel = database.find(ProgramModel.class).where().idEq(id).findOne();
+
+    assertThat(programModel).isNotNull();
+    assertThat(programModel.id).isEqualTo(id);
+
+    return programModel;
+  }
+}

--- a/server/test/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJobTest.java
+++ b/server/test/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJobTest.java
@@ -813,6 +813,60 @@ public class RemoveOperatorFromLeafAddressServiceAreaJobTest extends ResetPostgr
     // ProgramModel programModel = findProgramModelById(id);
   }
 
+  @Test
+  public void run_verifyExistingOperatorsAreUntouched() throws JsonProcessingException {
+    String blockDefinitions =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitions);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(blockDefinitions, findBlockDefinitionsForProgramId(id));
+  }
+
   /**
    * Directly inserts a record into `public.programs` populated with default values and the provided
    * json for the `block_definitions` column.

--- a/server/test/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJobTest.java
+++ b/server/test/durablejobs/jobs/RemoveOperatorFromLeafAddressServiceAreaJobTest.java
@@ -1,0 +1,926 @@
+package durablejobs.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.SqlRow;
+import io.ebean.Transaction;
+import io.ebean.annotation.TxIsolation;
+import java.time.Instant;
+import models.JobType;
+import models.PersistedDurableJobModel;
+import models.ProgramModel;
+import org.junit.Test;
+import repository.ResetPostgres;
+
+public class RemoveOperatorFromLeafAddressServiceAreaJobTest extends ResetPostgres {
+
+  private final Database database = DB.getDefault();
+
+  @Test
+  public void run_verifyEligibilityDefinitionRemovesOperatorPropertyFromSingleRootLevelAddressNode()
+      throws JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "operator": "IN_SERVICE_AREA",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the removal of the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model
+    // If this job needs to be used uncomment this line to test that you have a working data model
+    // Do no rely solely on the json string assertions
+    // ProgramModel programModel = findProgramModelById(id);
+  }
+
+  @Test
+  public void run_verifyEligibilityDefinitionRemovesOperatorPropertyFromNestedAddressNodes()
+      throws JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              },
+              {
+                "id": 2349,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2511,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2509,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "or",
+                    "children": [
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"4\\", \\"2\\", \\"5\\", \\"3\\", \\"1\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"14\\", \\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "320716800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "operator": "IN_SERVICE_AREA",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"16\\", \\"17\\", \\"15\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "operator": "IN_SERVICE_AREA",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "1701388800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the removal of the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              },
+              {
+                "id": 2349,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2511,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              },
+              {
+                "id": 2509,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "or",
+                    "children": [
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"4\\", \\"2\\", \\"5\\", \\"3\\", \\"1\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"14\\", \\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "320716800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "node": {
+                          "type": "and",
+                          "children": [
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"16\\", \\"17\\", \\"15\\"]"
+                                },
+                                "scalar": "SELECTION",
+                                "operator": "IN",
+                                "questionId": 2349
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leafAddressServiceArea",
+                                "questionId": 2513,
+                                "serviceAreaId": "Seattle"
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "LIST_OF_STRINGS",
+                                  "value": "[\\"12\\", \\"15\\", \\"13\\"]"
+                                },
+                                "scalar": "SELECTIONS",
+                                "operator": "ANY_OF",
+                                "questionId": 2509
+                              }
+                            },
+                            {
+                              "node": {
+                                "type": "leaf",
+                                "value": {
+                                  "type": "DATE",
+                                  "value": "1701388800000"
+                                },
+                                "scalar": "DATE",
+                                "operator": "IS_AFTER",
+                                "questionId": 2511
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model.
+    // If this job needs to be used uncomment this line to test that you have a working data model
+    // Do no rely solely on the json string assertions.
+    // ProgramModel programModel = findProgramModelById(id);
+  }
+
+  @Test
+  public void run_verifyHidePredicateRemovesOperatorPropertyFromAddressNode()
+      throws JsonProcessingException {
+    String blockDefinitionsBeforeJob =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "operator": "IN_SERVICE_AREA",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": {
+              "action": "HIDE_BLOCK",
+              "rootNode": {
+                "node": {
+                  "type": "leafAddressServiceArea",
+                  "operator": "IN_SERVICE_AREA",
+                  "questionId": 2513,
+                  "serviceAreaId": "Seattle"
+                }
+              }
+            },
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          },
+          {
+            "id": 3,
+            "name": "Screen 3",
+            "repeaterId": null,
+            "description": "Screen 3 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2515,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    // The only difference in this string is the removal of the "operator" property on
+    // leafAddressServiceArea node(s).
+    String expectedBlockDefinitionsAfterUpdate =
+        """
+        [
+          {
+            "id": 1,
+            "name": "Screen 1",
+            "repeaterId": null,
+            "description": "Screen 1 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2513,
+                "optional": false,
+                "addressCorrectionEnabled": true
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 1 description"
+              }
+            },
+            "eligibilityDefinition": {
+              "predicate": {
+                "action": "ELIGIBLE_BLOCK",
+                "rootNode": {
+                  "node": {
+                    "type": "leafAddressServiceArea",
+                    "questionId": 2513,
+                    "serviceAreaId": "Seattle"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "Screen 2",
+            "repeaterId": null,
+            "description": "Screen 2 description",
+            "hidePredicate": {
+              "action": "HIDE_BLOCK",
+              "rootNode": {
+                "node": {
+                  "type": "leafAddressServiceArea",
+                  "questionId": 2513,
+                  "serviceAreaId": "Seattle"
+                }
+              }
+            },
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2514,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 2 description"
+              }
+            }
+          },
+          {
+            "id": 3,
+            "name": "Screen 3",
+            "repeaterId": null,
+            "description": "Screen 3 description",
+            "hidePredicate": null,
+            "localizedName": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3"
+              }
+            },
+            "optionalPredicate": null,
+            "questionDefinitions": [
+              {
+                "id": 2515,
+                "optional": false,
+                "addressCorrectionEnabled": false
+              }
+            ],
+            "localizedDescription": {
+              "isRequired": true,
+              "translations": {
+                "en_US": "Screen 3 description"
+              }
+            }
+          }
+        ]
+        """;
+
+    Long id = insertProgram(blockDefinitionsBeforeJob);
+
+    runJob();
+
+    assertJsonStringsAreTheSame(
+        expectedBlockDefinitionsAfterUpdate, findBlockDefinitionsForProgramId(id));
+
+    // Load the program and verify the changes work in the context of the pojo data model.
+    // If this job needs to be used uncomment this line to test that you have a working data model
+    // Do no rely solely on the json string assertions.
+    // ProgramModel programModel = findProgramModelById(id);
+  }
+
+  /**
+   * Directly inserts a record into `public.programs` populated with default values and the provided
+   * json for the `block_definitions` column.
+   *
+   * @param blockDefinitions Json string representing the block definition configuration to store
+   * @return the new Id of the inserted record
+   */
+  private Long insertProgram(String blockDefinitions) {
+    String insertSql =
+        """
+        INSERT INTO public.programs
+        (
+          name,
+          description,
+          block_definitions,
+          slug,
+          localized_name,
+          localized_description,
+          external_link,
+          display_mode,
+          create_time,
+          last_modified_time,
+          program_type,
+          eligibility_is_gating,
+          localized_confirmation_message
+        )
+        VALUES
+        (
+          'program-name',
+          '',
+          CAST(:block_definitions AS jsonb),
+          'program-name',
+          CAST('{ "translations": {} }' AS jsonb),
+          CAST('{ "translations": {} }' AS jsonb),
+          '',
+          'PUBLIC',
+          '2024-06-01',
+          '2024-06-01',
+          'default',
+          true,
+          CAST('{ "translations": {} }' AS jsonb)
+        )
+        RETURNING id;
+        """;
+
+    try (Transaction transaction = database.beginTransaction(TxIsolation.SERIALIZABLE)) {
+      SqlRow sqlRow =
+          database
+              .sqlQuery(insertSql)
+              .setParameter("block_definitions", blockDefinitions)
+              .findOne();
+      transaction.commit();
+
+      assertThat(sqlRow).isNotNull();
+
+      Long id = sqlRow.getLong("id");
+      assertThat(id).isGreaterThan(0);
+
+      return id;
+    }
+  }
+
+  /**
+   * Both strings will be serialized to a Jackson JsonNode and compared against their pretty strings
+   * in order to normalize whitespace, formatting, and property ordering.
+   *
+   * @param expected, a json string value
+   * @param actual, a json string value
+   */
+  private void assertJsonStringsAreTheSame(String expected, String actual)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    assertThat(objectMapper.readTree(expected).toPrettyString())
+        .isEqualTo(objectMapper.readTree(actual).toPrettyString());
+  }
+
+  /** Build and run the job */
+  private void runJob() {
+    RemoveOperatorFromLeafAddressServiceAreaJob job =
+        new RemoveOperatorFromLeafAddressServiceAreaJob(
+            new PersistedDurableJobModel("fake-job", JobType.RUN_ONCE, Instant.now()),
+            "Orpheus's lyre");
+
+    job.run();
+  }
+
+  /** Load block_definitons from the database for the supplied program id */
+  private String findBlockDefinitionsForProgramId(Long id) {
+    String selectSql =
+        """
+        SELECT block_definitions
+        FROM programs
+        WHERE id = :id
+        """;
+
+    SqlRow sqlRow = database.sqlQuery(selectSql).setParameter("id", id).findOne();
+
+    return sqlRow.getString("block_definitions");
+  }
+
+  /** Find the {@link ProgramModel} from the supplied id */
+  private ProgramModel findProgramModelById(Long id) {
+    ProgramModel programModel = database.find(ProgramModel.class).where().idEq(id).findOne();
+
+    assertThat(programModel).isNotNull();
+    assertThat(programModel.id).isEqualTo(id);
+
+    return programModel;
+  }
+}

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -674,7 +674,8 @@ public class VersionRepositoryTest extends ResetPostgres {
             LeafOperationExpressionNode.create(
                 oldTwo.id, Scalar.TEXT, Operator.EQUAL_TO, PredicateValue.of("")));
     PredicateExpressionNode leafAddress =
-        PredicateExpressionNode.create(LeafAddressServiceAreaExpressionNode.create(oldOne.id, ""));
+        PredicateExpressionNode.create(
+            LeafAddressServiceAreaExpressionNode.create(oldOne.id, "", Operator.IN_SERVICE_AREA));
     PredicateExpressionNode or =
         PredicateExpressionNode.create(OrNode.create(ImmutableList.of(leafTwo, leafAddress)));
     PredicateExpressionNode and =

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -1581,7 +1581,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
@@ -1637,7 +1637,7 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -1585,7 +1585,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =
@@ -1641,7 +1641,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     ProgramDefinition programDefinition =

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -18,6 +18,7 @@ import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.predicate.LeafAddressServiceAreaExpressionNode;
+import services.program.predicate.Operator;
 import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
@@ -864,7 +865,7 @@ public class BlockTest {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     BlockDefinition blockDefinition =

--- a/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
+++ b/server/test/services/applicant/ServiceAreaUpdateResolverTest.java
@@ -18,6 +18,7 @@ import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.predicate.LeafAddressServiceAreaExpressionNode;
+import services.program.predicate.Operator;
 import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
@@ -53,7 +54,7 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Seattle")),
+                            addressQuestion.getId(), "Seattle", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     blockDefinition =
@@ -142,7 +143,7 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Moon")),
+                            addressQuestion.getId(), "Moon", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     BlockDefinition blockDefinition =
@@ -190,7 +191,7 @@ public class ServiceAreaUpdateResolverTest extends ResetPostgres {
                 PredicateDefinition.create(
                     PredicateExpressionNode.create(
                         LeafAddressServiceAreaExpressionNode.create(
-                            addressQuestion.getId(), "Moon")),
+                            addressQuestion.getId(), "Moon", Operator.IN_SERVICE_AREA)),
                     PredicateAction.ELIGIBLE_BLOCK))
             .build();
     BlockDefinition blockDefinition =

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -519,27 +519,32 @@ public class JsonPathPredicateGeneratorTest {
 
     JsonPathPredicate predicate =
         generator.fromLeafAddressServiceAreaNode(
-            LeafAddressServiceAreaExpressionNode.create(question.getId(), "seattle"));
+            LeafAddressServiceAreaExpressionNode.create(
+                question.getId(), "seattle", Operator.IN_SERVICE_AREA));
     assertThat(data.evalPredicate(predicate)).isTrue();
 
     predicate =
         generator.fromLeafAddressServiceAreaNode(
-            LeafAddressServiceAreaExpressionNode.create(question.getId(), "bloomington"));
+            LeafAddressServiceAreaExpressionNode.create(
+                question.getId(), "bloomington", Operator.IN_SERVICE_AREA));
     assertThat(data.evalPredicate(predicate)).isTrue();
 
     predicate =
         generator.fromLeafAddressServiceAreaNode(
-            LeafAddressServiceAreaExpressionNode.create(question.getId(), "king-county"));
+            LeafAddressServiceAreaExpressionNode.create(
+                question.getId(), "king-county", Operator.IN_SERVICE_AREA));
     assertThat(data.evalPredicate(predicate)).isTrue();
 
     predicate =
         generator.fromLeafAddressServiceAreaNode(
-            LeafAddressServiceAreaExpressionNode.create(question.getId(), "Arkansas"));
+            LeafAddressServiceAreaExpressionNode.create(
+                question.getId(), "Arkansas", Operator.IN_SERVICE_AREA));
     assertThat(data.evalPredicate(predicate)).isFalse();
 
     predicate =
         generator.fromLeafAddressServiceAreaNode(
-            LeafAddressServiceAreaExpressionNode.create(question.getId(), "Kansas"));
+            LeafAddressServiceAreaExpressionNode.create(
+                question.getId(), "Kansas", Operator.IN_SERVICE_AREA));
     assertThat(data.evalPredicate(predicate)).isFalse();
   }
 
@@ -548,7 +553,8 @@ public class JsonPathPredicateGeneratorTest {
     assertThatThrownBy(
             () ->
                 generator.fromLeafAddressServiceAreaNode(
-                    LeafAddressServiceAreaExpressionNode.create(question.getId(), "busted ID")))
+                    LeafAddressServiceAreaExpressionNode.create(
+                        question.getId(), "busted ID", Operator.IN_SERVICE_AREA)))
         .isInstanceOf(InvalidPredicateException.class);
   }
 }

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -115,12 +115,14 @@ public class BlockDefinitionTest {
 
   @Test
   public void setAndGetEligibilityDefinition() {
-    var visibilityAddress = LeafAddressServiceAreaExpressionNode.create(1L, "");
+    var visibilityAddress =
+        LeafAddressServiceAreaExpressionNode.create(1L, "", Operator.IN_SERVICE_AREA);
     PredicateDefinition visibilityPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(visibilityAddress), PredicateAction.HIDE_BLOCK);
 
-    var eligibilityAddress = LeafAddressServiceAreaExpressionNode.create(2L, "");
+    var eligibilityAddress =
+        LeafAddressServiceAreaExpressionNode.create(2L, "", Operator.IN_SERVICE_AREA);
     PredicateDefinition eligibilityPredicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(eligibilityAddress), PredicateAction.HIDE_BLOCK);

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -165,10 +165,10 @@ public class ProgramDefinitionTest extends ResetPostgres {
                     .setPredicate(
                         PredicateDefinition.create(
                             PredicateExpressionNode.create(
-                                LeafAddressServiceAreaExpressionNode.builder()
-                                    .setQuestionId(testQuestionBank.addressApplicantAddress().id)
-                                    .setServiceAreaId("seattle")
-                                    .build()),
+                                LeafAddressServiceAreaExpressionNode.create(
+                                    testQuestionBank.addressApplicantAddress().id,
+                                    "seattle",
+                                    Operator.IN_SERVICE_AREA)),
                             PredicateAction.ELIGIBLE_BLOCK))
                     .build())
             .withVisibilityPredicate(

--- a/server/test/services/program/predicate/PredicateAddressServiceAreaNodeExtractorTest.java
+++ b/server/test/services/program/predicate/PredicateAddressServiceAreaNodeExtractorTest.java
@@ -13,7 +13,8 @@ public class PredicateAddressServiceAreaNodeExtractorTest {
     var leaf1 =
         LeafOperationExpressionNode.create(
             123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
-    var addressNode = LeafAddressServiceAreaExpressionNode.create(456L, "Seattle");
+    var addressNode =
+        LeafAddressServiceAreaExpressionNode.create(456L, "Seattle", Operator.IN_SERVICE_AREA);
     var rootNode =
         PredicateExpressionNode.create(
             OrNode.create(

--- a/server/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/server/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -78,7 +78,8 @@ public class PredicateExpressionNodeTest {
     QuestionDefinition question =
         testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     LeafAddressServiceAreaExpressionNode leaf =
-        LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
+        LeafAddressServiceAreaExpressionNode.create(
+            question.getId(), "Seattle", Operator.IN_SERVICE_AREA);
 
     assertThat(PredicateExpressionNode.create(leaf).toDisplayString(ImmutableList.of(question)))
         .isEqualTo(String.format("\"%s\" is in service area \"Seattle\"", question.getName()));
@@ -89,7 +90,8 @@ public class PredicateExpressionNodeTest {
     QuestionDefinition question =
         testQuestionBank.addressApplicantAddress().getQuestionDefinition();
     LeafAddressServiceAreaExpressionNode leaf =
-        LeafAddressServiceAreaExpressionNode.create(question.getId(), "Seattle");
+        LeafAddressServiceAreaExpressionNode.create(
+            question.getId(), "Seattle", Operator.IN_SERVICE_AREA);
 
     assertThat(PredicateExpressionNode.create(leaf).toDisplayString(ImmutableList.of()))
         .isEqualTo(String.format("address is in service area \"Seattle\""));

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -344,10 +344,10 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThat(predicateDefinition.rootNode())
         .isEqualTo(
             PredicateExpressionNode.create(
-                LeafAddressServiceAreaExpressionNode.builder()
-                    .setQuestionId(testQuestionBank.addressApplicantAddress().id)
-                    .setServiceAreaId("seattle")
-                    .build()));
+                LeafAddressServiceAreaExpressionNode.create(
+                    testQuestionBank.addressApplicantAddress().id,
+                    "seattle",
+                    Operator.IN_SERVICE_AREA)));
   }
 
   @Test


### PR DESCRIPTION
### Description

This adds the `Operator` enum to the `LeafAddressServiceAreaExpressionNode`. Originally it was made with a hard-coded assumption that this would only ever have a single option. Adding the operator will opens up related work to allow for doing eligibility not in an area.

There are two startup jobs being created. One adds the operator to existing `program.block_definitions` jsonb columns; the other removes it. The removal one should hopefully never be used and is guarded by the three-headed dog cerberus to prevent accidental use.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Related to #6800
