### PR TITLE
Add DevRoutesFilter to ensure all /dev routes are only available in dev/staging

### DIFF
--- a/server/app/controllers/dev/AddressCheckerController.java
+++ b/server/app/controllers/dev/AddressCheckerController.java
@@ -15,7 +15,6 @@ import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 import services.Address;
-import services.DeploymentType;
 import services.geo.AddressLocation;
 import services.geo.esri.EsriClient;
 import services.geo.esri.EsriServiceAreaValidationConfig;
@@ -32,7 +31,6 @@ public final class AddressCheckerController extends Controller {
   private static final Logger logger = LoggerFactory.getLogger(AddressCheckerController.class);
 
   private final SettingsManifest settingsManifest;
-  private final DeploymentType deploymentType;
   private final AddressCheckerView addressCheckerView;
   private final CorrectAddressViewPartial correctAddressViewPartial;
   private final ServiceAreaCheckViewPartial checkServiceAreaViewPartial;
@@ -43,7 +41,6 @@ public final class AddressCheckerController extends Controller {
   @Inject
   AddressCheckerController(
       SettingsManifest settingsManifest,
-      DeploymentType deploymentType,
       AddressCheckerView addressCheckerView,
       CorrectAddressViewPartial correctAddressViewPartial,
       ServiceAreaCheckViewPartial checkServiceAreaViewPartial,
@@ -51,7 +48,6 @@ public final class AddressCheckerController extends Controller {
       EsriServiceAreaValidationConfig esriServiceAreaValidationConfig,
       FormFactory formFactory) {
     this.settingsManifest = checkNotNull(settingsManifest);
-    this.deploymentType = checkNotNull(deploymentType);
     this.addressCheckerView = checkNotNull(addressCheckerView);
     this.correctAddressViewPartial = checkNotNull(correctAddressViewPartial);
     this.checkServiceAreaViewPartial = checkServiceAreaViewPartial;
@@ -61,19 +57,11 @@ public final class AddressCheckerController extends Controller {
   }
 
   public Result index(Http.Request request) {
-    if (!deploymentType.isDevOrStaging()) {
-      return notFound();
-    }
-
     return ok(addressCheckerView.render(request));
   }
 
   /** Performs address correction and returns the results */
   public CompletionStage<Result> hxCorrectAddress(Http.Request request) {
-    if (!deploymentType.isDevOrStaging()) {
-      return CompletableFuture.completedFuture(notFound());
-    }
-
     Address address;
 
     try {
@@ -126,10 +114,6 @@ public final class AddressCheckerController extends Controller {
 
   /** Performs service area validation check and returns the results */
   public CompletionStage<Result> hxCheckServiceArea(Http.Request request) {
-    if (!deploymentType.isDevOrStaging()) {
-      return CompletableFuture.completedFuture(notFound());
-    }
-
     EsriServiceAreaValidationOption esriServiceAreaValidationOption;
     AddressLocation addressLocation;
     String validationOption;

--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -8,7 +8,6 @@ import play.mvc.Controller;
 import play.mvc.Http.HeaderNames;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import services.DeploymentType;
 import services.settings.SettingsManifest;
 import services.settings.SettingsService;
 
@@ -21,13 +20,10 @@ import services.settings.SettingsService;
 public final class FeatureFlagOverrideController extends Controller {
 
   private final SettingsService settingsService;
-  private final boolean isDevOrStaging;
 
   @Inject
-  public FeatureFlagOverrideController(
-      SettingsService settingsService, DeploymentType deploymentType) {
+  public FeatureFlagOverrideController(SettingsService settingsService) {
     this.settingsService = Preconditions.checkNotNull(settingsService);
-    this.isDevOrStaging = deploymentType.isDevOrStaging();
   }
 
   public Result enable(Request request, String rawFlagName) {
@@ -39,9 +35,6 @@ public final class FeatureFlagOverrideController extends Controller {
   }
 
   private Result updateFlag(Request request, String rawFlagName, String newValue) {
-    if (!isDevOrStaging) {
-      return notFound();
-    }
     var flagName = rawFlagName.toUpperCase(Locale.ROOT);
     var currentSettings =
         settingsService.loadSettings().toCompletableFuture().join().orElse(ImmutableMap.of());

--- a/server/app/controllers/dev/IconsController.java
+++ b/server/app/controllers/dev/IconsController.java
@@ -6,24 +6,18 @@ import com.google.inject.Inject;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
-import services.DeploymentType;
 import views.dev.IconsView;
 
 public final class IconsController extends Controller {
 
   private final IconsView iconsView;
-  private final boolean isDevOrStaging;
 
   @Inject
-  public IconsController(IconsView iconsView, DeploymentType deploymentType) {
+  public IconsController(IconsView iconsView) {
     this.iconsView = checkNotNull(iconsView);
-    this.isDevOrStaging = deploymentType.isDevOrStaging();
   }
 
   public Result index(Http.Request request) {
-    if (!isDevOrStaging) {
-      return notFound();
-    }
     return ok(iconsView.render(request));
   }
 }

--- a/server/app/filters/DevRoutesFilter.java
+++ b/server/app/filters/DevRoutesFilter.java
@@ -1,0 +1,33 @@
+package filters;
+
+import static play.mvc.Results.notFound;
+
+import com.google.inject.Inject;
+import java.util.Locale;
+import javax.inject.Provider;
+import play.libs.streams.Accumulator;
+import play.mvc.EssentialAction;
+import play.mvc.EssentialFilter;
+import services.DeploymentType;
+
+/** Ensure that all /dev routes are only accessible in dev and staging. */
+public class DevRoutesFilter extends EssentialFilter {
+  private boolean isDevOrStaging;
+
+  @Inject
+  public DevRoutesFilter(Provider<DeploymentType> deploymentType) {
+    this.isDevOrStaging = deploymentType.get().isDevOrStaging();
+  }
+
+  @Override
+  public EssentialAction apply(EssentialAction next) {
+    return EssentialAction.of(
+        request -> {
+          boolean isDevPath = request.uri().toLowerCase(Locale.ROOT).startsWith("/dev");
+          if (!isDevOrStaging && isDevPath) {
+            return Accumulator.done(notFound());
+          }
+          return next.apply(request);
+        });
+  }
+}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -348,6 +348,7 @@ play.filters {
   enabled += filters.UnsupportedBrowserFilter
   enabled += filters.SettingsFilter
   enabled += play.filters.csp.CSPFilter
+  enabled += filters.DevRoutesFilter
 
   csp {
     reportOnly = true

--- a/server/test/controllers/dev/DevToolsControllerTest.java
+++ b/server/test/controllers/dev/DevToolsControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static support.FakeRequestBuilder.fakeRequest;
@@ -100,39 +99,6 @@ public class DevToolsControllerTest {
     controller.clearCache();
     assertThat(result.status()).isEqualTo(OK);
     assertThat(programsByVersionCache.get(cacheKey).isPresent()).isFalse();
-  }
-
-  @Test
-  public void index_inNonDevMode_returnsNotFound() {
-    setupControllerInMode(Mode.TEST);
-    Result result = controller.index(fakeRequest());
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
-  public void data_inNonDevMode_returnsNotFound() {
-
-    setupControllerInMode(Mode.TEST);
-    Result result = controller.data(fakeRequest());
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
-  public void seedPrograms_inNonDevMode_returnsNotFound() {
-    setupControllerInMode(Mode.TEST);
-    Result result = controller.seedPrograms();
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
-  public void clear_inNonDevMode_returnsNotFound() {
-    setupControllerInMode(Mode.TEST);
-    Result result = controller.clear();
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   private void setupControllerInMode(Mode mode) {

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static support.FakeRequestBuilder.fakeRequest;
 
@@ -9,7 +8,6 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
-import services.DeploymentType;
 import services.settings.SettingsService;
 
 public class FeatureFlagOverrideControllerTest extends ResetPostgres {
@@ -26,21 +24,9 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void disable_nonDevMode_fails() {
-    // Execute
-    var result = controller.disable(fakeRequest(), FLAG_NAME);
-
-    // Verify
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
   public void disable() {
     // Setup
-    controller =
-        new FeatureFlagOverrideController(
-            instanceOf(SettingsService.class),
-            new DeploymentType(/* isDev= */ true, /* isStaging= */ true));
+    controller = new FeatureFlagOverrideController(instanceOf(SettingsService.class));
 
     // Execute
     var result = controller.disable(fakeRequest(), FLAG_NAME);
@@ -51,21 +37,9 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void enable_nonDevMode_fails() {
-    // Execute
-    var result = controller.enable(fakeRequest(), FLAG_NAME);
-
-    // Verify
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-  }
-
-  @Test
   public void enable() {
     // Setup
-    controller =
-        new FeatureFlagOverrideController(
-            instanceOf(SettingsService.class),
-            new DeploymentType(/* isDev= */ true, /* isStaging= */ true));
+    controller = new FeatureFlagOverrideController(instanceOf(SettingsService.class));
 
     // Execute
     var result = controller.enable(fakeRequest(), FLAG_NAME);


### PR DESCRIPTION
### Description

Add DevRoutesFilter, which returns 404 not found in prod for all /dev routes. Remove now-unnecessary checks in the relevant controller methods.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #8583
