### PR TITLE
Add floating "Not Production" banner in North Star

### DIFF
--- a/browser-test/src/applicant/northstar_not_production_banner.test.ts
+++ b/browser-test/src/applicant/northstar_not_production_banner.test.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '../support/civiform_fixtures'
+import {enableFeatureFlag, validateAccessibility} from '../support'
+
+test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
+  test.beforeEach(async ({page}) => {
+    await enableFeatureFlag(page, 'show_not_production_banner_enabled')
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+  })
+
+  test('View "Not Production" banner', async ({page}) => {
+    await test.step('Verify banner', async () => {
+      await expect(
+        page.getByText(
+          'This site is for testing purposes only. Do not enter personal information.',
+        ),
+      ).toBeVisible()
+      await expect(
+        page.getByText(
+          'To apply to a program or service go to City of TestCity.',
+        ),
+      ).toBeVisible()
+
+      await validateAccessibility(page)
+    })
+  })
+})

--- a/server/app/services/AlertSettings.java
+++ b/server/app/services/AlertSettings.java
@@ -9,12 +9,14 @@ import java.util.Optional;
  * @param show Determines if the alert be displayed or not
  * @param title Alert title, if any
  * @param text Alert text
+ * @param unescapedDescription true to use an unescaped description (th:utext). false otherwise.
  * @param alertType {@link AlertType}
  */
 public record AlertSettings(
     Boolean show,
     Optional<String> title,
     String text,
+    Boolean unescapedDescription,
     AlertType alertType,
     ImmutableList<String> additionalText) {
   public static AlertSettings empty() {
@@ -23,5 +25,14 @@ public record AlertSettings(
 
   public AlertSettings(Boolean show, Optional<String> title, String text, AlertType alertType) {
     this(show, title, text, alertType, ImmutableList.of());
+  }
+
+  public AlertSettings(
+      Boolean show,
+      Optional<String> title,
+      String text,
+      AlertType alertType,
+      ImmutableList<String> additionalText) {
+    this(show, title, text, false, alertType, additionalText);
   }
 }

--- a/server/app/services/AlertType.java
+++ b/server/app/services/AlertType.java
@@ -9,5 +9,6 @@ public enum AlertType {
   ERROR,
   INFO,
   SUCCESS,
-  WARNING
+  WARNING,
+  EMERGENCY
 }

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -1,4 +1,9 @@
 <th:block th:fragment="pageHeader">
+  <div class="sticky top-0 z-50" th:if="${showNotProductionBannerEnabled}">
+    <div
+      th:replace="~{components/AlertFragment :: alert(alertSettings=${notProductionAlertSettings}, headingLevel='H2')}"
+    ></div>
+  </div>
   <div th:replace="~{this :: officialGovermentWebsiteBanner}"></div>
   <div class="usa-overlay"></div>
   <header class="usa-header usa-header--basic" role="banner">

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -32,7 +32,13 @@
       th:text="${alertSettings.title.get()}"
     ></h6>
 
-    <p class="usa-alert__text" th:text="${alertSettings.text}"></p>
+    <!-- TODO ssandbekkhaug fix why both texts appear -->
+    <div th:if="${alertSettings.unescapedDescription()} == true">
+      <p class="usa-alert__text" th:utext="${alertSettings.text}"></p>
+    </div>
+    <div th:if="${alertSettings.unescapedDescription()} == false">
+      <p class="usa-alert__text" th:text="${alertSettings.text}"></p>
+    </div>
 
     <!-- padding-left-205 indents the list -->
     <ul


### PR DESCRIPTION
### Description

Add floating "Not Production" banner in North Star.

This component does not have mocks. See https://github.com/civiform/civiform/issues/8490

#### Screenshots

<img width="1283" alt="home" src="https://github.com/user-attachments/assets/a6c34b7d-557d-4954-bdd5-067ac038d27a">

<img width="1283" alt="block" src="https://github.com/user-attachments/assets/8a3dbba6-3275-452b-a57b-f8762d5ff0bc">

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8490
