### PR TITLE
Fix intermittent test bug

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -810,14 +810,15 @@ test.describe('file upload applicant flow', () => {
             'file-upload.png',
           )
 
-          await applicantFileQuestion.expectFileNameDisplayed('file-upload.png')
+          await applicantFileQuestion.expectFileNameCount('file-upload.png', 1)
 
           await applicantQuestions.answerFileUploadQuestionFromAssets(
             'file-upload-second.png',
           )
 
-          await applicantFileQuestion.expectFileNameDisplayed(
+          await applicantFileQuestion.expectFileNameCount(
             'file-upload-second.png',
+            1,
           )
 
           await validateScreenshot(


### PR DESCRIPTION
### Description

There has been an intermittent file upload failure when both multi-file upload and northstar are enabled. Swapping to use a different (existing) way to check that the file name was added. The other method uses the older and not great  `expect->await` order and tries to check the entire page for the filename.

It's more involved right now to fix the other assert as older non-mfu/non-ns tests failed. Some of this will get cleaned up when northstar goes live so as long as the flaky test is working we should be fine.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
