### PR TITLE
Remove login modal when clicking on "Apply" for the first time

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -515,39 +515,6 @@ test.describe('applicant program index page', () => {
         )
       })
 
-      test('shows login prompt for guest users when they click apply', async ({
-        page,
-      }) => {
-        await test.step('Verify that login dialog appears', async () => {
-          // Click Apply on the primary program. This should show the login prompt modal.
-          await page.click(
-            `.cf-application-card:has-text("${primaryProgramName}") .cf-apply-button`,
-          )
-          expect(await page.textContent('html')).toContain(
-            'Create an account or sign in',
-          )
-          await validateScreenshot(
-            page.getByRole('dialog').getByTestId('login'),
-            'apply-program-login-prompt-northstar',
-            /* fullPage= */ false,
-            /* mobileScreenshot= */ true,
-          )
-        })
-
-        await test.step('Verify that login dialog does not appear a second time', async () => {
-          // Close the modal and click Apply again. This time, we should not see the login prompt modal.
-          await page
-            .getByRole('button', {class: 'usa-modal__close', isVisible: true})
-            .click()
-          await page.click(
-            `.cf-application-card:has-text("${primaryProgramName}") .cf-apply-button`,
-          )
-          expect(await page.textContent('html')).not.toContain(
-            'Create an account or sign in',
-          )
-        })
-      })
-
       test('categorizes programs for draft and applied applications as guest user', async ({
         applicantQuestions,
         page,

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -65,24 +65,6 @@
 </div>
 
 <div
-  th:fragment="programIndexLogin"
-  id="modal-container"
-  class="display-none position-fixed height-viewport width-full z-100"
->
-  <div th:each="programIdAndLoginBypassUrl: ${programIdsToLoginBypassUrls}">
-    <div
-      th:replace="~{this :: loginPromptModal(${'login-dialog-' + programIdAndLoginBypassUrl.key},
-                                             ${programIdAndLoginBypassUrl.value},
-                                             ${programIdsToLoginUrls.get(programIdAndLoginBypassUrl.key)},
-                                             #{content.initialLoginModalPrompt(${authProviderName})},
-                                             #{button.continueToApplication},
-                                             'login-prompt',
-                                             false)}"
-    ></div>
-  </div>
-</div>
-
-<div
   th:fragment="reviewLogin"
   id="modal-container"
   class="display-none position-fixed height-viewport width-full z-100"

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -5,7 +5,6 @@ import static services.applicant.ApplicantPersonalInfo.ApplicantType.GUEST;
 
 import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import controllers.AssetsFinder;
 import controllers.LanguageUtils;
@@ -135,24 +134,6 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
         settingsManifest.getApplicantPortalName(request).get());
     context.setVariable("createAccountLink", routes.LoginController.register().url());
     context.setVariable("isGuest", personalInfo.getType() == GUEST);
-    ImmutableMap<Long, String> programIdsToLoginBypassUrls =
-        applicationPrograms.allPrograms().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    program -> program.programId(),
-                    program ->
-                        applicantRoutes.review(profile, applicantId, program.programId()).url()));
-    context.setVariable("programIdsToLoginBypassUrls", programIdsToLoginBypassUrls);
-    context.setVariable(
-        "programIdsToLoginUrls",
-        applicationPrograms.allPrograms().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    program -> program.programId(),
-                    program ->
-                        routes.LoginController.applicantLogin(
-                                Optional.of(programIdsToLoginBypassUrls.get(program.programId())))
-                            .url())));
 
     // Toasts
     context.setVariable("bannerMessage", bannerMessage);

--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -77,13 +77,10 @@
         th:text="#{button.viewDetails}"
       ></a>
 
-      <!--/* TODO(#6902): Check local storage to avoid always showing login dialogs.  */-->
       <a
-        th:href="${card.isGuest() ? '#' + card.loginModalId().get() : card.actionUrl()}"
+        th:href="${card.actionUrl()}"
         class="usa-button cf-apply-button"
         th:text="${card.actionText()}"
-        th:data-open-modal="${card.isGuest()}"
-        th:aria-controls="${card.isGuest() ? card.loginModalId().get() : null}"
       ></a>
     </div>
   </div>

--- a/server/app/views/applicant/ProgramIndexTemplate.html
+++ b/server/app/views/applicant/ProgramIndexTemplate.html
@@ -99,7 +99,6 @@
         </th:block>
       </div>
     </main>
-    <div th:replace="~{applicant/ModalFragment:: programIndexLogin}"></div>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>
 </html>


### PR DESCRIPTION
### Description

1. User is NOT logged in
1. User opens program index (home) page for the first time in a session
1. User clicks "Apply"
    * Before: Login modal appears
    * After: CiviForm navigates directly to the application

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Issue(s) this completes

Fixes #8496
