### PR TITLE
Send email to guest applicant when PAI email question is answered

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -569,8 +569,6 @@ public final class ApplicantService {
   @VisibleForTesting
   CompletionStage<ApplicationModel> submitApplication(
       long applicantId, long programId, Optional<String> tiSubmitterEmail, Request request) {
-    CompletableFuture<ApplicantPersonalInfo> applicantLabelFuture =
-        getPersonalInfo(applicantId).toCompletableFuture();
     CompletableFuture<Optional<ApplicationModel>> applicationFuture =
         applicationRepository
             .submitApplication(applicantId, programId, tiSubmitterEmail)
@@ -579,88 +577,89 @@ public final class ApplicantService {
                 classLoaderExecutionContext.current())
             .toCompletableFuture();
 
-    return CompletableFuture.allOf(applicantLabelFuture, applicationFuture)
-        .thenComposeAsync(
-            (v) -> {
-              Optional<ApplicationModel> applicationMaybe = applicationFuture.join();
-              if (applicationMaybe.isEmpty()) {
-                return CompletableFuture.failedFuture(
-                    new ApplicationSubmissionException(applicantId, programId));
-              }
+    return applicationFuture.thenComposeAsync(
+        (v) -> {
+          Optional<ApplicationModel> applicationMaybe = applicationFuture.join();
+          if (applicationMaybe.isEmpty()) {
+            return CompletableFuture.failedFuture(
+                new ApplicationSubmissionException(applicantId, programId));
+          }
 
-              ApplicationModel application = applicationMaybe.get();
-              ProgramModel applicationProgram = application.getProgram();
-              ProgramDefinition programDefinition =
-                  programRepository.getShallowProgramDefinition(applicationProgram);
-              String programName = programDefinition.adminName();
-              StatusDefinitions activeStatusDefinitions =
-                  applicationStatusesRepository.lookupActiveStatusDefinitions(programName);
-              Optional<StatusDefinitions.Status> maybeDefaultStatus =
-                  activeStatusDefinitions.getDefaultStatus();
+          ApplicationModel application = applicationMaybe.get();
+          ProgramModel applicationProgram = application.getProgram();
+          ProgramDefinition programDefinition =
+              programRepository.getShallowProgramDefinition(applicationProgram);
+          String programName = programDefinition.adminName();
+          StatusDefinitions activeStatusDefinitions =
+              applicationStatusesRepository.lookupActiveStatusDefinitions(programName);
+          Optional<StatusDefinitions.Status> maybeDefaultStatus =
+              activeStatusDefinitions.getDefaultStatus();
 
-              CompletableFuture<ApplicationEventModel> updateStatusFuture =
-                  maybeDefaultStatus
-                      .map(
-                          status -> setApplicationStatus(application, status).toCompletableFuture())
-                      .orElse(CompletableFuture.completedFuture(null));
+          CompletableFuture<ApplicationEventModel> updateStatusFuture =
+              maybeDefaultStatus
+                  .map(status -> setApplicationStatus(application, status).toCompletableFuture())
+                  .orElse(CompletableFuture.completedFuture(null));
 
-              CompletableFuture<Void> notifyProgramAdminsFuture =
-                  CompletableFuture.runAsync(
-                      () ->
-                          notifyProgramAdmins(applicantId, programId, application.id, programName),
-                      classLoaderExecutionContext.current());
+          CompletableFuture<Void> notifyProgramAdminsFuture =
+              CompletableFuture.runAsync(
+                  () -> notifyProgramAdmins(applicantId, programId, application.id, programName),
+                  classLoaderExecutionContext.current());
 
-              CompletableFuture<Void> notifyTiSubmitterFuture =
-                  tiSubmitterEmail
-                      .map(
-                          email ->
-                              notifyTiSubmitter(
-                                      email,
-                                      applicantId,
-                                      application.id,
-                                      programName,
-                                      maybeDefaultStatus)
-                                  .toCompletableFuture())
-                      .orElse(CompletableFuture.completedFuture(null));
+          CompletableFuture<Void> notifyTiSubmitterFuture =
+              tiSubmitterEmail
+                  .map(
+                      email ->
+                          notifyTiSubmitter(
+                                  email,
+                                  applicantId,
+                                  application.id,
+                                  programName,
+                                  maybeDefaultStatus)
+                              .toCompletableFuture())
+                  .orElse(CompletableFuture.completedFuture(null));
 
-              ApplicantPersonalInfo applicantPersonalInfo = applicantLabelFuture.join();
-              Optional<ImmutableSet<String>> applicantEmails =
-                  getApplicantEmails(applicantPersonalInfo);
+          return getPersonalInfo(applicantId)
+              .thenComposeAsync(
+                  applicantPersonalInfo -> {
+                    Optional<ImmutableSet<String>> applicantEmails =
+                        getApplicantEmails(applicantPersonalInfo);
 
-              CompletableFuture<Void> notifyApplicantFuture;
-              if (applicantEmails.isEmpty() || applicantEmails.get().isEmpty()) {
-                notifyApplicantFuture = CompletableFuture.completedFuture(null);
-              } else {
-                ImmutableList<CompletableFuture<Void>> futures =
-                    applicantEmails.get().stream()
-                        .map(
-                            email -> {
-                              return notifyApplicant(
-                                      applicantId,
-                                      application.id,
-                                      email,
-                                      programDefinition,
-                                      maybeDefaultStatus)
-                                  .toCompletableFuture();
-                            })
-                        .collect(ImmutableList.toImmutableList());
-                notifyApplicantFuture =
-                    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-              }
-              return CompletableFuture.allOf(
-                      updateStatusFuture,
-                      notifyProgramAdminsFuture,
-                      notifyApplicantFuture,
-                      notifyTiSubmitterFuture,
-                      updateStoredFileAclsForSubmit(
-                              applicantId,
-                              programId,
-                              settingsManifest.getMultipleFileUploadEnabled(request))
-                          .toCompletableFuture())
-                  .thenApplyAsync(
-                      (ignoreVoid) -> application, classLoaderExecutionContext.current());
-            },
-            classLoaderExecutionContext.current());
+                    CompletableFuture<Void> notifyApplicantFuture;
+                    if (applicantEmails.isEmpty() || applicantEmails.get().isEmpty()) {
+                      notifyApplicantFuture = CompletableFuture.completedFuture(null);
+                    } else {
+                      ImmutableList<CompletableFuture<Void>> futures =
+                          applicantEmails.get().stream()
+                              .map(
+                                  email -> {
+                                    return notifyApplicant(
+                                            applicantId,
+                                            application.id,
+                                            email,
+                                            programDefinition,
+                                            maybeDefaultStatus)
+                                        .toCompletableFuture();
+                                  })
+                              .collect(ImmutableList.toImmutableList());
+                      notifyApplicantFuture =
+                          CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+                    }
+                    return CompletableFuture.allOf(
+                            updateStatusFuture,
+                            notifyProgramAdminsFuture,
+                            notifyApplicantFuture,
+                            notifyTiSubmitterFuture,
+                            updateStoredFileAclsForSubmit(
+                                    applicantId,
+                                    programId,
+                                    settingsManifest.getMultipleFileUploadEnabled(request))
+                                .toCompletableFuture())
+                        .thenApplyAsync(
+                            (ignoreVoid) -> application, classLoaderExecutionContext.current());
+                  },
+                  classLoaderExecutionContext.current());
+        },
+        classLoaderExecutionContext.current());
   }
 
   public Optional<ImmutableSet<String>> getApplicantEmails(

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -941,6 +941,67 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void submitApplication_emailSentToGuestApplicantWhoAnsweredPaiEmailQuestion() {
+    ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
+    applicant.setAccount(resourceCreator.insertAccount());
+    applicant.save();
+
+    EmailQuestionDefinition emailQuestion =
+        (EmailQuestionDefinition)
+            questionService
+                .create(
+                    new EmailQuestionDefinition(
+                        QuestionDefinitionConfig.builder()
+                            .setName("emailplz")
+                            .setDescription("Email plz")
+                            .setQuestionText(LocalizedStrings.of(Locale.US, "Give email plz"))
+                            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "Email!"))
+                            .setPrimaryApplicantInfoTags(
+                                ImmutableSet.of(PrimaryApplicantInfoTag.APPLICANT_EMAIL))
+                            .build()))
+                .getResult();
+
+    ProgramDefinition progDef =
+        ProgramBuilder.newDraftProgram("Email program", "desc")
+            .withBlock()
+            .withRequiredQuestionDefinitions(ImmutableList.of(emailQuestion))
+            .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
+    StatusDefinitions.Status status =
+        APPROVED_STATUS.toBuilder().setDefaultStatus(Optional.of(true)).build();
+    repo.createOrUpdateStatusDefinitions(
+        progDef.adminName(), new StatusDefinitions(ImmutableList.of(status)));
+
+    ImmutableMap<String, String> updates =
+        ImmutableMap.<String, String>builder()
+            .put(
+                Path.create("applicant.emailplz").join(Scalar.EMAIL).toString(),
+                "picard@starfleet.com")
+            .build();
+
+    subject
+        .stageAndUpdateIfValid(applicant.id, progDef.id(), "1", updates, false, false)
+        .toCompletableFuture()
+        .join();
+
+    subject
+        .submitApplication(applicant.id, progDef.id(), trustedIntermediaryProfile, fakeRequest())
+        .toCompletableFuture()
+        .join();
+
+    Messages messages = getMessages(Locale.US);
+    String programName = progDef.adminName();
+    Mockito.verify(amazonSESClient)
+        .send(
+            "picard@starfleet.com",
+            messages.at(MessageKey.EMAIL_APPLICATION_RECEIVED_SUBJECT.getKeyName(), programName),
+            String.format(
+                "%s\n%s",
+                APPROVED_STATUS.localizedEmailBodyText().get().getOrDefault(Locale.US),
+                messages.at(MessageKey.EMAIL_LOGIN_TO_CIVIFORM.getKeyName(), baseUrl)));
+  }
+
+  @Test
   public void submitApplication_savesPrimaryApplicantInfoAnswers() {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());


### PR DESCRIPTION
Previously, we were creating the ApplicantPersonalInfo object before we had actually submitted the application and saved the PAI data to the appropriate columns in the applicant table. This meant that guest applicants who answered a PAI email question never got the initial notification about applying to the program, including a default status message if it was set. This changes the logic to not create the ApplicantPersonalInfo object until after the application has been submitted.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Use `bin/localhost/get-emails` to check that an email is sent when applying as a guest to a program with an email PAI question.

### Issue(s) this completes
https://github.com/civiform/civiform/issues/8465
