### PR TITLE
Add config flag for session replay protection

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -993,6 +993,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * (NOT FOR PRODUCTION USE) Enable session replay protection, so that a session cookie cannot be
+   * replayed if the user logs out
+   */
+  public boolean getSessionReplayProtectionEnabled() {
+    return getBool("SESSION_REPLAY_PROTECTION_ENABLED");
+  }
+
+  /**
    * (NOT FOR PRODUCTION USE) Enables showing new UI with an updated user experience in Applicant
    * flows
    */
@@ -2084,6 +2092,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
                       SettingMode.ADMIN_WRITEABLE),
+                  SettingDescription.create(
+                      "SESSION_REPLAY_PROTECTION_ENABLED",
+                      "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a session"
+                          + " cookie cannot be replayed if the user logs out",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "NORTH_STAR_APPLICANT_UI",
                       "(NOT FOR PRODUCTION USE) Enables showing new UI with an updated user"

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -839,6 +839,11 @@
         "description": "(NOT FOR PRODUCTION USE) Enables suffix dropdown field in name question.",
         "type": "bool"
       },
+      "SESSION_REPLAY_PROTECTION_ENABLED": {
+        "mode": "ADMIN_READABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a session cookie cannot be replayed if the user logs out",
+        "type": "bool"
+      },
       "NORTH_STAR_APPLICANT_UI": {
         "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Enables showing new UI with an updated user experience in Applicant flows",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -91,3 +91,7 @@ bulk_status_update_enabled = ${?BULK_STATUS_UPDATE_ENABLED}
 # Name suffix dropdown field
 name_suffix_dropdown_enabled = false
 name_suffix_dropdown_enabled = ${?NAME_SUFFIX_DROPDOWN_ENABLED}
+
+# Session replay protection
+session_replay_protection_enabled = false
+session_replay_protection_enabled = ${?SESSION_REPLAY_PROTECTION_ENABLED}


### PR DESCRIPTION
### Description

Add a feature flag for session replay protection. We don't want admins to change it so it's ADMIN_READABLE.

This is for #6975.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)