### PR TITLE
[Multiple File Upload] Redirect instead of re-serving page

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -366,6 +366,8 @@ test.describe('file upload applicant flow', () => {
         0,
       )
 
+      await applicantQuestions.clickNext()
+
       await applicantQuestions.expectRequiredQuestionError(
         '.cf-question-fileupload',
       )

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -621,33 +621,15 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 return failedFuture(new ProgramBlockNotFoundException(programId, blockId));
               }
 
+              // Re-direct back to the current page.
               return supplyAsync(
                   () -> {
-                    ApplicantPersonalInfo personalInfo =
-                        applicantStage.toCompletableFuture().join();
-                    CiviFormProfile submittingProfile =
-                        profileUtils.currentUserProfileOrThrow(request);
-
-                    ApplicationBaseViewParams applicationParams =
-                        buildApplicationBaseViewParams(
-                            request,
-                            applicantId,
-                            programId,
-                            blockId,
-                            inReview,
-                            roApplicantProgramService,
-                            block.get(),
-                            personalInfo,
-                            DISPLAY_ERRORS,
-                            applicantRoutes,
-                            submittingProfile);
-                    if (settingsManifest.getNorthStarApplicantUi(request)) {
-                      return ok(northStarApplicantProgramBlockEditView.render(
-                              request, applicationParams))
-                          .as(Http.MimeTypes.HTML);
-                    } else {
-                      return ok(editView.render(applicationParams));
-                    }
+                    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                    return redirect(
+                        applicantRoutes
+                            .blockEditOrBlockReview(
+                                profile, applicantId, programId, blockId, inReview)
+                            .url());
                   });
             },
             classLoaderExecutionContext.current())
@@ -784,34 +766,15 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 return failedFuture(new ProgramBlockNotFoundException(programId, blockId));
               }
 
-              // Re-render the current page, with the updated file info.
+              // Re-direct back to the current page.
               return supplyAsync(
                   () -> {
-                    ApplicantPersonalInfo personalInfo =
-                        applicantStage.toCompletableFuture().join();
-                    CiviFormProfile submittingProfile =
-                        profileUtils.currentUserProfileOrThrow(request);
-
-                    ApplicationBaseViewParams applicationParams =
-                        buildApplicationBaseViewParams(
-                            request,
-                            applicantId,
-                            programId,
-                            blockId,
-                            inReview,
-                            roApplicantProgramService,
-                            block.get(),
-                            personalInfo,
-                            DISPLAY_ERRORS,
-                            applicantRoutes,
-                            submittingProfile);
-                    if (settingsManifest.getNorthStarApplicantUi(request)) {
-                      return ok(northStarApplicantProgramBlockEditView.render(
-                              request, applicationParams))
-                          .as(Http.MimeTypes.HTML);
-                    } else {
-                      return ok(editView.render(applicationParams));
-                    }
+                    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                    return redirect(
+                        applicantRoutes
+                            .blockEditOrBlockReview(
+                                profile, applicantId, programId, blockId, inReview)
+                            .url());
                   });
             },
             classLoaderExecutionContext.current())

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -1935,7 +1935,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void addFile_civiformAdminAccessToDraftProgram_isOk() {
+  public void addFile_civiformAdminAccessToDraftProgram_redirects() {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     applicant = adminAccount.newestApplicant().orElseThrow();
     ProgramModel draftProgram =
@@ -1963,11 +1963,11 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test
-  public void addFile_obsoleteProgram_isOk() {
+  public void addFile_obsoleteProgram_redirects() {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock()
@@ -1993,7 +1993,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test
@@ -2109,8 +2109,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("1 of 2");
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .contains(String.format("/programs/%s/blocks/1/edit", program.id));
 
     applicant.refresh();
     String applicantData = applicant.getApplicantData().asJsonString();
@@ -2160,7 +2161,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     // Now add the second file.
     RequestBuilder secondRequest =
@@ -2262,7 +2263,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     result =
         subject
@@ -2275,7 +2276,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     applicant.refresh();
     String applicantData = applicant.getApplicantData().asJsonString();
@@ -2358,7 +2359,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void removeFile_civiformAdminAccessToDraftProgram_isOk() {
+  public void removeFile_civiformAdminAccessToDraftProgram_redirects() {
     AccountModel adminAccount = createGlobalAdminWithMockedProfile();
     applicant = adminAccount.newestApplicant().orElseThrow();
     ProgramModel draftProgram =
@@ -2389,11 +2390,11 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test
-  public void removeFile_obsoleteProgram_isOk() {
+  public void removeFile_obsoleteProgram_redirects() {
     ProgramModel obsoleteProgram =
         ProgramBuilder.newObsoleteProgram("program")
             .withBlock("block 1")
@@ -2420,7 +2421,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test
@@ -2583,7 +2584,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     applicant.refresh();
     String applicantDataString = applicant.getApplicantData().asJsonString();
@@ -2629,7 +2630,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     applicant.refresh();
     assertThat(applicant.getApplicantData().asJsonString()).doesNotContain("key-to-remove");
@@ -2674,7 +2675,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
 
     applicant.refresh();
     String applicantDataString = applicant.getApplicantData().asJsonString();


### PR DESCRIPTION
### Description

Redirect instead of re-serving after adding/removing files. This is needed because otherwise we end up showing the URL of the re-directed Amazon request in the URL bar, which when refreshed tries to add/remove the file again (which is a no-op, but it's ugly).

Note this does change the behavior slightly, since before we retained error information and now we don't, I think this is OK since the errors will show up when they click "next" (like all the other questions do).

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary


### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
