### PR TITLE
Remove config variable for CSP enforcement

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -766,15 +766,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * Overrides the default configuration for the content security policy. If set to true, the
-   * browser reports content security policy violations but does not enforce the policy. If set to
-   * false, the browser enforces the policy.
-   */
-  public boolean getCspReportOnly() {
-    return getBool("CSP_REPORT_ONLY");
-  }
-
-  /**
    * Specifies the allowed file types that can be uploaded. Uses any valid [file type
    * specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers).
    * Multiple are separated by commas. Default: "image/*,.pdf"
@@ -2212,15 +2203,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE),
-                  SettingDescription.create(
-                      "CSP_REPORT_ONLY",
-                      "Overrides the default configuration for the content security policy. If set"
-                          + " to true, the browser reports content security policy violations but"
-                          + " does not enforce the policy. If set to false, the browser enforces"
-                          + " the policy.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
-                      SettingMode.HIDDEN),
                   SettingDescription.create(
                       "FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS",
                       "Specifies the allowed file types that can be uploaded. Uses any valid [file"

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -358,7 +358,6 @@ play.filters {
 
   csp {
     reportOnly = false
-    reportOnly = ${?CSP_REPORT_ONLY}
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
   }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -656,11 +656,6 @@
     "description": "The count of reverse proxies between the internet and the server. In typical deployments, this value is 1.",
     "type": "int"
   },
-  "CSP_REPORT_ONLY": {
-    "mode": "HIDDEN",
-    "description": "Overrides the default configuration for the content security policy. If set to true, the browser reports content security policy violations but does not enforce the policy. If set to false, the browser enforces the policy.",
-    "type": "bool"
-  },
   "FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS": {
     "mode": "ADMIN_READABLE",
     "description": "Specifies the allowed file types that can be uploaded. Uses any valid [file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers). Multiple are separated by commas. Default: \"image/*,.pdf\"",


### PR DESCRIPTION
### Description

Remove the CSP_REPORT_ONLY config variable, which allowed overriding the enablement of CSP enforcement.

CSP enforcement was enabled by default in #8218, and it has been in prod long enough that we are confident we won't need to disable it suddenly.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Fixes #7574
