### PR TITLE
Revert "Enable multi-file upload on dev (#8923)"

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -44,4 +44,3 @@ api_generated_docs_enabled = true
 application_exportable = true
 primary_applicant_info_questions_enabled = true
 program_filtering_enabled = true
-multiple_file_upload_enabled = true

--- a/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
+++ b/server/test/services/applicant/ApplicantServiceFastForwardEnabledTest.java
@@ -1068,22 +1068,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     applicant.save();
 
     var fileKey = "test-file-key";
-    var fileKey2 = "test-file-key-2";
 
     ImmutableMap<String, String> updates =
         ImmutableMap.<String, String>builder()
-            .put(
-                Path.create("applicant.fileupload")
-                    .join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX)
-                    .atIndex(0)
-                    .toString(),
-                fileKey)
-            .put(
-                Path.create("applicant.fileupload")
-                    .join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX)
-                    .atIndex(1)
-                    .toString(),
-                fileKey2)
+            .put(Path.create("applicant.fileupload").join(Scalar.FILE_KEY).toString(), fileKey)
             .build();
 
     var fileUploadQuestion =
@@ -1121,14 +1109,10 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
         .join();
 
     var storedFile = new StoredFileModel().setName(fileKey);
-    var storedFile2 = new StoredFileModel().setName(fileKey2);
-
     storedFile.save();
-    storedFile2.save();
 
-    Request request = fakeRequest();
     subject
-        .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, request)
+        .submitApplication(applicant.id, firstProgram.id, trustedIntermediaryProfile, fakeRequest())
         .toCompletableFuture()
         .join();
 
@@ -1136,23 +1120,14 @@ public class ApplicantServiceFastForwardEnabledTest extends ResetPostgres {
     assertThat(storedFile.getAcls().getProgramReadAcls())
         .containsOnly(firstProgram.getProgramDefinition().adminName());
 
-    storedFile2.refresh();
-    assertThat(storedFile2.getAcls().getProgramReadAcls())
-        .containsOnly(firstProgram.getProgramDefinition().adminName());
-
     subject
-        .submitApplication(applicant.id, secondProgram.id, trustedIntermediaryProfile, request)
+        .submitApplication(
+            applicant.id, secondProgram.id, trustedIntermediaryProfile, fakeRequest())
         .toCompletableFuture()
         .join();
 
     storedFile.refresh();
     assertThat(storedFile.getAcls().getProgramReadAcls())
-        .containsOnly(
-            firstProgram.getProgramDefinition().adminName(),
-            secondProgram.getProgramDefinition().adminName());
-
-    storedFile2.refresh();
-    assertThat(storedFile2.getAcls().getProgramReadAcls())
         .containsOnly(
             firstProgram.getProgramDefinition().adminName(),
             secondProgram.getProgramDefinition().adminName());

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -1174,22 +1174,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicant.save();
 
     var fileKey = "test-file-key";
-    var fileKey2 = "test-file-key-2";
 
     ImmutableMap<String, String> updates =
         ImmutableMap.<String, String>builder()
-            .put(
-                Path.create("applicant.fileupload")
-                    .join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX)
-                    .atIndex(0)
-                    .toString(),
-                fileKey)
-            .put(
-                Path.create("applicant.fileupload")
-                    .join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX)
-                    .atIndex(1)
-                    .toString(),
-                fileKey2)
+            .put(Path.create("applicant.fileupload").join(Scalar.FILE_KEY).toString(), fileKey)
             .build();
 
     var fileUploadQuestion =
@@ -1227,10 +1215,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         .join();
 
     var storedFile = new StoredFileModel().setName(fileKey);
-    var storedFile2 = new StoredFileModel().setName(fileKey2);
-
     storedFile.save();
-    storedFile2.save();
 
     Request request = fakeRequest();
     subject
@@ -1242,10 +1227,6 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(storedFile.getAcls().getProgramReadAcls())
         .containsOnly(firstProgram.getProgramDefinition().adminName());
 
-    storedFile2.refresh();
-    assertThat(storedFile2.getAcls().getProgramReadAcls())
-        .containsOnly(firstProgram.getProgramDefinition().adminName());
-
     subject
         .submitApplication(applicant.id, secondProgram.id, trustedIntermediaryProfile, request)
         .toCompletableFuture()
@@ -1253,12 +1234,6 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     storedFile.refresh();
     assertThat(storedFile.getAcls().getProgramReadAcls())
-        .containsOnly(
-            firstProgram.getProgramDefinition().adminName(),
-            secondProgram.getProgramDefinition().adminName());
-
-    storedFile2.refresh();
-    assertThat(storedFile2.getAcls().getProgramReadAcls())
         .containsOnly(
             firstProgram.getProgramDefinition().adminName(),
             secondProgram.getProgramDefinition().adminName());


### PR DESCRIPTION
### Description

This reverts commit 3206db42ed6abe7c7fd0ba9eac1a81e6d90d6573.

Having it enabled by default right now results in tests failing on dev staging with CSP errors. Jeff's fix to USWDS is tentatively slated for November.


Related to: #8923
