### PR TITLE
Show categories on North Star program cards

### DIFF
--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -45,6 +45,18 @@
     </div>
 
     <div class="usa-card__body">
+      <div
+        th:if="${sectionType != 'MY_APPLICATIONS' and !card.categories().isEmpty()}"
+        class="flex flex-wrap gap-2 mx-4 mt-4"
+      >
+        <th:block th:each="category : ${card.categories()}">
+          <div
+            th:text="${category}"
+            class="text-xs bg-gray-200 px-2 py-1"
+          ></div>
+        </th:block>
+      </div>
+
       <p
         th:if="${card.applicationStatus().isPresent()}"
         class="border rounded-full px-2 py-1 mb-4 gap-x-2 inline-block w-auto bg-blue-100"

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -172,12 +172,19 @@ public final class ProgramCardsSectionParamsFactory {
 
     boolean isGuest = personalInfo.getType() == GUEST;
 
+    ImmutableList.Builder<String> categoriesBuilder = ImmutableList.builder();
+    categoriesBuilder.addAll(
+        program.categories().stream()
+            .map(c -> c.getLocalizedName().getOrDefault(preferredLocale))
+            .collect(ImmutableList.toImmutableList()));
+
     cardBuilder
         .setTitle(program.localizedName().getOrDefault(preferredLocale))
         .setBody(program.localizedDescription().getOrDefault(preferredLocale))
         .setDetailsUrl(detailsUrl)
         .setActionUrl(actionUrl)
         .setIsGuest(isGuest)
+        .setCategories(categoriesBuilder.build())
         .setActionText(messages.at(buttonText.getKeyName()));
 
     if (isGuest) {
@@ -292,6 +299,8 @@ public final class ProgramCardsSectionParamsFactory {
 
     public abstract Optional<String> altText();
 
+    public abstract ImmutableList<String> categories();
+
     public static Builder builder() {
       return new AutoValue_ProgramCardsSectionParamsFactory_ProgramCardParams.Builder();
     }
@@ -323,6 +332,8 @@ public final class ProgramCardsSectionParamsFactory {
       public abstract Builder setImageSourceUrl(String imageSourceUrl);
 
       public abstract Builder setAltText(String altText);
+
+      public abstract Builder setCategories(ImmutableList<String> categories);
 
       public abstract ProgramCardParams build();
     }


### PR DESCRIPTION
### Description

Adding category tags to program cards in the North Star.  This PR only includes basic styling.  Styling and accessibility considerations will be addressed in #8157. 

![image](https://github.com/user-attachments/assets/63ccc081-b347-43e2-83c6-705c8d4d5e43)


### Instructions for manual testing

1. Enable the North Star and program filtering flags.
2. Go to Dev Tools, Additional Tools and click "Seed Programs and Categories", if you haven't already.
3. Log in as an admin.
4. Edit a few programs and add categories. 
5. Publish your changes.
6. Go to the homepage.
7. Categories should show on program cards that are in the "Programs and services" section, but should not show on those in the "My applications" section.


