### PR TITLE
Remove the networkidle wait on test user logins

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -185,10 +185,8 @@ async function loginAsTestUserFakeOidc(
   loginButton: string,
   isTi: boolean,
 ) {
-  await Promise.all([
-    page.waitForURL('**/interaction/*', {waitUntil: 'networkidle'}),
-    page.click(loginButton),
-  ])
+  await page.click(loginButton)
+  await page.waitForURL('**/interaction/*')
 
   // If the user has previously signed in to the provider, a prompt is shown
   // to reauthorize rather than sign-in. In this case, click "Continue" instead
@@ -207,18 +205,14 @@ async function loginAsTestUserFakeOidc(
 
   await page.fill('input[name=login]', TEST_USER_LOGIN)
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
-  await Promise.all([
-    page.waitForURL('**/interaction/*', {waitUntil: 'networkidle'}),
-    page.click('button:has-text("Sign-in"):not([disabled])'),
-  ])
+
+  await page.click('button:has-text("Sign-in"):not([disabled])')
+  await page.waitForURL('**/interaction/*')
+
   // A screen is shown prompting the user to authorize a set of scopes.
   // This screen is skipped if the user has already logged in once.
-  await Promise.all([
-    page.waitForURL(isTi ? '**/admin/**' : /\/programs.*/, {
-      waitUntil: 'networkidle',
-    }),
-    page.click('button:has-text("Continue")'),
-  ])
+  await page.click('button:has-text("Continue")')
+  await page.waitForURL(isTi ? '**/admin/**' : /\/programs.*/)
 }
 
 export const testUserDisplayName = () => {


### PR DESCRIPTION
### Description

The `loginAsTestUserFakeOidc` was using `networkidle` on `waitForURL` calls. Playwright recommends avoiding the use of network idle. This PR removes it for the default of `load`. It cuts around `1000ms` from the call.

> 'networkidle' - DISCOURAGED consider operation to be finished when there are no network connections for at least 500 ms. Don't use this method for testing, rely on web assertions to assess readiness instead.

This will only affect the dev and ci. Going to let this run for a bit to make sure there no issues and look at doing the same to the other test user login methods.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
