### PR TITLE
Create a feature flag for program migration without duplicate questions created

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -952,6 +952,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("PROGRAM_MIGRATION_ENABLED", request);
   }
 
+  /**
+   * (NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs
+   * between deployed environments. Note: this should only be used on new environments, since
+   * existing programs will be modified if a program with the same question gets imported.
+   */
+  public boolean getNoDuplicateQuestionsForMigrationEnabled(RequestHeader request) {
+    return getBool("NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED", request);
+  }
+
   /** (NOT FOR PRODUCTION USE) Enables filtering programs by category on the homepage */
   public boolean getProgramFilteringEnabled(RequestHeader request) {
     return getBool("PROGRAM_FILTERING_ENABLED", request);
@@ -1997,6 +2006,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "PROGRAM_MIGRATION_ENABLED",
                       "(NOT FOR PRODUCTION USE) Enables migrating programs between deployed"
                           + " environments",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.ADMIN_WRITEABLE),
+                  SettingDescription.create(
+                      "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED",
+                      "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when"
+                          + " migrating programs between deployed environments. Note: this should"
+                          + " only be used on new environments, since existing programs will be"
+                          + " modified if a program with the same question gets imported.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -794,6 +794,11 @@
         "description": "(NOT FOR PRODUCTION USE) Enables migrating programs between deployed environments",
         "type": "bool"
       },
+      "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs between deployed environments. Note: this should only be used on new environments, since existing programs will be modified if a program with the same question gets imported.",
+        "type": "bool"
+      },
       "PROGRAM_FILTERING_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Enables filtering programs by category on the homepage",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -64,6 +64,9 @@ program_filtering_enabled = ${?PROGRAM_FILTERING_ENABLED}
 # Program migration
 program_migration_enabled = false
 program_migration_enabled = ${?PROGRAM_MIGRATION_ENABLED}
+# Ensure no duplicate questions during program migration
+no_duplicate_questions_for_migration_enabled = false
+no_duplicate_questions_for_migration_enabled = ${?NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED}
 
 # Program disabled
 disabled_visibility_condition_enabled = false


### PR DESCRIPTION
### Description

This will gate an alternate version of program migration, where no duplicate questions are created and instead we use existing questions when available. This should only be used on new environments or non-production environments.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.

#### New Features

- [x] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.


### Issue(s) this completes

https://github.com/civiform/civiform/issues/8533