### PR TITLE
Add browser tests for program email notifications settings

### DIFF
--- a/browser-test/src/admin/admin_program_email_notifications.test.ts
+++ b/browser-test/src/admin/admin_program_email_notifications.test.ts
@@ -1,0 +1,72 @@
+import {test} from '../support/civiform_fixtures'
+import {loginAsAdmin} from '../support'
+
+// TODO(#8576): Add tests that emails are actually sent, once #8575 is complete
+
+test.describe('program email notifications', () => {
+  test('program admin application submission email preference persists through error', async ({
+    page,
+    adminPrograms,
+  }) => {
+    await test.step('create new program and verify default', async () => {
+      await loginAsAdmin(page)
+      await adminPrograms.addProgram(
+        '', // empty string will error
+        'program description',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        /* submitNewProgram */ false,
+      )
+      await adminPrograms.expectEmailNotificationPreferenceIsChecked(true)
+    })
+
+    await test.step('unselect email notifications and verify it persists through form error', async () => {
+      await adminPrograms.setEmailNotificationPreferenceCheckbox(false)
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminPrograms.expectDisplayNameErrorToast()
+      await adminPrograms.expectEmailNotificationPreferenceIsChecked(false)
+    })
+  })
+
+  test('program admin application submission email preference persists through publish', async ({
+    page,
+    adminPrograms,
+  }) => {
+    const programName = 'test program'
+
+    await test.step('create new program and unset notifications', async () => {
+      await loginAsAdmin(page)
+      await adminPrograms.addProgram(programName)
+    })
+
+    await test.step('unset email preference', async () => {
+      await adminPrograms.goToProgramDescriptionPage(programName)
+      await adminPrograms.setEmailNotificationPreferenceCheckbox(false)
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('verify unset email preference persists through publish', async () => {
+      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.expectEmailNotificationPreferenceIsChecked(false)
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('set email preference', async () => {
+      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.setEmailNotificationPreferenceCheckbox(true)
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('verify set email preference persists through publish', async () => {
+      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.expectEmailNotificationPreferenceIsChecked(true)
+    })
+  })
+})


### PR DESCRIPTION
### Description

Add browser tests for program email notifications settings

Details:
- Until #8575 is complete, we can't add tests that verify the entire flow. That's captured in #8576.
- Here, we test that the setting is persisted to the database. There are unit tests verify that the email sending code works correctly when an application is submitted.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary

### Issue(s) this completes

Part of #8436
