### PR TITLE
Add tests related to non gating / gating eligibility

### DIFF
--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -332,6 +332,14 @@ test.describe('Applicant navigation flow', () => {
         fullProgramName,
         /* isEligible= */ true,
       )
+
+      // Verify eligibility banner shows on pages
+      await applicantQuestions.applyProgram(fullProgramName)
+      await applicantQuestions.expectMayBeEligibileAlertToBeVisible()
+      await applicantQuestions.answerEmailQuestion('test@test.com')
+      await applicantQuestions.expectMayBeEligibileAlertToBeVisible()
+      await applicantQuestions.clickNext()
+
     })
 
     test('does not show not eligible with nongating eligibility', async ({
@@ -351,18 +359,21 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.applyProgram(fullProgramName)
 
       // Fill out application without submitting.
+      await applicantQuestions.expectMayNotBeEligibleAlertToBeHidden()
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickNext()
+      await applicantQuestions.expectMayNotBeEligibleAlertToBeHidden()
 
       // Verify that there's no indication of eligibility.
       await applicantQuestions.gotoApplicantHomePage()
       await applicantQuestions.seeNoEligibilityTags(fullProgramName)
 
-      // Go back to in progress application and submit.
+      // Go back to in progress application and validate no eligibility alert and submit.
       await applicantQuestions.applyProgram(fullProgramName)
+      await applicantQuestions.expectMayNotBeEligibleAlertToBeHidden()
       await applicantQuestions.answerEmailQuestion('test@test.com')
       await applicantQuestions.clickNext()
-      await validateToastMessage(page, '')
+      await applicantQuestions.expectMayNotBeEligibleAlertToBeHidden()
       await applicantQuestions.submitFromReviewPage()
       await applicantQuestions.gotoApplicantHomePage()
       await applicantQuestions.seeNoEligibilityTags(fullProgramName)

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -835,4 +835,10 @@ export class ApplicantQuestions {
       this.page.getByRole('heading', {name: 'may be eligible'}),
     ).not.toBeAttached()
   }
+
+  async expectMayNotBeEligibleAlertToBeHidden() {
+    await expect(
+      this.page.getByRole('heading', {name: 'may not be eligible'}),
+    ).not.toBeAttached()
+  }
 }


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
