### PR TITLE
Make demo mode login button configurable in settings panel

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -884,11 +884,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * If this is a staging deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:'
-   * buttons are not shown on the login page.
+   * If this is a staging or demo deployment and this variable is set to true, the 'DEMO MODE. LOGIN
+   * AS:' buttons are not shown on the login page. Warning: if you turn on this flag, you will need
+   * to log in through the admin authenticator to get back to this settings page
    */
-  public boolean getStagingDisableDemoModeLogins() {
-    return getBool("STAGING_DISABLE_DEMO_MODE_LOGINS");
+  public boolean getStagingDisableDemoModeLogins(RequestHeader request) {
+    return getBool("STAGING_DISABLE_DEMO_MODE_LOGINS", request);
   }
 
   /** Enables the API docs tab on CiviForm. */
@@ -1932,11 +1933,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       SettingMode.HIDDEN),
                   SettingDescription.create(
                       "STAGING_DISABLE_DEMO_MODE_LOGINS",
-                      "If this is a staging deployment and this variable is set to true, the 'DEMO"
-                          + " MODE. LOGIN AS:' buttons are not shown on the login page.",
+                      "If this is a staging or demo deployment and this variable is set to true,"
+                          + " the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page."
+                          + " Warning: if you turn on this flag, you will need to log in through"
+                          + " the admin authenticator to get back to this settings page",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.HIDDEN),
+                      SettingMode.ADMIN_WRITEABLE),
                   SettingDescription.create(
                       "API_GENERATED_DOCS_ENABLED",
                       "Enables the API docs tab on CiviForm.",

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -110,7 +110,7 @@ public abstract class NorthStarBaseView {
 
     context.setVariable("isDevOrStaging", isDevOrStaging);
 
-    boolean showDebugTools = isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins();
+    boolean showDebugTools = isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request);
     context.setVariable("showDebugTools", showDebugTools);
     if (showDebugTools) {
       context.setVariable(

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -110,7 +110,8 @@ public abstract class NorthStarBaseView {
 
     context.setVariable("isDevOrStaging", isDevOrStaging);
 
-    boolean showDebugTools = isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request);
+    boolean showDebugTools =
+        isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request);
     context.setVariable("showDebugTools", showDebugTools);
     if (showDebugTools) {
       context.setVariable(

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -80,7 +80,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
   private final LanguageUtils languageUtils;
   private final LanguageSelector languageSelector;
   private final boolean isDevOrStaging;
-  private final boolean disableDemoModeLogins;
   private final DebugContent debugContent;
   private final PageNotProductionBanner pageNotProductionBanner;
   private String tiDashboardHref = getTiDashboardHref();
@@ -103,19 +102,17 @@ public class ApplicantLayout extends BaseHtmlLayout {
     this.languageSelector = checkNotNull(languageSelector);
     this.languageUtils = checkNotNull(languageUtils);
     this.isDevOrStaging = deploymentType.isDevOrStaging();
-    this.disableDemoModeLogins =
-        this.isDevOrStaging && settingsManifest.getStagingDisableDemoModeLogins();
     this.debugContent = debugContent;
     this.pageNotProductionBanner = checkNotNull(pageNotProductionBanner);
   }
 
   @Override
-  public Content render(HtmlBundle bundle) {
+  public Content render(HtmlBundle bundle, Http.Request request) {
     bundle.addBodyStyles(ApplicantStyles.BODY);
 
     bundle.addFooterStyles("mt-24");
 
-    if (isDevOrStaging && !disableDemoModeLogins) {
+    if (isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request)) {
       bundle.addModals(DEBUG_CONTENT_MODAL);
     }
 
@@ -272,7 +269,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                 .with(redirectInput)
                 .with(languageDropdown)
                 .condWith(
-                    isDevOrStaging && !disableDemoModeLogins,
+                    isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request),
                     div()
                         .withClasses("w-full", "flex", "justify-center")
                         .with(

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -107,14 +107,10 @@ public class ApplicantLayout extends BaseHtmlLayout {
   }
 
   @Override
-  public Content render(HtmlBundle bundle, Http.Request request) {
+  public Content render(HtmlBundle bundle) {
     bundle.addBodyStyles(ApplicantStyles.BODY);
 
     bundle.addFooterStyles("mt-24");
-
-    if (isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request)) {
-      bundle.addModals(DEBUG_CONTENT_MODAL);
-    }
 
     Content rendered = super.render(bundle);
     if (!rendered.body().contains("<h1")) {
@@ -150,6 +146,10 @@ public class ApplicantLayout extends BaseHtmlLayout {
       boolean includeAdminLogin,
       Long applicantId) {
     bundle.addPageNotProductionBanner(pageNotProductionBanner.render(request, messages));
+
+    if (isDevOrStaging && !settingsManifest.getStagingDisableDemoModeLogins(request)) {
+      bundle.addModals(DEBUG_CONTENT_MODAL);
+    }
 
     String supportEmail = settingsManifest.getSupportEmailAddress(request).get();
     String language = languageUtils.getPreferredLanguage(request).code();

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -735,8 +735,8 @@
         "type": "bool"
       },
       "STAGING_DISABLE_DEMO_MODE_LOGINS": {
-        "mode": "HIDDEN",
-        "description": "If this is a staging deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page.",
+        "mode": "ADMIN_WRITEABLE",
+        "description": "If this is a staging or demo deployment and this variable is set to true, the 'DEMO MODE. LOGIN AS:' buttons are not shown on the login page. Warning: if you turn on this flag, you will need to log in through the admin authenticator to get back to this settings page",
         "type": "bool"
       },
       "API_GENERATED_DOCS_ENABLED": {


### PR DESCRIPTION
### Description

Charlotte would like the ability to hide the "demo tools" button, so they can share their staging programs without people logging in as an admin and changing things. This flag already existed, but was hidden, so this makes it admin writeable. This flag won't do anything in non demo / staging environments


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
