### PR TITLE
Remove more missing-profile redirects

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -113,12 +113,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   @Secure
   public CompletionStage<Result> reviewWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> submittingProfile = profileUtils.optionalCurrentUserProfile(request);
-
-    // If the user isn't already logged in within their browser session, send them home.
-    if (submittingProfile.isEmpty()) {
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
 
     Optional<String> flashBannerMessage = request.flash().get(FlashKey.BANNER);
     Optional<ToastMessage> flashBanner = flashBannerMessage.map(m -> ToastMessage.alert(m));
@@ -167,9 +162,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                       .setMessages(messages)
                       .setProgramId(programId)
                       .setRequest(request)
-                      .setProfile(
-                          submittingProfile.orElseThrow(
-                              () -> new MissingOptionalException(CiviFormProfile.class)));
+                      .setProfile(submittingProfile);
 
               // Show a login prompt on the review page if we were redirected from a program slug
               // and user is a guest.
@@ -208,9 +201,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                         .setBlocks(roApplicantProgramService.getAllActiveBlocks())
                         .setApplicantId(applicantId)
                         .setApplicantPersonalInfo(applicantStage.toCompletableFuture().join())
-                        .setProfile(
-                            submittingProfile.orElseThrow(
-                                () -> new MissingOptionalException(CiviFormProfile.class)))
+                        .setProfile(submittingProfile)
                         .setProgramId(programId)
                         .setCompletedBlockCount(completedBlockCount)
                         .setTotalBlockCount(totalBlockCount)
@@ -263,14 +254,8 @@ public class ApplicantProgramReviewController extends CiviFormController {
   @Secure
   public CompletionStage<Result> submitWithApplicantId(
       Request request, long applicantId, long programId) {
-    Optional<CiviFormProfile> submittingProfile = profileUtils.optionalCurrentUserProfile(request);
-
-    // If the user isn't already logged in within their browser session, send them home.
-    if (submittingProfile.isEmpty()) {
-      return CompletableFuture.completedFuture(redirectToHome());
-    }
-
-    if (submittingProfile.get().isCiviFormAdmin()) {
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
+    if (submittingProfile.isCiviFormAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.AdminProgramPreviewController.back(programId).url()));
     }

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -36,7 +36,6 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   private ApplicantProgramBlocksController blockController;
   private ProgramModel activeProgram;
   public ApplicantModel applicant;
-  public ApplicantModel applicantWithoutProfile;
 
   @Before
   public void setUpWithFreshApplicants() {
@@ -50,20 +49,12 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .build();
     applicant = createApplicantWithMockedProfile();
-    applicantWithoutProfile = createApplicant();
   }
 
   @Test
   public void review_invalidApplicant_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.review(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation()).hasValue("/");
-  }
-
-  @Test
-  public void review_applicantWithoutProfile_redirectsToHome() {
-    Result result = this.review(applicantWithoutProfile.id, activeProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -117,13 +108,6 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   public void submit_invalid_redirectsToHome() {
     long badApplicantId = applicant.id + 1000;
     Result result = this.submit(badApplicantId, activeProgram.id);
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation()).hasValue("/");
-  }
-
-  @Test
-  public void submit_applicantWithoutProfile_redirectsToHome() {
-    Result result = this.submit(applicantWithoutProfile.id, activeProgram.id);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
   }
@@ -410,13 +394,12 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   public Result review(long applicantId, long programId) {
-    Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         fakeRequestBuilder()
             .call(
                 routes.ApplicantProgramReviewController.reviewWithApplicantId(
                     applicantId, programId))
-            .header(skipUserProfile, shouldSkipUserProfile.toString())
+            .header(skipUserProfile, "false")
             .build();
     return subject
         .reviewWithApplicantId(request, applicantId, programId)
@@ -425,13 +408,12 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   }
 
   public Result submit(long applicantId, long programId) {
-    Boolean shouldSkipUserProfile = applicantId == applicantWithoutProfile.id;
     Request request =
         fakeRequestBuilder()
             .call(
                 routes.ApplicantProgramReviewController.submitWithApplicantId(
                     applicantId, programId))
-            .header(skipUserProfile, shouldSkipUserProfile.toString())
+            .header(skipUserProfile, "false")
             .build();
     return subject
         .submitWithApplicantId(request, applicantId, programId)


### PR DESCRIPTION
### Description

#6809 created CiviFormProfileFilter which ensures that all user-facing requests have a CiviFormProfile. So all user-facing controllers should now be able to assume that the profile exists, rather than handling the case where it doesn't.

* Remove missing-profile handling from ApplicantProgramReviewController and ApplicantProgramsController
* Remove redundant calls to currentUserProfile() within the same method

This is similar to #8445.

This is for #5971.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
