### PR TITLE
Style eligibility tag. Add check-circle icon.

### DIFF
--- a/server/app/assets/Images/uswds/icon-check-circle.svg
+++ b/server/app/assets/Images/uswds/icon-check-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM8 15L3 10L4.41 8.59L8 12.17L15.59 4.58L17 6L8 15Z" fill="black"/>
+</svg>

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -233,3 +233,24 @@ main {
   flex-wrap: wrap;
   row-gap: 0.5rem;
 }
+
+.flex-parent {
+  display: flex;
+}
+
+.flex-fill {
+  flex-grow: 1;
+}
+
+.success-state {
+  border-radius: 2px;
+  background: var(--State-tokens-success-success-lighter, #ecf3ec);
+  @include u-padding-y(0.5);
+  @include u-padding-x(1);
+  align-items: center;
+  gap: units(1);
+}
+
+.cf-eligible-tag {
+  @include u-font('sans', 'xs');
+}

--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -52,17 +52,22 @@
         <span th:text="#{title.status}"></span>:
         <span th:text="${card.applicationStatus().get()}"></span>
       </p>
-      <p
-        th:if="${card.eligible().isPresent()}"
-        class="border rounded-full px-2 py-1 mb-4 gap-x-2 inline-block w-auto bg-gray-200"
-      >
-        <span
-          th:text="${card.eligibilityMessage().get()}"
-          class="p-2 text-xs font-medium text-black"
-          th:classappend="${card.eligible().get()} ? cf-eligible-tag : cf-not-eligible-tag"
-        ></span>
-      </p>
+
       <p th:text="${card.body()}"></p>
+
+      <div th:if="${card.eligible().isPresent()}">
+        <div class="content-spacing"></div>
+        <div class="flex-parent">
+          <div class="flex-parent success-state">
+            <cf:icon type="icon-check-circle" />
+            <span
+              th:text="${card.eligibilityMessage().get()}"
+              th:classappend="${card.eligible().get()} ? cf-eligible-tag : cf-not-eligible-tag"
+            ></span>
+          </div>
+          <div class="flex-fill"></div>
+        </div>
+      </div>
     </div>
     <div class="usa-card__footer cf-card-footer">
       <a


### PR DESCRIPTION
### Description

In North Star program cards, style the eligibility tag.

Add the USWDS check-circle icon to CiviForm.

[Mocks](https://www.figma.com/design/RmhVJCLgAKWGENJLWWAtNS/CiviForm%3A-Components%2C-Styles?node-id=3336-1526&m=dev)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Issue(s) this completes

Contributes to #8157