### PR TITLE
[Multiple File Upload] Add duplicate file handling to North Star

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -828,6 +828,18 @@ test.describe('file upload applicant flow', () => {
           )
         })
 
+        await test.step('uploading duplicate file appends suffix', async () => {
+          await applicantQuestions.answerFileUploadQuestionFromAssets(
+            'file-upload.png',
+          )
+          await applicantFileQuestion.expectFileNameCount('file-upload.png', 1)
+
+          await applicantFileQuestion.expectFileNameCount(
+            'file-upload-2.png',
+            1,
+          )
+        })
+
         await test.step('Remove files', async () => {
           await applicantFileQuestion.removeFileUpload('file-upload.png')
 

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -53,7 +53,7 @@
 
               <ul
                 th:if="${fileUploadQuestion.getFileKeyListValue().isPresent()}"
-                th:attr="aria-label=#{label.uploadedFiles}"
+                data-th-attr="data-uploaded-files=${fileUploadViewStrategy.getUploadedFileData(fileUploadQuestion)}, aria-label=#{label.uploadedFiles}"
                 class="grid"
               >
                 <li

--- a/server/app/views/fileupload/FileUploadViewStrategy.java
+++ b/server/app/views/fileupload/FileUploadViewStrategy.java
@@ -17,7 +17,11 @@ import j2html.tags.specialized.FormTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.ScriptTag;
 import java.util.Optional;
+import play.api.libs.json.JsArray;
+import play.api.libs.json.JsString;
+import play.api.libs.json.JsValue;
 import play.i18n.Messages;
+import play.libs.Scala;
 import play.mvc.Http;
 import play.mvc.Http.RequestHeader;
 import services.AlertType;
@@ -57,6 +61,15 @@ public abstract class FileUploadViewStrategy {
   /** Returns the file name for a given file key. */
   public String getFileName(String fileKey) {
     return FileUploadQuestion.getFileName(fileKey);
+  }
+
+  /** Returns a JsArray containing all uploaded file names. This is used by file_upload.ts */
+  public JsArray getUploadedFileData(FileUploadQuestion fileUploadQuestion) {
+    ImmutableList<JsValue> fileNames =
+        fileUploadQuestion.getFileKeyListValue().get().stream()
+            .map(key -> new JsString(getFileName(key)))
+            .collect(toImmutableList());
+    return new JsArray(Scala.toSeq(fileNames));
   }
 
   /**

--- a/server/test/views/fileupload/FileUploadViewStrategyTest.java
+++ b/server/test/views/fileupload/FileUploadViewStrategyTest.java
@@ -5,11 +5,28 @@ import static play.test.Helpers.stubMessagesApi;
 import static views.fileupload.FileUploadViewStrategy.FILE_INPUT_HINT_ID_PREFIX;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.InputTag;
+import j2html.tags.specialized.ScriptTag;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalLong;
 import org.junit.Test;
+import play.api.libs.json.JsArray;
+import play.api.libs.json.JsString;
 import play.i18n.Lang;
 import play.i18n.Messages;
+import play.libs.Scala;
+import services.LocalizedStrings;
+import services.applicant.ApplicantData;
+import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.FileUploadQuestion;
+import services.cloud.StorageUploadRequest;
+import services.question.QuestionAnswerer;
+import services.question.types.FileUploadQuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import views.style.ReferenceClasses;
 
 public class FileUploadViewStrategyTest {
@@ -17,6 +34,32 @@ public class FileUploadViewStrategyTest {
 
   private final Messages messages =
       stubMessagesApi().preferred(ImmutableSet.of(Lang.defaultLang()));
+
+  private class StubViewStrategy extends FileUploadViewStrategy {
+    @Override
+    public ImmutableList<InputTag> additionalFileUploadFormInputs(
+        Optional<StorageUploadRequest> request) {
+      throw new UnsupportedOperationException(
+          "Unimplemented method 'additionalFileUploadFormInputs'");
+    }
+
+    @Override
+    public ImmutableMap<String, String> additionalFileUploadFormInputFields(
+        Optional<StorageUploadRequest> request) {
+      throw new UnsupportedOperationException(
+          "Unimplemented method 'additionalFileUploadFormInputFields'");
+    }
+
+    @Override
+    public String getUploadFormClass() {
+      throw new UnsupportedOperationException("Unimplemented method 'getUploadFormClass'");
+    }
+
+    @Override
+    protected ImmutableList<ScriptTag> extraScriptTags() {
+      throw new UnsupportedOperationException("Unimplemented method 'extraScriptTags'");
+    }
+  }
 
   @Test
   public void createUswdsFileInputFormElement_hasAriaDescribedByLabels() {
@@ -68,5 +111,40 @@ public class FileUploadViewStrategyTest {
 
     assertThat(uswdsForm.render())
         .containsPattern("<input type=\"file\".*data-file-limit-mb=\"5\"");
+  }
+
+  @Test
+  public void getUploadedFileData() {
+
+    FileUploadQuestionDefinition fileUploadQuestionDefinition =
+        new FileUploadQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("question name")
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+                .setId(OptionalLong.of(1))
+                .setLastModifiedTime(Optional.empty())
+                .build());
+
+    ApplicantData applicantData = new ApplicantData();
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(fileUploadQuestionDefinition, applicantData, Optional.empty());
+
+    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        ImmutableList.of("test", "test2", "test3"));
+
+    FileUploadQuestion fileUploadQuestion = applicantQuestion.createFileUploadQuestion();
+
+    FileUploadViewStrategy viewStrategy = new StubViewStrategy();
+
+    JsArray expectedArray =
+        new JsArray(
+            Scala.toSeq(
+                ImmutableList.of(
+                    new JsString("test"), new JsString("test2"), new JsString("test3"))));
+    assertThat(viewStrategy.getUploadedFileData(fileUploadQuestion)).isEqualTo(expectedArray);
   }
 }


### PR DESCRIPTION
### Description

Support adding a file with the same name as an already uploaded file in north star.


#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

