### PR TITLE
[Multiple File Upload] Add context for remove link for screen readers

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -586,6 +586,42 @@ test.describe('file upload applicant flow', () => {
       )
     })
 
+    test('remove button has correct aria-labelled by', async ({
+      applicantQuestions,
+      page,
+    }) => {
+      await applicantQuestions.applyProgram(programName)
+
+      await applicantQuestions.answerFileUploadQuestionFromAssets(
+        'file-upload.png',
+      )
+      await applicantQuestions.answerFileUploadQuestionFromAssets(
+        'file-upload-second.png',
+      )
+
+      await expect(page.locator('#uploaded-file-1')).toContainText(
+        'file-upload.png',
+      )
+      await expect(
+        page
+          .getByRole('list', {name: 'Uploaded files'})
+          .locator('li')
+          .filter({hasText: 'file-upload.png'})
+          .getByText('Remove File'),
+      ).toHaveAttribute('aria-labelledby', 'uploaded-file-1')
+
+      await expect(page.locator('#uploaded-file-2')).toContainText(
+        'file-upload-second.png',
+      )
+      await expect(
+        page
+          .getByRole('list', {name: 'Uploaded files'})
+          .locator('li')
+          .filter({hasText: 'file-upload-second.png'})
+          .getByText('Remove File'),
+      ).toHaveAttribute('aria-labelledby', 'uploaded-file-2')
+    })
+
     // TODO remove ".fixme" once https://github.com/civiform/civiform/issues/8143 is fixed
     test.fixme(
       'too large file error',

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -113,7 +113,10 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
     JsonArray uploadedFileNames = new JsonArray();
 
     if (fileUploadQuestion.getFileKeyListValue().isPresent()) {
+      int i = 0;
       for (String fileKey : fileUploadQuestion.getFileKeyListValue().get()) {
+        i++;
+        String fileNameId = "uploaded-file-" + i;
         String fileName = FileUploadQuestion.getFileName(fileKey);
 
         uploadedFileNames.add(fileName);
@@ -132,10 +135,12 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
         result.with(
             li().withClass("flex justify-between mb-2")
                 .withText(fileName)
+                .withId(fileNameId)
                 .with(
                     TagCreator.a()
                         .withText(params.messages().at(MessageKey.LINK_REMOVE_FILE.getKeyName()))
                         .withHref(removeUrl)
+                        .attr("aria-labelledby", fileNameId)
                         .withClasses(
                             BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT, "underline")));
       }


### PR DESCRIPTION
### Description

Adds aria-labelled by to remove flie link so that screen readers alert which file will be removed.
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
#### User visible changes

- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)


### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #8721
