### PR TITLE
[Suffix] implement name suffix field in thymeleaf

### DIFF
--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -259,6 +259,24 @@ test.describe('name applicant flow', () => {
         })
       })
 
+      test('validate name suffix field with north star flag and name suffix dropdown flag enabled', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
+
+        await test.step('name suffix field available to use', async () => {
+          await applicantQuestions.applyProgram(programName)
+          await expect(page.getByLabel('Suffix')).toBeVisible()
+          await expect(page.getByLabel('Suffix')).toHaveValue('')
+        })
+
+        await test.step('selects an option in name suffix dropdown', async () => {
+          await applicantQuestions.answerDropdownQuestion('III')
+          await expect(page.getByLabel('Suffix')).toHaveValue('III')
+        })
+      })
+
       test('has no accessiblity violations', async ({
         page,
         applicantQuestions,

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -80,6 +80,8 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
       context.setVariable("nameSuffixOptions", Suffix.values());
+      context.setVariable(
+          "isNameSuffixEnabled", settingsManifest.getNameSuffixDropdownEnabled(request));
       return templateEngine.process("applicant/ApplicantProgramBlockEditTemplate", context);
     }
   }

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -9,6 +9,7 @@ import controllers.applicant.ApplicantRoutes;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
 import org.thymeleaf.TemplateEngine;
 import play.mvc.Http.Request;
@@ -78,6 +79,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
           getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
+      context.setVariable("nameSuffixOptions", Suffix.values());
       return templateEngine.process("applicant/ApplicantProgramBlockEditTemplate", context);
     }
   }

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -74,8 +74,7 @@
     fieldErrors=${nameQuestion.getValidationErrors().get(lastNamePath)},
     hasErrors=${questionRendererParams.shouldShowErrors() && fieldErrors != null && !fieldErrors.isEmpty()}"
     class="cf-name-last cf-applicant-question-field"
-    th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
-    th:classappend="${isNameSuffixEnabled? 'margin-bottom-1' : ''}"
+    th:classappend="${(hasErrors ? 'cf-question-field-with-error' : '') + (isNameSuffixEnabled? 'margin-bottom-1' : '')}"
   >
     <div
       th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(lastNamePath)}, ${questionRendererParams})}"

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -73,8 +73,9 @@
     lastNamePath=${nameQuestion.getLastNamePath()},
     fieldErrors=${nameQuestion.getValidationErrors().get(lastNamePath)},
     hasErrors=${questionRendererParams.shouldShowErrors() && fieldErrors != null && !fieldErrors.isEmpty()}"
-    class="cf-name-last cf-applicant-question-field margin-bottom-1"
+    class="cf-name-last cf-applicant-question-field"
     th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
+    th:classappend="${isNameSuffixEnabled? 'margin-bottom-1' : ''}"
   >
     <div
       th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(lastNamePath)}, ${questionRendererParams})}"
@@ -99,6 +100,7 @@
   </div>
 
   <div
+    th:if="${isNameSuffixEnabled}"
     th:with="nameSuffixId=${'id-' + #strings.randomAlphanumeric(8)}"
     class="cf-dropdown-question cf-applicant-question-field"
   >

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -73,7 +73,7 @@
     lastNamePath=${nameQuestion.getLastNamePath()},
     fieldErrors=${nameQuestion.getValidationErrors().get(lastNamePath)},
     hasErrors=${questionRendererParams.shouldShowErrors() && fieldErrors != null && !fieldErrors.isEmpty()}"
-    class="cf-name-last cf-applicant-question-field"
+    class="cf-name-last cf-applicant-question-field margin-bottom-1"
     th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   >
     <div
@@ -96,5 +96,34 @@
       th:name="${lastNamePath}"
       th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(lastNamePath)}"
     />
+  </div>
+
+  <div
+    th:with="nameSuffixId=${'id-' + #strings.randomAlphanumeric(8)}"
+    class="cf-dropdown-question cf-applicant-question-field"
+  >
+    <label
+      class="use-label"
+      th:for="${nameSuffixId}"
+      th:text="#{label.nameSuffix}"
+    ></label>
+    <select
+      class="usa-select cf-input-large"
+      th:maxlength="${maxInputLength}"
+      th:classappend="${hasErrors ? 'usa-input--error' : ''}"
+      th:id="${nameSuffixId}"
+      th:name="${nameQuestion.getNameSuffixPath()}"
+      th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(nameSuffixPath)}"
+    >
+      <option
+        th:selected="${!nameQuestion.getNameSuffixValue.isEmpty()}"
+      ></option>
+      <option
+        th:each="option,iterator: ${nameSuffixOptions}"
+        th:value="${option.getValue()}"
+        th:text="${option.getValue()}"
+        th:selected="${!nameQuestion.getNameSuffixValue.isEmpty()}"
+      ></option>
+    </select>
   </div>
 </div>


### PR DESCRIPTION
### Description

Implement name suffix field in name question in thymeleaf. Name suffix is an optional dropdown field provided to the applicant when answering name question.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size


### Instructions for manual testing

Enabled `NORTH_STAR_APPLICANT_UI` and `NAME_SUFFIX_DROPDOWN_ENABLED` flag as a civiform admin. Apply to a program and open name question as an applicant. Name suffix field should be there.

### Issue(s) this completes

Fixes #7999
