### PR TITLE
Fix bug in program filtering when user switches to another language

### DIFF
--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -346,7 +346,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                     program.program().categories().stream()
                         .anyMatch(
                             category ->
-                                selectedCategoriesFromParams.contains(category.getDefaultName())))
+                                selectedCategoriesFromParams.contains(
+                                    category.getLocalizedName().getOrDefault(preferredLocale))))
             .collect(ImmutableList.toImmutableList());
 
     // Find all programs that don't have any of the selected categories


### PR DESCRIPTION
### Description

Programs weren't being filtered in languages other than English because we were trying to match the localized names of the categories to the default category names (English) on programs.

### Instructions for manual testing

1. If you haven't already, go to the Dev Tools and click "Seed programs and categories".
2. Log in as an admin and add a couple of categories to a program.
3. Publish your changes.
4. Logout
5. Use the language dropdown to switch to another language.
6. Click a program filter.
7. Any programs with that category should appear in the "Programs based on your selections" section.

![image](https://github.com/user-attachments/assets/f736a85a-5f13-4747-bcd7-34e72c7488a8)

### Issue(s) this completes

Fixes #8865 
