### PR TITLE
[Program Migration] Reset program type to default on export

### DIFF
--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -19,6 +19,7 @@ import models.ProgramNotificationPreference;
 import repository.QuestionRepository;
 import services.ErrorAnd;
 import services.program.ProgramDefinition;
+import services.program.ProgramType;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -146,6 +147,9 @@ public final class ProgramMigrationService {
         .setAcls(new ProgramAcls())
         // Don't export environment specific notification preferences
         .setNotificationPreferences(ImmutableList.of())
+        // Explicitly set program type to DEFAULT so we don't import program as a
+        // pre-screener/common intake
+        .setProgramType(ProgramType.DEFAULT)
         .build();
   }
 

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -239,6 +239,19 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void prepForExport_clearsPreScreenerSetting() {
+    ProgramDefinition program =
+        ProgramBuilder.newActiveProgram()
+            .withProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .build()
+            .getProgramDefinition();
+
+    ProgramDefinition output = service.prepForExport(program);
+
+    assertThat(output.programType()).isEqualTo(ProgramType.DEFAULT);
+  }
+
+  @Test
   public void prepForImport_setNotificationPreferencesToDefaults() {
     ProgramDefinition program = ProgramBuilder.newActiveProgram().build().getProgramDefinition();
 


### PR DESCRIPTION
### Description

This is a bug fix for program migration to prevent importing pre-screener/common intake programs. All programs should be imported with the "default" type and set to "pre-screener" explicitly in the import environment. 

Corresponding docs update: https://github.com/civiform/docs/pull/528

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Instructions for manual testing

1. Turn on the program migration flag
2. Add a program and mark it as a pre-screener
3. Export the program -- should see "programType: DEFAULT" in the export json
4. Import the program -- program should not be imported as a pre-screener

### Issue(s) this completes

Fixes #8652 