### PR TITLE
Fix navigation when applying to a program with admin-specified block order

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -907,7 +907,7 @@ test.describe('applicant program index page with images', () => {
           programName,
           /* northStarEnabled= */ true,
         )
-        await applicantQuestions.clickContinue()
+        await applicantQuestions.clickSubmitApplication()
         await applicantQuestions.gotoApplicantHomePage()
       })
 

--- a/browser-test/src/applicant/applicant_prevent_duplicate_submission.test.ts
+++ b/browser-test/src/applicant/applicant_prevent_duplicate_submission.test.ts
@@ -102,7 +102,6 @@ test.describe('Prevent Duplicate Submission', () => {
 
       await test.step('Submit another application to the same program without changing anything', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )

--- a/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
@@ -53,7 +53,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -96,7 +95,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -128,7 +126,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -159,7 +156,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -208,7 +204,6 @@ test.describe(
       await test.step('Setup: submit application', async () => {
         await tiDashboard.clickOnViewApplications()
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -249,7 +244,6 @@ test.describe(
       await test.step('Setup: submit application', async () => {
         await tiDashboard.clickOnViewApplications()
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )

--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -189,6 +189,11 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
       // Click "Continue" on the program card
       await applicantQuestions.clickApplyProgramButton(programName)
 
+      // All questions have been answered
+      await applicantQuestions.expectReviewPage(/* northStarEnabled */ true)
+
+      // Edit the block (there is only one block)
+      await applicantQuestions.clickEdit()
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage(

--- a/browser-test/src/applicant/northstar_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_upsell.test.ts
@@ -53,7 +53,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
     })
 
@@ -92,7 +91,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
     })
 
@@ -121,7 +119,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
     })
 
@@ -151,7 +148,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
     })
 
@@ -159,7 +155,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await test.step('Apply to related program', async () => {
       await applicantQuestions.clickApplyProgramButton(relatedProgramName)
-      await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
     })
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -846,6 +846,12 @@ export class AdminPrograms {
 
     if (editBlockScreenDetails) {
       await clickAndWaitForModal(this.page, 'block-description-modal')
+
+      // Only update the block name if a name was provided. Otherwise, keep the default (which should be something like "Block 1")
+      if (block.name !== undefined) {
+        await this.page.fill('#block-name-input', block.name)
+      }
+
       await this.page.fill(
         'textarea',
         block.description || 'screen description',

--- a/server/app/controllers/applicant/ApplicantRoutes.java
+++ b/server/app/controllers/applicant/ApplicantRoutes.java
@@ -63,6 +63,10 @@ public final class ApplicantRoutes {
     return controllers.applicant.routes.ApplicantProgramsController.show(String.valueOf(programId));
   }
 
+  public Call edit(long programId) {
+    return routes.ApplicantProgramsController.edit(programId);
+  }
+
   /**
    * Returns the route corresponding to the applicant edit action.
    *

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -385,6 +385,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     // Move up button is invisible for the first block
     String moveUpInvisible =
         blockDefinition.id() == blockDefinitions.get(0).id() ? "invisible" : "";
+    String moveUpTestId = "move-block-up-" + blockDefinition.id();
     DivTag moveUp =
         div()
             .withClass(moveUpInvisible)
@@ -394,7 +395,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
                     .withMethod(HttpVerbs.POST)
                     .with(makeCsrfTokenInputTag(request))
                     .with(input().isHidden().withName("direction").withValue(Direction.UP.name()))
-                    .with(submitButton("^").withClasses(AdminStyles.MOVE_BLOCK_BUTTON)));
+                    .with(
+                        submitButton("^")
+                            .withClasses(AdminStyles.MOVE_BLOCK_BUTTON)
+                            .attr("data-test-id", moveUpTestId)));
 
     String moveDownFormAction =
         routes.AdminProgramBlocksController.move(programId, blockDefinition.id()).url();
@@ -403,6 +407,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
         blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id()
             ? "invisible"
             : "";
+    String moveDownTestId = "move-block-down-" + blockDefinition.id();
     DivTag moveDown =
         div()
             .withClasses("transform", "rotate-180", moveDownInvisible)
@@ -412,7 +417,10 @@ public final class ProgramBlocksView extends ProgramBaseView {
                     .withMethod(HttpVerbs.POST)
                     .with(makeCsrfTokenInputTag(request))
                     .with(input().isHidden().withName("direction").withValue(Direction.DOWN.name()))
-                    .with(submitButton("^").withClasses(AdminStyles.MOVE_BLOCK_BUTTON)));
+                    .with(
+                        submitButton("^")
+                            .withClasses(AdminStyles.MOVE_BLOCK_BUTTON)
+                            .attr("data-test-id", moveDownTestId)));
     return div().withClasses("flex", "flex-col", "self-center").with(moveUp, moveDown);
   }
 


### PR DESCRIPTION
### Description

Fix navigation when applying to a program with admin-specified block order. (See #8876 and #8944 for details)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

To manually test, follow the instructions in #8876 and #8944

### Issue(s) this completes

Fixes #8876 and #8944
