### PR TITLE
Fast-forward deep link bug for guest

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -323,7 +323,7 @@ public final class ApplicationRepository {
   }
 
   /**
-   * Updates an application to point to a new program
+   * Updates a draft application, if one exists, to point to a new program
    *
    * @param applicantId the applicant ID
    * @param programId the program ID
@@ -353,17 +353,11 @@ public final class ApplicationRepository {
                   queryProfileLocationBuilder.create("updateDraftApplicationProgram"))
               .findOne();
 
-      if (existingDraft == null) {
-        throw new RuntimeException(
-            String.format(
-                "Did not find expected draft application for applicantId=%d, programId=%d.",
-                applicantId, programId));
+      if (existingDraft != null) {
+        existingDraft.setProgram(program);
+        existingDraft.save();
+        transaction.commit();
       }
-
-      existingDraft.setProgram(program);
-      existingDraft.save();
-
-      transaction.commit();
     }
   }
 }


### PR DESCRIPTION
### Description

If a new guest account tries to load a deep link with an old program id it was hitting an error since the guest account may not have yet had an draft application created. This will just update drafts if found and stop erroring if one isn't found.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
