### PR TITLE
Fixing address correction spliterator bug

### DIFF
--- a/server/app/services/Address.java
+++ b/server/app/services/Address.java
@@ -1,5 +1,6 @@
 package services;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -26,6 +27,17 @@ public abstract class Address {
 
   @JsonProperty("zip")
   public abstract String getZip();
+
+  @JsonIgnore
+  @Override
+  public final String toString() {
+    // Examples
+    //   700 5th Ave, Seattle, WA, 98104
+    //   700 5th Ave, Suite 123, Seattle, WA, 98104
+    return String.format(
+        "%s%s, %s, %s, %s",
+        getStreet(), hasLine2() ? ", " + getLine2() : "", getCity(), getState(), getZip());
+  }
 
   public Boolean hasLine2() {
     return !getLine2().isEmpty();

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -2,8 +2,9 @@ package services.geo.esri;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -13,7 +14,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.StreamSupport;
 import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +24,7 @@ import play.libs.ws.WSRequest;
 import play.libs.ws.WSResponse;
 import services.AddressField;
 import services.geo.AddressLocation;
+import services.geo.esri.models.FindAddressCandidatesResponse;
 import services.settings.SettingsManifest;
 
 /**
@@ -40,9 +41,7 @@ import services.settings.SettingsManifest;
  */
 public final class RealEsriClient extends EsriClient implements WSBodyReadables, WSBodyWritables {
   private final WSClient ws;
-
-  private static final String CANDIDATES_NODE_NAME = "candidates";
-  private static final String SCORE_NODE_NAME = "score";
+  private final ObjectMapper mapper = new ObjectMapper();
 
   private static final Counter ESRI_REQUEST_C0UNT =
       Counter.build()
@@ -142,7 +141,8 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
 
   @Override
   @VisibleForTesting
-  CompletionStage<Optional<JsonNode>> fetchAddressSuggestions(ObjectNode addressJson) {
+  CompletionStage<Optional<FindAddressCandidatesResponse>> fetchAddressSuggestions(
+      ObjectNode addressJson) {
     return processAddressSuggestionUrlsSequentially(
         addressJson, ESRI_FIND_ADDRESS_CANDIDATES_URLS, Optional.empty());
   }
@@ -161,10 +161,11 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
    * @return The CompletionStage for result of findAddressCandidates, if any. The `candidates` array
    *     will be the merged results of multiple endpoints if more than one is called.
    */
-  private CompletionStage<Optional<JsonNode>> processAddressSuggestionUrlsSequentially(
-      ObjectNode addressJson,
-      ImmutableList<String> urls,
-      Optional<JsonNode> optionalPreviousRootNode) {
+  private CompletionStage<Optional<FindAddressCandidatesResponse>>
+      processAddressSuggestionUrlsSequentially(
+          ObjectNode addressJson,
+          ImmutableList<String> urls,
+          Optional<FindAddressCandidatesResponse> optionalPreviousRootNode) {
     // Base case: All URLs processed or no valid URLs left
     if (urls.isEmpty()) {
       return CompletableFuture.completedFuture(optionalPreviousRootNode);
@@ -176,30 +177,33 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
     // Perform the request and handle response
     return tryRequest(request, this.ESRI_EXTERNAL_CALL_TRIES)
         .thenCompose(
-            response -> {
-              ESRI_REQUEST_C0UNT.labels(String.valueOf(response.getStatus())).inc();
+            wsResponse -> {
+              ESRI_REQUEST_C0UNT.labels(String.valueOf(wsResponse.getStatus())).inc();
               // Skip the first url which we've just called, send the rest to the next recursive
               // call
               var nextSetOfUrls = urls.stream().skip(1).collect(ImmutableList.toImmutableList());
 
-              if (response.getStatus() != 200) {
+              if (wsResponse.getStatus() != 200) {
                 // If request fails, proceed to the next URL
                 return processAddressSuggestionUrlsSequentially(
                     addressJson, nextSetOfUrls, Optional.empty());
               } else {
                 // Process the successful response
-                JsonNode rootNode = response.asJson();
+                JsonNode rootNode = wsResponse.asJson();
+
+                FindAddressCandidatesResponse response;
+                try {
+                  response =
+                      mapper.readValue(rootNode.toString(), FindAddressCandidatesResponse.class);
+                } catch (JsonProcessingException e) {
+                  LOGGER.error("Unable to parse JSON from wsResponse", e);
+                  return processAddressSuggestionUrlsSequentially(
+                      addressJson, nextSetOfUrls, Optional.empty());
+                }
 
                 // If we have data from a previous call we'll stitch the candidate records together
-                if (optionalPreviousRootNode.isPresent()
-                    && hasCandidatesArray(optionalPreviousRootNode.get())
-                    && hasCandidatesArray(rootNode)) {
-                  optionalPreviousRootNode
-                      .get()
-                      .get(CANDIDATES_NODE_NAME)
-                      .forEach(
-                          candidateNode ->
-                              ((ArrayNode) rootNode.get(CANDIDATES_NODE_NAME)).add(candidateNode));
+                if (optionalPreviousRootNode.isPresent()) {
+                  response.addCandidates(optionalPreviousRootNode.get().candidates());
                 }
 
                 // This will check that all results are under the score threshold.
@@ -210,24 +214,21 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
                 // Reason for doing this is to not make more external calls than are needed. This
                 // is both for performance and billing reasons.
                 boolean hasAnyNodesUnderTheScoreThreshold =
-                    StreamSupport.stream(rootNode.get(CANDIDATES_NODE_NAME).spliterator(), false)
-                        .anyMatch(
-                            candidateNode ->
-                                candidateNode.path(SCORE_NODE_NAME).asDouble() < SCORE_THRESHOLD);
+                    response.candidates().stream()
+                        .anyMatch(candidate -> candidate.score() < SCORE_THRESHOLD);
 
                 // If there are no results from this url we definitely want to check the next
                 // available url to see if there are any there.
-                boolean hasNoResults =
-                    hasCandidatesArray(rootNode) && rootNode.get(CANDIDATES_NODE_NAME).isEmpty();
+                boolean hasNoResults = response.candidates().isEmpty();
 
                 boolean loadAnotherUrl = hasAnyNodesUnderTheScoreThreshold || hasNoResults;
 
                 if (loadAnotherUrl == true) {
                   return processAddressSuggestionUrlsSequentially(
-                      addressJson, nextSetOfUrls, Optional.of(rootNode));
+                      addressJson, nextSetOfUrls, Optional.of(response));
                 }
 
-                return CompletableFuture.completedFuture(Optional.of(rootNode));
+                return CompletableFuture.completedFuture(Optional.of(response));
               }
             });
   }
@@ -291,13 +292,6 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
    */
   private static boolean isArcGisOnlineService(String url) {
     return url.contains("arcgis.com");
-  }
-
-  /** Determines if the node has a candidates property that is an array */
-  private static Boolean hasCandidatesArray(JsonNode rootNode) {
-    return rootNode != null
-        && rootNode.get(CANDIDATES_NODE_NAME) != null
-        && rootNode.get(CANDIDATES_NODE_NAME).isArray();
   }
 
   @Override

--- a/server/app/services/geo/esri/models/FindAddressCandidatesResponse.java
+++ b/server/app/services/geo/esri/models/FindAddressCandidatesResponse.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class FindAddressCandidatesResponse {
   private final Optional<SpatialReference> spatialReference;
-  private final ImmutableList<Candidate> candidates;
+  private ImmutableList<Candidate> candidates;
 
   public FindAddressCandidatesResponse(
       @JsonProperty("spatialReference") SpatialReference spatialReference,
@@ -31,5 +31,14 @@ public final class FindAddressCandidatesResponse {
 
   public ImmutableList<Candidate> candidates() {
     return candidates;
+  }
+
+  public void addCandidates(ImmutableList<Candidate> newCandidates) {
+    if (newCandidates == null) {
+      return;
+    }
+
+    candidates =
+        ImmutableList.<Candidate>builder().addAll(candidates).addAll(newCandidates).build();
   }
 }

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -113,6 +113,7 @@ public class EsriClientTest {
     // First item is guaranteed to be here since the response is taken from the JSON file.
     // This also tests that we are rejecting the responses that do not include a number
     // in the street address or any street address at all.
+    assertThat(suggestions).hasSizeGreaterThan(0);
     Optional<AddressSuggestion> addressSuggestion = suggestions.stream().findFirst();
     assertThat(addressSuggestion.isPresent()).isTrue();
     String street = addressSuggestion.get().getAddress().getStreet();
@@ -158,6 +159,26 @@ public class EsriClientTest {
         helper.getClient().getAddressSuggestions(address).toCompletableFuture().join();
     ImmutableList<AddressSuggestion> suggestions = group.getAddressSuggestions();
     assertThat(suggestions).isEmpty();
+    assertThat(group.getOriginalAddress()).isEqualTo(address);
+  }
+
+  @Test
+  public void getAddressSuggestionsWithEmptyResponse() throws Exception {
+    helper = new EsriTestHelper(TestType.EMPTY_RESPONSE);
+    Address address =
+        Address.builder()
+            .setStreet("380 New York St")
+            .setLine2("")
+            .setCity("Redlands")
+            .setState("CA")
+            .setZip("92373")
+            .build();
+
+    AddressSuggestionGroup group =
+        helper.getClient().getAddressSuggestions(address).toCompletableFuture().join();
+    ImmutableList<AddressSuggestion> suggestions = group.getAddressSuggestions();
+    assertThat(suggestions).isEmpty();
+    assertThat(group.getWellKnownId()).isEqualTo(0);
     assertThat(group.getOriginalAddress()).isEqualTo(address);
   }
 

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -58,6 +58,7 @@ public class EsriTestHelper {
     STANDARD,
     STANDARD_WITH_LINE_2,
     NO_CANDIDATES,
+    EMPTY_RESPONSE,
     ERROR,
     SERVICE_AREA_VALIDATION,
     SERVICE_AREA_VALIDATION_ERROR,
@@ -111,6 +112,11 @@ public class EsriTestHelper {
         serverSettings =
             createServerSettingsThatReturnOk(
                 "/findAddressCandidates", "esri/findAddressCandidatesNoCandidates.json");
+        break;
+      case EMPTY_RESPONSE:
+        serverSettings =
+            createServerSettingsThatReturnOk(
+                "/findAddressCandidates", "esri/findAddressCandidatesEmptyResponse.json");
         break;
       case ERROR:
         serverSettings = createServerSettingsThatReturnError("/findAddressCandidates");


### PR DESCRIPTION
### Description

Fixes address correction bug that may occur if the response from calling ESRI is an empty JSON object. This bug can happen if the arcgis.com token is incorrect or if the arcgis.com token has expired or is out of credits.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
