### PR TITLE
Enable multi-line answers on the "Application Summary" page

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -181,11 +181,20 @@ it is around the label */
   margin-top: 0;
 }
 
+// Resolve conflict between zero-margin and usa-prose>ol by directly specifying ID
+#summary-multiline-list {
+  margin: 0;
+  text-align: right;
+  padding-left: 0;
+}
+
 .summary-answer {
   @include u-line-height('sans', 5);
   @include u-text('ink');
   font-weight: font-weight('bold');
   text-align: right;
+  text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 .summary-button-section {

--- a/server/app/views/applicant/QuestionSummaryFragment.html
+++ b/server/app/views/applicant/QuestionSummaryFragment.html
@@ -9,10 +9,21 @@
         class="grid-col-6 left-align zero-margin mobile-truncate-3"
         th:utext="${answerData.questionHtml()}"
       ></span>
-      <span
-        class="grid-col-6 right-align zero-margin summary-answer mobile-truncate-3"
-        th:text="${answerData.answerText()}"
-      ></span>
+      <div th:replace="~{this :: multilineAnswer(${answerData})}"></div>
     </div>
   </div>
+</th:block>
+
+<th:block th:fragment="multilineAnswer(answerData)">
+  <ol id="summary-multiline-list" class="grid-col-6 right-align">
+    <li
+      th:each="answerLine : ${answerData.multilineAnswerText()}"
+      class="usa-prose"
+    >
+      <span
+        th:text="${answerLine}"
+        class="zero-margin summary-answer mobile-truncate-3"
+      ></span>
+    </li>
+  </ol>
 </th:block>


### PR DESCRIPTION
### Description

Enable multi-line answers on the "Application Summary" page. This allows displaying multiple file names for file upload questions.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #8793
