### PR TITLE
Don't run two checks on PRs from forks

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -10,9 +10,7 @@ jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
-    # Only run this for the main civiform owner. PRs from forks don't have the permissions
-    # needed to run this. See #6681 for notes on a possible better option.
-    if: github.repository_owner == 'civiform'
+    if: github.repository_owner == 'civiform' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.13.0

--- a/.github/workflows/scan_for_secrets.yaml
+++ b/.github/workflows/scan_for_secrets.yaml
@@ -14,6 +14,7 @@ jobs:
   scan:
     name: gitleaks
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'civiform' && github.event.pull_request.head.repo.fork == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Neither of these are critical when running checks of PRs from forks.