### PR TITLE
Fix North Star bug when program has no external link

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -625,6 +625,41 @@ test.describe('applicant program index page', () => {
         // Verify the program details URL matches the external link
         expect(popupURL).toMatch('https://www.usa.gov/')
       })
+
+      test('Click "View details" button on program with no external link and expect to open a new tab with the program details', async ({
+        page,
+        adminPrograms,
+      }) => {
+        const programWithoutExternalLink = 'No Link Program'
+
+        await test.step('Create a new program without an external link', async () => {
+          await loginAsAdmin(page)
+          await adminPrograms.addProgram(
+            programWithoutExternalLink,
+            'program description',
+            '' /* no external link */,
+          )
+          await adminPrograms.publishAllDrafts()
+          await logout(page)
+        })
+
+        await test.step('Find the program card and click on "View details"', async () => {
+          const cardLocator = page.locator('.cf-application-card', {
+            has: page.getByText(programWithoutExternalLink),
+          })
+          await cardLocator.getByText('View details').click()
+        })
+
+        await test.step('Verify the URL of the new tab', async () => {
+          // Clicking the button opens a new tab
+          const popupPromise = page.waitForEvent('popup')
+          const popup = await popupPromise
+          const popupURL = await popup.evaluate('location.href')
+
+          // Verify the program details URL matches the program details page
+          expect(popupURL).toMatch(/\/programs\/\d+/)
+        })
+      })
     },
   )
 })

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -17,22 +17,35 @@
         </h2>
         <div class="display-flex flex-column">
           <p>Log in as:</p>
-          <a th:href="${fakeCiviformAdminUrl}" class="usa-button margin-y-2"
+          <a
+            th:href="${fakeCiviformAdminUrl}"
+            class="usa-button margin-y-2"
+            id="admin"
             >Civiform Admin</a
           >
-          <a th:href="${fakeProgramAdminUrl}" class="usa-button margin-y-2"
+          <a
+            th:href="${fakeProgramAdminUrl}"
+            class="usa-button margin-y-2"
+            id="program-admin"
             >Program Admin</a
           >
-          <a th:href="${fakeDualAdminUrl}" class="usa-button margin-y-2"
+          <a
+            th:href="${fakeDualAdminUrl}"
+            class="usa-button margin-y-2"
+            id="dual-admin"
             >Program and Civiform Admin</a
           >
           <a
             th:href="${fakeTrustedIntermediaryUrl}"
             class="usa-button margin-y-2"
+            id="trusted-intermediary"
             >Trusted Intermediary</a
           >
           <p>Other:</p>
-          <a th:href="${additionalToolsUrl}" class="usa-button margin-y-2"
+          <a
+            th:href="${additionalToolsUrl}"
+            class="usa-button margin-y-2"
+            id="additional-tools"
             >Additional tools</a
           >
         </div>

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -101,7 +101,10 @@ public final class ProgramCardsSectionParamsFactory {
       cardBuilder
           .setTitle(program.localizedName().getOrDefault(preferredLocale))
           .setBody(program.localizedDescription().getOrDefault(preferredLocale))
-          .setDetailsUrl(program.externalLink())
+          .setDetailsUrl(
+              program.externalLink().isEmpty()
+                  ? applicantRoutes.show(profile, applicantId, program.id()).url()
+                  : program.externalLink())
           .setActionUrl(actionUrl)
           .setIsGuest(isGuest)
           .setActionText(messages.at(buttonText.getKeyName()));


### PR DESCRIPTION
### Description

In the North Star, if a program didn't have an external link, clicking on "View details" in the program card would redirect to the homepage.  The expected behavior is to open the program details page in a new tab.  This is the existing behavior pre-North Star.

### Instructions for manual testing

1. Log in as a CiviForm admin.
2. Edit the details for a program, removing anything under "Link to program website".
3. Publish your changes.
4. Log out.
5. Find that program card on the homepage and click "View details".
6. Observe that a new tab opens with the program details view and this URL: "/programs/<program id>"

### Issue(s) this completes

Fixes #8498 
