### PR TITLE
Add debugging to troubleshoot global admin permissions

### DIFF
--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -61,7 +61,8 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
       LOGGER.debug("No groups found in OIDC profile.");
     }
     if (!groups.contains(this.adminGroupName)) {
-      LOGGER.debug("List of groups ({}) doesn't include adminGroupName: {}.", groups, this.adminGroupName);
+      LOGGER.debug(
+          "List of groups ({}) doesn't include adminGroupName: {}.", groups, this.adminGroupName);
     }
     return groups != null && groups.contains(this.adminGroupName);
   }

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -11,12 +11,15 @@ import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class creates a pac4j `UserProfile` for admins when the identity provider is a generic OIDC
  * provider.
  */
 public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GenericOidcProfileCreator.class);
   private String groupsAttributeName;
   private String adminGroupName;
 
@@ -54,6 +57,12 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
   private boolean isGlobalAdmin(OidcProfile profile) {
     @SuppressWarnings("unchecked")
     List<String> groups = (List) profile.getAttribute(this.groupsAttributeName);
+    if (groups == null) {
+      LOGGER.debug("No groups found in OIDC profile.");
+    }
+    if (!groups.contains(this.adminGroupName)) {
+      LOGGER.debug("List of groups doesn't include adminGroupName: {}.", this.adminGroupName);
+    }
     return groups != null && groups.contains(this.adminGroupName);
   }
 

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -59,12 +59,13 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
     List<String> groups = (List) profile.getAttribute(this.groupsAttributeName);
     if (groups == null) {
       LOGGER.debug("No groups found in OIDC profile.");
+      return false;
     }
     if (!groups.contains(this.adminGroupName)) {
       LOGGER.debug(
           "List of groups ({}) doesn't include adminGroupName: {}.", groups, this.adminGroupName);
     }
-    return groups != null && groups.contains(this.adminGroupName);
+    return groups.contains(this.adminGroupName);
   }
 
   @Override

--- a/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
+++ b/server/app/auth/oidc/admin/GenericOidcProfileCreator.java
@@ -61,7 +61,7 @@ public class GenericOidcProfileCreator extends CiviformOidcProfileCreator {
       LOGGER.debug("No groups found in OIDC profile.");
     }
     if (!groups.contains(this.adminGroupName)) {
-      LOGGER.debug("List of groups doesn't include adminGroupName: {}.", this.adminGroupName);
+      LOGGER.debug("List of groups ({}) doesn't include adminGroupName: {}.", groups, this.adminGroupName);
     }
     return groups != null && groups.contains(this.adminGroupName);
   }


### PR DESCRIPTION
### Description

Charlotte set up Okta and admins are able to login, but people added to their CiviForm admins group are not being recognized as global admins, and instead just seeing the program admin view.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/8965
