### PR TITLE
Pull file upload file type specifiers from config

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -775,6 +775,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * Specifies the allowed file types that can be uploaded. Uses any valid [file type
+   * specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers).
+   * Multiple are separated by commas. Default: "image/*,.pdf"
+   */
+  public Optional<String> getFileUploadAllowedFileTypeSpecifiers() {
+    return getString("FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS");
+  }
+
+  /**
    * If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If
    * disabled, '/metrics' returns a 404.
    */
@@ -2211,5 +2220,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " the policy.",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.HIDDEN))));
+                      SettingMode.HIDDEN),
+                  SettingDescription.create(
+                      "FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS",
+                      "Specifies the allowed file types that can be uploaded. Uses any valid [file"
+                          + " type"
+                          + " specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers)."
+                          + " Multiple are separated by commas. Default: \"image/*,.pdf\"",
+                      /* isRequired= */ false,
+                      SettingType.STRING,
+                      SettingMode.ADMIN_READABLE))));
 }

--- a/server/app/views/applicant/ApplicantFileUploadRenderer.java
+++ b/server/app/views/applicant/ApplicantFileUploadRenderer.java
@@ -55,7 +55,7 @@ import views.style.ReferenceClasses;
 /** A helper class for rendering the file upload question for applicants. */
 public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
 
-  private static final String MIME_TYPES_IMAGES_AND_PDF = "image/*,.pdf";
+  private static final String ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK = "image/*,.pdf";
   private static final String BLOCK_FORM_ID = "cf-block-form";
   private static final String FILEUPLOAD_CONTINUE_FORM_ID = "cf-fileupload-continue-form";
   private static final String FILEUPLOAD_DELETE_FORM_ID = "cf-fileupload-delete-form";
@@ -200,7 +200,9 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
       result.with(
           FileUploadViewStrategy.createUswdsFileInputFormElement(
               fileInputId,
-              MIME_TYPES_IMAGES_AND_PDF,
+              settingsManifest
+                  .getFileUploadAllowedFileTypeSpecifiers()
+                  .orElse(ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK),
               ImmutableList.of(getFileInputHint(fileUploadQuestion, params)),
               /* disabled= */ !fileUploadQuestion.canUploadFile(),
               applicantStorageClient.getFileLimitMb(),
@@ -365,7 +367,10 @@ public final class ApplicantFileUploadRenderer extends ApplicationBaseView {
         .withName("file")
         .withClass("hidden")
         .attr("data-file-limit-mb", applicantStorageClient.getFileLimitMb())
-        .withAccept(MIME_TYPES_IMAGES_AND_PDF);
+        .withAccept(
+            settingsManifest
+                .getFileUploadAllowedFileTypeSpecifiers()
+                .orElse(ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK));
   }
 
   /**

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -27,6 +27,7 @@ import views.questiontypes.ApplicantQuestionRendererParams;
 
 /** Renders a page for answering questions in a program screen (block). */
 public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseView {
+  private static final String ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK = "image/*,.pdf";
   private final FileUploadViewStrategy fileUploadViewStrategy;
 
   @Inject
@@ -208,6 +209,11 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       ApplicationBaseViewParams params, ThymeleafModule.PlayThymeleafContext context) {
     context.setVariable("fileUploadViewStrategy", fileUploadViewStrategy);
     context.setVariable("maxFileSizeMb", params.applicantStorageClient().getFileLimitMb());
+    context.setVariable(
+        "fileUploadAllowedFileTypeSpecifiers",
+        settingsManifest
+            .getFileUploadAllowedFileTypeSpecifiers()
+            .orElse(ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK));
     context.setVariable(
         "previousBlockWithoutFile",
         params.baseUrl()

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -27,7 +27,14 @@ import views.questiontypes.ApplicantQuestionRendererParams;
 
 /** Renders a page for answering questions in a program screen (block). */
 public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseView {
+  /**
+   * This fallback should not ever be reached, but it is here in the event that the {@link
+   * SettingsManifest} can't find it in the config to allow for basic functionality to continue.
+   * This should be kept in sync with the config value `file_upload_allowed_file_type_specifiers` in
+   * the application.conf file.
+   */
   private static final String ALLOWED_FILE_TYPE_SPECIFIERS_FALLBACK = "image/*,.pdf";
+
   private final FileUploadViewStrategy fileUploadViewStrategy;
 
   @Inject

--- a/server/app/views/questiontypes/FileUploadQuestionFragment.html
+++ b/server/app/views/questiontypes/FileUploadQuestionFragment.html
@@ -57,7 +57,7 @@
     type="file"
     name="file"
     th:aria-describedby="${questionId} + '-description'"
-    accept="image/*,.pdf"
+    th:accept="${fileUploadAllowedFileTypeSpecifiers}"
     th:data-file-limit-mb="${maxFileSizeMb}"
   />
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -603,3 +603,7 @@ civiform_applicant_enabled_languages = ${?CIVIFORM_APPLICANT_ENABLED_LANGUAGES}
 # Typically, this value is 1.
 num_trusted_proxies = 1
 num_trusted_proxies = ${?NUM_TRUSTED_PROXIES}
+
+# These are file types allowed to be uploaded by the file upload components
+file_upload_allowed_file_type_specifiers = "image/*,.pdf"
+file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS}

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -661,6 +661,11 @@
     "description": "Overrides the default configuration for the content security policy. If set to true, the browser reports content security policy violations but does not enforce the policy. If set to false, the browser enforces the policy.",
     "type": "bool"
   },
+  "FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS": {
+    "mode": "ADMIN_READABLE",
+    "description": "Specifies the allowed file types that can be uploaded. Uses any valid [file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers). Multiple are separated by commas. Default: \"image/*,.pdf\"",
+    "type": "string"
+  },
   "Observability": {
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {


### PR DESCRIPTION
### Description

File upload used a hard-coded accept list of file type specifiers. It was brought to my attention that a new program now live in Seattle requires applicants to submit a spreadsheet filled out from a template supplied by the program.

This change just allows setting the value from the config file.

## Release notes

There is a new, optional, configuration value to control the types of files that applicants are allowed to upload on file upload questions.

The default options remain as images and PDFs. To customize set the `FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS`. This uses any valid [file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers). Multiple are separated by commas.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

