### PR TITLE
Replace filter chip id with CSS class for simplicity

### DIFF
--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -123,7 +123,7 @@
     background-color: #f0f0f0;
   }
 
-  [id^="filter-chip-"] {
+  .filter-chip {
     @apply border border-gray-700 rounded-full mr-2 mb-2 text-sm
      has-[:checked]:bg-blue-100 has-[:checked]:border-blue-100
       has-[:checked]:font-semibold has-[:checked]:text-blue-900 flex;

--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -25,7 +25,7 @@ See the radio-option below as an example.
 }
 
 // Put the focus outline around the chip instead of the underlying checkbox
-[id^='filter-chip-']:focus-within {
+.filter-chip:focus-within {
   @include u-outline('05');
   @include u-outline-color('blue-40v');
   outline-offset: 4px;

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -603,7 +603,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                         relevantCategories,
                         category ->
                             div()
-                                .withId("filter-chip-" + category.replace(' ', '-'))
+                                .withClass("filter-chip")
                                 .with(
                                     input()
                                         .withId("check-category-" + category.replace(' ', '-'))


### PR DESCRIPTION
### Description

Replace the filter chip `<div>` id with a CSS class for simplicity.  There was no other use of the id.



