### PR TITLE
Add step to evolutions PR template to test downs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@ Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#wr
 - [ ] Assigned two reviewers
 - [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
 - [ ] Downs created to undo changes in Ups
+- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
 - [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
 
 #### Durable jobs


### PR DESCRIPTION
### Description

The Downs script in https://github.com/civiform/civiform/pull/8664 has a syntax error, so it can't run. But fixing the syntax error in 78.sql prompts play to try to run the broken downs script it has stored in its database.

To help guard against this happening again, we should manually test the downs script, including comments.