### PR TITLE
Refactor North Star modals to be easier to use

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -536,7 +536,9 @@ test.describe('applicant program index page', () => {
 
         await test.step('Verify that login dialog does not appear a second time', async () => {
           // Close the modal and click Apply again. This time, we should not see the login prompt modal.
-          await page.click(`.cf-ns-modal .usa-modal__close`)
+          await page
+            .getByRole('button', {class: 'usa-modal__close', isVisible: true})
+            .click()
           await page.click(
             `.cf-application-card:has-text("${primaryProgramName}") .cf-apply-button`,
           )

--- a/server/app/views/applicant/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/AddressCorrectionBlockTemplate.html
@@ -87,11 +87,6 @@
         </div>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
@@ -53,11 +53,11 @@
         </div>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                           <!--/* showReviewLogin= */-->false,
-                                                           <!--/* showUpsellLogin= */-->${isGuest})}"
-    ></div>
+
+    <div th:if="${isGuest}">
+      <div th:replace="~{applicant/ModalFragment:: upsellLogin}"></div>
+    </div>
+
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
@@ -64,11 +64,6 @@
         </div>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -99,11 +99,6 @@
         ></button>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -99,12 +99,9 @@
         </div>
       </div>
     </main>
-
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->${isGuest && redirectedFromProgramSlug.isPresent()},
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
+    <div th:if="${isGuest and redirectedFromProgramSlug.isPresent()}">
+      <div th:replace="~{applicant/ModalFragment:: reviewLogin}"></div>
+    </div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ApplicantUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantUpsellTemplate.html
@@ -146,11 +146,11 @@
         ></div>
       </section>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->${isGuest})}"
-    ></div>
+
+    <div th:if="${isGuest}">
+      <div th:replace="~{applicant/ModalFragment:: upsellLogin}"></div>
+    </div>
+
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/IneligibleTemplate.html
+++ b/server/app/views/applicant/IneligibleTemplate.html
@@ -62,11 +62,6 @@
         </div>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -1,103 +1,114 @@
 <div
-  th:fragment="modalContainer(showProgramIndexLogin, showReviewLogin, showUpsellLogin)"
+  th:fragment="devTools"
+  th:if="${showDebugTools}"
   id="modal-container"
   class="display-none position-fixed height-viewport width-full z-100"
 >
-  <th:block th:if="${showDebugTools}">
-    <div th:replace="~{this :: devToolsModal}"></div>
-  </th:block>
-  <th:block th:if="${showProgramIndexLogin}">
-    <div th:each="programIdAndLoginBypassUrl: ${programIdsToLoginBypassUrls}">
-      <div
-        th:replace="~{this :: loginPromptModal(${'login-dialog-' + programIdAndLoginBypassUrl.key},
+  <dialog
+    class="usa-modal cf-ns-modal"
+    id="debug-content-modal"
+    aria-labelledby="debug-content-modal-heading"
+    aria-describedby="debug-content-modal-heading"
+  >
+    <div class="usa-modal__content">
+      <div class="usa-modal__main">
+        <h2 class="usa-modal__heading" id="debug-content-modal-heading">
+          Dev Tools
+        </h2>
+        <div class="display-flex flex-column">
+          <p>Log in as:</p>
+          <a th:href="${fakeCiviformAdminUrl}" class="usa-button margin-y-2"
+            >Civiform Admin</a
+          >
+          <a th:href="${fakeProgramAdminUrl}" class="usa-button margin-y-2"
+            >Program Admin</a
+          >
+          <a th:href="${fakeDualAdminUrl}" class="usa-button margin-y-2"
+            >Program and Civiform Admin</a
+          >
+          <a
+            th:href="${fakeTrustedIntermediaryUrl}"
+            class="usa-button margin-y-2"
+            >Trusted Intermediary</a
+          >
+          <p>Other:</p>
+          <a th:href="${additionalToolsUrl}" class="usa-button margin-y-2"
+            >Additional tools</a
+          >
+        </div>
+      </div>
+      <button
+        type="button"
+        class="usa-button usa-modal__close"
+        th:aria-label="#{button.close}"
+        data-close-modal
+      >
+        <svg
+          th:replace="~{applicant/ApplicantBaseFragment :: icon(${closeIcon})}"
+        ></svg>
+      </button>
+    </div>
+  </dialog>
+</div>
+
+<div
+  th:fragment="programIndexLogin"
+  id="modal-container"
+  class="display-none position-fixed height-viewport width-full z-100"
+>
+  <div th:each="programIdAndLoginBypassUrl: ${programIdsToLoginBypassUrls}">
+    <div
+      th:replace="~{this :: loginPromptModal(${'login-dialog-' + programIdAndLoginBypassUrl.key},
                                              ${programIdAndLoginBypassUrl.value},
                                              ${programIdsToLoginUrls.get(programIdAndLoginBypassUrl.key)},
                                              #{content.initialLoginModalPrompt(${authProviderName})},
                                              #{button.continueToApplication},
                                              'login-prompt',
                                              false)}"
-      ></div>
-    </div>
-  </th:block>
-  <th:block
-    th:if="${showReviewLogin}"
-    th:with="dialogId=${'login-dialog-' + #strings.randomAlphanumeric(8)}"
-  >
-    <div
-      th:replace="~{this :: loginPromptModal(${dialogId},
+    ></div>
+  </div>
+</div>
+
+<div
+  th:fragment="reviewLogin"
+  id="modal-container"
+  class="display-none position-fixed height-viewport width-full z-100"
+  th:with="dialogId=${'login-dialog-' + #strings.randomAlphanumeric(8)}"
+>
+  <div
+    th:replace="~{this :: loginPromptModal(${dialogId},
                                          ${slugBypassUrl},
                                          ${slugLoginUrl},
                                          #{content.initialLoginModalPrompt(${authProviderName})},
                                          #{button.continueToApplication},
                                          'program_slug_login_prompt',
                                          true)}"
-    ></div>
-    <!--/* Create an invisible button that we will use to trigger this modal on load */-->
-    <a
-      th:href="${'#' + dialogId}"
-      class="usa-button is-hidden"
-      th:aria-controls="${dialogId}"
-      data-open-modal
-      >Login</a
-    >
-  </th:block>
-  <th:block th:if="${showUpsellLogin}">
-    <div
-      th:replace="~{this :: loginPromptModal('login-dialog-upsell',
-                                       ${upsellBypassUrl},
-                                       ${upsellLoginUrl},
-                                       #{content.generalLoginModalPrompt},
-                                       #{button.continueWithoutAnAccount},
-                                       null,
-                                       false)}"
-    ></div>
-  </th:block>
+  ></div>
+  <!--/* Create an invisible button that we will use to trigger this modal on load */-->
+  <a
+    th:href="${'#' + dialogId}"
+    class="usa-button is-hidden"
+    th:aria-controls="${dialogId}"
+    data-open-modal
+    >Login</a
+  >
 </div>
 
-<dialog
-  th:fragment="devToolsModal"
-  class="usa-modal"
-  id="debug-content-modal"
-  aria-labelledby="debug-content-modal-heading"
-  aria-describedby="debug-content-modal-heading"
+<div
+  th:fragment="upsellLogin"
+  id="modal-container"
+  class="display-none position-fixed height-viewport width-full z-100"
 >
-  <div class="usa-modal__content">
-    <div class="usa-modal__main">
-      <h2 class="usa-modal__heading" id="debug-content-modal-heading">
-        Dev Tools
-      </h2>
-      <div class="display-flex flex-column">
-        <p>Log in as:</p>
-        <a th:href="${fakeCiviformAdminUrl}" class="usa-button margin-y-2"
-          >Civiform Admin</a
-        >
-        <a th:href="${fakeProgramAdminUrl}" class="usa-button margin-y-2"
-          >Program Admin</a
-        >
-        <a th:href="${fakeDualAdminUrl}" class="usa-button margin-y-2"
-          >Program and Civiform Admin</a
-        >
-        <a th:href="${fakeTrustedIntermediaryUrl}" class="usa-button margin-y-2"
-          >Trusted Intermediary</a
-        >
-        <p>Other:</p>
-        <a th:href="${additionalToolsUrl}" class="usa-button margin-y-2"
-          >Additional tools</a
-        >
-      </div>
-    </div>
-    <button
-      type="button"
-      class="usa-button usa-modal__close"
-      th:aria-label="#{button.close}"
-      data-close-modal
-    >
-      <svg
-        th:replace="~{applicant/ApplicantBaseFragment :: icon(${closeIcon})}"
-      ></svg>
-    </button>
-  </div>
-</dialog>
+  <div
+    th:replace="~{this :: loginPromptModal('login-dialog-upsell',
+                                   ${upsellBypassUrl},
+                                   ${upsellLoginUrl},
+                                   #{content.generalLoginModalPrompt},
+                                   #{button.continueWithoutAnAccount},
+                                   null,
+                                   false)}"
+  ></div>
+</div>
 
 <dialog
   th:fragment="loginPromptModal(dialogId, bypassUrl, loginLink, descriptionText, bypassButtonText, onlyShowOnceGroup, showOnLoad)"

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -155,16 +155,18 @@
   </section>
 </nav>
 
-<a
-  th:fragment="showDebugTools"
-  type="button"
-  class="usa-button usa-button--outline"
-  id="debug-content-modal-button"
-  href="#debug-content-modal"
-  data-open-modal
-  aria-controls="debug-content-modal"
-  >DevTools</a
->
+<div th:fragment="showDebugTools">
+  <a
+    type="button"
+    class="usa-button usa-button--outline"
+    id="debug-content-modal-button"
+    href="#debug-content-modal"
+    data-open-modal
+    aria-controls="debug-content-modal"
+    >DevTools</a
+  >
+  <div th:replace="~{applicant/ModalFragment:: devTools}"></div>
+</div>
 
 <th:block th:fragment="loginOrLogout">
   <th:block th:if="${isGuest}">

--- a/server/app/views/applicant/PreventDuplicateSubmissionTemplate.html
+++ b/server/app/views/applicant/PreventDuplicateSubmissionTemplate.html
@@ -34,11 +34,6 @@
         </div>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->false,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>

--- a/server/app/views/applicant/ProgramIndexTemplate.html
+++ b/server/app/views/applicant/ProgramIndexTemplate.html
@@ -99,11 +99,7 @@
         </th:block>
       </div>
     </main>
-    <div
-      th:replace="~{applicant/ModalFragment:: modalContainer(<!--/* showProgramIndexLogin= */-->true,
-                                                             <!--/* showReviewLogin= */-->false,
-                                                             <!--/* showUpsellLogin= */-->false)}"
-    ></div>
+    <div th:replace="~{applicant/ModalFragment:: programIndexLogin}"></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>


### PR DESCRIPTION
### Description

Separate fragments for different kinds of modals.

With this refactoring, it is no longer necessary to remove the modal container in issue #7880 (we just add id="modal-container" to each modal parent div and keep north_star_modal.ts unchanged)

Credit to Greg for paving the way with https://github.com/civiform/civiform/pull/7879

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Issue(s) this completes

Fixes #7880.