### PR TITLE
Rename ProfileUtils methods

### DIFF
--- a/server/app/actions/ApplicantAuthorizationAction.java
+++ b/server/app/actions/ApplicantAuthorizationAction.java
@@ -75,7 +75,10 @@ public class ApplicantAuthorizationAction extends Action.Simple {
 
   /** Check if the profile is authorized to access the applicant's data. */
   private CompletionStage<Void> checkApplicantAuthorization(Request request, long applicantId) {
-    return profileUtils.currentUserProfile(request).orElseThrow().checkAuthorization(applicantId);
+    return profileUtils
+        .optionalCurrentUserProfile(request)
+        .orElseThrow()
+        .checkAuthorization(applicantId);
   }
 
   /** Checks that the profile is authorized to access the specified program. */
@@ -85,7 +88,10 @@ public class ApplicantAuthorizationAction extends Action.Simple {
         .thenAccept(
             (isDraftProgram) -> {
               if (isDraftProgram
-                  && !profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+                  && !profileUtils
+                      .optionalCurrentUserProfile(request)
+                      .orElseThrow()
+                      .isCiviFormAdmin()) {
                 throw new SecurityException();
               }
             });

--- a/server/app/auth/ProfileUtils.java
+++ b/server/app/auth/ProfileUtils.java
@@ -28,30 +28,25 @@ public class ProfileUtils {
   }
 
   /**
-   * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
-   * request's cookies, using the injected session store to decrypt it.
-   */
-  public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
-    PlayWebContext webContext = new PlayWebContext(request);
-    return currentUserProfile(webContext);
-  }
-
-  /**
-   * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
-   * request's cookies, using the injected session store to decrypt it.
+   * Fetch the current profile, or throw an exception if none is present. Note that {@link
+   * filters.CiviFormProfileFilter} should guarantee that a profile is present for user-facing
+   * requests.
    *
    * @throws MissingOptionalException if we can't find the profile from the request
    */
-  public CiviFormProfile currentUserProfileOrThrow(Http.RequestHeader request) {
-    return currentUserProfile(request)
+  public CiviFormProfile currentUserProfile(Http.RequestHeader request) {
+    return optionalCurrentUserProfile(request)
         .orElseThrow(() -> new MissingOptionalException(CiviFormProfile.class));
   }
 
-  /**
-   * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
-   * context's cookies, using the injected session store to decrypt it.
-   */
-  public Optional<CiviFormProfile> currentUserProfile(WebContext webContext) {
+  /** Fetch the current pac4j profile for the given request. */
+  public Optional<CiviFormProfile> optionalCurrentUserProfile(Http.RequestHeader request) {
+    PlayWebContext webContext = new PlayWebContext(request);
+    return optionalCurrentUserProfile(webContext);
+  }
+
+  /** Fetch the current pac4j profile for the given web context. */
+  public Optional<CiviFormProfile> optionalCurrentUserProfile(WebContext webContext) {
     ProfileManager profileManager = new ProfileManager(webContext, sessionStore);
     Optional<CiviFormProfileData> p = profileManager.getProfile(CiviFormProfileData.class);
     if (p.isEmpty()) {
@@ -110,7 +105,7 @@ public class ProfileUtils {
 
   /** Retrieves the applicant id from the user profile, if present. */
   public Optional<Long> getApplicantId(Http.Request request) {
-    Optional<CiviFormProfile> profile = currentUserProfile(request);
+    Optional<CiviFormProfile> profile = optionalCurrentUserProfile(request);
     if (profile.isEmpty()) {
       return Optional.empty();
     }

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -192,7 +192,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
     OidcProfile profile = (OidcProfile) oidcProfile.get();
     Optional<ApplicantModel> existingApplicant = getExistingApplicant(profile);
-    Optional<CiviFormProfile> guestProfile = profileUtils.currentUserProfile(context);
+    Optional<CiviFormProfile> guestProfile = profileUtils.optionalCurrentUserProfile(context);
 
     // The merge function signature specifies the two profiles as parameters.
     // We need to supply an extra parameter (context), so bind it here.

--- a/server/app/auth/saml/SamlProfileCreator.java
+++ b/server/app/auth/saml/SamlProfileCreator.java
@@ -78,7 +78,7 @@ public class SamlProfileCreator extends AuthenticatorProfileCreator {
 
     SAML2Profile profile = (SAML2Profile) samlProfile.get();
     Optional<ApplicantModel> existingApplicant = getExistingApplicant(profile);
-    Optional<CiviFormProfile> guestProfile = profileUtils.currentUserProfile(context);
+    Optional<CiviFormProfile> guestProfile = profileUtils.optionalCurrentUserProfile(context);
     return civiFormProfileMerger.mergeProfiles(
         existingApplicant, guestProfile, profile, this::mergeCiviFormProfile);
   }

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -40,7 +40,10 @@ public class CiviFormController extends Controller {
 
   protected CompletableFuture<Void> checkApplicantAuthorization(
       Http.Request request, long applicantId) {
-    return profileUtils.currentUserProfile(request).orElseThrow().checkAuthorization(applicantId);
+    return profileUtils
+        .optionalCurrentUserProfile(request)
+        .orElseThrow()
+        .checkAuthorization(applicantId);
   }
 
   /**
@@ -51,7 +54,7 @@ public class CiviFormController extends Controller {
   protected CompletableFuture<Void> checkProgramAdminAuthorization(
       Http.Request request, String programName) {
     return profileUtils
-        .currentUserProfile(request)
+        .optionalCurrentUserProfile(request)
         .orElseThrow()
         .checkProgramAuthorization(programName, request);
   }
@@ -63,7 +66,10 @@ public class CiviFormController extends Controller {
         .thenAccept(
             (isDraftProgram) -> {
               if (isDraftProgram
-                  && !profileUtils.currentUserProfile(request).orElseThrow().isCiviFormAdmin()) {
+                  && !profileUtils
+                      .optionalCurrentUserProfile(request)
+                      .orElseThrow()
+                      .isCiviFormAdmin()) {
                 throw new SecurityException();
               }
             });

--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -119,7 +119,7 @@ public class FileController extends CiviFormController {
     }
 
     AccountModel adminAccount =
-        profileUtils.currentUserProfile(request).orElseThrow().getAccount().join();
+        profileUtils.optionalCurrentUserProfile(request).orElseThrow().getAccount().join();
 
     // An admin is eligible if they are a global admin with the program access flag turned on
     // or if they have been explicitly given read permission to the program.

--- a/server/app/controllers/HomeController.java
+++ b/server/app/controllers/HomeController.java
@@ -48,7 +48,7 @@ public class HomeController extends Controller {
   }
 
   public CompletionStage<Result> index(Http.Request request) {
-    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     if (profile.isCiviFormAdmin()) {
       return CompletableFuture.completedFuture(

--- a/server/app/controllers/ProfileController.java
+++ b/server/app/controllers/ProfileController.java
@@ -32,7 +32,7 @@ public class ProfileController extends Controller {
   }
 
   public CompletionStage<Result> myProfile(Http.Request request) {
-    Optional<CiviFormProfile> maybeProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> maybeProfile = profileUtils.optionalCurrentUserProfile(request);
 
     if (maybeProfile.isEmpty()) {
       return CompletableFuture.completedFuture(ok(profileView.renderNoProfile(request)));

--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -83,7 +83,7 @@ public class AdminApiKeysController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result retire(Http.Request request, Long apiKeyId) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     if (profile.isEmpty()) {
       throw new RuntimeException("Unable to resolve profile.");
@@ -107,7 +107,7 @@ public class AdminApiKeysController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     if (profile.isEmpty()) {
       throw new RuntimeException("Unable to resolve profile.");

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -415,7 +415,7 @@ public final class AdminApplicationController extends CiviFormController {
             .setStatusText(newStatus)
             .setEmailSent(sendEmail)
             .build(),
-        profileUtils.currentUserProfile(request).get().getAccount().join());
+        profileUtils.optionalCurrentUserProfile(request).get().getAccount().join());
     // Only allow relative URLs to ensure that we redirect to the same domain.
     String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeRedirectUri.orElse(""));
     return redirect(redirectUrl).flashing(FlashKey.SUCCESS, "Application status updated");
@@ -458,7 +458,7 @@ public final class AdminApplicationController extends CiviFormController {
     programAdminApplicationService.setNote(
         application,
         ApplicationEventDetails.NoteEvent.create(note),
-        profileUtils.currentUserProfile(request).get().getAccount().join());
+        profileUtils.optionalCurrentUserProfile(request).get().getAccount().join());
 
     // Only allow relative URLs to ensure that we redirect to the same domain.
     String redirectUrl = UrlUtils.checkIsRelativeUrl(maybeRedirectUri.orElse(""));
@@ -550,7 +550,7 @@ public final class AdminApplicationController extends CiviFormController {
 
   private CiviFormProfile getCiviFormProfile(Http.Request request) {
     return profileUtils
-        .currentUserProfile(request)
+        .optionalCurrentUserProfile(request)
         .orElseThrow(() -> new RuntimeException("User authorized as admin but no profile found."));
   }
 }

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -73,7 +73,7 @@ public final class AdminProgramController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Request request) {
-    Optional<CiviFormProfile> profileMaybe = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profileMaybe = profileUtils.optionalCurrentUserProfile(request);
     return ok(
         listView.render(
             programService.getInUseActiveAndDraftProgramsWithoutQuestionLoad(),
@@ -89,7 +89,7 @@ public final class AdminProgramController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result indexDisabled(Request request) {
-    Optional<CiviFormProfile> profileMaybe = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profileMaybe = profileUtils.optionalCurrentUserProfile(request);
     return ok(
         listView.render(
             programService.getDisabledActiveAndDraftProgramsWithoutQuestionLoad(),

--- a/server/app/controllers/admin/AdminProgramPreviewController.java
+++ b/server/app/controllers/admin/AdminProgramPreviewController.java
@@ -50,7 +50,7 @@ public final class AdminProgramPreviewController extends CiviFormController {
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result preview(Request request, long programId) {
-    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     try {
       return redirect(applicantRoutes.review(profile, profile.getApplicant().get().id, programId));

--- a/server/app/controllers/admin/AdminReportingController.java
+++ b/server/app/controllers/admin/AdminReportingController.java
@@ -52,7 +52,7 @@ public final class AdminReportingController extends CiviFormController {
 
   private CiviFormProfile getCiviFormProfile(Http.Request request) {
     return profileUtils
-        .currentUserProfile(request)
+        .optionalCurrentUserProfile(request)
         .orElseThrow(() -> new RuntimeException("User authorized as admin but no profile found."));
   }
 

--- a/server/app/controllers/admin/AdminSettingsController.java
+++ b/server/app/controllers/admin/AdminSettingsController.java
@@ -46,7 +46,7 @@ public class AdminSettingsController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     if (profile.isEmpty()) {
       throw new RuntimeException("Unable to resolve profile.");

--- a/server/app/controllers/admin/NorthStarQuestionPreviewController.java
+++ b/server/app/controllers/admin/NorthStarQuestionPreviewController.java
@@ -50,7 +50,7 @@ public final class NorthStarQuestionPreviewController extends CiviFormController
 
     Representation representation = Representation.builder().build();
     ApplicantPersonalInfo api = ApplicantPersonalInfo.ofGuestUser(representation);
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     QuestionType questionTypeEnum;
     try {

--- a/server/app/controllers/admin/ProgramAdminController.java
+++ b/server/app/controllers/admin/ProgramAdminController.java
@@ -35,7 +35,7 @@ public class ProgramAdminController extends CiviFormController {
   /** Return a HTML page showing all programs the program admin administers. */
   @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
   public Result index(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     if (profile.isEmpty()) {
       throw new RuntimeException("No profile found for program admin");

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -86,7 +86,10 @@ public final class ApplicantInformationController extends CiviFormController {
               String redirectLink;
               if (request.session().data().containsKey(REDIRECT_TO_SESSION_KEY)) {
                 redirectLink = request.session().data().get(REDIRECT_TO_SESSION_KEY);
-              } else if (profileUtils.currentUserProfile(request).get().isTrustedIntermediary()) {
+              } else if (profileUtils
+                  .optionalCurrentUserProfile(request)
+                  .get()
+                  .isTrustedIntermediary()) {
                 redirectLink =
                     controllers.ti.routes.TrustedIntermediaryController.dashboard(
                             /* nameQuery= */ Optional.empty(),
@@ -96,7 +99,7 @@ public final class ApplicantInformationController extends CiviFormController {
                             /* page= */ Optional.of(1))
                         .url();
               } else {
-                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                CiviFormProfile profile = profileUtils.currentUserProfile(request);
                 redirectLink = applicantRoutes.index(profile, applicantId).url();
               }
 
@@ -136,7 +139,7 @@ public final class ApplicantInformationController extends CiviFormController {
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
     String redirectLocation;
     Session session;
-    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     if (infoForm.getRedirectLink().isEmpty()) {
       redirectLocation = applicantRoutes.index(profile, applicantId).url();

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -326,7 +326,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         .thenComposeAsync(
             roApplicantProgramService -> {
               removeAddressJsonFromSession(request);
-              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+              CiviFormProfile profile = profileUtils.currentUserProfile(request);
               return renderErrorOrRedirectToRequestedPage(
                   request,
                   profile,
@@ -368,7 +368,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 classLoaderExecutionContext.current())
             .toCompletableFuture();
 
-    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     CompletableFuture<ReadOnlyApplicantProgramService> applicantProgramServiceCompletableFuture =
         applicantStage
@@ -486,7 +486,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
 
               if (block.isPresent()) {
                 ApplicantPersonalInfo personalInfo = applicantStage.toCompletableFuture().join();
-                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                CiviFormProfile profile = profileUtils.currentUserProfile(request);
                 ApplicationBaseViewParams applicationParams =
                     applicationBaseViewParamsBuilder(
                             request,
@@ -624,7 +624,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
               // Re-direct back to the current page.
               return supplyAsync(
                   () -> {
-                    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                    CiviFormProfile profile = profileUtils.currentUserProfile(request);
                     return redirect(
                         applicantRoutes
                             .blockEditOrBlockReview(
@@ -769,7 +769,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
               // Re-direct back to the current page.
               return supplyAsync(
                   () -> {
-                    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                    CiviFormProfile profile = profileUtils.currentUserProfile(request);
                     return redirect(
                         applicantRoutes
                             .blockEditOrBlockReview(
@@ -860,7 +860,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             classLoaderExecutionContext.current())
         .thenComposeAsync(
             (roApplicantProgramService) -> {
-              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+              CiviFormProfile profile = profileUtils.currentUserProfile(request);
               return renderErrorOrRedirectToRequestedPage(
                   request,
                   profile,
@@ -980,7 +980,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
               ImmutableMap<String, String> formData = formDataCompletableFuture.join();
               ReadOnlyApplicantProgramService readOnlyApplicantProgramService =
                   applicantProgramServiceCompletableFuture.join();
-              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+              CiviFormProfile profile = profileUtils.currentUserProfile(request);
               Optional<Block> optionalBlockBeforeUpdate =
                   readOnlyApplicantProgramService.getActiveBlock(blockId);
               ApplicantRequestedAction applicantRequestedAction =
@@ -1104,7 +1104,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     }
     Block thisBlockUpdated = thisBlockUpdatedMaybe.get();
 
-    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile =
+        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
 
     // Validation errors: re-render this block with errors and previously entered data.
     if (thisBlockUpdated.hasErrors()) {
@@ -1320,7 +1321,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       Boolean isEligibilityEnabledOnThisBlock =
           thisBlockUpdated.getLeafAddressNodeServiceAreaIds().isPresent();
 
-      CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+      CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
       ApplicationBaseViewParams applicationParams =
           buildApplicationBaseViewParams(
@@ -1391,7 +1392,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     AlertSettings eligibilityAlertSettings =
         eligibilityAlertSettingsCalculator.calculate(
             request,
-            profileUtils.currentUserProfile(request).get().isTrustedIntermediary(),
+            profileUtils.optionalCurrentUserProfile(request).get().isTrustedIntermediary(),
             !roApplicantProgramService.isApplicationNotEligible(),
             settingsManifest.getNorthStarApplicantUi(request),
             false,

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -113,7 +113,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   @Secure
   public CompletionStage<Result> reviewWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> submittingProfile = profileUtils.optionalCurrentUserProfile(request);
 
     // If the user isn't already logged in within their browser session, send them home.
     if (submittingProfile.isEmpty()) {
@@ -148,7 +148,10 @@ public class ApplicantProgramReviewController extends CiviFormController {
               AlertSettings eligibilityAlertSettings =
                   eligibilityAlertSettingsCalculator.calculate(
                       request,
-                      profileUtils.currentUserProfile(request).get().isTrustedIntermediary(),
+                      profileUtils
+                          .optionalCurrentUserProfile(request)
+                          .get()
+                          .isTrustedIntermediary(),
                       !roApplicantProgramService.isApplicationNotEligible(),
                       settingsManifest.getNorthStarApplicantUi(request),
                       false,
@@ -260,7 +263,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   @Secure
   public CompletionStage<Result> submitWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> submittingProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> submittingProfile = profileUtils.optionalCurrentUserProfile(request);
 
     // If the user isn't already logged in within their browser session, send them home.
     if (submittingProfile.isEmpty()) {
@@ -333,7 +336,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
   private CompletionStage<Result> submitInternal(
       Request request, long applicantId, long programId) {
-    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile =
+        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
 
     CompletableFuture<ApplicationModel> submitAppFuture =
         applicantService
@@ -404,7 +408,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                 if (cause instanceof DuplicateApplicationException) {
                   return renderPreventDuplicateSubmissionPage(
                       request,
-                      profileUtils.currentUserProfileOrThrow(request),
+                      profileUtils.currentUserProfile(request),
                       applicantId,
                       applicantPersonalInfo.join(),
                       readOnlyApplicantProgramServiceFuture.join());
@@ -472,7 +476,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               roApplicantProgramService,
               messagesApi.preferred(request),
               applicantId,
-              profileUtils.currentUserProfileOrThrow(request)));
+              profileUtils.currentUserProfile(request)));
     }
   }
 

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -88,7 +88,7 @@ public final class ApplicantProgramsController extends CiviFormController {
       Request request,
       long applicantId, /* The selected program categories */
       List<String> categories) {
-    Optional<CiviFormProfile> requesterProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> requesterProfile = profileUtils.optionalCurrentUserProfile(request);
 
     // If the user doesn't have a profile, send them home.
     if (requesterProfile.isEmpty()) {
@@ -172,7 +172,7 @@ public final class ApplicantProgramsController extends CiviFormController {
   @Secure
   public CompletionStage<Result> showWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> requesterProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> requesterProfile = profileUtils.optionalCurrentUserProfile(request);
 
     // If the user doesn't have a profile, send them home.
     if (requesterProfile.isEmpty()) {
@@ -196,7 +196,7 @@ public final class ApplicantProgramsController extends CiviFormController {
                       .map(ApplicantProgramData::program)
                       .filter(program -> program.id() == programId)
                       .findFirst();
-              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+              CiviFormProfile profile = profileUtils.currentUserProfile(request);
               if (programDefinition.isPresent()) {
                 return ok(
                     programInfoView.render(
@@ -251,7 +251,7 @@ public final class ApplicantProgramsController extends CiviFormController {
   @Secure
   public CompletionStage<Result> editWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> requesterProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> requesterProfile = profileUtils.optionalCurrentUserProfile(request);
 
     // If the user doesn't have a profile, send them home.
     if (requesterProfile.isEmpty()) {
@@ -266,7 +266,7 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenApplyAsync(
             roApplicantService -> {
               Optional<Block> blockMaybe = roApplicantService.getFirstIncompleteOrStaticBlock();
-              CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+              CiviFormProfile profile = profileUtils.currentUserProfile(request);
               return blockMaybe.flatMap(
                   block ->
                       Optional.of(
@@ -282,7 +282,7 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenComposeAsync(
             resultMaybe -> {
               if (resultMaybe.isEmpty()) {
-                CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+                CiviFormProfile profile = profileUtils.currentUserProfile(request);
                 return supplyAsync(
                     () -> redirect(applicantRoutes.review(profile, applicantId, programId)));
               }

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -50,7 +50,7 @@ public final class ProgramSlugHandler {
 
   public CompletionStage<Result> showProgram(
       CiviFormController controller, Http.Request request, String programSlug) {
-    CiviFormProfile profile = profileUtils.currentUserProfileOrThrow(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     return profile
         .getApplicant()
@@ -131,7 +131,8 @@ public final class ProgramSlugHandler {
       long applicantId, String programSlug, Http.Request request) {
     // Find all applicant's DRAFT applications for programs of the same slug
     // redirect to the newest program version with a DRAFT application.
-    CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile requesterProfile =
+        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
     return applicantService
         .relevantProgramsForApplicant(applicantId, requesterProfile, request)
         .thenApplyAsync(

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -98,7 +98,7 @@ public final class UpsellController extends CiviFormController {
       long applicationId,
       String redirectTo,
       String submitTime) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
     if (profile.isEmpty()) {
       // should definitely never happen.
       return CompletableFuture.completedFuture(

--- a/server/app/controllers/dev/ProfileController.java
+++ b/server/app/controllers/dev/ProfileController.java
@@ -22,7 +22,7 @@ public final class ProfileController extends Controller {
 
   /** Returns a text/plain page containing the user profile, if present. */
   public Result index(Http.Request request) {
-    Optional<CiviFormProfile> maybeProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> maybeProfile = profileUtils.optionalCurrentUserProfile(request);
     String profileContent =
         maybeProfile
             .map((p) -> JsonPrettifier.asPrettyJsonString(p.getProfileData()))

--- a/server/app/controllers/ti/TrustedIntermediaryController.java
+++ b/server/app/controllers/ti/TrustedIntermediaryController.java
@@ -83,7 +83,7 @@ public final class TrustedIntermediaryController {
           routes.TrustedIntermediaryController.dashboard(
               nameQuery, dayQuery, monthQuery, yearQuery, Optional.of(1)));
     }
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
     if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
@@ -127,7 +127,7 @@ public final class TrustedIntermediaryController {
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result accountSettings(Http.Request request) {
 
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
 
     if (civiformProfile.isEmpty()) {
       return unauthorized();
@@ -155,7 +155,7 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result showAddClientForm(Long id, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
     if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
@@ -185,7 +185,7 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result showEditClientForm(Long accountId, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
     if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
@@ -210,7 +210,7 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result addClient(Long id, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
     if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
@@ -246,7 +246,7 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result editClient(Long id, Http.Request request) throws ApplicantNotFoundException {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
     if (civiformProfile.isEmpty()) {
       return unauthorized();
     }

--- a/server/app/filters/CiviFormProfileFilter.java
+++ b/server/app/filters/CiviFormProfileFilter.java
@@ -39,7 +39,7 @@ public final class CiviFormProfileFilter extends Filter {
   }
 
   private boolean profileIsMissing(Http.RequestHeader requestHeader) {
-    return profileUtils.currentUserProfile(requestHeader).isEmpty();
+    return profileUtils.optionalCurrentUserProfile(requestHeader).isEmpty();
   }
 
   private boolean shouldApplyThisFilter(Http.RequestHeader requestHeader) {

--- a/server/app/filters/ValidAccountFilter.java
+++ b/server/app/filters/ValidAccountFilter.java
@@ -28,7 +28,7 @@ public class ValidAccountFilter extends EssentialFilter {
   public EssentialAction apply(EssentialAction next) {
     return EssentialAction.of(
         request -> {
-          Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+          Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
           if (profile.isPresent() && !profileUtils.validCiviFormProfile(profile.get())) {
             // The cookie is present but the profile is not valid, redirect to logout and clear the
             // cookie.

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -318,7 +318,7 @@ public final class ProgramImageView extends BaseHtmlView {
     DivTag currentProgramCardSection =
         div().withClass("mx-auto").with(h2("What the applicant will see").withClasses("mb-4"));
 
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
     Long applicantId;
     try {
       applicantId = profile.get().getApplicant().get().id;

--- a/server/app/views/api/ApiDocsView.java
+++ b/server/app/views/api/ApiDocsView.java
@@ -308,7 +308,7 @@ public class ApiDocsView extends BaseHtmlView {
   }
 
   private boolean isAuthenticatedAdmin(Http.Request request) {
-    Optional<CiviFormProfile> currentUserProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> currentUserProfile = profileUtils.optionalCurrentUserProfile(request);
     return currentUserProfile.isPresent()
         && (currentUserProfile.get().isCiviFormAdmin()
             || currentUserProfile.get().isProgramAdmin());

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -213,7 +213,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
       ApplicantPersonalInfo applicantPersonalInfo,
       Messages messages,
       Long applicantId) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     return nav()
         .with(
@@ -541,7 +541,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
 
   protected Optional<DivTag> maybeRenderBackToAdminViewButton(
       Http.Request request, long programId) {
-    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
     if (profile.isPresent() && profile.get().isCiviFormAdmin()) {
       return Optional.of(
           div()

--- a/server/app/views/applicant/ProgramCardViewRenderer.java
+++ b/server/app/views/applicant/ProgramCardViewRenderer.java
@@ -415,7 +415,8 @@ public final class ProgramCardViewRenderer {
 
   private PTag eligibilityTag(
       Http.Request request, Messages messages, boolean isEligible, ProfileUtils profileUtils) {
-    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile =
+        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     MessageKey mayQualifyMessage =
         isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -121,7 +121,8 @@ public final class ProgramCardsSectionParamsFactory {
 
       if (shouldShowEligibilityTag(programDatum)) {
         boolean isEligible = programDatum.isProgramMaybeEligible().get();
-        CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
+        CiviFormProfile submittingProfile =
+            profileUtils.optionalCurrentUserProfile(request).orElseThrow();
         boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
         MessageKey mayQualifyMessage =
             isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;

--- a/server/test/actions/ApplicantAuthorizationActionTest.java
+++ b/server/test/actions/ApplicantAuthorizationActionTest.java
@@ -116,7 +116,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
 
     ProfileUtils profileUtils = Mockito.mock(ProfileUtils.class);
     when(profileUtils.getApplicantId(any(Http.Request.class))).thenReturn(Optional.of(applicantId));
-    when(profileUtils.currentUserProfile(any(Http.RequestHeader.class)))
+    when(profileUtils.optionalCurrentUserProfile(any(Http.RequestHeader.class)))
         .thenReturn(Optional.of(profile));
 
     // Setup fakeRequest and configure it to use the specified route pattern

--- a/server/test/controllers/WithMockedProfiles.java
+++ b/server/test/controllers/WithMockedProfiles.java
@@ -162,8 +162,8 @@ public class WithMockedProfiles {
   }
 
   private void mockProfile(CiviFormProfile profile) {
-    when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile()))))
+    when(MOCK_UTILS.optionalCurrentUserProfile(not(argThat(skipUserProfile()))))
         .thenReturn(Optional.of(profile));
-    when(MOCK_UTILS.currentUserProfileOrThrow(not(argThat(skipUserProfile())))).thenReturn(profile);
+    when(MOCK_UTILS.currentUserProfile(not(argThat(skipUserProfile())))).thenReturn(profile);
   }
 }

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -594,7 +594,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     // Returns a Profile that will never fail auth checks.
     @Override
-    public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
+    public Optional<CiviFormProfile> optionalCurrentUserProfile(Http.RequestHeader request) {
       return Optional.of(profileTester);
     }
 

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -64,7 +64,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
-                profileUtils.currentUserProfile(requestBuilder.build()).get())
+                profileUtils.optionalCurrentUserProfile(requestBuilder.build()).get())
             .get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, requestBuilder.build());
     assertThat(result.status()).isEqualTo(OK);
@@ -150,7 +150,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
-                profileUtils.currentUserProfile(requestBuilder.build()).get())
+                profileUtils.optionalCurrentUserProfile(requestBuilder.build()).get())
             .get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, requestBuilder.build());
     assertThat(result.status()).isEqualTo(OK);
@@ -236,7 +236,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
-                profileUtils.currentUserProfile(requestBuilder.build()).get())
+                profileUtils.optionalCurrentUserProfile(requestBuilder.build()).get())
             .get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, requestBuilder.build());
     assertThat(result.status()).isEqualTo(OK);
@@ -266,7 +266,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
-                profileUtils.currentUserProfile(requestBuilder.build()).get())
+                profileUtils.optionalCurrentUserProfile(requestBuilder.build()).get())
             .get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, requestBuilder.build());
     assertThat(result.status()).isEqualTo(OK);
@@ -298,7 +298,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
 
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
         repo.getTrustedIntermediaryGroup(
-                profileUtils.currentUserProfile(requestBuilder.build()).get())
+                profileUtils.optionalCurrentUserProfile(requestBuilder.build()).get())
             .get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, requestBuilder.build());
     assertThat(result.status()).isEqualTo(OK);


### PR DESCRIPTION
### Description

Rename ProfileUtils methods:

* currentUserProfile to optionalCurrentUserProfile, because it returns an Optional
* currentUserProfileOrThrow to currentUserProfile, because since #5971 the profile should always be present for user-facing controllers, and thus this method should be sufficient for most use cases, and the throwing is an edge case rather than expected

Also move currentUserProfile above the two versions of optionalCurrentUserProfile so they are next to each other.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)