### PR TITLE
Don't apply markdown formatting to empty/whitespace only text

### DIFF
--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -59,6 +59,10 @@ public final class TextFormatter {
   /** Passes provided text through Markdown formatter, generating an HTML String */
   public static String formatTextToSanitizedHTML(
       String text, boolean preserveEmptyLines, boolean addRequiredIndicator) {
+    if (text.isBlank()) {
+      return "";
+    }
+
     if (preserveEmptyLines) {
       text = preserveEmptyLines(text);
     }

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -324,4 +324,12 @@ public class TextFormatterTest extends ResetPostgres {
                 + "<p>This is a string with <em>italics</em> and <strong>bold</strong> and"
                 + " <code>inline code</code></p>\n");
   }
+
+  @Test
+  public void formatTextToSanitizedHTML_emptyStringReturnsEmptyString() {
+    assertThat(TextFormatter.formatTextToSanitizedHTML("", false, false)).isEmpty();
+    assertThat(TextFormatter.formatTextToSanitizedHTML("", true, false)).isEmpty();
+    assertThat(TextFormatter.formatTextToSanitizedHTML("", false, true)).isEmpty();
+    assertThat(TextFormatter.formatTextToSanitizedHTML("", true, true)).isEmpty();
+  }
 }


### PR DESCRIPTION
### Description

When an empty string was passed to the markdown text formatting it would return `<p></p>`. This will now return an empty string if the input string is solely empty or whitespace so aberrant paragraph elements are not added. Normal formatting will remain as long as there is some content to show.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #8537

