### PR TITLE
Fix answerDateQuestion in North Star

### DIFF
--- a/browser-test/src/applicant/questions/date.test.ts
+++ b/browser-test/src/applicant/questions/date.test.ts
@@ -135,7 +135,10 @@ test.describe('Date question for applicant flow', () => {
       })
 
       test('validate screenshot', async ({page, applicantQuestions}) => {
-        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.applyProgram(
+          programName,
+          /* northStarEnabled= */ true,
+        )
 
         await test.step('Screenshot without errors', async () => {
           await validateScreenshot(
@@ -161,11 +164,17 @@ test.describe('Date question for applicant flow', () => {
         applicantQuestions,
       }) => {
         await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.answerMemorableDateQuestion(
-          '2022',
-          '05 - May',
-          '2',
+        await applicantQuestions.answerDateQuestion(
+          '2022-05-02',
+          0,
+          /* northStarEnabled= */ true,
         )
+
+        await applicantQuestions.checkDateQuestionValue(
+          '2022-05-02',
+          /* northStarEnabled= */ true,
+        )
+
         await applicantQuestions.clickContinue()
 
         await applicantQuestions.submitFromReviewPage(
@@ -174,7 +183,10 @@ test.describe('Date question for applicant flow', () => {
       })
 
       test('Renders existing values', async ({page, applicantQuestions}) => {
-        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.applyProgram(
+          programName,
+          /* northStarEnabled= */ true,
+        )
         await applicantQuestions.answerMemorableDateQuestion(
           '2022',
           '05 - May',
@@ -195,7 +207,10 @@ test.describe('Date question for applicant flow', () => {
         page,
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.applyProgram(
+          programName,
+          /* northStarEnabled= */ true,
+        )
 
         await validateAccessibility(page)
       })

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -140,13 +140,46 @@ export class ApplicantQuestions {
     await this.validateInputValue(number)
   }
 
-  async answerDateQuestion(date: string, index = 0) {
-    await this.page.fill(`input[type="date"] >> nth=${index}`, date)
+  /**
+   *
+   * @param date string formatted "yyyy-mm-dd"
+   * @param index Index of the date question on the page
+   * @param northStarEnabled
+   */
+  async answerDateQuestion(date: string, index = 0, northStarEnabled = false) {
+    if (northStarEnabled) {
+      const yearMonthDay = date.split('-')
+      const year = this.trimLeadingZeros(yearMonthDay[0])
+      const month = this.trimLeadingZeros(yearMonthDay[1])
+      const day = this.trimLeadingZeros(yearMonthDay[2])
+
+      // In the UI, the left-to-right order is month, day, year
+      await this.page.getByLabel('Month *').selectOption(month)
+      await this.page.getByLabel('Day *').fill(day)
+      await this.page.getByLabel('Year *').fill(year)
+    } else {
+      await this.page.fill(`input[type="date"] >> nth=${index}`, date)
+    }
   }
 
-  async checkDateQuestionValue(date: string) {
-    await this.validateInputTypePresent('date')
-    await this.validateInputValue(date)
+  trimLeadingZeros(str: string): string {
+    return str.replace(/^0+/, '')
+  }
+
+  async checkDateQuestionValue(date: string, northStarEnabled = false) {
+    if (northStarEnabled) {
+      const yearMonthDay = date.split('-')
+      const year = this.trimLeadingZeros(yearMonthDay[0])
+      const month = this.trimLeadingZeros(yearMonthDay[1])
+      const day = this.trimLeadingZeros(yearMonthDay[2])
+
+      await expect(this.page.getByLabel('Month *')).toHaveValue(month)
+      await expect(this.page.getByLabel('Day *')).toHaveValue(day)
+      await expect(this.page.getByLabel('Year *')).toHaveValue(year)
+    } else {
+      await this.validateInputTypePresent('date')
+      await this.validateInputValue(date)
+    }
   }
 
   async answerMemorableDateQuestion(


### PR DESCRIPTION
### Description

Fix answerDateQuestion in North Star.

Legacy UX had a single input in the format mm/dd/yyyy.

North Star has:
- Selector (dropdown) for month
- Input for day
- Input for year

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Issue(s) this completes

Fixes #8519
