### PR TITLE
Delete button.print from messages since it's unused

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -104,7 +104,6 @@ public enum MessageKey {
   BUTTON_NEXT("button.nextPage"),
   BUTTON_NEXT_SCREEN("button.nextScreen"),
   BUTTON_PREVIOUS_SCREEN("button.previousScreen"),
-  BUTTON_PRINT("button.print"), // North Star only
   BUTTON_BACK("button.back"),
   BUTTON_REVIEW_AND_EXIT("button.reviewAndExit"),
   BUTTON_REVIEW("button.review"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -546,8 +546,6 @@ heading.dateSubmitted=Date submitted
 heading.forYourRecords=Confirmation for your records
 # Text above a button to print this page
 content.youCanPrint=You can print this confirmation for your records.
-# Button to print this webpage
-button.print=Print this page
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=What are my next steps?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.am
+++ b/server/conf/i18n/messages.am
@@ -544,8 +544,6 @@ heading.dateSubmitted=የገባበት ቀን
 heading.forYourRecords=የመዝገቦችዎ ማረጋገጫ
 # Text above a button to print this page
 content.youCanPrint=ይህን የመዝገቦችዎ ማረጋገጫ ማተም ይችላሉ።
-# Button to print this webpage
-button.print=ይህን ገጽ ያትሙ
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=ቀጣይ እርምጃዎቼ ምንድናቸው?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.ar
+++ b/server/conf/i18n/messages.ar
@@ -544,8 +544,6 @@ heading.dateSubmitted=تاريخ الإرسال
 heading.forYourRecords=الاحتفاظ برسالة التأكيد
 # Text above a button to print this page
 content.youCanPrint=يمكنك طباعة رسالة التأكيد هذه للاحتفاظ بها.
-# Button to print this webpage
-button.print=طباعة هذه الصفحة
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=ما هي خطواتي التالية؟
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.es-US
+++ b/server/conf/i18n/messages.es-US
@@ -544,8 +544,6 @@ heading.dateSubmitted=Fecha de envío
 heading.forYourRecords=Confirmación de tus registros
 # Text above a button to print this page
 content.youCanPrint=Puedes imprimir esta confirmación de tus registros.
-# Button to print this webpage
-button.print=Imprimir esta página
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=¿Qué debo hacer a continuación?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.fr
+++ b/server/conf/i18n/messages.fr
@@ -544,8 +544,6 @@ heading.dateSubmitted=Date d''envoi
 heading.forYourRecords=Confirmation à conserver
 # Text above a button to print this page
 content.youCanPrint=Vous pouvez imprimer cette confirmation et la conserver à titre d''information.
-# Button to print this webpage
-button.print=Imprimer cette page
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=Quelles sont les prochaines étapes ?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.ko
+++ b/server/conf/i18n/messages.ko
@@ -544,8 +544,6 @@ heading.dateSubmitted=제출일
 heading.forYourRecords=기록을 위한 확인
 # Text above a button to print this page
 content.youCanPrint=기록을 위해 이 확인 페이지를 인쇄할 수 있습니다.
-# Button to print this webpage
-button.print=이 페이지 인쇄
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=다음 단계는 무엇인가요?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.lo
+++ b/server/conf/i18n/messages.lo
@@ -544,8 +544,6 @@ heading.dateSubmitted=ວັນທີທີ່ສົ່ງ
 heading.forYourRecords=ການຢືນຢັນເພື່ອຮັກສາໄວ້ເປັນຂໍ້ມູນອ້າງອີງຂອງທ່ານ
 # Text above a button to print this page
 content.youCanPrint=ທ່ານສາມາດພິມການຢືນຢັນນີ້ເພື່ອຮັກສາໄວ້ເປັນຂໍ້ມູນອ້າງອີງຂອງທ່ານໄດ້.
-# Button to print this webpage
-button.print=ພິມໜ້ານີ້
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=ຂັ້ນຕອນຕໍ່ໄປຂອງຂ້ອຍແມ່ນຫຍັງ?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.so
+++ b/server/conf/i18n/messages.so
@@ -544,8 +544,6 @@ heading.dateSubmitted=Taariikhda la gudbiyay
 heading.forYourRecords=Xaqiijinta diiwaannadaada
 # Text above a button to print this page
 content.youCanPrint=Waxaad xaqiijintan u daabacan kartaa diiwaannadaada.
-# Button to print this webpage
-button.print=Daabac boggan
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=Waa maxay tallaabooyinkayga xiga?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -544,8 +544,6 @@ heading.dateSubmitted=Petsa ng pagsusumite
 heading.forYourRecords=Kumpirmasyon para sa iyong mga record
 # Text above a button to print this page
 content.youCanPrint=Puwede mong i-print ang kumpirmasyong ito para sa iyong mga record.
-# Button to print this webpage
-button.print=I-print ang page na ito
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=Ano ang mga susunod na hakbang ko?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.vi
+++ b/server/conf/i18n/messages.vi
@@ -544,8 +544,6 @@ heading.dateSubmitted=Ngày gửi
 heading.forYourRecords=Bản xác nhận để lưu hồ sơ
 # Text above a button to print this page
 content.youCanPrint=Bạn có thể in bản xác nhận này để lưu hồ sơ.
-# Button to print this webpage
-button.print=In trang này
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=Tôi cần làm gì tiếp theo?
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"

--- a/server/conf/i18n/messages.zh-TW
+++ b/server/conf/i18n/messages.zh-TW
@@ -544,8 +544,6 @@ heading.dateSubmitted=提交日期
 heading.forYourRecords=記錄確認頁面
 # Text above a button to print this page
 content.youCanPrint=您可以列印本記錄確認頁面。
-# Button to print this webpage
-button.print=列印此頁面
 # Heading above a paragraph explaining the next steps in the application process
 heading.nextSteps=後續步驟
 # Confirmation "alert" message that appears next to a checkmark icon. {0} is the program name, such as "Housing Assistance Program"


### PR DESCRIPTION
### Description

Delete button.print from messages since it's unused. It became obsolete in PR #8950.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Issue(s) this completes

Related to #8299