### PR TITLE
Fix format on play.http.session.maxAge setting example

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -243,10 +243,11 @@ play.http {
     sameSite = null
 
     # Sets the max-age field of the cookie to 5 minutes.
+    # Format spec: https://www.playframework.com/documentation/2.3.4/Configuration#Duration-format
     # NOTE: this only sets when the browser will discard the cookie. Play will consider any
     # cookie value with a valid signature to be a valid session forever. To implement a server side session timeout,
     # you need to put a timestamp in the session and check it at regular intervals to possibly expire it.
-    #maxAge = 300
+    #maxAge = 300s
 
     # Sets the domain on the session cookie.
     #domain = "localhost"


### PR DESCRIPTION
### Description

Fix the commented-out play.http.session.maxAge setting to have a value that actually works so future readers don't get confused like I did.

Relevant docs: https://www.playframework.com/documentation/2.9.x/ConfigFile#Duration-format

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)