### PR TITLE
Allow OLs to continue numbering

### DIFF
--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -179,6 +179,7 @@ public final class TextFormatter {
                 "target",
                 "xmlns",
                 "fill",
+                "start", // <--- Allow OLs to continue numbering instead of resetting to 1.
                 "stroke",
                 "stroke-width",
                 "aria-label",

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -152,11 +152,17 @@ public class TextFormatterTest extends ResetPostgres {
   @Test
   public void orderedListRendersCorrectly() {
     String withList =
-        "This is my list:\n"
-            + "1.\tcream cheese\n\n**hello**\n\n"
-            + "2.\teggs\n"
-            + "3.\tsugar\n"
-            + "4.\tvanilla";
+        """
+        This is my list:
+        1.\tcream cheese
+
+        **hello**
+
+        2.\teggs
+        3.\tsugar
+        4.\tvanilla
+        """;
+
     ImmutableList<DomContent> content =
         TextFormatter.formatText(
             withList, /* preserveEmptyLines= */ false, /* addRequiredIndicator= */ false);

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -150,6 +150,29 @@ public class TextFormatterTest extends ResetPostgres {
   }
 
   @Test
+  public void orderedListRendersCorrectly() {
+    String withList =
+        "This is my list:\n"
+            + "1.\tcream cheese\n\n**hello**\n\n"
+            + "2.\teggs\n"
+            + "3.\tsugar\n"
+            + "4.\tvanilla";
+    ImmutableList<DomContent> content =
+        TextFormatter.formatText(
+            withList, /* preserveEmptyLines= */ false, /* addRequiredIndicator= */ false);
+    String htmlContent = content.get(0).render();
+
+    assertThat(htmlContent)
+        .isEqualTo(
+            """
+<p>This is my list:</p>
+<ol class="list-decimal mx-8"><li>cream cheese</li></ol>
+<p><strong>hello</strong></p>
+<ol start="2" class="list-decimal mx-8"><li>eggs</li><li>sugar</li><li>vanilla</li></ol>
+""");
+  }
+
+  @Test
   public void preservesLines() {
     String withBlankLine =
         "This is the first line of content.\n"

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -154,13 +154,13 @@ public class TextFormatterTest extends ResetPostgres {
     String withList =
         """
         This is my list:
-        1.\tcream cheese
+        1. cream cheese
 
         **hello**
 
-        2.\teggs
-        3.\tsugar
-        4.\tvanilla
+        2. eggs
+        3. sugar
+        4. vanilla
         """;
 
     ImmutableList<DomContent> content =


### PR DESCRIPTION
### Description

Allow `<ol>` elements to continue numbering as entered instead of resetting to 1 in places that use custom markdown.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
