### PR TITLE
Fix create account button and login link

### DIFF
--- a/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
@@ -80,6 +80,41 @@ test.describe(
       })
     })
 
+    test('As guest, validate login link in alert', async ({
+      page,
+      adminPrograms,
+      applicantQuestions,
+    }) => {
+      await test.step('Setup: publish one program', async () => {
+        await adminPrograms.addProgram(eligibleProgram1)
+        await adminPrograms.publishProgram(eligibleProgram1)
+        await logout(page)
+      })
+
+      await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+      await test.step('Setup: submit application', async () => {
+        await applicantQuestions.clickApplyProgramButton(programName)
+        await applicantQuestions.submitFromReviewPage(
+          /* northStarEnabled= */ true,
+        )
+      })
+
+      await test.step('Validate the login link logs the user in and navigates to the home page', async () => {
+        await expect(
+          page.getByText(
+            'Create an account to save your application information',
+          ),
+        ).toBeVisible()
+
+        await loginAsTestUser(
+          page,
+          'a:has-text("Login to an existing account")',
+        )
+        await applicantQuestions.expectProgramsPage()
+      })
+    })
+
     test('view application submitted page with zero eligible programs', async ({
       page,
       applicantQuestions,

--- a/browser-test/src/applicant/northstar_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_upsell.test.ts
@@ -118,6 +118,28 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     })
   })
 
+  test('Validate login link in alert', async ({page, applicantQuestions}) => {
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('Submit application', async () => {
+      await applicantQuestions.clickApplyProgramButton(programName)
+      await applicantQuestions.submitFromReviewPage(
+        /* northStarEnabled= */ true,
+      )
+    })
+
+    await test.step('Validate the login link logs the user in and navigates to the home page', async () => {
+      await expect(
+        page.getByText(
+          'Create an account to save your application information',
+        ),
+      ).toBeVisible()
+
+      await loginAsTestUser(page, 'a:has-text("Login to an existing account")')
+      await applicantQuestions.expectProgramsPage()
+    })
+  })
+
   test('Page does not show programs the user already applied to', async ({
     page,
     adminPrograms,

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
@@ -82,7 +82,7 @@
 
             <section class="section-external" th:if="${isGuest}">
               <div
-                th:replace="~{applicant/CreateAccountAlertFragment :: createAccount}"
+                th:replace="~{applicant/CreateAccountAlertFragment :: createAccount(${createAccountLink}, ${loginLink})}"
               ></div>
             </section>
           </div>

--- a/server/app/views/applicant/ApplicantUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantUpsellTemplate.html
@@ -74,7 +74,7 @@
               </section>
 
               <div
-                th:replace="~{applicant/CreateAccountAlertFragment :: createAccount}"
+                th:replace="~{applicant/CreateAccountAlertFragment :: createAccount(${createAccountLink}, ${loginLink})}"
               ></div>
 
               <div class="section-internal">

--- a/server/app/views/applicant/CreateAccountAlertFragment.html
+++ b/server/app/views/applicant/CreateAccountAlertFragment.html
@@ -1,6 +1,9 @@
 <!-- Element that looks similar to a USWDS alert. It has more customization,
      such as the "Create account" button. -->
-<div th:fragment="createAccount" class="usa-alert usa-alert--info">
+<div
+  th:fragment="createAccount(createAccountLink, loginLink)"
+  class="usa-alert usa-alert--info"
+>
   <div class="usa-alert__body">
     <h2 class="usa-alert__heading" th:text="#{alert.createAccount}"></h2>
 
@@ -8,7 +11,6 @@
 
     <div class="content-spacing"></div>
 
-    <!-- TODO(#8588): Trigger create account flow (this is broken) -->
     <button
       type="button"
       class="usa-button usa-button--inverse"
@@ -24,8 +26,8 @@
         class="usa-link"
         href="javascript:void(0);"
         th:text="#{content.loginToExistingAccount}"
-        >linktext</a
-      >
+        th:href="${loginLink}"
+      ></a>
     </p>
   </div>
 </div>

--- a/server/app/views/applicant/NorthStarApplicantCommonIntakeUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantCommonIntakeUpsellView.java
@@ -66,6 +66,9 @@ public class NorthStarApplicantCommonIntakeUpsellView extends NorthStarBaseView 
             .url();
     context.setVariable("goBackHref", goBackHref);
 
+    // Create account or login alert
+    context.setVariable("createAccountLink", controllers.routes.LoginController.register().url());
+
     if (params.eligiblePrograms().isPresent()) {
       Locale userLocale = params.messages().lang().toLocale();
 

--- a/server/app/views/applicant/NorthStarApplicantUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantUpsellView.java
@@ -88,6 +88,9 @@ public class NorthStarApplicantUpsellView extends NorthStarBaseView {
         routes.UpsellController.download(params.applicationId(), params.applicantId()).url();
     context.setVariable("downloadHref", downloadHref);
 
+    // Create account or login alert
+    context.setVariable("createAccountLink", controllers.routes.LoginController.register().url());
+
     ProgramSectionParams cardsSection =
         programCardsSectionParamsFactory.getSection(
             params.request(),


### PR DESCRIPTION
### Description

Fix create account button and login link. This applies to:
* "Application Submitted" page
* "Common Intake Submitted" page

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/8480