### PR TITLE
[Program Migration] Handle service area validation in program import

### DIFF
--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -695,7 +695,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     assertThat(eligibilityQuestionId).isEqualTo(savedQuestionId);
     assertThat(visibilityQuestionId).isEqualTo(savedQuestionId);
 
-    Long eligibilityAddressQuestionId =
+    Long eligibilityInServiceAreaAddressQuestionId =
         programDefinition
             .getBlockDefinition(3)
             .eligibilityDefinition()
@@ -704,7 +704,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             .rootNode()
             .getLeafAddressNode()
             .questionId();
-    Long savedAddressQuestionId =
+    Long savedInServiceAreaAddressQuestionId =
         database
             .find(QuestionModel.class)
             .where()
@@ -712,7 +712,28 @@ public class AdminImportControllerTest extends ResetPostgres {
             .findOne()
             .getQuestionDefinition()
             .getId();
-    assertThat(eligibilityAddressQuestionId).isEqualTo(savedAddressQuestionId);
+    assertThat(eligibilityInServiceAreaAddressQuestionId)
+        .isEqualTo(savedInServiceAreaAddressQuestionId);
+
+    Long eligibilityNotInServiceAreaAddressQuestionId =
+        programDefinition
+            .getBlockDefinition(4)
+            .eligibilityDefinition()
+            .get()
+            .predicate()
+            .rootNode()
+            .getLeafAddressNode()
+            .questionId();
+    Long savedNotInServiceAreaAddressQuestionId =
+        database
+            .find(QuestionModel.class)
+            .where()
+            .eq("name", "second-address")
+            .findOne()
+            .getQuestionDefinition()
+            .getId();
+    assertThat(eligibilityNotInServiceAreaAddressQuestionId)
+        .isEqualTo(savedNotInServiceAreaAddressQuestionId);
   }
 
   @Test
@@ -772,7 +793,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     assertThat(eligibilityQuestionId).isEqualTo(savedQuestionId);
     assertThat(visibilityQuestionId).isEqualTo(savedQuestionId);
 
-    Long eligibilityAddressQuestionId =
+    Long eligibilityInServiceAreaAddressQuestionId =
         programDefinition
             .getBlockDefinition(3)
             .eligibilityDefinition()
@@ -781,7 +802,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             .rootNode()
             .getLeafAddressNode()
             .questionId();
-    Long savedAddressQuestionId =
+    Long savedInServiceAreaAddressQuestionId =
         database
             .find(QuestionModel.class)
             .where()
@@ -789,7 +810,28 @@ public class AdminImportControllerTest extends ResetPostgres {
             .findOne()
             .getQuestionDefinition()
             .getId();
-    assertThat(eligibilityAddressQuestionId).isEqualTo(savedAddressQuestionId);
+    assertThat(eligibilityInServiceAreaAddressQuestionId)
+        .isEqualTo(savedInServiceAreaAddressQuestionId);
+
+    Long eligibilityNotInServiceAreaAddressQuestionId =
+        programDefinition
+            .getBlockDefinition(4)
+            .eligibilityDefinition()
+            .get()
+            .predicate()
+            .rootNode()
+            .getLeafAddressNode()
+            .questionId();
+    Long savedNotInServiceAreaAddressQuestionId =
+        database
+            .find(QuestionModel.class)
+            .where()
+            .eq("name", "second-address")
+            .findOne()
+            .getQuestionDefinition()
+            .getId();
+    assertThat(eligibilityNotInServiceAreaAddressQuestionId)
+        .isEqualTo(savedNotInServiceAreaAddressQuestionId);
   }
 
   @Test
@@ -1504,6 +1546,43 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "        \"optional\" : false,\n"
           + "        \"addressCorrectionEnabled\" : true\n"
           + "      } ]\n"
+          + "    }, {\n"
+          + "      \"id\" : 4,\n"
+          + "      \"name\" : \"Screen 4\",\n"
+          + "      \"description\" : \"Screen 4 description\",\n"
+          + "      \"localizedName\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Screen 4\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"localizedDescription\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Screen 4 description\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"repeaterId\" : null,\n"
+          + "      \"hidePredicate\" : null,\n"
+          + "      \"eligibilityDefinition\" : {\n"
+          + "        \"predicate\" : {\n"
+          + "          \"rootNode\" : {\n"
+          + "            \"node\" : {\n"
+          + "              \"type\" : \"leafAddressServiceArea\",\n"
+          + "              \"questionId\" : 6,\n"
+          + "              \"serviceAreaId\" : \"Seattle\",\n"
+          + "              \"operator\" : \"NOT_IN_SERVICE_AREA\"\n"
+          + "            }\n"
+          + "          },\n"
+          + "          \"action\" : \"ELIGIBLE_BLOCK\"\n"
+          + "        }\n"
+          + "      },\n"
+          + "      \"optionalPredicate\" : null,\n"
+          + "      \"questionDefinitions\" : [ {\n"
+          + "        \"id\" : 6,\n"
+          + "        \"optional\" : false,\n"
+          + "        \"addressCorrectionEnabled\" : true\n"
+          + "      } ]\n"
           + "    } ],\n"
           + "    \"programType\" : \"DEFAULT\",\n"
           + "    \"eligibilityIsGating\" : true,\n"
@@ -1581,6 +1660,31 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "        \"disallowPoBox\" : false\n"
           + "      },\n"
           + "      \"id\" : 5,\n"
+          + "      \"universal\" : false,\n"
+          + "      \"primaryApplicantInfoTags\" : [ ]\n"
+          + "    }\n"
+          + "  }, {\n"
+          + "    \"type\" : \"address\",\n"
+          + "    \"config\" : {\n"
+          + "      \"name\" : \"second-address\",\n"
+          + "      \"description\" : \"\",\n"
+          + "      \"questionText\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Second address question\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"questionHelpText\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Second address question\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"validationPredicates\" : {\n"
+          + "        \"type\" : \"address\",\n"
+          + "        \"disallowPoBox\" : false\n"
+          + "      },\n"
+          + "      \"id\" : 6,\n"
           + "      \"universal\" : false,\n"
           + "      \"primaryApplicantInfoTags\" : [ ]\n"
           + "    }\n"

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -694,6 +694,25 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     assertThat(eligibilityQuestionId).isEqualTo(savedQuestionId);
     assertThat(visibilityQuestionId).isEqualTo(savedQuestionId);
+
+    Long eligibilityAddressQuestionId =
+        programDefinition
+            .getBlockDefinition(3)
+            .eligibilityDefinition()
+            .get()
+            .predicate()
+            .rootNode()
+            .getLeafAddressNode()
+            .questionId();
+    Long savedAddressQuestionId =
+        database
+            .find(QuestionModel.class)
+            .where()
+            .eq("name", "Address")
+            .findOne()
+            .getQuestionDefinition()
+            .getId();
+    assertThat(eligibilityAddressQuestionId).isEqualTo(savedAddressQuestionId);
   }
 
   @Test
@@ -752,6 +771,25 @@ public class AdminImportControllerTest extends ResetPostgres {
 
     assertThat(eligibilityQuestionId).isEqualTo(savedQuestionId);
     assertThat(visibilityQuestionId).isEqualTo(savedQuestionId);
+
+    Long eligibilityAddressQuestionId =
+        programDefinition
+            .getBlockDefinition(3)
+            .eligibilityDefinition()
+            .get()
+            .predicate()
+            .rootNode()
+            .getLeafAddressNode()
+            .questionId();
+    Long savedAddressQuestionId =
+        database
+            .find(QuestionModel.class)
+            .where()
+            .eq("name", "Address")
+            .findOne()
+            .getQuestionDefinition()
+            .getId();
+    assertThat(eligibilityAddressQuestionId).isEqualTo(savedAddressQuestionId);
   }
 
   @Test
@@ -1305,7 +1343,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   public static final String PROGRAM_JSON_WITH_PREDICATES =
       "{\n"
           + "  \"program\" : {\n"
-          + "    \"id\" : 6,\n"
+          + "    \"id\" : 1,\n"
           + "    \"adminName\" : \"visibility-eligibility\",\n"
           + "    \"adminDescription\" : \"\",\n"
           + "    \"externalLink\" : \"\",\n"
@@ -1349,45 +1387,45 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "      \"hidePredicate\" : null,\n"
           + "      \"eligibilityDefinition\" : {\n"
           + "        \"predicate\" : {\n"
-          + "        \"rootNode\" : { \n"
-          + "          \"node\" : { \n"
-          + "            \"type\" : \"or\", \n"
-          + "            \"children\" : [ { \n"
-          + "              \"node\" : { \n"
-          + "                \"type\" : \"and\", \n"
-          + "                \"children\" : [ { \n"
-          + "                  \"node\" : { \n"
-          + "                    \"type\" : \"leaf\", \n"
-          + "                    \"questionId\" : 11, \n"
-          + "                    \"scalar\" : \"SELECTIONS\", \n"
-          + "                    \"operator\" : \"ANY_OF\", \n"
-          + "                    \"value\" : { \n"
-          + "                      \"value\" : \"[\\\"0\\\", \\\"9\\\", \\\"11\\\"]\", \n"
-          + "                      \"type\" : \"LIST_OF_STRINGS\" \n"
-          + "                    } \n"
-          + "                  } \n"
-          + "                }, { \n"
-          + "                  \"node\" : { \n"
-          + "                    \"type\" : \"leaf\", \n"
-          + "                    \"questionId\" : 11, \n"
-          + "                    \"scalar\" : \"SELECTION\", \n"
-          + "                    \"operator\" : \"IN\", \n"
-          + "                    \"value\" : { \n"
-          + "                      \"value\" : \"[\\\"1\\\"]\", \n"
-          + "                      \"type\" : \"LIST_OF_STRINGS\" \n"
-          + "                    } \n"
-          + "                  } \n"
-          + "                } ] \n"
-          + "              } \n"
-          + "            } ] \n"
-          + "          } \n"
-          + "        }, \n"
+          + "          \"rootNode\" : {\n"
+          + "            \"node\" : {\n"
+          + "              \"type\" : \"or\",\n"
+          + "              \"children\" : [ {\n"
+          + "                \"node\" : {\n"
+          + "                  \"type\" : \"and\",\n"
+          + "                  \"children\" : [ {\n"
+          + "                    \"node\" : {\n"
+          + "                      \"type\" : \"leaf\",\n"
+          + "                      \"questionId\" : 3,\n"
+          + "                      \"scalar\" : \"SELECTIONS\",\n"
+          + "                      \"operator\" : \"ANY_OF\",\n"
+          + "                      \"value\" : {\n"
+          + "                        \"value\" : \"[\\\"0\\\", \\\"9\\\", \\\"11\\\"]\",\n"
+          + "                        \"type\" : \"LIST_OF_STRINGS\"\n"
+          + "                      }\n"
+          + "                    }\n"
+          + "                  }, {\n"
+          + "                    \"node\" : {\n"
+          + "                      \"type\" : \"leaf\",\n"
+          + "                      \"questionId\" : 3,\n"
+          + "                      \"scalar\" : \"SELECTION\",\n"
+          + "                      \"operator\" : \"IN\",\n"
+          + "                      \"value\" : {\n"
+          + "                        \"value\" : \"[\\\"1\\\"]\",\n"
+          + "                        \"type\" : \"LIST_OF_STRINGS\"\n"
+          + "                      }\n"
+          + "                    }\n"
+          + "                  } ]\n"
+          + "                }\n"
+          + "              } ]\n"
+          + "            }\n"
+          + "          },\n"
           + "          \"action\" : \"ELIGIBLE_BLOCK\"\n"
           + "        }\n"
           + "      },\n"
           + "      \"optionalPredicate\" : null,\n"
           + "      \"questionDefinitions\" : [ {\n"
-          + "        \"id\" : 11,\n"
+          + "        \"id\" : 3,\n"
           + "        \"optional\" : false,\n"
           + "        \"addressCorrectionEnabled\" : false\n"
           + "      } ]\n"
@@ -1412,7 +1450,7 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "        \"rootNode\" : {\n"
           + "          \"node\" : {\n"
           + "            \"type\" : \"leaf\",\n"
-          + "            \"questionId\" : 11,\n"
+          + "            \"questionId\" : 3,\n"
           + "            \"scalar\" : \"ID\",\n"
           + "            \"operator\" : \"EQUAL_TO\",\n"
           + "            \"value\" : {\n"
@@ -1425,21 +1463,55 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "      },\n"
           + "      \"optionalPredicate\" : null,\n"
           + "      \"questionDefinitions\" : [ {\n"
-          + "        \"id\" : 12,\n"
+          + "        \"id\" : 4,\n"
           + "        \"optional\" : false,\n"
           + "        \"addressCorrectionEnabled\" : false\n"
           + "      } ]\n"
+          + "    }, {\n"
+          + "      \"id\" : 3,\n"
+          + "      \"name\" : \"Screen 3\",\n"
+          + "      \"description\" : \"Screen 3 description\",\n"
+          + "      \"localizedName\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Screen 3\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"localizedDescription\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"Screen 3 description\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"repeaterId\" : null,\n"
+          + "      \"hidePredicate\" : null,\n"
+          + "      \"eligibilityDefinition\" : {\n"
+          + "        \"predicate\" : {\n"
+          + "          \"rootNode\" : {\n"
+          + "            \"node\" : {\n"
+          + "              \"type\" : \"leafAddressServiceArea\",\n"
+          + "              \"questionId\" : 5,\n"
+          + "              \"serviceAreaId\" : \"Seattle\",\n"
+          + "              \"operator\" : \"IN_SERVICE_AREA\"\n"
+          + "            }\n"
+          + "          },\n"
+          + "          \"action\" : \"ELIGIBLE_BLOCK\"\n"
+          + "        }\n"
+          + "      },\n"
+          + "      \"optionalPredicate\" : null,\n"
+          + "      \"questionDefinitions\" : [ {\n"
+          + "        \"id\" : 5,\n"
+          + "        \"optional\" : false,\n"
+          + "        \"addressCorrectionEnabled\" : true\n"
+          + "      } ]\n"
           + "    } ],\n"
-          + "    \"statusDefinitions\" : {\n"
-          + "      \"statuses\" : [ ]\n"
-          + "    },\n"
           + "    \"programType\" : \"DEFAULT\",\n"
           + "    \"eligibilityIsGating\" : true,\n"
           + "    \"acls\" : {\n"
           + "      \"tiProgramViewAcls\" : [ ]\n"
           + "    },\n"
-          + "    \"categories\" : [ ], \n"
-          + "    \"localizedSummaryImageDescription\" : null\n"
+          + "    \"localizedSummaryImageDescription\" : null,\n"
+          + "    \"categories\" : [ ]\n"
           + "  },\n"
           + "  \"questions\" : [ {\n"
           + "    \"type\" : \"id\",\n"
@@ -1461,7 +1533,7 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "        \"minLength\" : null,\n"
           + "        \"maxLength\" : null\n"
           + "      },\n"
-          + "      \"id\" : 11,\n"
+          + "      \"id\" : 3,\n"
           + "      \"universal\" : false,\n"
           + "      \"primaryApplicantInfoTags\" : [ ]\n"
           + "    }\n"
@@ -1485,12 +1557,36 @@ public class AdminImportControllerTest extends ResetPostgres {
           + "        \"minLength\" : null,\n"
           + "        \"maxLength\" : null\n"
           + "      },\n"
-          + "      \"id\" : 12,\n"
+          + "      \"id\" : 4,\n"
+          + "      \"universal\" : false,\n"
+          + "      \"primaryApplicantInfoTags\" : [ ]\n"
+          + "    }\n"
+          + "  }, {\n"
+          + "    \"type\" : \"address\",\n"
+          + "    \"config\" : {\n"
+          + "      \"name\" : \"Address\",\n"
+          + "      \"description\" : \"\",\n"
+          + "      \"questionText\" : {\n"
+          + "        \"translations\" : {\n"
+          + "          \"en_US\" : \"What is your address?\"\n"
+          + "        },\n"
+          + "        \"isRequired\" : true\n"
+          + "      },\n"
+          + "      \"questionHelpText\" : {\n"
+          + "        \"translations\" : { },\n"
+          + "        \"isRequired\" : false\n"
+          + "      },\n"
+          + "      \"validationPredicates\" : {\n"
+          + "        \"type\" : \"address\",\n"
+          + "        \"disallowPoBox\" : false\n"
+          + "      },\n"
+          + "      \"id\" : 5,\n"
           + "      \"universal\" : false,\n"
           + "      \"primaryApplicantInfoTags\" : [ ]\n"
           + "    }\n"
           + "  } ]\n"
           + "}";
+
   public static final String PROGRAM_JSON_WITH_PAI_TAGS =
       "{\n"
           + "  \"program\" : {\n"


### PR DESCRIPTION
### Description

This change adds the ability to handle `LEAF_ADDRESS_SERVICE_AREA` type nodes for eligibility and visibility predicates which will allow importing programs that use service area validation in eligibility/visibility settings.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary.  [docs update](https://github.com/civiform/docs/pull/511) (will change this back once this change has been released)

### Instructions for manual testing

1. Enable the `PROGRAM_MIGRATION_ENABLED` flag
2. Create a program that uses service area validation on an address question to determine eligibility or visibility
3. Export the json for this program and test that you can successfully import this program.

### Issue(s) this completes

Fixes #8450 
