### PR TITLE
Include North Star HTML files in prod image

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -220,6 +220,15 @@ jacocoReportSettings := JacocoReportSettings()
 jacocoExcludes := Seq("views*", "*Routes*")
 jacocoDirectory := baseDirectory.value / "code-coverage"
 
+// Include North Star HTML files. We need these in the image in order
+// for Thymeleaf to be able to use them for templating.
+mappings in Universal ++= {
+  val viewsDir = baseDirectory.value / "app" / "views"
+  (viewsDir ** "*.html").get.map { file =>
+    file -> s"app/views/${file.relativeTo(viewsDir).get.getPath}"
+  }
+}
+
 // Define a transition to pull the "remote" (really local filesystem) cache on startup.
 lazy val startupTransition: State => State = { s: State =>
   "pullRemoteCache" :: s


### PR DESCRIPTION
When running in dev mode, since we volume mount the entire source path into the image, we have no problem referencing in the Thymeleaf HTML files. When we build the prod image, we are only copying in the files created by 'sbt dist'. Because we need to reference the HTML files directly in the code, we need to copy these files into the image. This maintains the same pathing present in the source so that we can reference the files in the same way, no matter if we're in dev or staging/prod mode.

I've tested this manually with a hacked way of running the prod image locally. I'll put up another PR to enable us to do this in the future (and so this PR can be tested if desired).