### PR TITLE
Prevent running one-off durable job when not dev or staging

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedController.java
@@ -128,6 +128,9 @@ public class DevDatabaseSeedController extends Controller {
   }
 
   public Result runDurableJob(Request request) throws InterruptedException {
+    if (!isDevOrStaging) {
+      return notFound();
+    }
     String jobName = request.body().asFormUrlEncoded().get("durableJobSelect")[0];
     // I think there's currently a bug where the job runner interprets the timestamps as local
     // times rather than UTC. So set it to yesterday to ensure it runs.


### PR DESCRIPTION
I missed guarding this function with the dev or staging check. Shouldn't be anything in there that's particularly problematic if someone decided to run a durable job on prod, but we should guard this in case we add more sensitive jobs later.