### PR TITLE
[Program Migration] Ignore program categories

### DIFF
--- a/server/app/controllers/admin/AdminExportController.java
+++ b/server/app/controllers/admin/AdminExportController.java
@@ -75,6 +75,9 @@ public class AdminExportController extends CiviFormController {
       return badRequest(String.format("Program with ID %s could not be found", programId));
     }
 
+    // TODO(#7087) migrate program categories
+    program = program.toBuilder().setCategories(ImmutableList.of()).build();
+
     ImmutableList<QuestionDefinition> questionsUsedByProgram =
         program.getQuestionIdsInProgram().stream()
             .map(

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -101,6 +101,8 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void index_removesProgramCategories() {
+    when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
+
     ImmutableMap<Locale, String> translations =
         ImmutableMap.of(
             Lang.forCode("en-US").toLocale(), "Health", Lang.forCode("es-US").toLocale(), "Salud");

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -101,8 +101,6 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void index_removesProgramCategories() {
-    when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
-
     ImmutableMap<Locale, String> translations =
         ImmutableMap.of(
             Lang.forCode("en-US").toLocale(), "Health", Lang.forCode("es-US").toLocale(), "Salud");

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import models.CategoryModel;
 import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
@@ -292,6 +293,11 @@ public class ProgramBuilder {
 
   public ProgramBuilder withProgramType(ProgramType programType) {
     builder.setProgramType(programType);
+    return this;
+  }
+
+  public ProgramBuilder withCategories(ImmutableList<CategoryModel> categories) {
+    builder.setCategories(categories);
     return this;
   }
 


### PR DESCRIPTION
### Description

Currently, program import will break if the program being imported has categories on it. We want to remove the categories on export to get around this error for now. We will add handling of program categories at a later time.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Make sure the program migration and program filtering feature flags are one
2. Create a program with categories
3. Export it (categories should be an empty array in the json)
4. Attempt to import it
5. You should see the program preview with no errors

### Issue(s) this completes

Fixes #8422 
