### PR TITLE
Run the prod image locally with bin/run-dev --prod

### DIFF
--- a/bin/lib/docker.sh
+++ b/bin/lib/docker.sh
@@ -19,6 +19,15 @@ function docker::compose_dev() {
 }
 
 #######################################
+# Runs docker compose with the prod image in a dev-like way.
+# Arguments:
+#   @: arguments for compose
+#######################################
+function docker::compose_dev_with_prod() {
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.prod-dev.yml "$@"
+}
+
+#######################################
 # Runs docker compose with the unit test settings.
 # Arguments:
 #   @: arguments for compose
@@ -255,4 +264,12 @@ function docker::dev_and_test_server_sbt_command() {
 
   # -Dsbt.offline tells sbt to run in "offline" mode and not re-download dependancies.
   docker exec -it $server_container_name ./entrypoint.sh -jvm-debug "$server_container_ip:$1" -Dsbt.offline $2
+}
+
+#######################################
+# Tail the application log inside the prod civiform container.
+#######################################
+function docker::tail_prod_civiform_log() {
+  local server_container_name="${COMPOSE_PROJECT_NAME}-civiform-1"
+  docker exec -it $server_container_name bin/bash -c "tail -F /civiform-server-0.0.1/logs/application.log 2>/dev/null"
 }

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,9 +1,16 @@
 #! /usr/bin/env bash
 
 # DOC: Run the app locally using Docker. Useful for manual testing.
+# DOC: When providing the --prod flag, it uses the production image instead
+# DOC: of the dev image. This is useful for testing bugs that only show
+# DOC: up in staging/prod. Note that in this mode, it will *not* recompile
+# DOC: the app when you make code changes. It will use the version of the code
+# DOC: compiled when the prod image was built. Also, because we only build
+# DOC: prod for linux/amd64, this will run in emulation on M1 Macs.
 
 source bin/lib.sh
 docker::set_project_name_dev
+truth::declare_var_false runprod
 
 # Default to using Localstack emulator.
 emulators::set_localstack_emulator_vars
@@ -31,6 +38,9 @@ function set_args() {
         emulators::ensure_only_one_cloud_provider_flag aws
         # Already defaulted to AWS.
         ;;
+      "--prod")
+        truth::enable runprod
+        ;;
     esac
 
     shift
@@ -42,17 +52,21 @@ set_args "$@"
 bin/pull-image
 
 # Start containers w/ specified emulator.
-docker::compose_dev --profile "${cloud_provider}" \
-  up \
-  -d "${emulator}"
+if truth::is_enabled runprod; then
+  docker::compose_dev_with_prod --profile "${cloud_provider}" up -d "${emulator}"
+else
+  docker::compose_dev --profile "${cloud_provider}" up -d "${emulator}"
+fi
 
 # Wait until the emulator is running.
 "bin/${emulator}/wait"
 
-# Start the civiform container and dependancies.
-docker::compose_dev up \
-  --wait \
-  -d
+# Start the civiform container and dependencies.
+if truth::is_enabled runprod; then
+  docker::compose_dev_with_prod up --wait -d
+else
+  docker::compose_dev up --wait -d
+fi
 
 # Start a warmup request loop so that when the subsequent server startup is ready, we trigger lazy
 # loading its edit-refresh resources so save developer time.
@@ -65,6 +79,13 @@ done &
 
 echo "Civiform starting locally at http://localhost:9000"
 
-docker::dev_and_test_server_sbt_command "8457" runDevServer
-
-docker::compose_dev stop civiform
+if truth::is_enabled runprod; then
+  docker::tail_prod_civiform_log
+  # This doesn't really do anything, since we have to Ctrl+C out of
+  # tailing the log. But one of these days we should fix this up
+  # to trap the Ctrl+C and stop the containers.
+  docker::compose_dev_with_prod stop civiform
+else
+  docker::dev_and_test_server_sbt_command "8457" runDevServer
+  docker::compose_dev stop civiform
+fi

--- a/docker-compose.prod-dev.yml
+++ b/docker-compose.prod-dev.yml
@@ -1,0 +1,12 @@
+# Builds on docker-compose.yml and docker-compose.dev.yml
+# Runs the prod image in like dev mode, but as if it was deployed to staging.
+
+services:
+  civiform:
+    build: prod
+    image: civiform
+    platform: linux/amd64
+    environment:
+      - SECRET_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - STAGING_HOSTNAME=localhost
+    entrypoint: /__cacert_entrypoint.sh /civiform-server-0.0.1/bin/civiform-server -Dconfig.file=/civiform-server-0.0.1/conf/application.conf


### PR DESCRIPTION
Because the prod image is built prettty differently from the dev image, we sometimes run into bugs that are only present on the prod image and we don't see them when running the civiform-dev container with the full source volume mounted into the container.

This provides a mechanism for using the civiform prod image with the dev environment. It won't recompile the code when things change like the dev image does, but it will allow us to poke at the prod image. It will run in staging mode so that we still have access to dev tools.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
