### PR TITLE
Fix banner bug when civic entity production URL is an empty string

### DIFF
--- a/browser-test/src/applicant/northstar_not_production_banner.test.ts
+++ b/browser-test/src/applicant/northstar_not_production_banner.test.ts
@@ -14,11 +14,6 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
           'This site is for testing purposes only. Do not enter personal information.',
         ),
       ).toBeVisible()
-      await expect(
-        page.getByText(
-          'To apply to a program or service go to City of TestCity.',
-        ),
-      ).toBeVisible()
 
       await validateAccessibility(page)
     })

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -205,7 +205,7 @@ public abstract class NorthStarBaseView {
     Optional<String> linkHref = settingsManifest.getCivicEntityProductionUrl(request);
     Optional<String> linkText = settingsManifest.getWhitelabelCivicEntityFullName(request);
     Optional<String> unescapedDescription = Optional.empty();
-    if (linkHref.isPresent() && linkText.isPresent()) {
+    if (!linkHref.orElse("").isEmpty() && !linkText.orElse("").isEmpty()) {
       String linkHtml =
           "<a href=\"" + linkHref.get() + "\" class=\"usa-link\">" + linkText.get() + "</a>";
       String rawString = messages.at(MessageKey.NOT_FOR_PRODUCTION_BANNER_LINE_2.getKeyName());

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -32,7 +32,6 @@
       th:text="${alertSettings.title.get()}"
     ></h6>
 
-    <!-- TODO ssandbekkhaug fix why both texts appear -->
     <div th:if="${alertSettings.unescapedDescription()} == true">
       <p class="usa-alert__text" th:utext="${alertSettings.text}"></p>
     </div>


### PR DESCRIPTION
### Description

Gwen noticed a bug in PR https://github.com/civiform/civiform/pull/8767: This doesn't work correctly if you've set CIVIC_ENTITY_PRODUCTION_URL back to an empty string at some point. The settings will return isPresent=true but with an empty string. Causing the second line to show a link with no href

This PR fixes said bug.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #8490
