### PR TITLE
Remove backwards compatibility for session ID in Play session

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -25,7 +25,6 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
-import org.pac4j.play.PlayWebContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.AccountRepository;
@@ -153,8 +152,8 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
     civiformProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
 
-    setSessionIdInProfile(civiformProfile, context);
-    String sessionId = getSessionId(civiformProfile, context);
+    String sessionId = UUID.randomUUID().toString();
+    civiformProfile.getProfileData().addAttribute(SESSION_ID, sessionId);
 
     if (enhancedLogoutEnabled()) {
       // Save the id_token from the returned OidcProfile in the account so that it can be
@@ -171,44 +170,6 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
     }
 
     return civiformProfile.getProfileData();
-  }
-
-  private void setSessionIdInProfile(CiviFormProfile profile, WebContext context) {
-    PlayWebContext playWebContext = (PlayWebContext) context;
-    // The code below is for migration. We used to create the session id via
-    // a filter and store in the session alongside the profile. Now we will
-    // store it in the profile itself.
-    //
-    // If the session id exists in the session, then use that value in the
-    // profile. Otherwise, generate a new session ID to store in the profile.
-    //
-    // Once current profiles expire, this won't be a problem, and we will always
-    // generate a new session id here.
-    Optional<String> existingSessionIdFromCookie =
-        playWebContext.getNativeSession().get(SESSION_ID);
-    String sessionId = existingSessionIdFromCookie.orElse(UUID.randomUUID().toString());
-    profile.getProfileData().addAttribute(SESSION_ID, sessionId);
-  }
-
-  private String getSessionId(CiviFormProfile profile, WebContext context) {
-    String sessionIdFromProfile = profile.getProfileData().getAttribute(SESSION_ID, String.class);
-
-    // As described in setSessionIdInProfile(), these values should match if both
-    // are present. We log warnings if they do not match so that we can investigate.
-    // However, the value from the profile is authoritative.
-    PlayWebContext playWebContext = (PlayWebContext) context;
-    Optional<String> sessionIdFromContext = playWebContext.getNativeSession().get(SESSION_ID);
-    if (sessionIdFromContext.isPresent()) {
-      final boolean matchingSessionIds = sessionIdFromContext.get().equals(sessionIdFromProfile);
-      if (!matchingSessionIds) {
-        LOGGER.warn(
-            "Non-matching session IDs: id from context = {}, id from session = {}",
-            sessionIdFromContext.get(),
-            sessionIdFromProfile);
-      }
-    }
-
-    return sessionIdFromProfile;
   }
 
   @Override

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static support.FakeRequestBuilder.fakeRequest;
-import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfile;
 import auth.CiviFormProfileData;
@@ -37,7 +36,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
   private static final String ISSUER = "issuer";
   private static final String SUBJECT = "subject";
   private static final String AUTHORITY_ID = "iss: issuer sub: subject";
-  private static final String SESSION_ID = "session_id";
+  private static final String ID_TOKEN_STRING = "id token string";
 
   private static OidcProfile profile;
 
@@ -57,6 +56,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     profile.addAttribute("user_locale", "fr");
     profile.addAttribute("iss", ISSUER);
     profile.setId(SUBJECT);
+    profile.setIdTokenString(ID_TOKEN_STRING);
   }
 
   private CiviformOidcProfileCreator getOidcProfileCreator(boolean enhancedLogoutEnabled) {
@@ -173,12 +173,7 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
 
   @Test
   public void mergeCiviFormProfile_succeeds_new_user_with_enhanced_logout() {
-    // Create a web context containing a session id.
-    PlayWebContext context =
-        new PlayWebContext(
-            fakeRequestBuilder()
-                .session(CiviformOidcProfileCreator.SESSION_ID, SESSION_ID)
-                .build());
+    PlayWebContext context = new PlayWebContext(fakeRequest());
     CiviformOidcProfileCreator oidcProfileAdapter =
         getOidcProfileCreatorWithEnhancedLogoutEnabled();
 
@@ -207,7 +202,9 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     AccountModel account = maybeApplicant.get().getAccount();
     SerializedIdTokens serializedIdTokens = account.getSerializedIdTokens();
     assertThat(serializedIdTokens).isNotNull();
-    assertThat(serializedIdTokens.containsKey(SESSION_ID)).isTrue();
+    assertThat(serializedIdTokens.size()).isEqualTo(1);
+    assertThat(serializedIdTokens.entrySet().iterator().next().getValue())
+        .isEqualTo(ID_TOKEN_STRING);
   }
 
   @Test


### PR DESCRIPTION
### Description

Since March 2024, we have stored the session ID in the pac4j profile instead of the Play session. https://github.com/civiform/civiform/pull/6736 maintained backwards compatibility with existing sessions by continuing to read the session ID from the play session if it was there. Now that it's been 5 months, all sessions from March and earlier should have ended, and we no longer need to do that.

* Stop reading the session ID from the Play session (playWebContext.getNativeSession()) during login profile merge in CiviformOidcProfileCreator
* Stop reading the session ID from the Play session in order to get the id tokens for logout in CiviformOidcLogoutActionBuilder
* Update CiviformOidcProfileCreatorTest to actually test that the ID tokens are saved to the account during login when the enhanced login flag is on

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Fixes #6113
