### PR TITLE
Remove more missing-profile handling

### DIFF
--- a/server/app/controllers/admin/NorthStarQuestionPreviewController.java
+++ b/server/app/controllers/admin/NorthStarQuestionPreviewController.java
@@ -6,7 +6,6 @@ import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
-import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.i18n.Lang;
@@ -50,7 +49,7 @@ public final class NorthStarQuestionPreviewController extends CiviFormController
 
     Representation representation = Representation.builder().build();
     ApplicantPersonalInfo api = ApplicantPersonalInfo.ofGuestUser(representation);
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     QuestionType questionTypeEnum;
     try {
@@ -64,7 +63,7 @@ public final class NorthStarQuestionPreviewController extends CiviFormController
             .setRequest(request)
             .setApplicantId(0l)
             .setApplicantPersonalInfo(api)
-            .setProfile(profile.orElse(null))
+            .setProfile(profile)
             .setType(questionTypeEnum)
             .setMessages(messages)
             .build();

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.controllers.MissingOptionalException;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import controllers.FlashKey;
@@ -98,12 +97,7 @@ public final class UpsellController extends CiviFormController {
       long applicationId,
       String redirectTo,
       String submitTime) {
-    Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
-    if (profile.isEmpty()) {
-      // should definitely never happen.
-      return CompletableFuture.completedFuture(
-          badRequest("You are not signed in - you cannot perform this action."));
-    }
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
 
     CompletableFuture<Boolean> isCommonIntake =
         programService
@@ -119,8 +113,7 @@ public final class UpsellController extends CiviFormController {
             .thenComposeAsync(
                 v -> checkApplicantAuthorization(request, applicantId),
                 classLoaderExecutionContext.current())
-            .thenComposeAsync(
-                v -> profile.get().getAccount(), classLoaderExecutionContext.current())
+            .thenComposeAsync(v -> profile.getAccount(), classLoaderExecutionContext.current())
             .toCompletableFuture();
 
     CompletableFuture<ReadOnlyApplicantProgramService> roApplicantProgramService =
@@ -130,7 +123,7 @@ public final class UpsellController extends CiviFormController {
 
     CompletableFuture<ApplicantService.ApplicationPrograms> relevantProgramsFuture =
         applicantService
-            .relevantProgramsForApplicant(applicantId, profile.get(), request)
+            .relevantProgramsForApplicant(applicantId, profile, request)
             .toCompletableFuture();
 
     return CompletableFuture.allOf(
@@ -150,7 +143,7 @@ public final class UpsellController extends CiviFormController {
                       // We are already checking if profile is empty
                       v ->
                           applicantService.maybeEligibleProgramsForApplicant(
-                              applicantId, profile.get(), request),
+                              applicantId, profile, request),
                       classLoaderExecutionContext.current())
                   .thenApplyAsync(
                       eligiblePrograms -> {
@@ -180,9 +173,7 @@ public final class UpsellController extends CiviFormController {
                 UpsellParams.Builder paramsBuilder =
                     UpsellParams.builder()
                         .setRequest(request)
-                        .setProfile(
-                            profile.orElseThrow(
-                                () -> new MissingOptionalException(CiviFormProfile.class)))
+                        .setProfile(profile)
                         .setApplicantPersonalInfo(applicantPersonalInfo.join())
                         .setApplicationId(applicationId)
                         .setMessages(messagesApi.preferred(request))
@@ -215,8 +206,7 @@ public final class UpsellController extends CiviFormController {
                         applicantPersonalInfo.join(),
                         applicantId,
                         programId,
-                        profile.orElseThrow(
-                            () -> new MissingOptionalException(CiviFormProfile.class)),
+                        profile,
                         maybeEligiblePrograms.orElseGet(ImmutableList::of),
                         messagesApi.preferred(request),
                         toastMessage,
@@ -233,8 +223,7 @@ public final class UpsellController extends CiviFormController {
                       roApplicantProgramService.join().getCustomConfirmationMessage(),
                       applicantPersonalInfo.join(),
                       applicantId,
-                      profile.orElseThrow(
-                          () -> new MissingOptionalException(CiviFormProfile.class)),
+                      profile,
                       applicationId,
                       messagesApi.preferred(request),
                       toastMessage,

--- a/server/app/controllers/ti/TrustedIntermediaryController.java
+++ b/server/app/controllers/ti/TrustedIntermediaryController.java
@@ -83,12 +83,9 @@ public final class TrustedIntermediaryController {
           routes.TrustedIntermediaryController.dashboard(
               nameQuery, dayQuery, monthQuery, yearQuery, Optional.of(1)));
     }
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
@@ -108,7 +105,7 @@ public final class TrustedIntermediaryController {
         PaginationInfo.paginate(trustedIntermediarySearchResult.accounts(), PAGE_SIZE, page.get());
 
     Optional<String> applicantName =
-        civiformProfile.get().getApplicant().join().getApplicantData().getApplicantName();
+        civiformProfile.getApplicant().join().getApplicantData().getApplicantName();
 
     return ok(
         tiClientListView.render(
@@ -126,22 +123,16 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result accountSettings(Http.Request request) {
-
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
-
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
 
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
 
     Optional<String> applicantName =
-        civiformProfile.get().getApplicant().join().getApplicantData().getApplicantName();
+        civiformProfile.getApplicant().join().getApplicantData().getApplicantName();
 
     return ok(
         tiAccountSettingsView.render(
@@ -155,12 +146,9 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result showAddClientForm(Long id, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
@@ -168,7 +156,7 @@ public final class TrustedIntermediaryController {
       return unauthorized();
     }
     Optional<String> applicantName =
-        civiformProfile.get().getApplicant().join().getApplicantData().getApplicantName();
+        civiformProfile.getApplicant().join().getApplicantData().getApplicantName();
 
     return ok(
         editTiClientView.render(
@@ -185,12 +173,9 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result showEditClientForm(Long accountId, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
@@ -210,12 +195,9 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result addClient(Long id, Http.Request request) {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
@@ -246,13 +228,10 @@ public final class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result editClient(Long id, Http.Request request) throws ApplicantNotFoundException {
-    Optional<CiviFormProfile> civiformProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (civiformProfile.isEmpty()) {
-      return unauthorized();
-    }
+    CiviFormProfile civiformProfile = profileUtils.currentUserProfile(request);
 
     Optional<TrustedIntermediaryGroupModel> trustedIntermediaryGroup =
-        accountRepository.getTrustedIntermediaryGroup(civiformProfile.get());
+        accountRepository.getTrustedIntermediaryGroup(civiformProfile);
     if (trustedIntermediaryGroup.isEmpty()) {
       return unauthorized();
     }
@@ -276,7 +255,7 @@ public final class TrustedIntermediaryController {
             /* applicantIdOfNewlyAddedClient= */ null));
   }
 
-  private Long getTiApplicantIdFromCiviformProfile(Optional<CiviFormProfile> civiformProfile) {
-    return civiformProfile.get().getApplicant().toCompletableFuture().join().id;
+  private Long getTiApplicantIdFromCiviformProfile(CiviFormProfile civiformProfile) {
+    return civiformProfile.getApplicant().toCompletableFuture().join().id;
   }
 }

--- a/server/app/views/api/ApiDocsView.java
+++ b/server/app/views/api/ApiDocsView.java
@@ -308,6 +308,7 @@ public class ApiDocsView extends BaseHtmlView {
   }
 
   private boolean isAuthenticatedAdmin(Http.Request request) {
+    // CiviFormProfileFilter does not apply to API docs views, so there may be no profile
     Optional<CiviFormProfile> currentUserProfile = profileUtils.optionalCurrentUserProfile(request);
     return currentUserProfile.isPresent()
         && (currentUserProfile.get().isCiviFormAdmin()

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -3,6 +3,9 @@ package controllers.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -10,6 +13,7 @@ import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -21,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import play.data.FormFactory;
 import play.mvc.Http;
+import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
 import repository.ResetPostgres;
 import repository.VersionRepository;
@@ -44,6 +49,9 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
   @Before
   public void setup() {
     programService = instanceOf(ProgramService.class);
+    CiviFormProfile profile = mock(CiviFormProfile.class);
+    ProfileUtils profileUtils = mock(ProfileUtils.class);
+    when(profileUtils.currentUserProfile(any(RequestHeader.class))).thenReturn(profile);
     controller =
         new AdminProgramImageController(
             new FakePublicStorageClient(),


### PR DESCRIPTION
### Description

#6809 created CiviFormProfileFilter which ensures that all user-facing requests have a CiviFormProfile. So all user-facing controllers should now be able to assume that the profile exists, rather than handling the case where it doesn't.

This is for https://github.com/civiform/civiform/issues/5971.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)