### PR TITLE
Remove unused getSubmittedApplication() method

### DIFF
--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import auth.ProgramAcls;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Keep;
 import io.ebean.annotation.DbArray;
 import io.ebean.annotation.DbJson;
 import io.ebean.annotation.DbJsonB;
@@ -124,6 +125,7 @@ public class ProgramModel extends BaseModel {
       inverseJoinColumns = @JoinColumn(name = "versions_id"))
   private List<VersionModel> versions;
 
+  @Keep
   @OneToMany(mappedBy = "program")
   @OrderBy("id desc")
   private List<ApplicationModel> applications;
@@ -306,20 +308,6 @@ public class ProgramModel extends BaseModel {
       // Optional.empty field for the program definition.
       builder.setSummaryImageFileKey(Optional.empty());
     }
-  }
-
-  /**
-   * Returns submitted program applications sorted by descending application id. Applications are
-   * obsolete if the applicant submitted the application more than once, but are included since all
-   * submitted applications should be shown.
-   */
-  public ImmutableList<ApplicationModel> getSubmittedApplications() {
-    return applications.stream()
-        .filter(
-            application ->
-                application.getLifecycleStage().equals(LifecycleStage.ACTIVE)
-                    || application.getLifecycleStage().equals(LifecycleStage.OBSOLETE))
-        .collect(ImmutableList.toImmutableList());
   }
 
   public String getSlug() {


### PR DESCRIPTION
### Description

Remove unused `getSubmittedApplication()` method.

Details:
- It doesn't make sense to fetch applications for a single version, and we shouldn't do it this way anyway.
- Adds the @Keep annotation to supress Errorprone

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [n/a] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).


### Issue(s) this completes

N/A
