### PR TITLE
Update liberica openjdk to 17.0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:17.0.13_11-jdk-alpine AS amd64
-FROM bellsoft/liberica-openjdk-alpine:17.0.12-10 AS arm64
+FROM bellsoft/liberica-openjdk-alpine:17.0.13-12 AS arm64
 
 FROM ${TARGETARCH}
 

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -4,7 +4,7 @@
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM eclipse-temurin:17.0.13_11-jdk-alpine AS amd64
-FROM bellsoft/liberica-openjdk-alpine:17.0.12-10 AS arm64
+FROM bellsoft/liberica-openjdk-alpine:17.0.13-12 AS arm64
 
 FROM ${TARGETARCH}
 


### PR DESCRIPTION
Renovate still seems to have issues updating the `bellsoft/liberica-openjdk-alpine` version.