### PR TITLE
Replace optionalCurrentUserProfile with currentUserProfile where appropriate

### DIFF
--- a/server/app/actions/ApplicantAuthorizationAction.java
+++ b/server/app/actions/ApplicantAuthorizationAction.java
@@ -75,10 +75,7 @@ public class ApplicantAuthorizationAction extends Action.Simple {
 
   /** Check if the profile is authorized to access the applicant's data. */
   private CompletionStage<Void> checkApplicantAuthorization(Request request, long applicantId) {
-    return profileUtils
-        .optionalCurrentUserProfile(request)
-        .orElseThrow()
-        .checkAuthorization(applicantId);
+    return profileUtils.currentUserProfile(request).checkAuthorization(applicantId);
   }
 
   /** Checks that the profile is authorized to access the specified program. */
@@ -87,11 +84,7 @@ public class ApplicantAuthorizationAction extends Action.Simple {
         .isDraftProgramAsync(programId)
         .thenAccept(
             (isDraftProgram) -> {
-              if (isDraftProgram
-                  && !profileUtils
-                      .optionalCurrentUserProfile(request)
-                      .orElseThrow()
-                      .isCiviFormAdmin()) {
+              if (isDraftProgram && !profileUtils.currentUserProfile(request).isCiviFormAdmin()) {
                 throw new SecurityException();
               }
             });

--- a/server/app/controllers/CiviFormController.java
+++ b/server/app/controllers/CiviFormController.java
@@ -40,23 +40,17 @@ public class CiviFormController extends Controller {
 
   protected CompletableFuture<Void> checkApplicantAuthorization(
       Http.Request request, long applicantId) {
-    return profileUtils
-        .optionalCurrentUserProfile(request)
-        .orElseThrow()
-        .checkAuthorization(applicantId);
+    return profileUtils.currentUserProfile(request).checkAuthorization(applicantId);
   }
 
   /**
    * Checks that the profile in {@code request} is an admin for {@code programName}.
    *
-   * @throws java.util.NoSuchElementException if there is no profile in request.
+   * @throws auth.controllers.MissingOptionalException if there is no profile in request.
    */
   protected CompletableFuture<Void> checkProgramAdminAuthorization(
       Http.Request request, String programName) {
-    return profileUtils
-        .optionalCurrentUserProfile(request)
-        .orElseThrow()
-        .checkProgramAuthorization(programName, request);
+    return profileUtils.currentUserProfile(request).checkProgramAuthorization(programName, request);
   }
 
   /** Checks that the profile is authorized to access the specified program. */
@@ -65,11 +59,7 @@ public class CiviFormController extends Controller {
         .isDraftProgramAsync(programId)
         .thenAccept(
             (isDraftProgram) -> {
-              if (isDraftProgram
-                  && !profileUtils
-                      .optionalCurrentUserProfile(request)
-                      .orElseThrow()
-                      .isCiviFormAdmin()) {
+              if (isDraftProgram && !profileUtils.currentUserProfile(request).isCiviFormAdmin()) {
                 throw new SecurityException();
               }
             });

--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -118,8 +118,7 @@ public class FileController extends CiviFormController {
       return notFound();
     }
 
-    AccountModel adminAccount =
-        profileUtils.optionalCurrentUserProfile(request).orElseThrow().getAccount().join();
+    AccountModel adminAccount = profileUtils.currentUserProfile(request).getAccount().join();
 
     // An admin is eligible if they are a global admin with the program access flag turned on
     // or if they have been explicitly given read permission to the program.

--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -83,13 +83,9 @@ public class AdminApiKeysController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result retire(Http.Request request, Long apiKeyId) {
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
-    if (profile.isEmpty()) {
-      throw new RuntimeException("Unable to resolve profile.");
-    }
-
-    apiKeyService.retireApiKey(apiKeyId, profile.get());
+    apiKeyService.retireApiKey(apiKeyId, profile);
 
     return redirect(routes.AdminApiKeysController.index().url());
   }
@@ -107,14 +103,10 @@ public class AdminApiKeysController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
-
-    if (profile.isEmpty()) {
-      throw new RuntimeException("Unable to resolve profile.");
-    }
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     DynamicForm form = formFactory.form().bindFromRequest(request);
-    ApiKeyCreationResult result = apiKeyService.createApiKey(form, profile.get());
+    ApiKeyCreationResult result = apiKeyService.createApiKey(form, profile);
 
     if (result.isSuccessful()) {
       return created(

--- a/server/app/controllers/admin/AdminReportingController.java
+++ b/server/app/controllers/admin/AdminReportingController.java
@@ -1,7 +1,6 @@
 package controllers.admin;
 
 import auth.Authorizers;
-import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import com.google.common.base.Preconditions;
 import controllers.BadRequestException;
@@ -47,13 +46,10 @@ public final class AdminReportingController extends CiviFormController {
     return ok(
         adminReportingIndexView
             .get()
-            .render(request, getCiviFormProfile(request), reportingService.getMonthlyStats()));
-  }
-
-  private CiviFormProfile getCiviFormProfile(Http.Request request) {
-    return profileUtils
-        .optionalCurrentUserProfile(request)
-        .orElseThrow(() -> new RuntimeException("User authorized as admin but no profile found."));
+            .render(
+                request,
+                profileUtils.currentUserProfile(request),
+                reportingService.getMonthlyStats()));
   }
 
   @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
@@ -67,7 +63,7 @@ public final class AdminReportingController extends CiviFormController {
                         .get()
                         .render(
                             request,
-                            getCiviFormProfile(request),
+                            profileUtils.currentUserProfile(request),
                             programSlug,
                             programDefinition.adminName(),
                             programDefinition.localizedName().getDefault(),

--- a/server/app/controllers/admin/AdminSettingsController.java
+++ b/server/app/controllers/admin/AdminSettingsController.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import controllers.FlashKey;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.data.FormFactory;
@@ -46,11 +45,7 @@ public class AdminSettingsController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
-
-    if (profile.isEmpty()) {
-      throw new RuntimeException("Unable to resolve profile.");
-    }
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     ImmutableMap<String, String> settingUpdates =
         formFactory.form().bindFromRequest(request).rawData().entrySet().stream()
@@ -58,7 +53,7 @@ public class AdminSettingsController extends CiviFormController {
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
     SettingsService.SettingsGroupUpdateResult result =
-        settingsService.updateSettings(settingUpdates, profile.get());
+        settingsService.updateSettings(settingUpdates, profile);
 
     if (result.hasErrors()) {
       return ok(indexView.render(request, result.errorMessages()));

--- a/server/app/controllers/admin/ProgramAdminController.java
+++ b/server/app/controllers/admin/ProgramAdminController.java
@@ -35,17 +35,15 @@ public class ProgramAdminController extends CiviFormController {
   /** Return a HTML page showing all programs the program admin administers. */
   @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
   public Result index(Http.Request request) {
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
-
-    if (profile.isEmpty()) {
-      throw new RuntimeException("No profile found for program admin");
-    }
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     ImmutableList<String> administeredPrograms =
-        profile.get().getAccount().join().getAdministeredProgramNames();
+        profile.getAccount().join().getAdministeredProgramNames();
     ActiveAndDraftPrograms activeAndDraftPrograms =
         this.programService.getActiveAndDraftProgramsWithoutQuestionLoad();
 
-    return ok(listView.render(request, activeAndDraftPrograms, administeredPrograms, profile));
+    return ok(
+        listView.render(
+            request, activeAndDraftPrograms, administeredPrograms, Optional.of(profile)));
   }
 }

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -86,10 +86,7 @@ public final class ApplicantInformationController extends CiviFormController {
               String redirectLink;
               if (request.session().data().containsKey(REDIRECT_TO_SESSION_KEY)) {
                 redirectLink = request.session().data().get(REDIRECT_TO_SESSION_KEY);
-              } else if (profileUtils
-                  .optionalCurrentUserProfile(request)
-                  .get()
-                  .isTrustedIntermediary()) {
+              } else if (profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
                 redirectLink =
                     controllers.ti.routes.TrustedIntermediaryController.dashboard(
                             /* nameQuery= */ Optional.empty(),

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -1104,8 +1104,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     }
     Block thisBlockUpdated = thisBlockUpdatedMaybe.get();
 
-    CiviFormProfile submittingProfile =
-        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
 
     // Validation errors: re-render this block with errors and previously entered data.
     if (thisBlockUpdated.hasErrors()) {
@@ -1392,7 +1391,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     AlertSettings eligibilityAlertSettings =
         eligibilityAlertSettingsCalculator.calculate(
             request,
-            profileUtils.optionalCurrentUserProfile(request).get().isTrustedIntermediary(),
+            profileUtils.currentUserProfile(request).isTrustedIntermediary(),
             !roApplicantProgramService.isApplicationNotEligible(),
             settingsManifest.getNorthStarApplicantUi(request),
             false,

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -148,10 +148,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
               AlertSettings eligibilityAlertSettings =
                   eligibilityAlertSettingsCalculator.calculate(
                       request,
-                      profileUtils
-                          .optionalCurrentUserProfile(request)
-                          .get()
-                          .isTrustedIntermediary(),
+                      profileUtils.currentUserProfile(request).isTrustedIntermediary(),
                       !roApplicantProgramService.isApplicationNotEligible(),
                       settingsManifest.getNorthStarApplicantUi(request),
                       false,
@@ -336,8 +333,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
   private CompletionStage<Result> submitInternal(
       Request request, long applicantId, long programId) {
-    CiviFormProfile submittingProfile =
-        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
 
     CompletableFuture<ApplicationModel> submitAppFuture =
         applicantService

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -131,8 +131,7 @@ public final class ProgramSlugHandler {
       long applicantId, String programSlug, Http.Request request) {
     // Find all applicant's DRAFT applications for programs of the same slug
     // redirect to the newest program version with a DRAFT application.
-    CiviFormProfile requesterProfile =
-        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
+    CiviFormProfile requesterProfile = profileUtils.currentUserProfile(request);
     return applicantService
         .relevantProgramsForApplicant(applicantId, requesterProfile, request)
         .thenApplyAsync(

--- a/server/app/views/applicant/ProgramCardViewRenderer.java
+++ b/server/app/views/applicant/ProgramCardViewRenderer.java
@@ -415,8 +415,7 @@ public final class ProgramCardViewRenderer {
 
   private PTag eligibilityTag(
       Http.Request request, Messages messages, boolean isEligible, ProfileUtils profileUtils) {
-    CiviFormProfile submittingProfile =
-        profileUtils.optionalCurrentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     MessageKey mayQualifyMessage =
         isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -121,8 +121,7 @@ public final class ProgramCardsSectionParamsFactory {
 
       if (shouldShowEligibilityTag(programDatum)) {
         boolean isEligible = programDatum.isProgramMaybeEligible().get();
-        CiviFormProfile submittingProfile =
-            profileUtils.optionalCurrentUserProfile(request).orElseThrow();
+        CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
         boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
         MessageKey mayQualifyMessage =
             isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;

--- a/server/test/actions/ApplicantAuthorizationActionTest.java
+++ b/server/test/actions/ApplicantAuthorizationActionTest.java
@@ -116,8 +116,7 @@ public class ApplicantAuthorizationActionTest extends WithMockedProfiles {
 
     ProfileUtils profileUtils = Mockito.mock(ProfileUtils.class);
     when(profileUtils.getApplicantId(any(Http.Request.class))).thenReturn(Optional.of(applicantId));
-    when(profileUtils.optionalCurrentUserProfile(any(Http.RequestHeader.class)))
-        .thenReturn(Optional.of(profile));
+    when(profileUtils.currentUserProfile(any(Http.RequestHeader.class))).thenReturn(profile);
 
     // Setup fakeRequest and configure it to use the specified route pattern
     Request request =

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -598,6 +598,11 @@ public class AdminApplicationControllerTest extends ResetPostgres {
       return Optional.of(profileTester);
     }
 
+    @Override
+    public CiviFormProfile currentUserProfile(Http.RequestHeader request) {
+      return profileTester;
+    }
+
     // A test version of CiviFormProfile that disable functionality that is hard
     // to otherwise test around.
     public static class ProfileTester extends CiviFormProfile {

--- a/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
+++ b/server/test/controllers/ti/TrustedIntermediaryControllerTest.java
@@ -64,8 +64,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
                     "4259879090"))
             .build();
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
-        repo.getTrustedIntermediaryGroup(profileUtils.optionalCurrentUserProfile(request).get())
-            .get();
+        repo.getTrustedIntermediaryGroup(profileUtils.currentUserProfile(request)).get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, request);
     assertThat(result.status()).isEqualTo(OK);
     Optional<ApplicantModel> testApplicant =
@@ -149,8 +148,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
                     "4259879090"))
             .build();
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
-        repo.getTrustedIntermediaryGroup(profileUtils.optionalCurrentUserProfile(request).get())
-            .get();
+        repo.getTrustedIntermediaryGroup(profileUtils.currentUserProfile(request)).get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, request);
     assertThat(result.status()).isEqualTo(OK);
     Optional<ApplicantModel> testApplicant =
@@ -234,8 +232,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
                     "4259879090"))
             .build();
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
-        repo.getTrustedIntermediaryGroup(profileUtils.optionalCurrentUserProfile(request).get())
-            .get();
+        repo.getTrustedIntermediaryGroup(profileUtils.currentUserProfile(request)).get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, request);
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Date of birth required");
@@ -263,8 +260,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
                     "4259879090"))
             .build();
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
-        repo.getTrustedIntermediaryGroup(profileUtils.optionalCurrentUserProfile(request).get())
-            .get();
+        repo.getTrustedIntermediaryGroup(profileUtils.currentUserProfile(request)).get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, request);
     assertThat(result.status()).isEqualTo(OK);
     Optional<ApplicantModel> testApplicant =
@@ -294,8 +290,7 @@ public class TrustedIntermediaryControllerTest extends WithMockedProfiles {
                     "4259879090"))
             .build();
     TrustedIntermediaryGroupModel trustedIntermediaryGroup =
-        repo.getTrustedIntermediaryGroup(profileUtils.optionalCurrentUserProfile(request).get())
-            .get();
+        repo.getTrustedIntermediaryGroup(profileUtils.currentUserProfile(request)).get();
     Result result = tiController.addClient(trustedIntermediaryGroup.id, request);
     assertThat(result.status()).isEqualTo(OK);
     Optional<ApplicantModel> testApplicant =


### PR DESCRIPTION
### Description

Replace:
* ProfileUtils.optionalCurrentUserProfile(request).get()
* ProfileUtils.optionalCurrentUserProfile(request).orElseThrow()
* ProfileUtils.optionalCurrentUserProfile(request) followed by throwing an exception if profileOptional.isEmpty()

all of which throw an exception if the profile is missing, with ProfileUtils.currentUserProfile which also throws an exception if the profile isn't present.

currentUserProfile throws MissingOptionalException whereas Optional.get and orElseThrow throw NoSuchElementException, so I changed checkProgramAdminAuthorization's javadoc and its callers accordingly.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)