### PR TITLE
Refactor SimpleEmail to be in new services/email directory

### DIFF
--- a/server/app/durablejobs/AbstractDurableJobRunner.java
+++ b/server/app/durablejobs/AbstractDurableJobRunner.java
@@ -20,7 +20,7 @@ import models.PersistedDurableJobModel;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 
 /**
  * Executes {@link DurableJob}s when their time has come.

--- a/server/app/durablejobs/RecurringDurableJobRunner.java
+++ b/server/app/durablejobs/RecurringDurableJobRunner.java
@@ -12,7 +12,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import models.PersistedDurableJobModel;
 import repository.PersistedDurableJobRepository;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 
 /**
  * Executes {@link DurableJob}s when their time has come.

--- a/server/app/durablejobs/StartupDurableJobRunner.java
+++ b/server/app/durablejobs/StartupDurableJobRunner.java
@@ -11,7 +11,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import models.PersistedDurableJobModel;
 import repository.PersistedDurableJobRepository;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 
 /**
  * Executes {@link DurableJob}s when their time has come.

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -76,7 +76,7 @@ import services.applicant.question.DateQuestion;
 import services.applicant.question.PhoneQuestion;
 import services.applicant.question.Scalar;
 import services.application.ApplicationEventDetails;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import services.geo.AddressLocation;
 import services.geo.AddressSuggestion;
 import services.geo.AddressSuggestionGroup;

--- a/server/app/services/applications/ProgramAdminApplicationService.java
+++ b/server/app/services/applications/ProgramAdminApplicationService.java
@@ -28,7 +28,7 @@ import services.applicant.ApplicantService;
 import services.application.ApplicationEventDetails;
 import services.application.ApplicationEventDetails.NoteEvent;
 import services.application.ApplicationEventDetails.StatusEvent;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.statuses.StatusDefinitions.Status;

--- a/server/app/services/email/aws/SimpleEmail.java
+++ b/server/app/services/email/aws/SimpleEmail.java
@@ -1,4 +1,4 @@
-package services.cloud.aws;
+package services.email.aws;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static services.cloud.aws.AwsStorageUtils.AWS_LOCAL_ENDPOINT_CONF_PATH;
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Environment;
 import play.inject.ApplicationLifecycle;
+import services.cloud.aws.AwsRegion;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.Body;

--- a/server/test/durablejobs/RecurringDurableJobRunnerTest.java
+++ b/server/test/durablejobs/RecurringDurableJobRunnerTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mockito;
 import play.api.inject.BindingKey;
 import repository.PersistedDurableJobRepository;
 import repository.ResetPostgres;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import support.TestRetry;
 
 public class RecurringDurableJobRunnerTest extends ResetPostgres {

--- a/server/test/durablejobs/StartupDurableJobRunnerTest.java
+++ b/server/test/durablejobs/StartupDurableJobRunnerTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mockito;
 import play.api.inject.BindingKey;
 import repository.PersistedDurableJobRepository;
 import repository.ResetPostgres;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import support.TestRetry;
 
 public class StartupDurableJobRunnerTest extends ResetPostgres {

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -65,7 +65,7 @@ import services.applicant.question.AddressQuestion;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
 import services.application.ApplicationEventDetails.StatusEvent;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import services.geo.AddressLocation;
 import services.geo.AddressSuggestion;
 import services.geo.AddressSuggestionGroup;

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -65,7 +65,7 @@ import services.applicant.question.AddressQuestion;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
 import services.application.ApplicationEventDetails.StatusEvent;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import services.geo.AddressLocation;
 import services.geo.AddressSuggestion;
 import services.geo.AddressSuggestionGroup;

--- a/server/test/services/applications/ProgramAdminApplicationServiceTest.java
+++ b/server/test/services/applications/ProgramAdminApplicationServiceTest.java
@@ -41,7 +41,7 @@ import services.applicant.ApplicantService;
 import services.application.ApplicationEventDetails;
 import services.application.ApplicationEventDetails.NoteEvent;
 import services.application.ApplicationEventDetails.StatusEvent;
-import services.cloud.aws.SimpleEmail;
+import services.email.aws.SimpleEmail;
 import services.program.ProgramDefinition;
 import services.statuses.StatusDefinitions;
 import services.statuses.StatusNotFoundException;


### PR DESCRIPTION
### Description

Move SimpleEmail class from services/cloud/aws directory to services/email/aws directory. This makes email its own directory, so we are no longer 1:1 of cloud provider to email provider. This is based off the plan described in [TDD](https://docs.google.com/document/d/1rKkir5-9Y4Ka9icen_K2qCFCGOQ5BO2qtdROOl_002w/edit?tab=t.0#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.


### Issue(s) this completes

https://github.com/civiform/civiform/issues/8810