### PR TITLE
Add support for additional predicates with program migration

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -371,9 +371,8 @@ public class AdminImportController extends CiviFormController {
   }
 
   /**
-   * Update the eligibility or visibility predicate with the id from the newly saved question. We
-   * use the old question id from the json to fetch the question admin name and match it to the
-   * newly saved question so we can set the new question id on the predicate definition.
+   * Update the predicate definition by updating the predicate expression, starting with the root
+   * node.
    */
   private PredicateDefinition updatePredicateDefinition(
       PredicateDefinition predicateDefinition,
@@ -385,6 +384,12 @@ public class AdminImportController extends CiviFormController {
         predicateDefinition.action());
   }
 
+  /**
+   * Update the eligibility or visibility predicate with the id from the newly saved question. We
+   * use the old question id from the json to fetch the question admin name and match it to the
+   * newly saved question so we can set the new question id on the predicate definition. We
+   * recursively call this function on predicates with children.
+   */
   private PredicateExpressionNode updatePredicateExpression(
       PredicateExpressionNode predicateExpressionNode,
       ImmutableMap<Long, QuestionDefinition> questionsOnJsonById,
@@ -410,6 +415,7 @@ public class AdminImportController extends CiviFormController {
                 .collect(ImmutableList.toImmutableList());
         return PredicateExpressionNode.create(AndNode.create(andNodeChildren));
       case LEAF_ADDRESS_SERVICE_AREA:
+        // TODO(#8450): Ensure we support service area validation.
       case LEAF_OPERATION:
         LeafOperationExpressionNode leafNode = predicateExpressionNode.getLeafOperationNode();
         Long oldQuestionId = leafNode.questionId();

--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -25,7 +25,9 @@ import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
+import services.program.predicate.AndNode;
 import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.OrNode;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.question.types.QuestionDefinition;
@@ -377,16 +379,49 @@ public class AdminImportController extends CiviFormController {
       PredicateDefinition predicateDefinition,
       ImmutableMap<Long, QuestionDefinition> questionsOnJsonById,
       ImmutableMap<String, QuestionDefinition> updatedQuestionsMap) {
+    return PredicateDefinition.create(
+        updatePredicateExpression(
+            predicateDefinition.rootNode(), questionsOnJsonById, updatedQuestionsMap),
+        predicateDefinition.action());
+  }
 
-    LeafOperationExpressionNode leafNode = predicateDefinition.rootNode().getLeafOperationNode();
+  private PredicateExpressionNode updatePredicateExpression(
+      PredicateExpressionNode predicateExpressionNode,
+      ImmutableMap<Long, QuestionDefinition> questionsOnJsonById,
+      ImmutableMap<String, QuestionDefinition> updatedQuestionsMap) {
 
-    Long oldQuestionId = leafNode.questionId();
-    String questionAdminName = questionsOnJsonById.get(oldQuestionId).getName();
-    Long newQuestionId = updatedQuestionsMap.get(questionAdminName).getId();
-
-    PredicateExpressionNode newPredicateExpressionNode =
-        PredicateExpressionNode.create(leafNode.toBuilder().setQuestionId(newQuestionId).build());
-
-    return PredicateDefinition.create(newPredicateExpressionNode, predicateDefinition.action());
+    switch (predicateExpressionNode.getType()) {
+      case OR:
+        OrNode orNode = predicateExpressionNode.getOrNode();
+        ImmutableList<PredicateExpressionNode> orNodeChildren =
+            orNode.children().stream()
+                .map(
+                    child ->
+                        updatePredicateExpression(child, questionsOnJsonById, updatedQuestionsMap))
+                .collect(ImmutableList.toImmutableList());
+        return PredicateExpressionNode.create(OrNode.create(orNodeChildren));
+      case AND:
+        AndNode andNode = predicateExpressionNode.getAndNode();
+        ImmutableList<PredicateExpressionNode> andNodeChildren =
+            andNode.children().stream()
+                .map(
+                    child ->
+                        updatePredicateExpression(child, questionsOnJsonById, updatedQuestionsMap))
+                .collect(ImmutableList.toImmutableList());
+        return PredicateExpressionNode.create(AndNode.create(andNodeChildren));
+      case LEAF_ADDRESS_SERVICE_AREA:
+      case LEAF_OPERATION:
+        LeafOperationExpressionNode leafNode = predicateExpressionNode.getLeafOperationNode();
+        Long oldQuestionId = leafNode.questionId();
+        String questionAdminName = questionsOnJsonById.get(oldQuestionId).getName();
+        Long newQuestionId = updatedQuestionsMap.get(questionAdminName).getId();
+        return PredicateExpressionNode.create(
+            leafNode.toBuilder().setQuestionId(newQuestionId).build());
+      default:
+        throw new IllegalStateException(
+            String.format(
+                "Unsupported predicate expression type for import: %s",
+                predicateExpressionNode.getType()));
+    }
   }
 }

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -807,7 +807,7 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "                \"children\" : [ { \n"
           + "                  \"node\" : { \n"
           + "                    \"type\" : \"leaf\", \n"
-          + "                    \"questionId\" : 11, \n" 
+          + "                    \"questionId\" : 11, \n"
           + "                    \"scalar\" : \"SELECTIONS\", \n"
           + "                    \"operator\" : \"ANY_OF\", \n"
           + "                    \"value\" : { \n"

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -356,6 +356,12 @@ public class AdminImportControllerTest extends ResetPostgres {
             .get()
             .predicate()
             .rootNode()
+            .getOrNode()
+            .children()
+            .get(0)
+            .getAndNode()
+            .children()
+            .get(0)
             .getLeafOperationNode()
             .questionId();
     Long visibilityQuestionId =
@@ -792,18 +798,39 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "      \"hidePredicate\" : null,\n"
           + "      \"eligibilityDefinition\" : {\n"
           + "        \"predicate\" : {\n"
-          + "          \"rootNode\" : {\n"
-          + "            \"node\" : {\n"
-          + "              \"type\" : \"leaf\",\n"
-          + "              \"questionId\" : 11,\n"
-          + "              \"scalar\" : \"ID\",\n"
-          + "              \"operator\" : \"IN\",\n"
-          + "              \"value\" : {\n"
-          + "                \"value\" : \"[\\\"1\\\", \\\"2\\\", \\\"3\\\"]\",\n"
-          + "                \"type\" : \"LIST_OF_STRINGS\"\n"
-          + "              }\n"
-          + "            }\n"
-          + "          },\n"
+          + "        \"rootNode\" : { \n"
+          + "          \"node\" : { \n"
+          + "            \"type\" : \"or\", \n"
+          + "            \"children\" : [ { \n"
+          + "              \"node\" : { \n"
+          + "                \"type\" : \"and\", \n"
+          + "                \"children\" : [ { \n"
+          + "                  \"node\" : { \n"
+          + "                    \"type\" : \"leaf\", \n"
+          + "                    \"questionId\" : 11, \n" 
+          + "                    \"scalar\" : \"SELECTIONS\", \n"
+          + "                    \"operator\" : \"ANY_OF\", \n"
+          + "                    \"value\" : { \n"
+          + "                      \"value\" : \"[\\\"0\\\", \\\"9\\\", \\\"11\\\"]\", \n"
+          + "                      \"type\" : \"LIST_OF_STRINGS\" \n"
+          + "                    } \n"
+          + "                  } \n"
+          + "                }, { \n"
+          + "                  \"node\" : { \n"
+          + "                    \"type\" : \"leaf\", \n"
+          + "                    \"questionId\" : 11, \n"
+          + "                    \"scalar\" : \"SELECTION\", \n"
+          + "                    \"operator\" : \"IN\", \n"
+          + "                    \"value\" : { \n"
+          + "                      \"value\" : \"[\\\"1\\\"]\", \n"
+          + "                      \"type\" : \"LIST_OF_STRINGS\" \n"
+          + "                    } \n"
+          + "                  } \n"
+          + "                } ] \n"
+          + "              } \n"
+          + "            } ] \n"
+          + "          } \n"
+          + "        }, \n"
           + "          \"action\" : \"ELIGIBLE_BLOCK\"\n"
           + "        }\n"
           + "      },\n"


### PR DESCRIPTION
### Description

And and Or predicates didn't work with program migration, since we were assuming everything was a leaf. We now check the type and handle appropriately.

Tested the change with the program described in #8435

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

#8435