### PR TITLE
Support admin previews of NS program cards

### DIFF
--- a/browser-test/src/admin/admin_program_image.test.ts
+++ b/browser-test/src/admin/admin_program_image.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '../support/civiform_fixtures'
 import {
+  enableFeatureFlag,
   dismissToast,
   loginAsAdmin,
   validateScreenshot,
@@ -18,6 +19,51 @@ test.describe('Admin can manage program image', () => {
 
     await validateScreenshot(page, 'program-image-none')
   })
+
+  test(
+    'Views program card preview in North Star',
+    {tag: ['@northstar']},
+    async ({page, adminPrograms, adminProgramImage}) => {
+      const programName = 'Test Program'
+      const programDescription = 'Test description'
+
+      await test.step('Set up program', async () => {
+        await enableFeatureFlag(page, 'north_star_applicant_ui')
+        await loginAsAdmin(page)
+
+        await adminPrograms.addProgram(programName, programDescription)
+
+        await adminPrograms.goToProgramImagePage(programName)
+      })
+
+      await test.step('Verify preview without image', async () => {
+        await adminProgramImage.expectNoImagePreview()
+        await adminProgramImage.expectProgramPreviewCard(
+          programName,
+          programDescription,
+        )
+      })
+
+      await test.step('Verify preview with image', async () => {
+        await adminProgramImage.setImageFileAndSubmit(
+          'src/assets/program-summary-image-wide.png',
+        )
+        await adminProgramImage.expectProgramImagePage()
+
+        await validateToastMessage(
+          page,
+          adminProgramImage.imageUpdatedToastMessage(),
+        )
+        await dismissToast(page)
+
+        await adminProgramImage.expectImagePreview()
+        await adminProgramImage.expectProgramPreviewCard(
+          programName,
+          programDescription,
+        )
+      })
+    },
+  )
 
   test.describe('back button', () => {
     test('back button redirects to block page if came from block page', async ({

--- a/browser-test/src/support/admin_program_image.ts
+++ b/browser-test/src/support/admin_program_image.ts
@@ -174,6 +174,16 @@ export class AdminProgramImage {
     await this.page.click(this.translationsButtonLocator)
   }
 
+  async expectProgramPreviewCard(
+    programName: string,
+    programDescription: string,
+  ) {
+    await expect(this.page.getByText(programName)).toBeVisible()
+    await expect(this.page.getByText(programDescription)).toBeVisible()
+    await expect(this.page.getByText('View details')).toBeVisible()
+    await expect(this.page.getByText('Apply')).toBeVisible()
+  }
+
   descriptionUpdatedToastMessage(description: string) {
     return `Image description set to ${description}`
   }

--- a/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
+++ b/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
@@ -1,0 +1,74 @@
+package controllers.admin;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import auth.Authorizers;
+import auth.CiviFormProfile;
+import auth.ProfileUtils;
+import com.google.common.collect.ImmutableList;
+import controllers.CiviFormController;
+import java.util.concurrent.ExecutionException;
+import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
+import play.i18n.Lang;
+import play.i18n.Messages;
+import play.i18n.MessagesApi;
+import play.mvc.Http;
+import repository.VersionRepository;
+import services.applicant.ApplicantPersonalInfo;
+import services.applicant.ApplicantPersonalInfo.Representation;
+import services.applicant.ApplicantService.ApplicantProgramData;
+import services.program.ProgramDefinition;
+import services.program.ProgramService;
+import services.settings.SettingsManifest;
+import views.admin.programs.NorthStarProgramCardPreview;
+
+/** Controller for rendering a program card preview. */
+public final class NorthStarProgramCardPreviewController extends CiviFormController {
+  private final NorthStarProgramCardPreview northStarProgramCardPreview;
+  private final Messages messages;
+  private final SettingsManifest settingsManifest;
+  private final ProgramService programService;
+
+  @Inject
+  public NorthStarProgramCardPreviewController(
+      ProfileUtils profileUtils,
+      VersionRepository versionRepository,
+      NorthStarProgramCardPreview northStarProgramCardPreview,
+      MessagesApi messagesApi,
+      SettingsManifest settingsManifest,
+      ProgramService programService) {
+    super(profileUtils, versionRepository);
+    this.northStarProgramCardPreview = checkNotNull(northStarProgramCardPreview);
+    this.messages = messagesApi.preferred(ImmutableList.of(Lang.defaultLang()));
+    this.settingsManifest = checkNotNull(settingsManifest);
+    this.programService = checkNotNull(programService);
+  }
+
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
+  public String cardPreview(Http.Request request, long programId)
+      throws InterruptedException, ExecutionException {
+    if (!settingsManifest.getNorthStarApplicantUi(request)) {
+      return "";
+    }
+
+    Representation representation = Representation.builder().build();
+    ApplicantPersonalInfo api = ApplicantPersonalInfo.ofGuestUser(representation);
+    CiviFormProfile profile = profileUtils.currentUserProfile(request);
+
+    ProgramDefinition programDefinition =
+        programService.getFullProgramDefinitionAsync(programId).toCompletableFuture().get();
+    ApplicantProgramData apd = ApplicantProgramData.builder(programDefinition).build();
+
+    NorthStarProgramCardPreview.Params params =
+        NorthStarProgramCardPreview.Params.builder()
+            .setRequest(request)
+            .setApplicantPersonalInfo(api)
+            .setApplicantProgramData(apd)
+            .setProfile(profile)
+            .setMessages(messages)
+            .build();
+
+    return northStarProgramCardPreview.render(params);
+  }
+}

--- a/server/app/views/admin/programs/NorthStarProgramCardPreview.java
+++ b/server/app/views/admin/programs/NorthStarProgramCardPreview.java
@@ -1,0 +1,111 @@
+package views.admin.programs;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import auth.CiviFormProfile;
+import com.google.auto.value.AutoValue;
+import com.google.inject.Inject;
+import controllers.AssetsFinder;
+import controllers.LanguageUtils;
+import controllers.applicant.ApplicantRoutes;
+import java.util.Optional;
+import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
+import play.i18n.Messages;
+import play.mvc.Http.Request;
+import services.DeploymentType;
+import services.LocalizedStrings;
+import services.MessageKey;
+import services.applicant.ApplicantPersonalInfo;
+import services.applicant.ApplicantService.ApplicantProgramData;
+import services.settings.SettingsManifest;
+import views.NorthStarBaseView;
+import views.applicant.ProgramCardsSectionParamsFactory;
+import views.applicant.ProgramCardsSectionParamsFactory.ProgramCardParams;
+
+public class NorthStarProgramCardPreview extends NorthStarBaseView {
+  ProgramCardsSectionParamsFactory programCardsSectionParamsFactory;
+
+  @Inject
+  NorthStarProgramCardPreview(
+      TemplateEngine templateEngine,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      AssetsFinder assetsFinder,
+      ApplicantRoutes applicantRoutes,
+      SettingsManifest settingsManifest,
+      LanguageUtils languageUtils,
+      DeploymentType deploymentType,
+      ProgramCardsSectionParamsFactory programCardsSectionParamsFactory) {
+    super(
+        templateEngine,
+        playThymeleafContextFactory,
+        assetsFinder,
+        applicantRoutes,
+        settingsManifest,
+        languageUtils,
+        deploymentType);
+    this.programCardsSectionParamsFactory = checkNotNull(programCardsSectionParamsFactory);
+  }
+
+  public String render(Params params) {
+    ThymeleafModule.PlayThymeleafContext context =
+        createThymeleafContext(
+            params.request(),
+            params.applicantId(),
+            Optional.of(params.profile()),
+            params.applicantPersonalInfo(),
+            params.messages());
+
+    ProgramCardParams programCardParams =
+        programCardsSectionParamsFactory.getCard(
+            params.request(),
+            params.messages(),
+            MessageKey.BUTTON_APPLY,
+            params.applicantProgramData(),
+            LocalizedStrings.DEFAULT_LOCALE, // Admin console is not localized
+            Optional.of(params.profile()),
+            params.applicantId(),
+            params.applicantPersonalInfo());
+    context.setVariable("card", programCardParams);
+
+    return templateEngine.process("admin/programs/ProgramCardPreviewFragment.html", context);
+  }
+
+  @AutoValue
+  public abstract static class Params {
+
+    public static Builder builder() {
+      return new AutoValue_NorthStarProgramCardPreview_Params.Builder();
+    }
+
+    abstract Request request();
+
+    abstract Optional<Long> applicantId();
+
+    abstract ApplicantPersonalInfo applicantPersonalInfo();
+
+    abstract CiviFormProfile profile();
+
+    abstract ApplicantProgramData applicantProgramData();
+
+    abstract Messages messages();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder setRequest(Request request);
+
+      public abstract Builder setApplicantId(long applicantId);
+
+      public abstract Builder setApplicantPersonalInfo(ApplicantPersonalInfo personalInfo);
+
+      public abstract Builder setProfile(CiviFormProfile profile);
+
+      public abstract Builder setApplicantProgramData(ApplicantProgramData applicantProgramData);
+
+      public abstract Builder setMessages(Messages messages);
+
+      public abstract Params build();
+    }
+  }
+}

--- a/server/app/views/admin/programs/ProgramCardPreviewFragment.html
+++ b/server/app/views/admin/programs/ProgramCardPreviewFragment.html
@@ -1,0 +1,8 @@
+<div id="card-preview" class="margin-y-4">
+  <!-- Card group containing one card. -->
+  <ul class="usa-card-group cf-program-card-group">
+    <div
+      th:replace="~{applicant/ProgramCardsSectionFragment :: card(${card})}"
+    ></div>
+  </ul>
+</div>

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -90,75 +90,96 @@ public final class ProgramCardsSectionParamsFactory {
     ImmutableList.Builder<ProgramCardParams> cardsListBuilder = ImmutableList.builder();
 
     for (ApplicantProgramData programDatum : programData) {
-      ProgramCardParams.Builder cardBuilder = ProgramCardParams.builder();
-      ProgramDefinition program = programDatum.program();
-
-      boolean isGuest = personalInfo.getType() == GUEST;
-      String actionUrl =
-          profile.isPresent() && applicantId.isPresent()
-              ? applicantRoutes.review(profile.get(), applicantId.get(), program.id()).url()
-              : applicantRoutes.review(program.id()).url();
-
-      // Note this doesn't yet manage markdown, links and appropriate aria labels for links, and
-      // whatever else our current cards do.
-      String detailsUrl = program.externalLink();
-      if (detailsUrl.isEmpty() || detailsUrl.isBlank()) {
-        detailsUrl =
-            profile.isPresent() && applicantId.isPresent()
-                ? applicantRoutes.show(profile.get(), applicantId.get(), program.id()).url()
-                : applicantRoutes.show(program.id()).url();
-      }
-      cardBuilder
-          .setTitle(program.localizedName().getOrDefault(preferredLocale))
-          .setBody(program.localizedDescription().getOrDefault(preferredLocale))
-          .setDetailsUrl(detailsUrl)
-          .setActionUrl(actionUrl)
-          .setIsGuest(isGuest)
-          .setActionText(messages.at(buttonText.getKeyName()));
-
-      if (isGuest) {
-        cardBuilder.setLoginModalId("login-dialog-" + program.id());
-      }
-
-      if (programDatum.latestSubmittedApplicationStatus().isPresent()) {
-        cardBuilder.setApplicationStatus(
-            programDatum
-                .latestSubmittedApplicationStatus()
-                .get()
-                .localizedStatusText()
-                .getOrDefault(preferredLocale));
-      }
-
-      if (shouldShowEligibilityTag(programDatum)) {
-        boolean isEligible = programDatum.isProgramMaybeEligible().get();
-        CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
-        boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
-        MessageKey mayQualifyMessage =
-            isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;
-        MessageKey mayNotQualifyMessage =
-            isTrustedIntermediary
-                ? MessageKey.TAG_MAY_NOT_QUALIFY_TI
-                : MessageKey.TAG_MAY_NOT_QUALIFY;
-
-        cardBuilder.setEligible(isEligible);
-        cardBuilder.setEligibilityMessage(
-            messages.at(
-                isEligible ? mayQualifyMessage.getKeyName() : mayNotQualifyMessage.getKeyName()));
-      }
-
-      Optional<String> fileKey = program.summaryImageFileKey();
-      if (fileKey.isPresent()) {
-        String imageSourceUrl = publicStorageClient.getPublicDisplayUrl(fileKey.get());
-        cardBuilder.setImageSourceUrl(imageSourceUrl);
-
-        String altText = ProgramImageUtils.getProgramImageAltText(program, preferredLocale);
-        cardBuilder.setAltText(altText);
-      }
-
-      cardsListBuilder.add(cardBuilder.build());
+      cardsListBuilder.add(
+          getCard(
+              request,
+              messages,
+              buttonText,
+              programDatum,
+              preferredLocale,
+              profile,
+              applicantId,
+              personalInfo));
     }
 
     return cardsListBuilder.build();
+  }
+
+  public ProgramCardParams getCard(
+      Request request,
+      Messages messages,
+      MessageKey buttonText,
+      ApplicantProgramData programDatum,
+      Locale preferredLocale,
+      Optional<CiviFormProfile> profile,
+      Optional<Long> applicantId,
+      ApplicantPersonalInfo personalInfo) {
+    ProgramCardParams.Builder cardBuilder = ProgramCardParams.builder();
+    ProgramDefinition program = programDatum.program();
+
+    boolean isGuest = personalInfo.getType() == GUEST;
+    String actionUrl =
+        profile.isPresent() && applicantId.isPresent()
+            ? applicantRoutes.review(profile.get(), applicantId.get(), program.id()).url()
+            : applicantRoutes.review(program.id()).url();
+
+    // Note this doesn't yet manage markdown, links and appropriate aria labels for links, and
+    // whatever else our current cards do.
+    String detailsUrl = program.externalLink();
+    if (detailsUrl.isEmpty() || detailsUrl.isBlank()) {
+      detailsUrl =
+          profile.isPresent() && applicantId.isPresent()
+              ? applicantRoutes.show(profile.get(), applicantId.get(), program.id()).url()
+              : applicantRoutes.show(program.id()).url();
+    }
+    cardBuilder
+        .setTitle(program.localizedName().getOrDefault(preferredLocale))
+        .setBody(program.localizedDescription().getOrDefault(preferredLocale))
+        .setDetailsUrl(detailsUrl)
+        .setActionUrl(actionUrl)
+        .setIsGuest(isGuest)
+        .setActionText(messages.at(buttonText.getKeyName()));
+
+    if (isGuest) {
+      cardBuilder.setLoginModalId("login-dialog-" + program.id());
+    }
+
+    if (programDatum.latestSubmittedApplicationStatus().isPresent()) {
+      cardBuilder.setApplicationStatus(
+          programDatum
+              .latestSubmittedApplicationStatus()
+              .get()
+              .localizedStatusText()
+              .getOrDefault(preferredLocale));
+    }
+
+    if (shouldShowEligibilityTag(programDatum)) {
+      boolean isEligible = programDatum.isProgramMaybeEligible().get();
+      CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
+      boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
+      MessageKey mayQualifyMessage =
+          isTrustedIntermediary ? MessageKey.TAG_MAY_QUALIFY_TI : MessageKey.TAG_MAY_QUALIFY;
+      MessageKey mayNotQualifyMessage =
+          isTrustedIntermediary
+              ? MessageKey.TAG_MAY_NOT_QUALIFY_TI
+              : MessageKey.TAG_MAY_NOT_QUALIFY;
+
+      cardBuilder.setEligible(isEligible);
+      cardBuilder.setEligibilityMessage(
+          messages.at(
+              isEligible ? mayQualifyMessage.getKeyName() : mayNotQualifyMessage.getKeyName()));
+    }
+
+    Optional<String> fileKey = program.summaryImageFileKey();
+    if (fileKey.isPresent()) {
+      String imageSourceUrl = publicStorageClient.getPublicDisplayUrl(fileKey.get());
+      cardBuilder.setImageSourceUrl(imageSourceUrl);
+
+      String altText = ProgramImageUtils.getProgramImageAltText(program, preferredLocale);
+      cardBuilder.setAltText(altText);
+    }
+
+    return cardBuilder.build();
   }
 
   /**

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -89,8 +89,9 @@ POST    /admin/questions             controllers.admin.AdminQuestionController.c
 POST    /admin/questions/:id/discard controllers.admin.AdminQuestionController.discardDraft(request: Request, id: Long)
 POST    /admin/questions/:id/restore controllers.admin.AdminQuestionController.restore(request: Request, id: Long)
 POST    /admin/questions/:id/archive controllers.admin.AdminQuestionController.archive(request: Request, id: Long)
+
 # For rendering North Star question previews on the admin question page
-GET     /admin/preview/:questionType controllers.admin.NorthStarQuestionPreviewController.sampleQuestion(request: Request, questionType: String)
+GET     /admin/preview/:questionType        controllers.admin.NorthStarQuestionPreviewController.sampleQuestion(request: Request, questionType: String)
 
 # Routes for editing question localizations
 GET     /admin/questions/:questionName/translations/edit          controllers.admin.AdminQuestionTranslationsController.redirectToFirstLocale(request: Request, questionName: String)


### PR DESCRIPTION
### Description

As admin, on the image upload page, show previews of North Star program cards.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [n/a] Manually tested at 200% size
- [x] Manually evaluated tab order
- [n/a] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

1. Enable North Star
2. Log in as admin
3. Edit a program
4. Navigate to the "program image" page
5. Observe the North Star card preview on the right side of the page
    - Observe the preview with and without a program image

### Issue(s) this completes

Fixes #8158
