### PR TITLE
Add explicit joins to programs queries to reduce n+1 queries

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -354,6 +354,7 @@ public final class ProgramRepository {
         .find(ProgramModel.class)
         .setLabel("ProgramModel.findList")
         .setProfileLocation(queryProfileLocationBuilder.create("getAllProgramVersions"))
+        .fetch("categories")
         .where()
         .in("name", programNameQuery)
         .query()
@@ -382,6 +383,7 @@ public final class ProgramRepository {
             .setLabel("ApplicationModel.findList")
             .setProfileLocation(
                 queryProfileLocationBuilder.create("getApplicationsForAllProgramVersions"))
+            .fetch("applicant")
             .fetch("applicant.account.managedByGroup")
             .orderBy("id desc")
             .where()


### PR DESCRIPTION
### Description

Add explicit joins to two programs queries:
- `getAllProgramVersions()`, which was not joining on the Categories table, resulting in additional queries when building a ProgramDefinition
- `getApplicationsForAllProgramVersions()`, which was not joining on the Applicants table. The applicants table is needed because the `ReadOnlyApplicantProgramService` needs a full `Applicant`.

These were especially impactful when exporting thousands of applications at a time.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Issue(s) this completes

Part of fixing #8147
