### PR TITLE
Use ApplicantQuestions directly to build CsvExportConfig

### DIFF
--- a/browser-test/src/applicant/application_download.test.ts
+++ b/browser-test/src/applicant/application_download.test.ts
@@ -95,14 +95,40 @@ test.describe('csv export for multioption question', () => {
     await adminPrograms.viewApplications(programName)
     const csvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(csvContent).toContain(
-      'Applicant ID,Application ID,Applicant Language,Submit Time,Submitter Type,TI Email,TI Organization,Status,sample name question (first_name),sample name question (middle_name),sample name question (last_name),sample name question (suffix),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcolor (selections - black_admin),csvcolor (selections - white_admin)',
+      'Applicant ID,' +
+        'Application ID,' +
+        'Applicant Language,' +
+        'Submit Time,' +
+        'Submitter Type,' +
+        'TI Email,' +
+        'TI Organization,' +
+        'Status,' +
+        'csvcolor (selections - red_admin),' +
+        'csvcolor (selections - green_admin),' +
+        'csvcolor (selections - orange_admin),' +
+        'csvcolor (selections - blue_admin),' +
+        'csvcolor (selections - black_admin),' +
+        'csvcolor (selections - white_admin),' +
+        'sample name question (first_name),' +
+        'sample name question (middle_name),' +
+        'sample name question (last_name),' +
+        'sample name question (suffix),',
     )
     // colors headers are - red,green,orange,blue,black,white
     expect(csvContent).toContain(
-      ',John,,Do,,NOT_AN_OPTION_AT_PROGRAM_VERSION,SELECTED,NOT_AN_OPTION_AT_PROGRAM_VERSION,NOT_SELECTED,SELECTED,NOT_SELECTED',
+      'NOT_AN_OPTION_AT_PROGRAM_VERSION,' +
+        'SELECTED,' +
+        'NOT_AN_OPTION_AT_PROGRAM_VERSION,' +
+        'NOT_SELECTED,' +
+        'SELECTED,' +
+        'NOT_SELECTED,' +
+        'John,' +
+        ',' +
+        'Do,' +
+        ',',
     )
     expect(csvContent).toContain(
-      ',Jane,,Doe,,SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED,NOT_AN_OPTION_AT_PROGRAM_VERSION,NOT_AN_OPTION_AT_PROGRAM_VERSION',
+      'SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED,NOT_AN_OPTION_AT_PROGRAM_VERSION,NOT_AN_OPTION_AT_PROGRAM_VERSION,Jane,,Doe,,',
     )
   })
 })
@@ -188,7 +214,14 @@ test.describe('normal application flow', () => {
     await adminPrograms.viewApplications(programName)
     const csvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(csvContent).toContain(
-      ',sarah,,smith,,op2_admin,05/10/2021,1000.00,NOT_SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED',
+      'NOT_SELECTED,' + 'NOT_SELECTED,' + 'NOT_SELECTED,' + 'SELECTED',
+      +'1000.00,' +
+        '05/10/2021,' +
+        'op2_admin,' +
+        'sarah,' +
+        ',' +
+        'smith,' +
+        ',',
     )
 
     await logout(page)
@@ -242,15 +275,13 @@ test.describe('normal application flow', () => {
     await adminPrograms.viewApplications(programName)
     const postEditCsvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(postEditCsvContent).toContain(
-      'sarah,,smith,,op2_admin,05/10/2021,1000.00',
+      '1000.00,05/10/2021,op2_admin,,sarah,,smith,,',
     )
     expect(postEditCsvContent).toContain(
-      'Gus,,Guest,,op2_admin,01/01/1990,2000.00',
+      '2000.00,01/01/1990,op2_admin,1500,Gus,,Guest,,',
     )
 
-    const numberOfGusEntries =
-      postEditCsvContent.split('Gus,,Guest,,op2_admin,01/01/1990,2000.00')
-        .length - 1
+    const numberOfGusEntries = [...postEditCsvContent.matchAll('Gus')].length
     expect(numberOfGusEntries).toEqual(2)
 
     const postEditJsonContent = await adminPrograms.getJson(noApplyFilters)
@@ -286,11 +317,9 @@ test.describe('normal application flow', () => {
     await adminPrograms.filterProgramApplications({searchFragment: 'SARA'})
     const filteredCsvContent = await adminPrograms.getCsv(applyFilters)
     expect(filteredCsvContent).toContain(
-      'sarah,,smith,,op2_admin,05/10/2021,1000.00',
+      '1000.00,05/10/2021,op2_admin,sarah,,smith,,',
     )
-    expect(filteredCsvContent).not.toContain(
-      'Gus,,Guest,,op2_admin,01/01/1990,2000.00',
-    )
+    expect(filteredCsvContent).not.toContain('Gus')
     const filteredJsonContent = await adminPrograms.getJson(applyFilters)
     expect(filteredJsonContent.length).toEqual(1)
     expect(
@@ -300,9 +329,14 @@ test.describe('normal application flow', () => {
     // results.
     const allCsvContent = await adminPrograms.getCsv(noApplyFilters)
     expect(allCsvContent).toContain(
-      'sarah,,smith,,op2_admin,05/10/2021,1000.00',
+      '1000.00,05/10/2021,op2_admin,,sarah,,smith,,',
     )
-    expect(allCsvContent).toContain('Gus,,Guest,,op2_admin,01/01/1990,2000.00')
+    expect(allCsvContent).toContain(
+      '2000.00,01/01/1990,op2_admin,1500,Gus,,Guest,,',
+    )
+    expect(allCsvContent).toContain(
+      '2000.00,01/01/1990,op2_admin,1600,Gus,,Guest,,',
+    )
     const allJsonContent = await adminPrograms.getJson(noApplyFilters)
     expect(allJsonContent.length).toEqual(3)
     expect(
@@ -343,11 +377,9 @@ test.describe('normal application flow', () => {
     })
     const filteredContent = await adminPrograms.getCsv(applyFilters)
     expect(filteredContent).toContain(
-      'sarah,,smith,,op2_admin,05/10/2021,1000.00',
+      '1000.00,05/10/2021,op2_admin,sarah,,smith,,',
     )
-    expect(filteredContent).not.toContain(
-      'Gus,,Guest,,op2_admin,01/01/1990,2000.00',
-    )
+    expect(filteredContent).not.toContain('Gus')
 
     await logout(page)
 
@@ -363,17 +395,17 @@ test.describe('normal application flow', () => {
     // so test for both situations.
     if (demographicsCsvContent.includes('Status')) {
       expect(demographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,sample name question (first_name),sample name question (middle_name),sample name question (last_name),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,sample name question (first_name),sample name question (middle_name),sample name question (last_name),sample name question (suffix),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
       )
       expect(demographicsCsvContent).toContain(
-        'sarah,,smith,NOT_SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED,1000.00,05/10/2021,op2_admin,',
+        'sarah,,smith,,NOT_SELECTED,NOT_SELECTED,NOT_SELECTED,SELECTED,1000.00,05/10/2021,op2_admin,',
       )
     } else {
       expect(demographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,sample name question (first_name),sample name question (middle_name),sample name question (last_name),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,sample name question (first_name),sample name question (middle_name),sample name question (last_name),sample name question (suffix),csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number)',
       )
       expect(demographicsCsvContent).toContain(
-        'sarah,,smith,1000.00,05/10/2021,op2_admin',
+        'sarah,,smith,,1000.00,05/10/2021,op2_admin',
       )
     }
 
@@ -386,7 +418,7 @@ test.describe('normal application flow', () => {
 
     if (demographicsCsvContent.includes('Status')) {
       expect(newDemographicsCsvContent).toContain(
-        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),sample name question (first_name),sample name question (middle_name),sample name question (last_name)',
+        'Opaque ID,Program,Submitter Type,TI Email (Opaque),TI Organization,Create Time,Submit Time,Status,csvcolor (selections - red_admin),csvcolor (selections - green_admin),csvcolor (selections - orange_admin),csvcolor (selections - blue_admin),csvcurrency (currency),csvdate (date),dropdowncsvdownload (selection),numbercsvdownload (number),sample name question (first_name),sample name question (middle_name),sample name question (last_name),sample name question (suffix)',
       )
     } else {
       expect(newDemographicsCsvContent).toContain(

--- a/server/app/services/applicant/question/NameQuestion.java
+++ b/server/app/services/applicant/question/NameQuestion.java
@@ -31,7 +31,8 @@ public final class NameQuestion extends Question {
 
   @Override
   public ImmutableList<Path> getAllPaths() {
-    return ImmutableList.of(getFirstNamePath(), getMiddleNamePath(), getLastNamePath());
+    return ImmutableList.of(
+        getFirstNamePath(), getMiddleNamePath(), getLastNamePath(), getNameSuffixPath());
   }
 
   @Override

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -33,12 +33,10 @@ import repository.TimeFilter;
 import services.DateConverter;
 import services.IdentifierBasedPaginationSpec;
 import services.Path;
-import services.applicant.AnswerData;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
 import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.question.ApplicantQuestion;
-import services.applicant.question.MultiSelectQuestion;
 import services.applicant.question.Scalar;
 import services.program.Column;
 import services.program.ColumnType;
@@ -68,6 +66,8 @@ public final class CsvExporterService {
 
   private static final String CURRENCY_CENTS_TYPE_STRING =
       ScalarType.CURRENCY_CENTS.toString().toLowerCase(Locale.ROOT);
+  private static final String FILE_KEY_LIST =
+      Scalar.FILE_KEY_LIST.toString().toLowerCase(Locale.ROOT);
 
   private static final String NAME_SUFFIX = Scalar.NAME_SUFFIX.toString().toLowerCase(Locale.ROOT);
   private static final String SERVICE_AREA =
@@ -129,7 +129,7 @@ public final class CsvExporterService {
       ImmutableMap<Long, ProgramDefinition> programDefinitionsForAllVersions,
       boolean showEligibilityColumn)
       throws ProgramNotFoundException {
-    Map<Path, AnswerData> answerMap = new HashMap<>();
+    Map<Path, ApplicantQuestion> uniqueQuestions = new HashMap<>();
 
     applications.stream()
         .flatMap(
@@ -137,24 +137,15 @@ public final class CsvExporterService {
                 applicantService
                     .getReadOnlyApplicantProgramService(
                         app, programDefinitionsForAllVersions.get(app.getProgram().id))
-                    .getSummaryDataAllQuestions()
-                    .stream())
-        .forEach(
-            data -> {
-              answerMap.putIfAbsent(data.contextualizedPath(), data);
-            });
+                    .getAllQuestions())
+        .forEach(aq -> uniqueQuestions.putIfAbsent(aq.getContextualizedPath(), aq));
 
-    // Get the list of all answers, sorted by block ID, then question index, and finally
-    // contextualized path in string form.
-    ImmutableList<AnswerData> answers =
-        answerMap.values().stream()
-            .sorted(
-                Comparator.comparing(AnswerData::blockId)
-                    .thenComparing(AnswerData::questionIndex)
-                    .thenComparing(answerData -> answerData.contextualizedPath().toString()))
+    ImmutableList<ApplicantQuestion> sortedUniqueQuestions =
+        uniqueQuestions.values().stream()
+            .sorted(Comparator.comparing(aq -> aq.getContextualizedPath().toString()))
             .collect(ImmutableList.toImmutableList());
 
-    return buildColumnHeaders(answers, showEligibilityColumn);
+    return buildColumnHeaders(sortedUniqueQuestions, showEligibilityColumn);
   }
 
   /**
@@ -207,11 +198,11 @@ public final class CsvExporterService {
   }
 
   /**
-   * Produce the default {@link CsvExportConfig} for a list of {@link AnswerData}s. The config
-   * includes all the questions, the application id, and the application submission time.
+   * Produce the default {@link CsvExportConfig} for a list of {@link ApplicantQuestion}s. The
+   * config includes all the questions, the application id, and the application submission time.
    */
   private CsvExportConfig buildColumnHeaders(
-      ImmutableList<AnswerData> representativeAnswers, boolean showEligibilityColumn) {
+      ImmutableList<ApplicantQuestion> exemplarQuestions, boolean showEligibilityColumn) {
     ImmutableList.Builder<Column> columnsBuilder = new ImmutableList.Builder<>();
 
     // Metadata columns
@@ -251,17 +242,14 @@ public final class CsvExporterService {
     columnsBuilder.add(
         Column.builder().setHeader("Status").setColumnType(ColumnType.STATUS_TEXT).build());
 
-    // Add columns for each path to an answer.
-    representativeAnswers.stream()
-        .filter(
-            answerData ->
-                !NON_EXPORTED_QUESTION_TYPES.contains(
-                    answerData.questionDefinition().getQuestionType()))
+    // Add columns for each scalar path to an answer.
+    exemplarQuestions.stream()
+        .filter(aq -> !NON_EXPORTED_QUESTION_TYPES.contains(aq.getType()))
         .flatMap(
-            answerData ->
-                answerData.questionDefinition().getQuestionType().equals(QuestionType.CHECKBOX)
-                    ? buildColumnsForEveryOption(answerData)
-                    : buildColumnsForEveryScalar(answerData))
+            aq ->
+                aq.getType().equals(QuestionType.CHECKBOX)
+                    ? buildColumnsForEveryOption(aq)
+                    : buildColumnsForEveryScalar(aq))
         .forEachOrdered(columnsBuilder::add);
     // Adding ADMIN_NOTE as the last coloumn to make sure it doesn't break the existing CSV exports
     columnsBuilder.add(
@@ -269,24 +257,24 @@ public final class CsvExporterService {
     return CsvExportConfig.builder().setColumns(columnsBuilder.build()).build();
   }
 
-  private Stream<Column> buildColumnsForEveryOption(AnswerData answerData) {
+  private Stream<Column> buildColumnsForEveryOption(ApplicantQuestion applicantQuestion) {
     // Columns are looked up by the scalar path, so we use the scalar path here
-    Path path = ((MultiSelectQuestion) answerData.createQuestion()).getSelectionPath();
+    Path scalarPath = applicantQuestion.createMultiSelectQuestion().getSelectionPath();
     return exportServiceRepository
-        .getAllHistoricMultiOptionAdminNames(answerData.questionDefinition())
+        .getAllHistoricMultiOptionAdminNames(applicantQuestion.getQuestionDefinition())
         .stream()
         .map(
             option ->
                 Column.builder()
-                    .setHeader(formatHeader(path, Optional.of(option)))
-                    .setJsonPath(path)
+                    .setHeader(formatHeader(scalarPath, Optional.of(option)))
+                    .setJsonPath(scalarPath)
                     .setOptionAdminName(option)
                     .setColumnType(ColumnType.APPLICANT_ANSWER)
                     .build());
   }
 
-  private Stream<Column> buildColumnsForEveryScalar(AnswerData answerData) {
-    return answerData.scalarAnswersInDefaultLocale().keySet().stream()
+  private Stream<Column> buildColumnsForEveryScalar(ApplicantQuestion applicantQuestion) {
+    return applicantQuestion.getQuestion().getAllPaths().stream()
         .map(
             path ->
                 Column.builder()
@@ -335,6 +323,11 @@ public final class CsvExporterService {
     // Remove "name" from the name suffix string as it will be indicated in the name.
     if (path.keyName().equals(NAME_SUFFIX)) {
       scalarComponent = "(suffix)";
+    }
+
+    // Change scalar name for file_key_list
+    if (path.keyName().equals(FILE_KEY_LIST)) {
+      scalarComponent = "(file_urls)";
     }
 
     // TODO: #7134 Only here for backwards compatibility. Long term this should go away

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -130,8 +130,9 @@ public abstract class AbstractExporterTest extends ResetPostgres {
         break;
       case NAME:
         QuestionAnswerer.answerNameQuestion(
-            applicantDataOne, answerPath, "Alice", "", "Appleton", "");
-        QuestionAnswerer.answerNameQuestion(applicantDataTwo, answerPath, "Bob", "", "Baker", "");
+            applicantDataOne, answerPath, "Alice", "M", "Appleton", "Jr");
+        QuestionAnswerer.answerNameQuestion(
+            applicantDataTwo, answerPath, "Bob", "M", "Baker", "Sr");
         break;
       case NUMBER:
         QuestionAnswerer.answerNumberQuestion(applicantDataOne, answerPath, "123456");

--- a/server/test/services/export/CsvExporterServiceTest.java
+++ b/server/test/services/export/CsvExporterServiceTest.java
@@ -1,6 +1,7 @@
 package services.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static play.api.test.Helpers.testServerPort;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -48,6 +49,7 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
   private static final CSVFormat DEFAULT_FORMAT = CSVFormat.DEFAULT.builder().setHeader().build();
   private static final String SECRET_SALT = "super secret";
   private static final String EMPTY_VALUE = "";
+  private static final String BASE_URL = String.format("http://localhost:%d", testServerPort());
   CsvExporterService exporterService;
   private QuestionService questionService;
   private VersionRepository versionRepository;
@@ -167,6 +169,14 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "applicant address (longitude)",
             "applicant address (well_known_id)",
             "applicant address (service_area)",
+            "applicant birth date (date)",
+            "applicant email address (email)",
+            "applicant favorite color (text)",
+            "applicant favorite season (selection)",
+            "applicant file (file_key)",
+            "applicant file (file_urls)",
+            "applicant ice cream (selection)",
+            "applicant id (id)",
             "applicant monthly income (currency)",
             "applicant name (first_name)",
             "applicant name (middle_name)",
@@ -178,13 +188,6 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "kitchen tools (selections - pepper_grinder)",
             "kitchen tools (selections - garlic_press)",
             "number of items applicant can juggle (number)",
-            "applicant birth date (date)",
-            "applicant email address (email)",
-            "applicant favorite color (text)",
-            "applicant favorite season (selection)",
-            "applicant file (file_key)",
-            "applicant ice cream (selection)",
-            "applicant id (id)",
             "Admin Note");
 
     NameQuestion nameApplicantQuestion =
@@ -192,8 +195,11 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             .createNameQuestion();
     String firstNameHeader =
         CsvExporterService.formatHeader(nameApplicantQuestion.getFirstNamePath());
+    String middleNameHeader =
+        CsvExporterService.formatHeader(nameApplicantQuestion.getMiddleNamePath());
     String lastNameHeader =
         CsvExporterService.formatHeader(nameApplicantQuestion.getLastNamePath());
+    String suffixPath = CsvExporterService.formatHeader(nameApplicantQuestion.getNameSuffixPath());
     QuestionModel phoneQuestion =
         testQuestionBank.getSampleQuestionsForAllTypes().get(QuestionType.PHONE);
     PhoneQuestion phoneQuestion1 =
@@ -205,7 +211,9 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
 
     // Applications should appear most recent first.
     assertThat(records.get(0).get(firstNameHeader)).isEqualTo("Bob");
+    assertThat(records.get(0).get(middleNameHeader)).isEqualTo("M");
     assertThat(records.get(1).get(lastNameHeader)).isEqualTo("Appleton");
+    assertThat(records.get(0).get(suffixPath)).isEqualTo("Sr");
     assertThat(records.get(0).get("Status")).isEqualTo("");
     assertThat(records.get(1).get("Status")).isEqualTo(STATUS_VALUE);
     assertThat(records.get(0).get("Submitter Type")).isEqualTo("APPLICANT");
@@ -239,7 +247,8 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
     String fileKeyHeader =
         CsvExporterService.formatHeader(fileuploadApplicantQuestion.getFileKeyPath());
     assertThat(records.get(1).get(fileKeyHeader))
-        .contains(String.format("/admin/programs/%d/files/my-file-key", fakeProgram.id));
+        .isEqualTo(
+            String.format("%s/admin/programs/%d/files/my-file-key", BASE_URL, fakeProgram.id));
   }
 
   // TODO(#8563) This should be removed/rolled into the above tests when we remove support for
@@ -287,9 +296,11 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
     String fileKeyHeader =
         CsvExporterService.formatHeader(fileUploadApplicantQuestion.getFileKeyPath());
     assertThat(records.get(0).get(fileKeyHeader))
-        .contains(String.format("/admin/programs/%d/files/my-file-key", fakeProgram.id));
-    assertThat(records.get(0).get(fileKeyHeader))
-        .contains(String.format("/admin/programs/%d/files/my-file-key-2", fakeProgram.id));
+        .isEqualTo(
+            String.format(
+                "[%s/admin/programs/%d/files/my-file-key,"
+                    + " %s/admin/programs/%d/files/my-file-key-2]",
+                BASE_URL, fakeProgram.id, BASE_URL, fakeProgram.id));
   }
 
   @Test
@@ -317,11 +328,11 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "TI Organization",
             "Eligibility Status",
             "Status",
+            "applicant favorite color (text)",
             "applicant name (first_name)",
             "applicant name (middle_name)",
             "applicant name (last_name)",
             "applicant name (suffix)",
-            "applicant favorite color (text)",
             "Admin Note");
 
     NameQuestion nameApplicantQuestion =
@@ -445,28 +456,28 @@ public class CsvExporterServiceTest extends AbstractExporterTest {
             "TI Email",
             "TI Organization",
             "Status",
-            "applicant name (first_name)",
-            "applicant name (middle_name)",
-            "applicant name (last_name)",
-            "applicant name (suffix)",
             "applicant favorite color (text)",
-            "applicant monthly income (currency)",
-            "applicant household members[0] - household members name (first_name)",
-            "applicant household members[0] - household members name (middle_name)",
-            "applicant household members[0] - household members name (last_name)",
-            "applicant household members[0] - household members name (suffix)",
-            "applicant household members[1] - household members name (first_name)",
-            "applicant household members[1] - household members name (middle_name)",
-            "applicant household members[1] - household members name (last_name)",
-            "applicant household members[1] - household members name (suffix)",
             "applicant household members[0] - household members jobs[0] - household"
                 + " members days worked (number)",
             "applicant household members[0] - household members jobs[1] - household"
                 + " members days worked (number)",
             "applicant household members[0] - household members jobs[2] - household"
                 + " members days worked (number)",
+            "applicant household members[0] - household members name (first_name)",
+            "applicant household members[0] - household members name (middle_name)",
+            "applicant household members[0] - household members name (last_name)",
+            "applicant household members[0] - household members name (suffix)",
             "applicant household members[1] - household members jobs[0] - household"
                 + " members days worked (number)",
+            "applicant household members[1] - household members name (first_name)",
+            "applicant household members[1] - household members name (middle_name)",
+            "applicant household members[1] - household members name (last_name)",
+            "applicant household members[1] - household members name (suffix)",
+            "applicant monthly income (currency)",
+            "applicant name (first_name)",
+            "applicant name (middle_name)",
+            "applicant name (last_name)",
+            "applicant name (suffix)",
             "Admin Note");
 
     List<CSVRecord> records = parser.getRecords();

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -642,7 +642,7 @@ public class PdfExporterTest extends AbstractExporterTest {
           + "1234.56\n"
           + "Answered on : 1969-12-31\n"
           + "applicant name\n"
-          + "Alice Appleton\n"
+          + "Alice M Appleton Jr\n"
           + "Answered on : 1969-12-31\n"
           + "applicant phone\n"
           + "+1 615-757-1010\n"


### PR DESCRIPTION
### Description

Uses `ApplicantQuestion`s to build `CsvExportConfig` instead of building `AnswerData` objects we mostly ignore, which reduces CSV export time.

This PR also:
- Changes the sort order for CSV columns. They are now sorted only by the question admin name.
- Adds the `file_urls` column to the CSV export, to align with the JSON export.
- Adds tests for the `name_suffix` field to the CSV tests.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Issue(s) this completes

Fixes #8843
