### PR TITLE
Un-skip translation test

### DIFF
--- a/browser-test/src/admin/admin_program_translation.test.ts
+++ b/browser-test/src/admin/admin_program_translation.test.ts
@@ -302,8 +302,7 @@ test.describe('Admin can manage program translations', () => {
     await adminTranslations.expectNoProgramImageDescription()
   })
 
-  // TODO(#8796): Re-enable this test
-  test.skip(
+  test(
     'Add translations for block name and description',
     {tag: ['@northstar']},
     async ({
@@ -331,7 +330,7 @@ test.describe('Admin can manage program translations', () => {
         await adminTranslations.editProgramTranslations({
           name: 'Spanish name',
           description: 'Spanish description',
-          blockName: 'Spanish block name',
+          blockName: 'Spanish block name - bloque uno',
           blockDescription: 'Spanish block description',
           statuses: [],
         })
@@ -341,7 +340,7 @@ test.describe('Admin can manage program translations', () => {
         await adminPrograms.gotoDraftProgramManageTranslationsPage(programName)
         await adminTranslations.selectLanguage('Spanish')
         await adminTranslations.expectBlockTranslations(
-          'Spanish block name',
+          'Spanish block name - bloque uno',
           'Spanish block description',
         )
       })
@@ -355,8 +354,9 @@ test.describe('Admin can manage program translations', () => {
 
         await applicantQuestions.clickApplyProgramButton('Spanish name')
 
-        await expect(page.getByText('Spanish block name')).toBeVisible()
-        await expect(page.getByText('Spanish block description')).toBeVisible()
+        await expect(
+          page.getByText('Spanish block name - bloque uno'),
+        ).toBeVisible()
       })
     },
   )


### PR DESCRIPTION
### Description

Un-skip translation test.

History:
1. The test is created. It checks that the review page contains a translated title and description.
1. PR #8782 changes navigation to bypass the review page in North Star. The test is skipped.
1. PR #8848 adds translated block titles to the applicant block edit page. This indirectly fixes the test since a translated title is now present on the first page that the applicant sees after clicking "Apply".

Should we check block descriptions? No, because block descriptions are not used in North Star.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Issue(s) this completes

Fixes #8796