### PR TITLE
Handle Esri Error response

### DIFF
--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -334,6 +334,27 @@ test.describe('address correction', () => {
       await logout(page)
     })
 
+    test('prompts user to edit if an Esri error response object is returned from the Esri service', async ({
+      page,
+      applicantQuestions,
+    }) => {
+      // This is currently the same as when no suggestions are returned.
+      // We may change this later.
+      await enableFeatureFlag(page, 'esri_address_correction_enabled')
+      await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
+
+      // Fill out application and submit.
+      await applicantQuestions.answerAddressQuestion(
+        'Esri Error Response',
+        '',
+        'Seattle',
+        'WA',
+        '98109',
+      )
+      await applicantQuestions.clickNext()
+      await applicantQuestions.expectVerifyAddressPage(false)
+    })
+
     test('skips address correction screen if address exactly matches suggestions', async ({
       page,
       applicantQuestions,

--- a/server/app/services/geo/esri/RealEsriClient.java
+++ b/server/app/services/geo/esri/RealEsriClient.java
@@ -188,15 +188,21 @@ public final class RealEsriClient extends EsriClient implements WSBodyReadables,
                 return processAddressSuggestionUrlsSequentially(
                     addressJson, nextSetOfUrls, Optional.empty());
               } else {
-                // Process the successful response
-                JsonNode rootNode = wsResponse.asJson();
-
                 FindAddressCandidatesResponse response;
+
                 try {
                   response =
-                      mapper.readValue(rootNode.toString(), FindAddressCandidatesResponse.class);
+                      mapper.readValue(
+                          wsResponse.asJson().toString(), FindAddressCandidatesResponse.class);
                 } catch (JsonProcessingException e) {
                   LOGGER.error("Unable to parse JSON from wsResponse", e);
+                  return processAddressSuggestionUrlsSequentially(
+                      addressJson, nextSetOfUrls, Optional.empty());
+                }
+
+                // Check if an error result object was sent from the service.
+                if (response.error().isPresent()) {
+                  LOGGER.error(response.error().get().errorMessage());
                   return processAddressSuggestionUrlsSequentially(
                       addressJson, nextSetOfUrls, Optional.empty());
                 }

--- a/server/app/services/geo/esri/models/EsriError.java
+++ b/server/app/services/geo/esri/models/EsriError.java
@@ -1,0 +1,53 @@
+package services.geo.esri.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Error object from ESRI's findAddressCandidates results
+ *
+ * <p>@see <a
+ * href="https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm">Find
+ * Address Candidates</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class EsriError {
+  private final int code;
+  private final int extendedCode;
+  private final String message;
+  private final List<String> details;
+
+  public EsriError(
+      @JsonProperty("code") int code,
+      @JsonProperty("extendedCode") int extendedCode,
+      @JsonProperty("message") String message,
+      @JsonProperty("details") List<String> details) {
+    this.code = code;
+    this.extendedCode = extendedCode;
+    this.message = message;
+    this.details = details;
+  }
+
+  public int code() {
+    return code;
+  }
+
+  public int extendedCode() {
+    return extendedCode;
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public List<String> details() {
+    return details;
+  }
+
+  public String errorMessage() {
+    return String.format(
+        "Esri Error Response: Code: %d, Extended Code: %d, Message: %s, Details: %s",
+        code, extendedCode, message, details);
+  }
+}

--- a/server/app/services/geo/esri/models/FindAddressCandidatesResponse.java
+++ b/server/app/services/geo/esri/models/FindAddressCandidatesResponse.java
@@ -17,12 +17,15 @@ import java.util.Optional;
 public final class FindAddressCandidatesResponse {
   private final Optional<SpatialReference> spatialReference;
   private ImmutableList<Candidate> candidates;
+  private final Optional<EsriError> error;
 
   public FindAddressCandidatesResponse(
       @JsonProperty("spatialReference") SpatialReference spatialReference,
-      @JsonProperty("candidates") List<Candidate> candidates) {
-    this.spatialReference = Optional.of(spatialReference);
+      @JsonProperty("candidates") List<Candidate> candidates,
+      @JsonProperty("error") EsriError error) {
+    this.spatialReference = Optional.ofNullable(spatialReference);
     this.candidates = candidates != null ? ImmutableList.copyOf(candidates) : ImmutableList.of();
+    this.error = Optional.ofNullable(error);
   }
 
   public Optional<SpatialReference> spatialReference() {
@@ -31,6 +34,10 @@ public final class FindAddressCandidatesResponse {
 
   public ImmutableList<Candidate> candidates() {
     return candidates;
+  }
+
+  public Optional<EsriError> error() {
+    return error;
   }
 
   public void addCandidates(ImmutableList<Candidate> newCandidates) {

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -183,6 +183,26 @@ public class EsriClientTest {
   }
 
   @Test
+  public void getAddressSuggestionsWithEsriErrorResponse() {
+    helper = new EsriTestHelper(TestType.ESRI_ERROR_RESPONSE);
+    Address address =
+        Address.builder()
+            .setStreet("380 New York St")
+            .setLine2("")
+            .setCity("Redlands")
+            .setState("CA")
+            .setZip("92373")
+            .build();
+
+    AddressSuggestionGroup group =
+        helper.getClient().getAddressSuggestions(address).toCompletableFuture().join();
+    ImmutableList<AddressSuggestion> suggestions = group.getAddressSuggestions();
+    assertThat(suggestions).isEmpty();
+    assertThat(group.getWellKnownId()).isEqualTo(0);
+    assertThat(group.getOriginalAddress()).isEqualTo(address);
+  }
+
+  @Test
   public void getAddressSuggestionsWithError() throws Exception {
     helper = new EsriTestHelper(TestType.ERROR);
     Address address =

--- a/server/test/services/geo/esri/EsriTestHelper.java
+++ b/server/test/services/geo/esri/EsriTestHelper.java
@@ -59,6 +59,7 @@ public class EsriTestHelper {
     STANDARD_WITH_LINE_2,
     NO_CANDIDATES,
     EMPTY_RESPONSE,
+    ESRI_ERROR_RESPONSE,
     ERROR,
     SERVICE_AREA_VALIDATION,
     SERVICE_AREA_VALIDATION_ERROR,
@@ -117,6 +118,10 @@ public class EsriTestHelper {
         serverSettings =
             createServerSettingsThatReturnOk(
                 "/findAddressCandidates", "esri/findAddressCandidatesEmptyResponse.json");
+      case ESRI_ERROR_RESPONSE:
+        serverSettings =
+            createServerSettingsThatReturnOk(
+                "/findAddressCandidates", "esri/esriErrorResponse.json");
         break;
       case ERROR:
         serverSettings = createServerSettingsThatReturnError("/findAddressCandidates");


### PR DESCRIPTION
### Description

There are cases where the Esri service may return a 200, but the response is in an error object format. I know this can happen if you are using arcgis.com and run out of credits. This will aid in troubleshooting by logging the details of the error response object.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
