### PR TITLE
Use more efficient Application retrieval queries in CsvExporterService

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -205,8 +205,8 @@ public final class ApplicationRepository {
     ExpressionList<ApplicationModel> query =
         database
             .find(ApplicationModel.class)
-            .fetch("program")
-            .fetch("applicant.account")
+            .fetch("applicant")
+            .fetch("applicant.account.managedByGroup")
             .orderBy("id")
             .where();
     if (submitTimeFilter.fromTime().isPresent()) {

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -1552,21 +1552,6 @@ public final class ProgramService {
   }
 
   /**
-   * Get all the program's submitted applications. Does not include drafts or deleted applications.
-   *
-   * @throws ProgramNotFoundException when programId does not correspond to a real Program.
-   */
-  public ImmutableList<ApplicationModel> getSubmittedProgramApplications(long programId)
-      throws ProgramNotFoundException {
-    Optional<ProgramModel> programMaybe =
-        programRepository.lookupProgram(programId).toCompletableFuture().join();
-    if (programMaybe.isEmpty()) {
-      throw new ProgramNotFoundException(programId);
-    }
-    return programMaybe.get().getSubmittedApplications();
-  }
-
-  /**
    * Get all submitted applications for this program and all other previous and future versions of
    * it matches the specified filters.
    *


### PR DESCRIPTION
### Description

Use more efficient Application retrieval queries in CsvExporterService.

Details:
- Caches all ProgramDefinitions locally before exporting.
- Only fetch applications once, instead of once in `generateCsvConfig()` and again in `getProgramAllVersionsCsv()`.
- Retrieve applications with  `programService.getSubmittedProgramApplicationsAllVersions()`, which is optimized for export, instead of `programService.getSubmittedProgramApplications()`.
- Update `getDemographicsCsv()` to use the ProgramDefinition cache in CsvExporterService.
- Note: To enable `getProgramAllVersionsCsv()` and `getDemographicsCsv()` to use different caches, we had to pass the cache's retrieval method into `exportCsv()` instead of the cache itself. I don't love this, but I'm planning additional export improvements soon so hopefully it's not around long. 😬 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Issue(s) this completes

Fixes #1750
Part of #8147
