### PR TITLE
Adding esri error response to mock web services

### DIFF
--- a/mock-web-services/esri/__init__.py
+++ b/mock-web-services/esri/__init__.py
@@ -29,6 +29,9 @@ class EsriMockWebService(WebService):
         elif address == "Empty Response":
             return self.return_json_response_from_file(
                 self.file_root + "findAddressCandidatesEmptyResponse.json")
+        elif address == "Esri Error Response":
+            return self.return_json_response_from_file(
+                self.file_root + "esriErrorResponse.json")
         else:
             raise Exception("Invalid mock request")
 

--- a/server/test/resources/esri/esriErrorResponse.json
+++ b/server/test/resources/esri/esriErrorResponse.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "code": 403,
+    "extendedCode": -2147200253,
+    "message": "Message text",
+    "details": ["Details text 1", "Details text 2"]
+  }
+}


### PR DESCRIPTION
### Description

Add a sample of the generic esri error response format to the mock web services.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

