### PR TITLE
[Suffix] add suffix field on ti dashboard

### DIFF
--- a/browser-test/src/support/ti_dashboard.ts
+++ b/browser-test/src/support/ti_dashboard.ts
@@ -35,6 +35,12 @@ export class TIDashboard {
     await this.page.fill('#first-name-input', client.firstName)
     await this.page.fill('#middle-name-input', client.middleName)
     await this.page.fill('#last-name-input', client.lastName)
+    if (client.nameSuffix != undefined) {
+      await this.page.selectOption(
+        '#name-suffix-select',
+        client.nameSuffix.toString(),
+      )
+    }
     await this.page.fill('#date-of-birth-input', client.dobDate)
     if (client.notes != undefined) {
       await this.page.fill('#ti-note-input', client.notes)
@@ -288,6 +294,7 @@ export interface ClientInformation {
   firstName: string
   middleName: string
   lastName: string
+  nameSuffix?: string
   dobDate: string
   phoneNumber?: string
   notes?: string

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -1312,21 +1312,32 @@ test.describe('Trusted intermediaries', () => {
 
     test('TI is able to fill out name suffix info for the applicant', async ({
       page,
-      tiDashboard
+      tiDashboard,
     }) => {
       await loginAsTrustedIntermediary(page)
+      const client: ClientInformation = {
+        emailAddress: 'test@sample.com',
+        firstName: 'first',
+        middleName: 'middle',
+        lastName: 'last',
+        nameSuffix: 'II',
+        dobDate: '1995-06-10',
+      }
 
-      await test.step(`suffix shows up on TI dashboard when adding new client`, async () => {
-        await tiDashboard.gotoTIDashboardPage(page)
-        await page.getByRole('link', {name: 'Add new client'}).click()
+      await test.step('adds an applicant with name suffix', async () => {
+        await tiDashboard.createClient(client)
+        await waitForPageJsLoad(page)
+        await page.click('#ti-dashboard-link')
         await waitForPageJsLoad(page)
 
-        await expect(page.getByLabel('Suffix')).toBeVisible()
+        await tiDashboard.expectDashboardContainClient(client)
       })
 
-      await test.step(`TI selects name suffix for the applicant`, async () => {
-        await page.selectOption('#name-suffix-select', 'I')
-        await expect(page.getByLabel('Suffix')).toHaveValue('I')
+      await test.step('name suffix field is filled with preset value', async () => {
+        await page.click('#edit-client')
+        await waitForPageJsLoad(page)
+
+        await expect(page.getByLabel('Suffix')).toHaveValue('II')
       })
     })
   })

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from './support/civiform_fixtures'
 import {
+  enableFeatureFlag,
   ClientInformation,
   loginAsAdmin,
   loginAsTrustedIntermediary,
@@ -1300,6 +1301,32 @@ test.describe('Trusted intermediaries', () => {
           '(718) 867-5309',
         )
         await validateScreenshot(page, 'pai-ti-dash')
+      })
+    })
+  })
+
+  test.describe('ti can add suffix information with suffix feature flag enabled', () => {
+    test.beforeEach(async ({page}) => {
+      await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
+    })
+
+    test('TI is able to fill out name suffix info for the applicant', async ({
+      page,
+      tiDashboard
+    }) => {
+      await loginAsTrustedIntermediary(page)
+
+      await test.step(`suffix shows up on TI dashboard when adding new client`, async () => {
+        await tiDashboard.gotoTIDashboardPage(page)
+        await page.getByRole('link', {name: 'Add new client'}).click()
+        await waitForPageJsLoad(page)
+
+        await expect(page.getByLabel('Suffix')).toBeVisible()
+      })
+
+      await test.step(`TI selects name suffix for the applicant`, async () => {
+        await page.selectOption('#name-suffix-select', 'I')
+        await expect(page.getByLabel('Suffix')).toHaveValue('I')
       })
     })
   })

--- a/server/app/services/ti/TrustedIntermediaryService.java
+++ b/server/app/services/ti/TrustedIntermediaryService.java
@@ -44,6 +44,7 @@ public final class TrustedIntermediaryService {
   public static final String FORM_FIELD_NAME_DOB = "dob";
   public static final String FORM_FIELD_NAME_PHONE = "phoneNumber";
   public static final String FORM_FIELD_NAME_MIDDLE_NAME = "middleName";
+  public static final String FORM_FIELD_NAME_SUFFIX = "suffixName";
   public static final String FORM_FIELD_NAME_TI_NOTES = "tiNote";
 
   @Inject

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -2,6 +2,7 @@ package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
 
@@ -15,7 +16,9 @@ import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import java.util.Optional;
+import java.util.stream.Stream;
 import models.AccountModel;
+import models.ApplicantModel;
 import models.TrustedIntermediaryGroupModel;
 import play.data.Form;
 import play.i18n.Messages;
@@ -34,7 +37,9 @@ import views.HtmlBundle;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
+import views.components.SelectWithLabel;
 import views.style.BaseStyles;
+import views.style.ReferenceClasses;
 
 /** Renders a page for a trusted intermediary to edit a client */
 public class EditTiClientView extends TrustedIntermediaryDashboardView {
@@ -244,6 +249,22 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
             form,
             TrustedIntermediaryService.FORM_FIELD_NAME_LAST_NAME,
             messages);
+
+    SelectWithLabel nameSuffixField =
+        new SelectWithLabel()
+            .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
+            .setFieldName("nameSuffix")
+            .setPlaceholderText("")
+            .setOptions(
+                Stream.of(ApplicantModel.Suffix.values())
+                    .map(
+                        option ->
+                            SelectWithLabel.OptionValue.builder()
+                                .setLabel(option.getValue().toString())
+                                .setValue(option.toString())
+                                .build())
+                    .collect(ImmutableList.toImmutableList()));
+
     FieldWithLabel phoneNumberField =
         setStateIfPresent(
             FieldWithLabel.input()
@@ -315,6 +336,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
                     firstNameField.getUSWDSInputTag(),
                     middleNameField.getUSWDSInputTag(),
                     lastNameField.getUSWDSInputTag(),
+                    nameSuffixField.getSelectTag(),
                     phoneNumberField.getUSWDSInputTag(),
                     emailField.getUSWDSInputTag(),
                     dateOfBirthField.getUSWDSInputTag(),

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -2,7 +2,6 @@ package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
 
@@ -39,7 +38,6 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.SelectWithLabel;
 import views.style.BaseStyles;
-import views.style.ReferenceClasses;
 
 /** Renders a page for a trusted intermediary to edit a client */
 public class EditTiClientView extends TrustedIntermediaryDashboardView {
@@ -252,6 +250,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
 
     SelectWithLabel nameSuffixField =
         new SelectWithLabel()
+            .setId("name-suffix-select")
             .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
             .setFieldName("nameSuffix")
             .setPlaceholderText("")
@@ -336,7 +335,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
                     firstNameField.getUSWDSInputTag(),
                     middleNameField.getUSWDSInputTag(),
                     lastNameField.getUSWDSInputTag(),
-                    nameSuffixField.getSelectTag(),
+                    nameSuffixField.getUSWDSSelectTag(),
                     phoneNumberField.getUSWDSInputTag(),
                     emailField.getUSWDSInputTag(),
                     dateOfBirthField.getUSWDSInputTag(),

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
-import static j2html.TagCreator.iff;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -341,26 +340,35 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
                     /* yearQuery= */ Optional.empty(),
                     /* page= */ Optional.of(1))
                 .url();
-    return div()
-        .with(
-            formTag
-                .with(
-                    firstNameField.getUSWDSInputTag(),
-                    middleNameField.getUSWDSInputTag(),
-                    lastNameField.getUSWDSInputTag(),
-                    iff(isNameSuffixEnabled, nameSuffixField.getUSWDSSelectTag()),
-                    phoneNumberField.getUSWDSInputTag(),
-                    emailField.getUSWDSInputTag(),
-                    dateOfBirthField.getUSWDSInputTag(),
-                    tiNoteField.getUSWDSTextareaTag(),
-                    makeCsrfTokenInputTag(request),
-                    submitButton(messages.at(MessageKey.BUTTON_SAVE.getKeyName()))
-                        .withClasses("usa-button"),
-                    asRedirectElement(
-                        button(messages.at(MessageKey.BUTTON_CANCEL.getKeyName()))
-                            .withClasses("usa-button usa-button--outline", "m-2"),
-                        cancelUrl))
-                .withClasses("w-1/2", "mt-6"));
+    ImmutableList<Tag> nameTags =
+        ImmutableList.of(
+            firstNameField.getUSWDSInputTag(),
+            middleNameField.getUSWDSInputTag(),
+            lastNameField.getUSWDSInputTag());
+
+    ImmutableList<Tag> tags =
+        ImmutableList.of(
+            phoneNumberField.getUSWDSInputTag(),
+            emailField.getUSWDSInputTag(),
+            dateOfBirthField.getUSWDSInputTag(),
+            tiNoteField.getUSWDSTextareaTag(),
+            makeCsrfTokenInputTag(request),
+            submitButton(messages.at(MessageKey.BUTTON_SAVE.getKeyName()))
+                .withClasses("usa-button"),
+            asRedirectElement(
+                button(messages.at(MessageKey.BUTTON_CANCEL.getKeyName()))
+                    .withClasses("usa-button usa-button--outline", "m-2"),
+                cancelUrl));
+
+    FormTag addOrEditClientForm = formTag;
+    if (isNameSuffixEnabled) {
+      addOrEditClientForm =
+          formTag.with(nameTags).with(nameSuffixField.getUSWDSSelectTag()).with(tags);
+    } else {
+      addOrEditClientForm = formTag.with(nameTags).with(tags);
+    }
+
+    return div().with(addOrEditClientForm.withClasses("w-1/2", "mt-6"));
   }
 
   private String getDefaultDob(Optional<ApplicantData> optionalApplicantData) {

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
+import static j2html.TagCreator.iff;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -255,7 +256,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
 
     SelectWithLabel nameSuffixField =
         setStateIfPresent(
-            SelectWithLabel.select()
+            new SelectWithLabel()
                 .setId("name-suffix-select")
                 .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
                 .setFieldName("nameSuffix")
@@ -340,36 +341,26 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
                     /* yearQuery= */ Optional.empty(),
                     /* page= */ Optional.of(1))
                 .url();
-
-    ImmutableList<Tag> nameTags =
-        ImmutableList.of(
-            firstNameField.getUSWDSInputTag(),
-            middleNameField.getUSWDSInputTag(),
-            lastNameField.getUSWDSInputTag());
-
-    ImmutableList<Tag> tags =
-        ImmutableList.of(
-            phoneNumberField.getUSWDSInputTag(),
-            emailField.getUSWDSInputTag(),
-            dateOfBirthField.getUSWDSInputTag(),
-            tiNoteField.getUSWDSTextareaTag(),
-            makeCsrfTokenInputTag(request),
-            submitButton(messages.at(MessageKey.BUTTON_SAVE.getKeyName()))
-                .withClasses("usa-button"),
-            asRedirectElement(
-                button(messages.at(MessageKey.BUTTON_CANCEL.getKeyName()))
-                    .withClasses("usa-button usa-button--outline", "m-2"),
-                cancelUrl));
-
-    FormTag addOrEditClientForm = formTag;
-    if (isNameSuffixEnabled) {
-      addOrEditClientForm =
-          formTag.with(nameTags).with(nameSuffixField.getUSWDSSelectTag()).with(tags);
-    } else {
-      addOrEditClientForm = formTag.with(nameTags).with(tags);
-    }
-
-    return div().with(addOrEditClientForm.withClasses("w-1/2", "mt-6"));
+    return div()
+        .with(
+            formTag
+                .with(
+                    firstNameField.getUSWDSInputTag(),
+                    middleNameField.getUSWDSInputTag(),
+                    lastNameField.getUSWDSInputTag(),
+                    iff(isNameSuffixEnabled, nameSuffixField.getUSWDSSelectTag()),
+                    phoneNumberField.getUSWDSInputTag(),
+                    emailField.getUSWDSInputTag(),
+                    dateOfBirthField.getUSWDSInputTag(),
+                    tiNoteField.getUSWDSTextareaTag(),
+                    makeCsrfTokenInputTag(request),
+                    submitButton(messages.at(MessageKey.BUTTON_SAVE.getKeyName()))
+                        .withClasses("usa-button"),
+                    asRedirectElement(
+                        button(messages.at(MessageKey.BUTTON_CANCEL.getKeyName()))
+                            .withClasses("usa-button usa-button--outline", "m-2"),
+                        cancelUrl))
+                .withClasses("w-1/2", "mt-6"));
   }
 
   private String getDefaultDob(Optional<ApplicantData> optionalApplicantData) {

--- a/server/app/views/applicant/EditTiClientView.java
+++ b/server/app/views/applicant/EditTiClientView.java
@@ -249,20 +249,27 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
             messages);
 
     SelectWithLabel nameSuffixField =
-        new SelectWithLabel()
-            .setId("name-suffix-select")
-            .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
-            .setFieldName("nameSuffix")
-            .setPlaceholderText("")
-            .setOptions(
-                Stream.of(ApplicantModel.Suffix.values())
-                    .map(
-                        option ->
-                            SelectWithLabel.OptionValue.builder()
-                                .setLabel(option.getValue().toString())
-                                .setValue(option.toString())
-                                .build())
-                    .collect(ImmutableList.toImmutableList()));
+        setStateIfPresent(
+            SelectWithLabel.select()
+                .setId("name-suffix-select")
+                .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
+                .setFieldName("nameSuffix")
+                .setValue(
+                    setDefaultNameSuffix(optionalApplicantData).isEmpty()
+                        ? ""
+                        : setDefaultNameSuffix(optionalApplicantData).get())
+                .setOptions(
+                    Stream.of(ApplicantModel.Suffix.values())
+                        .map(
+                            option ->
+                                SelectWithLabel.OptionValue.builder()
+                                    .setLabel(option.getValue().toString())
+                                    .setValue(option.toString())
+                                    .build())
+                        .collect(ImmutableList.toImmutableList())),
+            form,
+            TrustedIntermediaryService.FORM_FIELD_NAME_SUFFIX,
+            messages);
 
     FieldWithLabel phoneNumberField =
         setStateIfPresent(
@@ -374,6 +381,12 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
     return optionalAccount.isPresent() ? optionalAccount.get().getTiNote() : "";
   }
 
+  private Optional<String> setDefaultNameSuffix(Optional<ApplicantData> optionalApplicantData) {
+    return optionalApplicantData.isPresent()
+        ? optionalApplicantData.get().getApplicantNameSuffix()
+        : Optional.empty();
+  }
+
   private Optional<String> setDefaultMiddleName(Optional<ApplicantData> optionalApplicantData) {
     return optionalApplicantData.isPresent()
         ? optionalApplicantData.get().getApplicantMiddleName()
@@ -390,6 +403,28 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
     return optionalApplicantData.isPresent()
         ? optionalApplicantData.get().getApplicantFirstName()
         : Optional.empty();
+  }
+
+  private SelectWithLabel setStateIfPresent(
+      SelectWithLabel select,
+      Optional<Form<TiClientInfoForm>> optionalForm,
+      String key,
+      Messages messages) {
+    if (optionalForm.isEmpty()) {
+      return select;
+    }
+
+    TiClientInfoForm form = optionalForm.get().value().get();
+    switch (key) {
+      case TrustedIntermediaryService.FORM_FIELD_NAME_SUFFIX:
+        select.setValue(form.getNameSuffix());
+        break;
+    }
+
+    if (optionalForm.get().error(key).isPresent()) {
+      select.setFieldErrors(messages, optionalForm.get().errors(key));
+    }
+    return select;
   }
 
   private FieldWithLabel setStateIfPresent(

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -698,10 +698,12 @@ public class FieldWithLabel {
     boolean isSelectTag = fieldTag instanceof SelectTag;
     boolean hasFieldErrors = hasFieldErrors();
     if (isTagTypeTextarea()) {
+      System.out.println("hi from isTagTypeTextarea");
       return hasFieldErrors ? "usa-textarea usa-input--error" : "usa-textarea";
     }
     if (isSelectTag) {
-      return hasFieldErrors ? BaseStyles.SELECT_WITH_ERROR : BaseStyles.SELECT;
+      System.out.println("hi from selecttag");
+      return hasFieldErrors ? BaseStyles.SELECT_WITH_ERROR : "usa-select";
     } else {
       return hasFieldErrors ? "usa-input usa-input--error" : "usa-input";
     }

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -698,11 +698,9 @@ public class FieldWithLabel {
     boolean isSelectTag = fieldTag instanceof SelectTag;
     boolean hasFieldErrors = hasFieldErrors();
     if (isTagTypeTextarea()) {
-      System.out.println("hi from isTagTypeTextarea");
       return hasFieldErrors ? "usa-textarea usa-input--error" : "usa-textarea";
     }
     if (isSelectTag) {
-      System.out.println("hi from selecttag");
       return hasFieldErrors ? BaseStyles.SELECT_WITH_ERROR : "usa-select";
     } else {
       return hasFieldErrors ? "usa-input usa-input--error" : "usa-input";
@@ -808,7 +806,7 @@ public class FieldWithLabel {
         .withText(this.labelText);
   }
 
-  private FieldWithLabel setTagTypeInput() {
+  protected FieldWithLabel setTagTypeInput() {
     tagType = "input";
     return this;
   }

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -59,6 +59,10 @@ public final class SelectWithLabel extends FieldWithLabel {
     return this;
   }
 
+  public DivTag getUSWDSSelectTag() {
+    return getSelectTag(true);
+  }
+
   @Override
   public SelectWithLabel setFieldName(String fieldName) {
     super.setFieldName(fieldName);
@@ -132,6 +136,10 @@ public final class SelectWithLabel extends FieldWithLabel {
   }
 
   public DivTag getSelectTag() {
+    return getSelectTag(false);
+  }
+
+  public DivTag getSelectTag(boolean isUSWDS) {
     SelectTag fieldTag = TagCreator.select();
     OptionTag placeholder = option(placeholderText).withValue("");
 
@@ -150,7 +158,7 @@ public final class SelectWithLabel extends FieldWithLabel {
       fieldTag.with(optionGroups.stream().map(this::renderOptionGroup));
     }
 
-    return applyAttrsClassesAndLabel(fieldTag);
+    return isUSWDS ? applyUSWDSAttrsClassesAndLabel(fieldTag) : applyAttrsClassesAndLabel(fieldTag);
   }
 
   private OptgroupTag renderOptionGroup(OptionGroup optionGroup) {

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -19,6 +19,10 @@ public final class SelectWithLabel extends FieldWithLabel {
   private ImmutableList<OptionTag> customOptions = ImmutableList.of();
   private boolean placeholderVisible = false;
 
+  public static SelectWithLabel select() {
+    return new SelectWithLabel();
+  }
+
   @Override
   public SelectWithLabel addReferenceClass(String referenceClass) {
     referenceClassesBuilder.add(referenceClass);

--- a/server/app/views/components/SelectWithLabel.java
+++ b/server/app/views/components/SelectWithLabel.java
@@ -19,10 +19,6 @@ public final class SelectWithLabel extends FieldWithLabel {
   private ImmutableList<OptionTag> customOptions = ImmutableList.of();
   private boolean placeholderVisible = false;
 
-  public static SelectWithLabel select() {
-    return new SelectWithLabel();
-  }
-
   @Override
   public SelectWithLabel addReferenceClass(String referenceClass) {
     referenceClassesBuilder.add(referenceClass);

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -86,7 +86,7 @@ public class NameQuestionRenderer extends ApplicantCompositeQuestionRenderer {
             .addReferenceClass(ReferenceClasses.DROPDOWN_QUESTION)
             .setLabelText(messages.at(MessageKey.NAME_LABEL_SUFFIX.getKeyName()))
             .setFieldName(nameQuestion.getNameSuffixPath().toString())
-            .setPlaceholderText("")
+            .setValue(nameQuestion.getNameSuffixValue().orElse(""))
             .setOptions(
                 Stream.of(ApplicantModel.Suffix.values())
                     .map(


### PR DESCRIPTION
### Description

1. Adds name suffix field to TI dashboard so that TI can add name suffix information for applicants. 
2. Making sure that the suffix field on TI dashboard fits USWDS standard.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing

Log in as a TI, add an new client,  fill out their info including suffix. Then try applying for an application for the applicant, when on name question page, suffix field should be filled with the value that was preset by the TI.

### Issue(s) this completes

Fixes #8405
