### PR TITLE
Don't set email as name when creating profiles

### DIFF
--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -816,7 +816,7 @@ test.describe('view program statuses', () => {
       await test.step('view submitted programs as a program admin', async () => {
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
+        await adminPrograms.viewApplicationForApplicant(otherTestUserEmail)
       })
 
       const [acccountEmailsBefore, applicantEmailsBefore] =

--- a/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
+++ b/server/app/auth/oidc/applicant/ApplicantProfileCreator.java
@@ -56,6 +56,16 @@ public abstract class ApplicantProfileCreator extends CiviformOidcProfileCreator
             .filter(s -> !Strings.isNullOrEmpty(s))
             .collect(Collectors.joining(" "));
 
+    // Special case for https://github.com/civiform/civiform/issues/8344, Auth0 (and possibly other
+    // auth providers) will put in the user's email for the "name" attribute, if no name is
+    // specified.
+    //
+    // Since we actually care about whether a real name was provided or not, return empty
+    // if it matches the email.
+    if (name.equals(oidcProfile.getAttribute(emailAttributeName()))) {
+      return Optional.empty();
+    }
+
     return Optional.ofNullable(Strings.emptyToNull(name));
   }
 

--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -314,7 +314,7 @@ public final class AdminApplicationController extends CiviFormController {
         String.format(
             "%s (%d)",
             ApplicantUtils.getApplicantName(
-                application.getApplicantData().getApplicantName(), messages),
+                application.getApplicantData().getApplicantDisplayName(), messages),
             application.id);
 
     ReadOnlyApplicantProgramService roApplicantService =

--- a/server/app/controllers/ti/TrustedIntermediaryController.java
+++ b/server/app/controllers/ti/TrustedIntermediaryController.java
@@ -105,7 +105,7 @@ public final class TrustedIntermediaryController {
         PaginationInfo.paginate(trustedIntermediarySearchResult.accounts(), PAGE_SIZE, page.get());
 
     Optional<String> applicantName =
-        civiformProfile.getApplicant().join().getApplicantData().getApplicantName();
+        civiformProfile.getApplicant().join().getApplicantData().getApplicantDisplayName();
 
     return ok(
         tiClientListView.render(
@@ -132,7 +132,7 @@ public final class TrustedIntermediaryController {
     }
 
     Optional<String> applicantName =
-        civiformProfile.getApplicant().join().getApplicantData().getApplicantName();
+        civiformProfile.getApplicant().join().getApplicantData().getApplicantDisplayName();
 
     return ok(
         tiAccountSettingsView.render(
@@ -179,7 +179,8 @@ public final class TrustedIntermediaryController {
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
-    String applicantName = accountRepository.lookupAccount(accountId).get().getApplicantName();
+    String applicantName =
+        accountRepository.lookupAccount(accountId).get().getApplicantDisplayName();
     return ok(
         editTiClientView.render(
             /* tiGroup= */ trustedIntermediaryGroup.get(),

--- a/server/app/models/AccountModel.java
+++ b/server/app/models/AccountModel.java
@@ -177,14 +177,14 @@ public class AccountModel extends BaseModel {
 
   /**
    * Returns the name, as a string, of the most-recently created Applicant associated with this
-   * Account. There is no particular reason for an Account to have more than one Applicant - this
-   * was a capability we built but did not use - so the ordering is somewhat arbitrary /
-   * unnecessary.
+   * Account. Or the email if no name is associated with the applicant. There is no particular
+   * reason for an Account to have more than one Applicant - this was a capability we built but did
+   * not use - so the ordering is somewhat arbitrary / unnecessary.
    */
-  public String getApplicantName() {
+  public String getApplicantDisplayName() {
     return this.getApplicants().stream()
         .max(Comparator.comparing(ApplicantModel::getWhenCreated))
-        .map(u -> u.getApplicantData().getApplicantName().orElse("<Unnamed User>"))
+        .map(u -> u.getApplicantData().getApplicantDisplayName().orElse("<Unnamed User>"))
         .orElse("<Unnamed User>");
   }
 }

--- a/server/app/models/TrustedIntermediaryGroupModel.java
+++ b/server/app/models/TrustedIntermediaryGroupModel.java
@@ -44,7 +44,7 @@ public class TrustedIntermediaryGroupModel extends BaseModel {
   /** Get all the accounts, sorted by applicant name. */
   public ImmutableList<AccountModel> getManagedAccounts() {
     return managedAccounts.stream()
-        .sorted(Comparator.comparing(AccountModel::getApplicantName))
+        .sorted(Comparator.comparing(AccountModel::getApplicantDisplayName))
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -84,6 +84,11 @@ public class ApplicantData extends CfJsonDocumentContext {
     this.preferredLocale = Optional.of(locale);
   }
 
+  /** Gets a formatted version of the applicant's name, or their email if no name is provided. */
+  public Optional<String> getApplicantDisplayName() {
+    return getApplicantName().isPresent() ? getApplicantName() : getApplicantEmail();
+  }
+
   /**
    * Gets a formatted version of the applicant's name. If only the first name is defined, returns
    * the first name. If both first and last are defined, returns "last, first".
@@ -94,30 +99,11 @@ public class ApplicantData extends CfJsonDocumentContext {
     Optional<String> firstName =
         Optional.ofNullable(applicant).flatMap(ApplicantModel::getFirstName);
     Optional<String> lastName = Optional.ofNullable(applicant).flatMap(ApplicantModel::getLastName);
-    Optional<String> accountEmail = getAccountEmail();
     if (firstName.isEmpty()) {
       // TODO (#5503): Return Optional.empty() when removing the feature flag
       return getApplicantNameAtWellKnownPath();
     }
-    /* TODO (#5503): Probably remove this.
-     * When the OIDC provider doesn't include the user's name, it inserts
-     * the email address as the name. When the CiviFormProfile is merged with
-     * the OidcProfile, the applicant name gets set to the OidcProfile name,
-     * which can be the email address.
-     * https://github.com/civiform/civiform/blob/eaa46a7edb4628b56e298e88aeb2dcfd8ffebeb2/server/app/auth/oidc/applicant/ApplicantProfileCreator.java#L112
-     * In this case, we want to check if there is a real name at the
-     * Well Known Path (answer to the preseeded question) and use that. If there
-     * isn't one there, then go ahead and use the email address as that's all we have.
-     * When we remove Well Known Paths in favor of Primary Applicant Info, we can
-     * probably remove this, since we expect there to be a name PAI question
-     * that will overwrite the email address in the PAI first name column.
-     * Additionally, the DurableJob we will create to move data from the WKP
-     * to the PAI columns will do this check and overwrite an email address
-     * in the first name field.
-     */
-    if (accountEmail.isPresent() && firstName.get().equals(accountEmail.get())) {
-      return Optional.of(getApplicantNameAtWellKnownPath().orElse(firstName.get()));
-    }
+
     return lastName.isEmpty()
         ? Optional.of(firstName.get())
         : Optional.of(String.format("%s, %s", lastName.get(), firstName.get()));

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -109,7 +109,7 @@ public final class PdfExporter {
     // We expect a name to be present at this point. However, if it's not, we use a placeholder
     // rather than throwing an error here.
     String applicantName =
-        application.getApplicantData().getApplicantName().orElse("name-unavailable");
+        application.getApplicantData().getApplicantDisplayName().orElse("name-unavailable");
     String applicantNameWithApplicationId = String.format("%s (%d)", applicantName, application.id);
     String filename = String.format("%s-%s.pdf", applicantNameWithApplicationId, nowProvider.get());
     byte[] bytes =

--- a/server/app/services/ti/TrustedIntermediaryService.java
+++ b/server/app/services/ti/TrustedIntermediaryService.java
@@ -273,7 +273,7 @@ public final class TrustedIntermediaryService {
                             .equals(maybeDOB.get()))
                     || (!missingParams.contains(SearchParameters.ParamTypes.NAME)
                         && account
-                            .getApplicantName()
+                            .getApplicantDisplayName()
                             .toLowerCase(Locale.ROOT)
                             .contains(
                                 searchParameters.nameQuery().get().toLowerCase(Locale.ROOT)))))

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -370,7 +370,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
     String applicantNameWithApplicationId =
         String.format(
             "%s (%d)",
-            applicantUtils.getApplicantNameEnUs(application.getApplicantData().getApplicantName()),
+            applicantUtils.getApplicantNameEnUs(
+                application.getApplicantData().getApplicantDisplayName()),
             application.id);
     String viewLinkText = "View →";
 

--- a/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
+++ b/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
@@ -117,7 +117,7 @@ public class EditTrustedIntermediaryGroupView extends BaseHtmlView {
   }
 
   private TdTag renderInfoCell(AccountModel ti) {
-    return td().with(div(ti.getApplicantName()).withClasses("font-semibold"))
+    return td().with(div(ti.getApplicantDisplayName()).withClasses("font-semibold"))
         .with(div(ti.getEmailAddress()).withClasses("text-xs"))
         .withClasses(BaseStyles.TABLE_CELL_STYLES, "pr-12");
   }

--- a/server/app/views/applicant/NorthStarApplicantUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantUpsellView.java
@@ -67,7 +67,8 @@ public class NorthStarApplicantUpsellView extends NorthStarBaseView {
             /* show= */ true, Optional.of(alertTitle), "", AlertType.SUCCESS, ImmutableList.of());
     context.setVariable("successAlertSettings", successAlertSettings);
 
-    String applicantName = params.profile().getApplicant().join().getAccount().getApplicantName();
+    String applicantName =
+        params.profile().getApplicant().join().getAccount().getApplicantDisplayName();
     context.setVariable("applicantName", applicantName);
 
     context.setVariable("dateSubmitted", params.dateSubmitted());

--- a/server/app/views/applicant/TrustedIntermediaryAccountSettingsView.java
+++ b/server/app/views/applicant/TrustedIntermediaryAccountSettingsView.java
@@ -89,7 +89,7 @@ public class TrustedIntermediaryAccountSettingsView extends TrustedIntermediaryD
                 tbody(
                     each(
                         tiGroup.getTrustedIntermediaries().stream()
-                            .sorted(Comparator.comparing(AccountModel::getApplicantName))
+                            .sorted(Comparator.comparing(AccountModel::getApplicantDisplayName))
                             .collect(Collectors.toList()),
                         this::renderOrgMembersTableRow))));
   }
@@ -121,7 +121,7 @@ public class TrustedIntermediaryAccountSettingsView extends TrustedIntermediaryD
   }
 
   private TdTag renderNameCell(AccountModel ti) {
-    return td(ti.getApplicantName());
+    return td(ti.getApplicantDisplayName());
   }
 
   private TdTag renderEmailCell(AccountModel ti) {

--- a/server/app/views/applicant/TrustedIntermediaryClientListView.java
+++ b/server/app/views/applicant/TrustedIntermediaryClientListView.java
@@ -220,7 +220,7 @@ public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashbo
                     .with(
                         each(
                             managedAccounts.stream()
-                                .sorted(Comparator.comparing(AccountModel::getApplicantName))
+                                .sorted(Comparator.comparing(AccountModel::getApplicantDisplayName))
                                 .collect(Collectors.toList()),
                             account -> renderClientCard(account, messages))));
 
@@ -250,7 +250,7 @@ public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashbo
                         .with(
                             div(
                                     div(
-                                            renderSubHeader(account.getApplicantName())
+                                            renderSubHeader(account.getApplicantDisplayName())
                                                 .withClass("usa-card__heading"),
                                             u(renderEditClientLink(account.id, messages))
                                                 .withClass("ml-2"))

--- a/server/test/services/applicant/ApplicantDataTest.java
+++ b/server/test/services/applicant/ApplicantDataTest.java
@@ -59,15 +59,6 @@ public class ApplicantDataTest extends ResetPostgres {
     assertThat(data.getApplicantName()).isEqualTo(Optional.of("Last, First"));
   }
 
-  // TODO (#5503): Remove this when we remove this check from ApplicantData#getApplicantName
-  @Test
-  public void getApplicantName_fallsBackToWKPWhenNameIsEmail() {
-    ApplicantData data = createNewApplicantData();
-    data.setUserName("test@email.com");
-    data.putString(WellKnownPaths.APPLICANT_FIRST_NAME, "first");
-    assertThat(data.getApplicantName().get()).isEqualTo("first");
-  }
-
   @Test
   public void getApplicantName_withMiddleNameWithoutSuffix_exists() {
     ApplicantData data = createNewApplicantData();
@@ -97,6 +88,36 @@ public class ApplicantDataTest extends ResetPostgres {
   public void getApplicantName_noName() {
     ApplicantData data = createNewApplicantData();
     assertThat(data.getApplicantName()).isEmpty();
+  }
+
+  @Test
+  public void getApplicantDisplayName() {
+    ApplicantData data = createNewApplicantData();
+    data.setUserName("First Middle Last Jr.");
+    assertThat(data.getApplicantDisplayName()).isEqualTo(Optional.of("Last, First"));
+  }
+
+  @Test
+  public void getApplicantDisplayName_fallsBackToEmail() {
+    ApplicantModel applicant = new ApplicantModel();
+    AccountModel account = new AccountModel();
+    account.setEmailAddress("myemail@email.com");
+    account.save();
+    applicant.setAccount(account);
+    applicant.save();
+
+    assertThat(new ApplicantData(applicant).getApplicantDisplayName())
+        .isEqualTo(Optional.of("myemail@email.com"));
+  }
+
+  @Test
+  public void getApplicantDisplayName_empty() {
+    ApplicantModel applicant = new ApplicantModel();
+    AccountModel account = new AccountModel();
+    account.save();
+    applicant.setAccount(account);
+    applicant.save();
+    assertThat(new ApplicantData(applicant).getApplicantDisplayName()).isEmpty();
   }
 
   @Test

--- a/server/test/services/ti/TrustedIntermediaryServiceTest.java
+++ b/server/test/services/ti/TrustedIntermediaryServiceTest.java
@@ -288,7 +288,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     assertThat(returnedForm.errors()).isEmpty();
     AccountModel account =
         tiGroup.getManagedAccounts().stream()
-            .filter(acct -> acct.getApplicantName().equals("Email, No"))
+            .filter(acct -> acct.getApplicantDisplayName().equals("Email, No"))
             .findFirst()
             .get();
     assertThat(account.getApplicants().get(0).getApplicantData().getDateOfBirth().get().toString())
@@ -429,7 +429,7 @@ public class TrustedIntermediaryServiceTest extends WithMockedProfiles {
     TrustedIntermediarySearchResult tiResult =
         service.getManagedAccounts(searchParameters, tiGroup);
     assertThat(tiResult.accounts().size()).isEqualTo(1);
-    assertThat(tiResult.accounts().get(0).getApplicantName()).contains("Bobo");
+    assertThat(tiResult.accounts().get(0).getApplicantDisplayName()).contains("Bobo");
   }
 
   @Test


### PR DESCRIPTION
### Description

Fixes #8344, we no longer populate applicant name with email if the auth provider fills in the name attribute with the same value as the email attribute. With this change, name is now empty if no name is provided, so we no longer populate an email  in the universal question first name field. Added a new "getApplicantDisplayName" which instead looks for name, and falls back to email if it's not there. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #8344
