### PR TITLE
Clean up Optional handling in ProfileUtils.getApplicantId

### DIFF
--- a/server/app/auth/ProfileUtils.java
+++ b/server/app/auth/ProfileUtils.java
@@ -111,14 +111,11 @@ public class ProfileUtils {
   /** Retrieves the applicant id from the user profile, if present. */
   public Optional<Long> getApplicantId(Http.Request request) {
     Optional<CiviFormProfile> profile = currentUserProfile(request);
-    if (profile.map(CiviFormProfile::getProfileData).isEmpty()) {
+    if (profile.isEmpty()) {
       return Optional.empty();
     }
 
-    CiviFormProfileData profileData =
-        profile
-            .orElseThrow(() -> new MissingOptionalException(CiviFormProfileData.class))
-            .getProfileData();
+    CiviFormProfileData profileData = profile.get().getProfileData();
     return Optional.ofNullable(
         profileData.getAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME, Long.class));
   }


### PR DESCRIPTION
### Description

Clean up Optional handling in ProfileUtils.getApplicantId:

* Remove an unnecessary call to Optional.map() - the result of map isEmpty iff the Optional itself was empty because getProfileData does not return Optional and map is not flatMap, so the map call is misleading and unnecessary.
* Remove the unnecessary orElseThrow - the conditional above already returns if the optional is empty, so it doesn't need to be handled again.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)