### PR TITLE
Improve performance of JSON export by only parsing all program versions once

### DIFF
--- a/server/app/services/export/JsonExporterService.java
+++ b/server/app/services/export/JsonExporterService.java
@@ -92,16 +92,52 @@ public final class JsonExporterService {
         programService.getAllVersionsFullProgramDefinition(programDefinition.id()).stream()
             .collect(ImmutableMap.toImmutableMap(ProgramDefinition::id, pd -> pd));
 
+    // Build a template JSON document of all possible questions that have ever been in the program.
+    // TODO(#8147): Reduce code duplication once we find a long term solution. Here we've moved the
+    // template creation outside of the loop, so we don't rebuild it for each application, but as a
+    // result we've duplicated the AnswerData -> questionEntries map -> add to JSON document flow.
+    Map<Path, AnswerData> answersToExport = new HashMap<>();
+    for (ProgramDefinition pd : programDefinitionsForAllVersions.values()) {
+      // We use an empty ApplicantData because these should all be exported as unanswered questions.
+      applicantService
+          .getReadOnlyApplicantProgramService(new ApplicantData(), pd)
+          .getSummaryDataAllQuestions()
+          .forEach(ad -> answersToExport.putIfAbsent(ad.contextualizedPath(), ad));
+    }
+    ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
+    for (AnswerData answerData : answersToExport.values()) {
+      // We suppress the unchecked warning because create() returns a genericized
+      // QuestionJsonPresenter, but we ignore the generic's type so that we can get
+      // the json entries for any Question in one line.
+      @SuppressWarnings("unchecked")
+      ImmutableMap<Path, Optional<?>> questionEntries =
+          presenterFactory
+              .create(answerData.applicantQuestion().getType())
+              .getAllJsonEntries(answerData.createQuestion(), multipleFileUploadEnabled);
+      entriesBuilder.putAll(questionEntries);
+    }
+    CfJsonDocumentContext template = new CfJsonDocumentContext();
+    exportApplicationEntriesToJsonApplication(template, entriesBuilder.build());
+    // TODO(#8147): I'm not sure if reading the template out into a string, just to re-parse it into
+    // a JsonData for each application, is more or less efficient than trying to clone a JsonData
+    // object.
+    String jsonStringTemplate = template.asJsonString();
+
+    // Then use the template when exporting each application.
     DocumentContext jsonData =
         applications.stream()
             .map(
-                a ->
+                app ->
                     buildApplicationExportData(
-                        a, programDefinitionsForAllVersions, multipleFileUploadEnabled))
+                        app,
+                        programDefinitionsForAllVersions.get(app.getProgram().id),
+                        multipleFileUploadEnabled))
             .collect(
                 Collectors.collectingAndThen(
                     ImmutableList.toImmutableList(),
-                    this::convertApplicationExportDataToJsonArray));
+                    appDataList ->
+                        convertApplicationExportDataListToJsonArray(
+                            appDataList, jsonStringTemplate)));
 
     return jsonData.jsonString();
   }
@@ -112,42 +148,29 @@ public final class JsonExporterService {
    * @param applicationExportDataList the list of applications to export as JSON
    * @return the exported applications, as a JSON array
    */
-  public DocumentContext convertApplicationExportDataToJsonArray(
-      ImmutableList<ApplicationExportData> applicationExportDataList) {
+  public DocumentContext convertApplicationExportDataListToJsonArray(
+      ImmutableList<ApplicationExportData> applicationExportDataList, String jsonTemplate) {
     DocumentContext applications = makeEmptyJsonArray();
     applicationExportDataList.forEach(
         applicationExportData -> {
           applications.add(
-              "$", convertExportDataToJson(applicationExportData).getDocumentContext().json());
+              "$",
+              convertExportDataToJson(applicationExportData, jsonTemplate)
+                  .getDocumentContext()
+                  .json());
         });
     return applications;
   }
 
   private ApplicationExportData buildApplicationExportData(
       ApplicationModel application,
-      ImmutableMap<Long, ProgramDefinition> programDefinitionsForAllVersions,
+      ProgramDefinition programDefinition,
       boolean multipleFileUploadEnabled) {
     Map<Path, AnswerData> answersToExport = new HashMap<>();
-
-    // First retrieve the answers for the program version that aligns with this application
-    ProgramDefinition pdForApplication =
-        programDefinitionsForAllVersions.get(application.getProgram().id);
     applicantService
-        .getReadOnlyApplicantProgramService(application.getApplicantData(), pdForApplication)
+        .getReadOnlyApplicantProgramService(application.getApplicantData(), programDefinition)
         .getSummaryDataAllQuestions()
         .forEach(ad -> answersToExport.putIfAbsent(ad.contextualizedPath(), ad));
-
-    // Then populate the questions that were not in the application's program version. We use an
-    // empty ApplicantData because these should all be exported as unanswered questions.
-    for (ProgramDefinition pd : programDefinitionsForAllVersions.values()) {
-      if (application.getProgram().id == pd.id()) {
-        continue;
-      }
-      applicantService
-          .getReadOnlyApplicantProgramService(new ApplicantData(), pd)
-          .getSummaryDataAllQuestions()
-          .forEach(ad -> answersToExport.putIfAbsent(ad.contextualizedPath(), ad));
-    }
 
     ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
     for (AnswerData answerData : answersToExport.values()) {
@@ -163,7 +186,7 @@ public final class JsonExporterService {
     }
 
     return ApplicationExportData.builder()
-        .setAdminName(programDefinitionsForAllVersions.get(application.getProgram().id).adminName())
+        .setAdminName(programDefinition.adminName())
         .setApplicantId(application.getApplicant().id)
         .setApplicationId(application.id)
         .setProgramId(application.getProgram().id)
@@ -193,8 +216,8 @@ public final class JsonExporterService {
   }
 
   private CfJsonDocumentContext convertExportDataToJson(
-      ApplicationExportData applicationExportData) {
-    CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext(makeEmptyJsonObject());
+      ApplicationExportData applicationExportData, String jsonTemplate) {
+    CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext(jsonTemplate);
 
     jsonApplication.putString(Path.create("program_name"), applicationExportData.adminName());
     jsonApplication.putLong(Path.create("program_version_id"), applicationExportData.programId());
@@ -277,10 +300,6 @@ public final class JsonExporterService {
 
   private DocumentContext makeEmptyJsonArray() {
     return JsonPathProvider.getJsonPath().parse("[]");
-  }
-
-  private DocumentContext makeEmptyJsonObject() {
-    return JsonPathProvider.getJsonPath().parse("{}");
   }
 
   private static RevisionState toRevisionState(LifecycleStage lifecycleStage) {

--- a/server/app/services/export/ProgramJsonSampler.java
+++ b/server/app/services/export/ProgramJsonSampler.java
@@ -89,7 +89,8 @@ public final class ProgramJsonSampler {
 
     return apiPayloadWrapper.wrapPayload(
         jsonExporterService
-            .convertApplicationExportDataToJsonArray(ImmutableList.of(jsonExportData.build()))
+            .convertApplicationExportDataListToJsonArray(
+                ImmutableList.of(jsonExportData.build()), "{}")
             .jsonString(),
         /* paginationTokenPayload= */ Optional.empty());
   }


### PR DESCRIPTION
### Description

Move parsing of all program versions outside of the loop that exports each application, so we're not re-parsing every version for every application.

This reduces JSON export time from `O(n * v)` to `O(n)`, where `n` is the number of applications being exported and `v` is the number of versions the program has.

On my local, with ~2000 applications to Comprehensive Sample Program, this reduces export time to ~10s, instead of 10-15s per version

This is a quick improvement for #8147, but more work will follow to further improve export performance.

## Release notes

As a result of these changes, the order of fields in the exported JSON objects may have changed. The order of objects themselves has not.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary



### Instructions for manual testing

Export applications and ensure all applications in the list have every question that has ever been in the program, even if they were added or removed before or after the application was submitted.

### Issue(s) this completes

Part of #8147
