### PR TITLE
Add flag PGADMIN_CONFIG_WTF_CSRF_ENABLED = False to the dev pgadmin docker container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,6 +72,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: password
       PGADMIN_CONFIG_SERVER_MODE: 'False'
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
+      PGADMIN_CONFIG_WTF_CSRF_ENABLED: 'False'
 
   prometheus:
     profiles: ['monitoring']


### PR DESCRIPTION
### Description

This makes it so that we dont run into CSRF errors when running the tool in a web-only codespace.

Disabling CSRF should not have an impact on usages of the container in a local VS code or other environments.  Typically this would be a security issue for producion code, but since this is a dev-only tool that is only run against local dev databsaes, there should be no security concern.

## Release notes

This change has no impact on release components, and can be ignored in the release notes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

