### PR TITLE
Rename dev seed classes to dev tools

### DIFF
--- a/server/app/controllers/dev/DevToolsController.java
+++ b/server/app/controllers/dev/DevToolsController.java
@@ -1,10 +1,11 @@
-package controllers.dev.seeding;
+package controllers.dev;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import controllers.FlashKey;
+import controllers.dev.seeding.DevDatabaseSeedTask;
 import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.Transaction;
@@ -30,13 +31,13 @@ import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
 import services.settings.SettingsService;
-import views.dev.DatabaseSeedView;
+import views.dev.DevToolsView;
 
 /** Controller for dev tools. */
-public class DevDatabaseSeedController extends Controller {
+public class DevToolsController extends Controller {
 
   private final DevDatabaseSeedTask devDatabaseSeedTask;
-  private final DatabaseSeedView view;
+  private final DevToolsView view;
   private final Database database;
   private final QuestionService questionService;
   private final ProgramService programService;
@@ -51,9 +52,9 @@ public class DevDatabaseSeedController extends Controller {
   private final Clock clock;
 
   @Inject
-  public DevDatabaseSeedController(
+  public DevToolsController(
       DevDatabaseSeedTask devDatabaseSeedTask,
-      DatabaseSeedView view,
+      DevToolsView view,
       QuestionService questionService,
       ProgramService programService,
       SettingsService settingsService,
@@ -109,7 +110,7 @@ public class DevDatabaseSeedController extends Controller {
 
     devDatabaseSeedTask.seedQuestions();
 
-    return redirect(routes.DevDatabaseSeedController.index().url())
+    return redirect(routes.DevToolsController.index().url())
         .flashing(FlashKey.SUCCESS, "Sample questions seeded");
   }
 
@@ -123,7 +124,7 @@ public class DevDatabaseSeedController extends Controller {
     devDatabaseSeedTask.seedProgramCategories();
     devDatabaseSeedTask.insertMinimalSampleProgram(createdSampleQuestions);
     devDatabaseSeedTask.insertComprehensiveSampleProgram(createdSampleQuestions);
-    return redirect(routes.DevDatabaseSeedController.index().url())
+    return redirect(routes.DevToolsController.index().url())
         .flashing(FlashKey.SUCCESS, "The database has been seeded");
   }
 
@@ -156,7 +157,7 @@ public class DevDatabaseSeedController extends Controller {
     }
     clearCacheIfEnabled();
     resetTables();
-    return redirect(routes.DevDatabaseSeedController.index().url())
+    return redirect(routes.DevToolsController.index().url())
         .flashing(FlashKey.SUCCESS, "The database has been cleared");
   }
 
@@ -166,7 +167,7 @@ public class DevDatabaseSeedController extends Controller {
       return notFound();
     }
     if (!settingsManifest.getVersionCacheEnabled() && !settingsManifest.getProgramCacheEnabled()) {
-      return redirect(routes.DevDatabaseSeedController.index().url())
+      return redirect(routes.DevToolsController.index().url())
           .flashing(
               "warning",
               "The cache is not enabled, so no cache was cleared. To enable caching, set"

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -134,8 +134,7 @@ public abstract class NorthStarBaseView {
                   FakeAdminClient.CLIENT_NAME, FakeAdminClient.TRUSTED_INTERMEDIARY)
               .url());
       context.setVariable(
-          "additionalToolsUrl",
-          controllers.dev.seeding.routes.DevDatabaseSeedController.index().url());
+          "additionalToolsUrl", controllers.dev.routes.DevToolsController.index().url());
     }
     return context;
   }

--- a/server/app/views/dev/AddressCheckerView.java
+++ b/server/app/views/dev/AddressCheckerView.java
@@ -14,7 +14,7 @@ import static j2html.TagCreator.text;
 import static j2html.TagCreator.ul;
 
 import com.google.inject.Inject;
-import controllers.dev.seeding.routes;
+import controllers.dev.routes;
 import j2html.tags.specialized.DivTag;
 import play.mvc.Http;
 import play.twirl.api.Content;
@@ -56,7 +56,7 @@ public class AddressCheckerView extends BaseHtmlView {
             .withClasses("m-8", "max-w-6xl")
             .with(
                 header(
-                        a().withHref(routes.DevDatabaseSeedController.index().url())
+                        a().withHref(routes.DevToolsController.index().url())
                             .with(
                                 span()
                                     .with(

--- a/server/app/views/dev/DebugContent.java
+++ b/server/app/views/dev/DebugContent.java
@@ -54,7 +54,7 @@ public final class DebugContent extends BaseHtmlView {
             redirectButton(
                 "additional-tools",
                 "Additional tools",
-                controllers.dev.seeding.routes.DevDatabaseSeedController.index().url()));
+                controllers.dev.routes.DevToolsController.index().url()));
   }
 
   public DivTag civiformVersionDiv() {

--- a/server/app/views/dev/DevToolsView.java
+++ b/server/app/views/dev/DevToolsView.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
-import controllers.dev.seeding.routes;
+import controllers.dev.routes;
 import durablejobs.DurableJobName;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
@@ -34,13 +34,13 @@ import views.HtmlBundle;
 import views.components.SelectWithLabel;
 
 /** Renders a page with various dev tools. This is only available in non-prod environments. */
-public class DatabaseSeedView extends BaseHtmlView {
+public class DevToolsView extends BaseHtmlView {
   private final BaseHtmlLayout layout;
   private final ObjectMapper objectMapper;
   private final DeploymentType deploymentType;
 
   @Inject
-  public DatabaseSeedView(
+  public DevToolsView(
       BaseHtmlLayout layout, ObjectMapper objectMapper, DeploymentType deploymentType) {
     this.layout = checkNotNull(layout);
     this.objectMapper = checkNotNull(objectMapper);
@@ -67,7 +67,7 @@ public class DatabaseSeedView extends BaseHtmlView {
     String prettyQuestions = getPrettyJson(questionDefinitions);
 
     ATag indexLinkTag =
-        a().withHref(routes.DevDatabaseSeedController.index().url())
+        a().withHref(routes.DevToolsController.index().url())
             .withId("index")
             .with(submitButton("index", "Go to dev database seeder page"));
 
@@ -130,21 +130,21 @@ public class DatabaseSeedView extends BaseHtmlView {
                 request,
                 "sample-programs",
                 "Seed sample programs and categories",
-                routes.DevDatabaseSeedController.seedPrograms().url()))
+                routes.DevToolsController.seedPrograms().url()))
         .with(
             createForm(
                 request,
                 "sample-questions",
                 "Seed sample questions",
-                routes.DevDatabaseSeedController.seedQuestions().url()))
+                routes.DevToolsController.seedQuestions().url()))
         .with(
             createForm(
                 request,
                 "clear",
                 "Clear entire database (irreversible!)",
-                routes.DevDatabaseSeedController.clear().url(),
+                routes.DevToolsController.clear().url(),
                 true))
-        .with(createLink("View seed data", routes.DevDatabaseSeedController.data().url()));
+        .with(createLink("View seed data", routes.DevToolsController.data().url()));
   }
 
   private SectionTag createCachingSection(Request request) {
@@ -157,7 +157,7 @@ public class DatabaseSeedView extends BaseHtmlView {
                 request,
                 "clear-cache",
                 "\uD83D\uDCB5 Clear cache",
-                routes.DevDatabaseSeedController.clearCache().url()));
+                routes.DevToolsController.clearCache().url()));
   }
 
   private SectionTag createDurableJobsSection(Request request) {
@@ -179,7 +179,7 @@ public class DatabaseSeedView extends BaseHtmlView {
                     .withClasses("w-full")
                     .withId("run-durable-job-button"))
             .withMethod("post")
-            .withAction(routes.DevDatabaseSeedController.runDurableJob().url())
+            .withAction(routes.DevToolsController.runDurableJob().url())
             .with(
                 new SelectWithLabel()
                     .setId("durable-job-select")

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -252,17 +252,17 @@ GET     /idcsRegister                controllers.LoginController.register(reques
 GET     /logout                      @org.pac4j.play.LogoutController.logout(request: Request)
 
 ## Dev tools
-GET     /dev/seed                                 controllers.dev.seeding.DevDatabaseSeedController.index(request: Request)
-GET     /dev/seed/data                            controllers.dev.seeding.DevDatabaseSeedController.data(request: Request)
-POST    /dev/seedQuestions                        controllers.dev.seeding.DevDatabaseSeedController.seedQuestions()
-POST    /dev/seedPrograms                         controllers.dev.seeding.DevDatabaseSeedController.seedPrograms()
-POST    /dev/seed/clear                           controllers.dev.seeding.DevDatabaseSeedController.clear()
-POST    /dev/seed/clearCache                      controllers.dev.seeding.DevDatabaseSeedController.clearCache()
+GET     /dev/seed                                 controllers.dev.DevToolsController.index(request: Request)
+GET     /dev/seed/data                            controllers.dev.DevToolsController.data(request: Request)
+POST    /dev/seedQuestions                        controllers.dev.DevToolsController.seedQuestions()
+POST    /dev/seedPrograms                         controllers.dev.DevToolsController.seedPrograms()
+POST    /dev/seed/clear                           controllers.dev.DevToolsController.clear()
+POST    /dev/seed/clearCache                      controllers.dev.DevToolsController.clearCache()
 GET     /dev/icons                                controllers.dev.IconsController.index(request: Request)
 GET     /dev/addressChecker                       controllers.dev.AddressCheckerController.index(request: Request)
 POST    /dev/addressChecker/hx/correctAddress     controllers.dev.AddressCheckerController.hxCorrectAddress(request: Request)
 POST    /dev/addressChecker/hx/checkServiceArea   controllers.dev.AddressCheckerController.hxCheckServiceArea(request: Request)
-POST    /dev/runDurableJob                        controllers.dev.seeding.DevDatabaseSeedController.runDurableJob(request: Request)
+POST    /dev/runDurableJob                        controllers.dev.DevToolsController.runDurableJob(request: Request)
 
 # Change feature flags
 GET     /dev/feature/:flag/disable     controllers.dev.FeatureFlagOverrideController.disable(request: Request, flag: String)

--- a/server/test/controllers/dev/DevToolsControllerTest.java
+++ b/server/test/controllers/dev/DevToolsControllerTest.java
@@ -1,4 +1,4 @@
-package controllers.dev.seeding;
+package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.NOT_FOUND;
@@ -21,10 +21,10 @@ import play.mvc.Result;
 import play.test.Helpers;
 import repository.VersionRepository;
 
-public class DevDatabaseSeedControllerTest {
+public class DevToolsControllerTest {
 
   private Optional<Application> maybeApp = Optional.empty();
-  private DevDatabaseSeedController controller;
+  private DevToolsController controller;
   private VersionRepository versionRepo;
   private SyncCacheApi programsByVersionCache;
 
@@ -47,7 +47,7 @@ public class DevDatabaseSeedControllerTest {
 
     // Seed the fake data.
     result = controller.seedPrograms();
-    assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
+    assertThat(result.redirectLocation()).hasValue(routes.DevToolsController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
     result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
@@ -60,7 +60,7 @@ public class DevDatabaseSeedControllerTest {
 
     // Clear the data.
     result = controller.clear();
-    assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
+    assertThat(result.redirectLocation()).hasValue(routes.DevToolsController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been cleared");
     result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
@@ -85,7 +85,7 @@ public class DevDatabaseSeedControllerTest {
 
     // Seed the fake data.
     result = controller.seedPrograms();
-    assertThat(result.redirectLocation()).hasValue(routes.DevDatabaseSeedController.index().url());
+    assertThat(result.redirectLocation()).hasValue(routes.DevToolsController.index().url());
     assertThat(result.flash().get(FlashKey.SUCCESS)).hasValue("The database has been seeded");
     result = controller.index(fakeRequest());
     assertThat(result.status()).isEqualTo(OK);
@@ -142,7 +142,7 @@ public class DevDatabaseSeedControllerTest {
                 .in(mode)
                 .configure("version_cache_enabled", true)
                 .build());
-    controller = maybeApp.get().injector().instanceOf(DevDatabaseSeedController.class);
+    controller = maybeApp.get().injector().instanceOf(DevToolsController.class);
     BindingKey<SyncCacheApi> versionProgramsKey =
         new BindingKey<>(SyncCacheApi.class).qualifiedWith(new NamedCacheImpl("version-programs"));
     programsByVersionCache = maybeApp.get().injector().instanceOf(versionProgramsKey.asScala());


### PR DESCRIPTION
### Description

Rename these classes because they are not specific to seeding anymore and are rather general dev tools classes:
* controllers.dev.seeding.DevDatabaseSeedController -> controllers.dev.DevToolsController
* DatabaseSeedView -> DevToolsView

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)