### PR TITLE
Working applicant and admin OIDC for dev env with Keycloak

### DIFF
--- a/bin/lib/docker.sh
+++ b/bin/lib/docker.sh
@@ -19,6 +19,15 @@ function docker::compose_dev() {
 }
 
 #######################################
+# Runs docker compose with the local development and the keycloak oidc server settings.
+# Arguments:
+#   @: arguments for compose
+#######################################
+function docker::compose_dev_keycloak() {
+  docker compose -f docker-compose.yml -f docker-compose.keycloak.yml -f docker-compose.dev.yml "$@"
+}
+
+#######################################
 # Runs docker compose with the prod image in a dev-like way.
 # Arguments:
 #   @: arguments for compose

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -11,6 +11,7 @@
 source bin/lib.sh
 docker::set_project_name_dev
 truth::declare_var_false runprod
+truth::declare_var_false is_keycloak
 
 # Default to using Localstack emulator.
 emulators::set_localstack_emulator_vars
@@ -41,6 +42,9 @@ function set_args() {
       "--prod")
         truth::enable runprod
         ;;
+      "--keycloak")
+        truth::enable is_keycloak
+        ;;
     esac
 
     shift
@@ -64,6 +68,8 @@ fi
 # Start the civiform container and dependencies.
 if truth::is_enabled runprod; then
   docker::compose_dev_with_prod up --wait -d
+elif truth::is_enabled is_keycloak; then
+  docker::compose_dev_keycloak up --wait -d
 else
   docker::compose_dev up --wait -d
 fi
@@ -85,6 +91,9 @@ if truth::is_enabled runprod; then
   # tailing the log. But one of these days we should fix this up
   # to trap the Ctrl+C and stop the containers.
   docker::compose_dev_with_prod stop civiform
+elif truth::is_enabled is_keycloak; then
+  docker::dev_and_test_server_sbt_command "8457" runDevServer
+  docker::compose_dev_keycloak stop civiform
 else
   docker::dev_and_test_server_sbt_command "8457" runDevServer
   docker::compose_dev stop civiform

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -1,0 +1,49 @@
+# Use postgres/example user/password credentials
+services:
+  # The dev oidc server needs to be visible to the Civiform server and web browsers
+  # on the same host:port. Developers need to add a localhost IP alias for this
+  # container name in their /etc/hosts file for the web brower to load the auth url.
+  # EG: 127.0.0.1 dev-oidc
+  dev-oidc:
+    image: quay.io/keycloak/keycloak:26.1
+    ports:
+      - 3390:3390
+    environment:
+      KC_HOSTNAME: dev-oidc
+      KC_HOSTNAME_PORT: 3390
+      KC_HTTP_PORT: 3390
+      KC_HOSTNAME_STRICT_BACKCHANNEL: false
+      KC_HTTP_ENABLED: true
+      KC_HOSTNAME_STRICT_HTTPS: false
+      KC_HEALTH_ENABLED: true
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: password
+      KC_DB: postgres
+      KC_DB_USERNAME: postgres
+      KC_DB_PASSWORD: example
+      KC_DB_SCHEMA: public
+      KC_DB_URL: jdbc:postgresql://db:5432/keycloak
+      KC_DB_URL_DATABASE: keycloak
+    depends_on:
+      - db
+    command: start --import-realm
+    volumes:
+      - ./test-support/keycloak/auth/import:/opt/keycloak/data/import
+
+  civiform:
+    image: civiform-dev
+    links:
+      - 'db:database'
+      - 'mock-web-services'
+      - 'dev-oidc'
+    depends_on:
+      - dev-oidc
+    expose:
+      - '9000'
+      - '8457'
+    environment:
+      - CIVIFORM_ADMIN_IDP=keycloak-admin
+      - ADMIN_OIDC_ADMIN_GROUP_NAME=/civiform_global_admin_group
+      - CIVIFORM_APPLICANT_IDP=keycloak-applicant
+      - APPLICANT_REGISTER_URI=http://dev-oidc:3390/realms/master/protocol/openid-connect/auth?client_id=applicant-client
+    entrypoint: /bin/bash

--- a/init_postgres.sql
+++ b/init_postgres.sql
@@ -3,6 +3,8 @@
 -- by tests while the default database used by the developer.
 CREATE DATABASE unittests;
 CREATE DATABASE browsertests;
+CREATE DATABASE keycloak;
 GRANT ALL PRIVILEGES ON DATABASE unittests TO postgres;
 GRANT ALL PRIVILEGES ON DATABASE browsertests TO postgres;
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO postgres;
 

--- a/server/app/auth/AuthIdentityProviderName.java
+++ b/server/app/auth/AuthIdentityProviderName.java
@@ -13,6 +13,8 @@ public enum AuthIdentityProviderName {
   GENERIC_OIDC_APPLICANT("generic-oidc"),
   LOGIN_GOV_APPLICANT("login-gov"),
   AUTH0_APPLICANT("auth0"),
+  KEYCLOAK_ADMIN("keycloak-admin"),
+  KEYCLOAK_APPLICANT("keycloak-applicant"),
   DISABLED_APPLICANT("disabled");
 
   public static final String AUTH_APPLICANT_CONFIG_PATH = "civiform_applicant_idp";

--- a/server/app/auth/oidc/admin/KeycloakAdminClientProvider.java
+++ b/server/app/auth/oidc/admin/KeycloakAdminClientProvider.java
@@ -1,0 +1,79 @@
+package auth.oidc.admin;
+
+import auth.oidc.OidcClientProviderParams;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import java.util.Optional;
+import org.pac4j.oidc.config.KeycloakOidcConfiguration;
+import org.pac4j.oidc.config.OidcConfiguration;
+import play.Environment;
+
+/**
+ * WARNING! This is EXPERIMENTAL only and not production ready
+ *
+ * <p>Customize the OIDC provider to handle Keycloak specific settings for the admin provider
+ */
+public class KeycloakAdminClientProvider extends GenericOidcClientProvider {
+  @Inject
+  public KeycloakAdminClientProvider(OidcClientProviderParams params, Environment env) {
+    super(params);
+
+    if (env.isProd()) {
+      throw new UnsupportedOperationException(
+          "Keycloak use is experimental and cannot be used in production environments at this"
+              + " time.");
+    }
+  }
+
+  @Override
+  @VisibleForTesting
+  public String attributePrefix() {
+    return "keycloak.admin.";
+  }
+
+  @Override
+  protected String getResponseMode() {
+    return "form_post";
+  }
+
+  @Override
+  protected String getResponseType() {
+    return "id_token token";
+  }
+
+  protected String getRealm() {
+    return getConfigurationValueOrThrow("realm");
+  }
+
+  protected String getBaseUri() {
+    return getConfigurationValueOrThrow("base_uri");
+  }
+
+  @Override
+  protected Optional<String> getProviderName() {
+    return Optional.of("keycloak-admin");
+  }
+
+  @Override
+  public OidcConfiguration getConfig() {
+    KeycloakOidcConfiguration config = new KeycloakOidcConfiguration();
+
+    config.setClientId(getClientID());
+    config.setSecret(
+        getClientSecret().orElseThrow(() -> new RuntimeException("client_secret must be set")));
+    config.setDiscoveryURI(getDiscoveryURI());
+    config.setResponseType(getResponseType());
+    config.setResponseMode(getResponseMode());
+    config.setRealm(getRealm());
+    config.setBaseUri(getBaseUri());
+    config.setAllowUnsignedIdTokens(true);
+    config.setUseNonce(true);
+    config.setDisablePkce(true);
+    config.setClientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+    config.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
+
+    return config;
+  }
+}

--- a/server/app/auth/oidc/applicant/KeycloakApplicantClientProvider.java
+++ b/server/app/auth/oidc/applicant/KeycloakApplicantClientProvider.java
@@ -1,0 +1,94 @@
+package auth.oidc.applicant;
+
+import auth.oidc.OidcClientProviderParams;
+import auth.oidc.StandardClaimsAttributeNames;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import java.util.Optional;
+import org.pac4j.core.profile.creator.ProfileCreator;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.KeycloakOidcConfiguration;
+import org.pac4j.oidc.config.OidcConfiguration;
+import play.Environment;
+
+/**
+ * WARNING! This is EXPERIMENTAL only and not production ready
+ *
+ * <p>Customize the OIDC provider to handle Keycloak specific settings for the applicant provider
+ */
+public class KeycloakApplicantClientProvider extends GenericOidcClientProvider {
+  private static final StandardClaimsAttributeNames standardClaimsAttributeNames =
+      StandardClaimsAttributeNames.builder()
+          .setEmail("email")
+          .setNames(ImmutableList.of("given_name", "family_name"))
+          .build();
+
+  @Inject
+  public KeycloakApplicantClientProvider(OidcClientProviderParams params, Environment env) {
+    super(params);
+
+    if (env.isProd()) {
+      throw new UnsupportedOperationException(
+          "Keycloak use is experimental and cannot be used in production environments at this"
+              + " time.");
+    }
+  }
+
+  @Override
+  @VisibleForTesting
+  public String attributePrefix() {
+    return "keycloak.applicant.";
+  }
+
+  @Override
+  protected String getResponseMode() {
+    return "form_post";
+  }
+
+  @Override
+  protected String getResponseType() {
+    return "id_token token";
+  }
+
+  protected String getRealm() {
+    return getConfigurationValueOrThrow("realm");
+  }
+
+  protected String getBaseUri() {
+    return getConfigurationValueOrThrow("base_uri");
+  }
+
+  @Override
+  protected Optional<String> getProviderName() {
+    return Optional.of("keycloak-applicant");
+  }
+
+  @Override
+  public ProfileCreator getProfileCreator(OidcConfiguration config, OidcClient client) {
+    return new GenericApplicantProfileCreator(config, client, params, standardClaimsAttributeNames);
+  }
+
+  @Override
+  public OidcConfiguration getConfig() {
+    KeycloakOidcConfiguration config = new KeycloakOidcConfiguration();
+
+    config.setClientId(getClientID());
+    config.setSecret(
+        getClientSecret().orElseThrow(() -> new RuntimeException("client_secret must be set")));
+    config.setDiscoveryURI(getDiscoveryURI());
+    config.setResponseType(getResponseType());
+    config.setResponseMode(getResponseMode());
+    config.setRealm(getRealm());
+    config.setBaseUri(getBaseUri());
+    config.setAllowUnsignedIdTokens(true);
+    config.setUseNonce(true);
+    config.setDisablePkce(true);
+    config.setClientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+    config.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
+
+    return config;
+  }
+}

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -17,9 +17,11 @@ import auth.ProfileFactory;
 import auth.ProfileUtils;
 import auth.Role;
 import auth.oidc.admin.AdfsClientProvider;
+import auth.oidc.admin.KeycloakAdminClientProvider;
 import auth.oidc.applicant.Auth0ClientProvider;
 import auth.oidc.applicant.GenericOidcClientProvider;
 import auth.oidc.applicant.IdcsClientProvider;
+import auth.oidc.applicant.KeycloakApplicantClientProvider;
 import auth.oidc.applicant.LoginGovClientProvider;
 import auth.saml.LoginRadiusClientProvider;
 import com.google.common.collect.ImmutableMap;
@@ -111,6 +113,12 @@ public class SecurityModule extends AbstractModule {
             .toProvider(auth.oidc.admin.GenericOidcClientProvider.class);
         logger.info("Using Generic OIDC for admin auth provider");
         break;
+      case KEYCLOAK_ADMIN:
+        bind(IndirectClient.class)
+            .annotatedWith(AdminAuthClient.class)
+            .toProvider(KeycloakAdminClientProvider.class);
+        logger.info("Using Keycloak for admin auth provider");
+        break;
       default:
         throw new ConfigurationException("Unable to create admin identity provider: " + idpName);
     }
@@ -156,6 +164,12 @@ public class SecurityModule extends AbstractModule {
             .annotatedWith(ApplicantAuthClient.class)
             .toProvider(Auth0ClientProvider.class);
         logger.info("Using Auth0 for applicant auth provider");
+        break;
+      case KEYCLOAK_APPLICANT:
+        bind(IndirectClient.class)
+            .annotatedWith(ApplicantAuthClient.class)
+            .toProvider(KeycloakApplicantClientProvider.class);
+        logger.info("Using Keycloak for applicant auth provider");
         break;
       default:
         logger.info("No provider specified for for applicants");

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -28,6 +28,22 @@ play.filters {
   }
 }
 
+## Keycloak
+### Keycloak OIDC for applicants
+keycloak.applicant.client_id = "applicant-client"
+keycloak.applicant.client_secret = "9ahHVoq5qu6Fussz1lf2AgLIzwrfLNqc" # gitleaks:allow
+keycloak.applicant.discovery_uri = "http://dev-oidc:3390/realms/applicant-realm/.well-known/openid-configuration"
+keycloak.applicant.realm = "applicant-realm"
+keycloak.applicant.base_uri = "http://dev-oidc:3390"
+### Keycloak OIDC for admins
+keycloak.admin.client_id = "admin-client"
+keycloak.admin.client_secret = "6YgUE89gbd1KeCPAuCjnU1v4AmiI4IcP" # gitleaks:allow
+keycloak.admin.discovery_uri = "http://dev-oidc:3390/realms/admin-realm/.well-known/openid-configuration"
+keycloak.admin.realm = "admin-realm"
+keycloak.admin.base_uri = "http://dev-oidc:3390"
+
+
+
 # Terms of service https://www.esri.com/content/dam/esrisites/en-us/media/legal/ma-translations/english.pdf
 # See sections 2.3.a.6, 2.5.b and 3.2.d
 # Esri Mock Service

--- a/server/conf/helper/auth.conf
+++ b/server/conf/helper/auth.conf
@@ -138,3 +138,33 @@ admin_generic_oidc_admin_group_name = "CIVIFORM_GLOBAL_ADMIN"
 admin_generic_oidc_admin_group_name = ${?ADMIN_OIDC_ADMIN_GROUP_NAME}
 # Additional Scopes should be space separated values.
 admin_generic_oidc_additional_scopes = ${?ADMIN_OIDC_ADDITIONAL_SCOPES}
+
+## Keycloak
+# Below configuration is for keycloak configured for local dev server. Not exposing
+# the settings right now as it is more experimental. Leaving the environment variables
+# options commented out so it's clear what they should be when we are ready.
+
+### Keycloak OIDC for applicants
+keycloak.applicant.client_id = ""
+# keycloak.applicant.client_id = ${?APPLICANT_OIDC_CLIENT_ID}
+keycloak.applicant.client_secret = ""
+# keycloak.applicant.client_secret = ${?APPLICANT_OIDC_CLIENT_SECRET}
+keycloak.applicant.discovery_uri = ""
+# keycloak.applicant.discovery_uri = ${?APPLICANT_OIDC_DISCOVERY_URI}
+keycloak.applicant.realm = ""
+# keycloak.applicant.realm = ${?KEYCLOAK_APPLICANT_REALM}
+keycloak.applicant.base_uri = ""
+# keycloak.applicant.base_uri = ${?KEYCLOAK_APPLICANT_BASE_URI}
+
+### Keycloak OIDC for admins
+keycloak.admin.client_id = ""
+# keycloak.admin.client_id = ${?ADMIN_OIDC_CLIENT_ID}
+keycloak.admin.client_secret = "" # gitleaks:allow
+# keycloak.admin.client_secret = ${?ADMIN_OIDC_CLIENT_SECRET}
+keycloak.admin.discovery_uri = ""
+# keycloak.admin.discovery_uri = ${?ADMIN_OIDC_DISCOVERY_URI}
+keycloak.admin.realm = ""
+# keycloak.admin.realm = ${?KEYCLOAK_ADMIN_REALM}
+keycloak.admin.base_uri = ""
+# keycloak.admin.base_uri = ${?KEYCLOAK_ADMIN_BASE_URI}
+

--- a/test-support/keycloak/auth/import/README.md
+++ b/test-support/keycloak/auth/import/README.md
@@ -1,0 +1,7 @@
+# Keycloak Realm Configuration Files
+
+> [!WARN] These Keycloak realms config files are for local development purposes only.
+>
+> Do NOT import these into Keycloak servers.
+
+These configurations are only configured to redirect to http://localhost:9000

--- a/test-support/keycloak/auth/import/admin.realm.json
+++ b/test-support/keycloak/auth/import/admin.realm.json
@@ -1,0 +1,2321 @@
+{
+  "id": "e3fd8cbc-af70-4113-bd00-d054192474c5",
+  "realm": "admin-realm",
+  "displayName": "Admin Realm",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "034f1913-4b3a-4219-82f3-4527b466ad01",
+        "name": "civiform_global_admin_role",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "e3fd8cbc-af70-4113-bd00-d054192474c5",
+        "attributes": {}
+      },
+      {
+        "id": "bd72f01e-cf18-49bf-a52f-40326a803d26",
+        "name": "default-roles-admin-realm",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": ["offline_access", "uma_authorization"],
+          "client": {
+            "account": ["view-profile", "manage-account"]
+          }
+        },
+        "clientRole": false,
+        "containerId": "e3fd8cbc-af70-4113-bd00-d054192474c5",
+        "attributes": {}
+      },
+      {
+        "id": "acb09692-fa08-43eb-945b-ae09cf6246a5",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "e3fd8cbc-af70-4113-bd00-d054192474c5",
+        "attributes": {}
+      },
+      {
+        "id": "843ae035-4bd0-4bda-a3a8-af7286e94901",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "e3fd8cbc-af70-4113-bd00-d054192474c5",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "admin-client": [],
+      "realm-management": [
+        {
+          "id": "d1ea28fe-89c5-4fd7-8819-55b4e0982513",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": ["query-users", "query-groups"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "6d1747ff-7f7b-41e2-bdbf-faa2ab41c835",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "ffedbd05-6af1-4260-bbf7-d006e9adddaf",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "a1bb572b-884f-4230-aa85-f351a265513c",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "view-users",
+                "manage-realm",
+                "manage-authorization",
+                "impersonation",
+                "query-clients",
+                "query-users",
+                "manage-events",
+                "create-client",
+                "view-realm",
+                "view-authorization",
+                "manage-clients",
+                "query-realms",
+                "manage-identity-providers",
+                "manage-users",
+                "view-clients",
+                "view-events",
+                "view-identity-providers",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "ea9ca658-d786-44fa-9423-5484b7319a5b",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "4ceb5e1b-b89c-4fda-b037-9b36e2538efb",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "3d4e1da4-63ae-4d7c-852b-d996c7c72e0a",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "af9d9c6d-952f-4e68-9cba-f69826036c23",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "2743427d-678e-4b34-bda2-458b0cd07715",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "bedeae3e-56be-4cf1-998c-295e7c2b0001",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "fde72429-5c95-4294-9639-02f88c4ec005",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "1351c893-f723-4bd5-a13b-f2b3e452e184",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "e125adc5-ff21-4625-873f-4c66f3fc1c5a",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "db2e8cd2-345c-4394-9169-08d8158d43f7",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "04938fc8-09d9-47e7-91c4-52e099801d69",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "52a4cdb1-c851-4569-8396-937eed24635e",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": ["query-clients"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "adf421d0-02f4-4665-9397-42577a57e708",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "e285ac3c-8aa7-49d4-998e-6ab6d28f36d6",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        },
+        {
+          "id": "f7525bc8-90c8-4293-911e-7d067353712f",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "3188634a-98d3-47dc-a389-d622a1b3c24a",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "618b86bf-4b6d-4b5a-b97d-68aa54ec4cd4",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "5aefe61c-403a-4bc0-b709-7b03e068de87",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "0f3b5fe8-5492-42e5-935b-e06e21de24a8",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "1b8ecfd2-0af7-44ed-964f-e18d9cf889d5",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "52e196da-b16c-4b94-984b-d2dc5128bdbe",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": ["manage-account-links"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "13850901-6d65-43ad-a6e0-d98daec6fdfc",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "1e2c3b30-5a77-452e-994c-0f7839754a11",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": ["view-consent"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "67fc6e89-1f93-4dfa-bdd6-db3e8fc355b2",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        },
+        {
+          "id": "1a3921b7-76c7-408f-adfa-d29bf9308772",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [
+    {
+      "id": "7305edfe-6234-42e3-8fdc-9042f9590afb",
+      "name": "civiform_global_admin_group",
+      "path": "/civiform_global_admin_group",
+      "subGroups": [],
+      "attributes": {},
+      "realmRoles": ["civiform_global_admin_role"],
+      "clientRoles": {}
+    }
+  ],
+  "defaultRole": {
+    "id": "bd72f01e-cf18-49bf-a52f-40326a803d26",
+    "name": "default-roles-admin-realm",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "e3fd8cbc-af70-4113-bd00-d054192474c5"
+  },
+  "requiredCredentials": ["password"],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": ["ES256"],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256"],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "75d08aaa-c477-4b67-bafb-4310630a8798",
+      "username": "civiformadmin1",
+      "firstName": "civiformadmin1Fn",
+      "lastName": "civiformadmin1Ln",
+      "email": "civiformadmin1@localhost.localdomain",
+      "emailVerified": true,
+      "createdTimestamp": 1729884108218,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "3690c6b6-b185-433c-b96b-a18e04762eb8",
+          "type": "password",
+          "createdDate": 1729884108233,
+          "secretData": "{\"value\":\"GEqm5INdY5EfbdEulg+hw/nKZf50P/YsrnO6sZedwpE=\",\"salt\":\"pK2Q2Wv2PBpA2k9mL80UJA==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["default-roles-admin-realm"],
+      "notBefore": 0,
+      "groups": ["/civiform_global_admin_group"]
+    },
+    {
+      "id": "ebc0b05d-d154-40b1-87bd-1c5f6be3b233",
+      "username": "programadmin1",
+      "firstName": "programadmin1Fn",
+      "lastName": "programadmin1Ln",
+      "email": "programadmin1@localhost.localdomain",
+      "emailVerified": true,
+      "createdTimestamp": 1729884200808,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "51ab0507-b84d-4edd-8008-3a9e2f9c46ad",
+          "type": "password",
+          "createdDate": 1729884200825,
+          "secretData": "{\"value\":\"ldrGPdjgLtplofF9feigK/xb7uGxujKcMItmVJRUH8E=\",\"salt\":\"d/Hpu9zLVw9Lm4x1VYeNNA==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["default-roles-admin-realm"],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": ["offline_access"]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": ["manage-account", "view-groups"]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "cfaaadd8-5521-4b60-988a-4dfbc5058bba",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/admin-realm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/realms/admin-realm/account/*"],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "39a2c74b-0533-447d-ad2f-f144f6232c3f",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/admin-realm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/realms/admin-realm/account/*"],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "3dc242f5-a3df-43ea-8c72-be81bc243d3b",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "691c2792-4a5e-4de0-b583-235830129096",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "dd8a4f58-06a0-4fb3-8cab-a86a05f43ac1",
+      "clientId": "admin-client",
+      "name": "Civiform Admin Client",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": ["http://localhost:9000/*"],
+      "webOrigins": ["http://localhost:9000/*"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1729824462",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "http://localhost:9000/*",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "3f40e068-e456-4aae-9767-b5271ed3027b",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "lightweight.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "618b86bf-4b6d-4b5a-b97d-68aa54ec4cd4",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "7c23edcd-09dd-487a-8c25-fd1b677d50ca",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "9fbafe32-ba8d-4868-b4e3-8f0c08b33d8b",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/admin-realm/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/admin/admin-realm/console/*"],
+      "webOrigins": ["+"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "8a578800-84dd-45a0-8a1f-8d8eb3104043",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "4a8aafc5-c748-4c13-8530-eaa83ec048e5",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "71fcc92e-b815-4030-8c2f-a2d762cbacd1",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "47d3a2c3-c09c-4cb0-bd05-a6639ef7debd",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "66f62ad1-f218-4cb2-850b-448bf4cfa28f",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "2a252712-9c39-45a9-b961-6080ade4638f",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "00fd7cff-5cf7-4a09-8b67-41cdc08969a7",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "5b488434-7b14-4b77-aadf-744d8cc800b6",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "94915fb2-3c3a-4be3-9246-de1045637ba4",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e592cfd1-c1db-4f41-be2d-8c156b6e7a85",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "0aa8086b-3764-4063-a89d-0195229c0d1c",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "d87a52f0-3b97-4af7-9db3-1987ded93671",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "fffee662-9f4c-434b-a26e-9bd93f8c476d",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "98d94b00-678d-44f6-97ba-4240dc9c4cfb",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "dfa0c304-7af0-444b-a27d-080d6235c7c4",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "b446abc4-7aad-4309-9e10-1875d0536bba",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "id": "ef1ee7e4-29d4-4b2a-ad67-eda8b66c00fd",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "21fcbd90-00e2-45db-aa92-721611d88850",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "7764b37e-7f77-44c6-a0bf-86903b404e59",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "0b03451a-684f-43cb-b922-70075d0ed710",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "2b8f0ad8-d615-4997-be53-d73e4a780345",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "c91dbfac-bf5b-4910-9824-95f9e916fc1a",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "f60b0a5b-9a5c-4eff-bda0-3aaceaad49f5",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6b097d7b-6328-422d-b74b-784df77c0361",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "b85eba49-1f50-439a-83bf-f71a920f4044",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "28695171-a9a7-4fac-83d7-28550abecec4",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1902d258-53c8-45a9-9b64-42e9add0b08a",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "ee41ef03-8ad6-46dc-8655-6f2f78f73541",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "dd8f61d7-4ee0-4be9-8b62-812452976d27",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "6d886838-b3bd-41be-a722-1bf3d6e92a52",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6e19d288-5641-4c8d-ab17-a7b456293b48",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ea2aff8c-089a-4fae-9118-a39d7da36934",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5998bed7-984e-41fe-8fa8-9f2d4d087450",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "fe4f40ff-1107-45aa-9465-6297dfc3ada2",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "38b7168f-3176-4efd-bd16-85ce7ae794d1",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "24744704-fa40-4719-adb1-b92c3003fa5b",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "60be6b5a-9d9a-430e-b8ef-99c68b966c14",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6bebef62-2dd2-4615-b152-13a37866e761",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "749c1c77-9dd2-4dc1-ae0f-c85df63d03b6",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "71553693-37b2-4d67-9ecb-1266c692c5d9",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b2ecac7c-296f-4f67-bf37-1791f69bede6",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": ["jboss-logging"],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "ce04b9a0-1f4e-4494-bbe0-cd9b3e35b459",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": ["true"]
+        }
+      },
+      {
+        "id": "a987f1d5-08df-4a9e-8971-a40e8dd8f707",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "9b7fde0d-df71-42e0-bb48-9274583f830f",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": ["200"]
+        }
+      },
+      {
+        "id": "60cd79c6-22f5-4165-8185-b71262ea4724",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "04e08dcc-1e8c-41e6-9e58-f567a05350a2",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "17172bd3-1c57-4214-94b3-5bad0c406a3f",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "aa2d9fd3-7596-4a7e-8a7d-b3ded4395f80",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": ["true"],
+          "client-uris-must-match": ["true"]
+        }
+      },
+      {
+        "id": "0ac71e2d-94c2-4715-b1f8-8af0072347ee",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": ["true"]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "2f13a722-4ee1-48da-a547-31f94d723d76",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEowIBAAKCAQEAyoFnk913DQrMWSNHlO4X+C3eEn/DhBFhUdC/28ITFyob9f1fcOdp6H4NIVRXK2iWkECCqgNaYit7U1FQRfOH0kFzBw9Qf3egSfqETNrSpxhtbcrJAVh8vCPPwqiQq+te5473pBqnxthGBSO/ld55bdiuFQbFF0g+jGqd4PA1IgUjF+nl4zW27IARCGCy+ZZeeZoiqFrYauggKGiZyjGT9Z4bSGfYkzKU1PxZWFopyp5cU/PWXVJsg2+Svw5P0uLhxnAg0WMmvtmf5NDrV5MEiv6+m2Yh4IiVd05Kg98XFhu7fhi2IarxE16eqamMiS8w0UmmcXcLqJwkJZGxzj1aCwIDAQABAoIBAAPFcizeSHvNMi4MyqX64yZjkEmu6HC6tCHGbfRFQn7BcYDcxZzAKohCZLM0s2TjDz7DfMt2wYWngqX0EzciSGrBfkdo4Rpmm20VRcZ6osaq3UrYpnKod7Y3QoTBB+SzvvI4BuOe/XXmDDPHTSeY25EQonlQxXXgCg4qZCNOxeaKwnQAxa+2CcFk9RWgXgOBtcW0pkSZhSi0tlTNxQiykMj+FgKJ1qHwx01BnrDrJVWgoiTTm1rmhvkbXnFwt9YCHCT6i68MfxRyJVrGOCRSKjC0hKMKQjo0XqAxnz6sxS3j3TfSPjz+t4ldDPDzVd2JinnFEbuwM6ttRBHRmhUDdjUCgYEA8fbAkg8ZdXjeKPJ52otltWWAt1zwgfnhvLt+ab6Gk1JlHpPNzUfbrryUwNq9pLkrv5CtnxnFCbS2o7wKBqggtBA1zKw8cod1/RMnc7717mvqFoXi5E2l4VCiUgj/p3eYcFaDTS4fXonGMEEzazxiRjQ9f1ZRG4oIg5Y+7vCs2QcCgYEA1kCueqLFoso28D+MGV/hUQBLWF1kuZsbWwg2rPVp4PQA4OMytNGZIQcd4Sk4oCxoRxaY7JdfRHhxgNP/t94bL3nig6I6tUb33caHnDBoiqo0yA8IRVecXj69tRaBFD1I2wEaRjARSA8wHx9ONheLKDb+n42vdX5XUyTxqu4FSd0CgYEAg8tErwn8cwkH8UPJ7ak6GCkWiEneUt26AGQcAhseEEaz/4jAc40tcqsTV0yOOZgG5Uw31c5ijdvaE6tLxr5zOcEOnNJABp4UPWnedmRQbrJnCieZI4PL08No9sgiAKTa6m2lDTgPLB5dTlFlYYa9fMHdsWthuF9iLdJ7qwh7DacCgYBMtUvCzJRF/HA/BAF89D8PaTOQp59wdIAOz5oDwrntuG64FaAJ7SEOGiYwfzmu3zdWfFi0HF4XfafloAFmKzdAgDsBNgwe6xHDbVkQKqTDQL01A2zKptttQrlZJH2CaY60Gmj1yC/nxMhN3D98TmGcPFRde7TeNCW/tvJvaFisYQKBgBIyfm44vbtmM8EUd/PitgQov063aFbGNQFNiBaTnXhWvV6gWI/jQIlqCvqq8V6ptpJUMnyjCNfVsp3rzC3Gk033mD2SkrC7CM2alWzkx1TXmlNaPVjqc6WTk93UAbz4lCKBAkpVH3+ufFjobOcUkOylVo8MbMuS/Y3yrD7YpZTS"
+          ],
+          "certificate": [
+            "MIICpTCCAY0CBgGSwc7QQzANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAthZG1pbi1yZWFsbTAeFw0yNDEwMjUwMzUxNDlaFw0zNDEwMjUwMzUzMjlaMBYxFDASBgNVBAMMC2FkbWluLXJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyoFnk913DQrMWSNHlO4X+C3eEn/DhBFhUdC/28ITFyob9f1fcOdp6H4NIVRXK2iWkECCqgNaYit7U1FQRfOH0kFzBw9Qf3egSfqETNrSpxhtbcrJAVh8vCPPwqiQq+te5473pBqnxthGBSO/ld55bdiuFQbFF0g+jGqd4PA1IgUjF+nl4zW27IARCGCy+ZZeeZoiqFrYauggKGiZyjGT9Z4bSGfYkzKU1PxZWFopyp5cU/PWXVJsg2+Svw5P0uLhxnAg0WMmvtmf5NDrV5MEiv6+m2Yh4IiVd05Kg98XFhu7fhi2IarxE16eqamMiS8w0UmmcXcLqJwkJZGxzj1aCwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA9Soc5TJcjcmrsNCHusRx8GkZiqhuvt1evYMe60rZqkmH3Zp2lcNrIUPEB4/2nYM079Idvp7WBA4j5j8ZtsWhHZPg8gJVXOA4d97DrkZ7DlDKAJr2vB7UmlP+ntQF15DhxQSZfTxw49EHS9Dva2maUorrreN60Um4/2TZMafAQqvbAOwQcZRiPC60qZ5ZNSTpucTArylbtVQn1Q4W15KcRA34A4YyxYbcpOL6FbVhS0Q+/g9vQzIxIkj1g9QigIC4wRhwT5nAnPgTM3Iyow0PnJjdQigdcDwXrMEWPpP0/D3jXt4cOkHzThsmgbik0y0gs2uA5gHOLJS4/mLWIJyI9"
+          ],
+          "priority": ["100"],
+          "algorithm": ["RSA-OAEP"]
+        }
+      },
+      {
+        "id": "e7878ced-23fd-45aa-9f8e-65c77e5d0f92",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "kid": ["3e87ca6d-5f07-4215-b835-71d5cce649f7"],
+          "secret": [
+            "8UfcMMOMpJe_DaQCMyXdPSiFzAfpfdwfGGBqbW711oSrmBYBwETqVMwJ1e6Fqe2rO1miL6BXGQ1c_rlO2HK_3TxkthgUVfiE48mXMUq2JJ4BBsTzsbDfyLWAqBMvX1dmmwgNmaTfF3I_CsB-EE0cGimvop3QTXknvWWJ8E2aVo8"
+          ],
+          "priority": ["100"],
+          "algorithm": ["HS512"]
+        }
+      },
+      {
+        "id": "d0e38a37-9c2b-49b8-ba59-4a730686cc00",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "kid": ["44971eec-4945-4aa9-b07f-d6c6f0799f1f"],
+          "secret": ["elWmKT2iGOk3YG7Y_UObjw"],
+          "priority": ["100"]
+        }
+      },
+      {
+        "id": "ee954ad1-d3a3-4a58-9c63-6dfd3de76ad6",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEpAIBAAKCAQEAqlofc63dCn/mQDnkcuajoJo6LTtUttJoe2bEgGcCCDGJpEIDUDDwUxD4efPEkuiDw8KTA1jOCZOm0dX1zpT40OTuZgPKiOFLHZaNysPN6zUCq1T/m/BRveF4XPtI3yjfYDeZYoFt7uYW1jAwR5CuJ93eQ127ZauUwSbu/ZwXS24iBFm9+/C3Tntbb9HoXcMhziRxj89EfDz2QHlscPUkOSs5HgoA5AiophDgL9/EfD57J5x+4ID8i57xLVRs1f/oWpnquMGPQnC5dyqyI5hdpNfxw32mWFZq8qLHZ22VNa3ehGdxqty2Oa6qJ7knXIPr6BBkjXFzFiJbEWazT8HgQwIDAQABAoIBAANwsXzpEHMzVQeMA8CMRtap9q3OKm5Mvn5re2FqcyCOO4zdJmr6qgfLanEwCpK67lpINibVpseLu002iHHFEWdKkEPwJKlx/03YKgHjxWdQGT8zhrvz9PqkMIWUL4sOLMCpLshN+9XcwK5Pp9HyKoo0kVYD8RJjDix+aEon2lKUHN0Y57QKYt1BaWX0CL3byE8a+9C4pS8rB6LMbwWoyEeWnXpsYblQLQdsuDpW8sO8FQSLDHdOt7B9AezAMpj61P3yYuL201e9m8UKVZL4yGV8sgYN0VslHDAF3VHpuvIFCVMed/iGNscuGFWLHyB+vGWxa+TTTsInQnjfkkdB56kCgYEA1Mtk4fAdjrRs670xv75xoVHPqfe8mleyKnYmtISKL96uu1+3z6IjmgbRXcWGLP6MRTTc4uPC47vcgKRSZYu3EBjgvmYZyiuFXe5DrXUI2zjxGh+7XN8vmOQEc8oSzVIr5xqcoPVcsMH+aDV+yyVKecrYgGOKVkbIQ6Pwu5SJ6PkCgYEAzPCo4aqDlP1smvRnWa09i+tl6cp32E+ih1m8RG4NJ4ovsB+kRgNXNZP7M0riUvuMu98zFUskOgqF6fUDUKlFRZXjLc1wrkCcukj0cHU8v5a6WieDWBWLJQLn9K9uJp6N/S+cYCLY16VcmQ7dGH5uj+ph2RcyueE9iW1CSyGaPhsCgYEAufO7hs1Dpw74F9FPBhYwSh6p8AezYtS7tutky17/OvHHk6oDgIhZwCGxF9aid/NBNMELPaJ3Dnd+K1RtRJuhL4nt67RhWRBLDVhG/+9D+/54grG0E2Zdu6eWVHEDmTTzdJMGyIlhpH0CCqKk2HUP7fpa02co3lggbSt4FROqqFECgYEAsPCrbsLwfkdbaGHRhWx8cfyYbgS/+kOvOJryYEaAFv5I9BAtncEun3SXco6Z3zmOJXqsuRq6OV5yhi9jYFX1GAI0NYxlWB0y8+cfHKUsAOJbHJF25isbiqX6rJh2SuOkBdAAfEQ54d3El+VsYMRwItMjDfLoefINVkS98u4dJLcCgYBiVDzgHgqv9hKQhm+WUu/z827KgF1tehQTTm4LL6HMs77qvIA3nzGArSjRh3GKWElecDv3oegqOwmxN9tPq/UX6ZPSET7iGpsdQXAMHOOmr5d6v34J8XD8g5gK0nxb3qoLPNS4ocLJEtocTIFBwusArvVH88gIEkFAUIpL5VQM4w=="
+          ],
+          "certificate": [
+            "MIICpTCCAY0CBgGSwc7RKjANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAthZG1pbi1yZWFsbTAeFw0yNDEwMjUwMzUxNDlaFw0zNDEwMjUwMzUzMjlaMBYxFDASBgNVBAMMC2FkbWluLXJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqlofc63dCn/mQDnkcuajoJo6LTtUttJoe2bEgGcCCDGJpEIDUDDwUxD4efPEkuiDw8KTA1jOCZOm0dX1zpT40OTuZgPKiOFLHZaNysPN6zUCq1T/m/BRveF4XPtI3yjfYDeZYoFt7uYW1jAwR5CuJ93eQ127ZauUwSbu/ZwXS24iBFm9+/C3Tntbb9HoXcMhziRxj89EfDz2QHlscPUkOSs5HgoA5AiophDgL9/EfD57J5x+4ID8i57xLVRs1f/oWpnquMGPQnC5dyqyI5hdpNfxw32mWFZq8qLHZ22VNa3ehGdxqty2Oa6qJ7knXIPr6BBkjXFzFiJbEWazT8HgQwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAW5GezFC3wFluMPKcLXYNwa+ttUMwunc/jl8pGcbowUi44b0y1mb4x76xwh6pEMiIUxz4k7H65JHAVZIvKqGya5C5nURjiU9DEDq66qmQhHSVOuMDQpDf4RjgwK8ojw8cI0wj4T7Rlf0WYAxGulIi0LrND0rq8ZgweUaMd/yjrKK/YVu4aWazSZsSiRIXAsp6fDKi775GAicfgXxHnVt8EwxkwO6amta0avPubHFGQUoWrOKM3xUBmEmz1LdEliPqm5NkDTVI7urloktddl/AhyuPApNFZcB2c2zYxnQpoKO1/stW9HCR3prz+muQfoRkdU18LpkIZeNVGozy1J4hZ"
+          ],
+          "priority": ["100"]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "c61d31e5-4a6e-44a2-a02a-43a705e9e2ac",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "55dc384b-383b-45b8-a0ad-f7ae56b3e217",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1790a8e0-958c-47b9-a85f-9fc327174772",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a54e5951-1009-4935-b1a4-6b0debb590a1",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b86e760e-ed36-4ebc-a33e-19ba495e646f",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5aa4dc7a-ec23-4b42-8bbc-033aeb6e4f70",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5dcb47a0-3740-452b-ba79-aefe0b1f0313",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8d73bd60-dc1d-4aa9-bc92-40ee0c5b2a07",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "13d3f5a5-d5e9-4e96-a171-441e9a6512ea",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "042a53c7-ad06-4933-9d2c-42dbfc962582",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ef588b2f-87ef-49f7-bf48-9f910bf3fb78",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "dd678ef7-a2cc-42de-8665-d48765e744d1",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "165bfbd8-d957-42f3-8ee5-e0a3eb401547",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c9f7b4da-5750-4393-961b-b0c7ffc29d3f",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a4d06ac9-ea2b-4b6b-9aa6-63ddd24f8aac",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0525dc5a-bd6f-41f4-9298-20a56eec5d51",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "127b01ba-68f9-4cf2-95cb-e8c9afa04d84",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "78f826b7-6eab-4839-8827-59a755c5ccf8",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "3a92c90b-e4e9-4493-8ffa-1e3abff0d593",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "4a2e6e2c-f97a-44d0-b0e0-e33538489d97",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "organizationsEnabled": "false",
+    "acr.loa.map": "{}"
+  },
+  "keycloakVersion": "25.0.6",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/test-support/keycloak/auth/import/applicant.realm.json
+++ b/test-support/keycloak/auth/import/applicant.realm.json
@@ -1,0 +1,2257 @@
+{
+  "id": "4d2114d6-7c03-4a09-b970-cf99cc5b6d57",
+  "realm": "applicant-realm",
+  "displayName": "Applicant Realm",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "18ec5fb0-8f65-44fe-94d4-ca0c69b33ccf",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "4d2114d6-7c03-4a09-b970-cf99cc5b6d57",
+        "attributes": {}
+      },
+      {
+        "id": "2c3e83f0-2412-4b39-b279-497d437aea9a",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "4d2114d6-7c03-4a09-b970-cf99cc5b6d57",
+        "attributes": {}
+      },
+      {
+        "id": "45b9a412-9067-4246-8f23-55a7d9e50aff",
+        "name": "default-roles-applicant-realm",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": ["offline_access", "uma_authorization"],
+          "client": {
+            "account": ["manage-account", "view-profile"]
+          }
+        },
+        "clientRole": false,
+        "containerId": "4d2114d6-7c03-4a09-b970-cf99cc5b6d57",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "e7533cbc-3410-40dd-bcac-4161fe8d93a2",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "17e0369e-d9c9-4589-830d-4d186c0f305a",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "ee4a5202-f638-4e68-ac70-25839a09acd7",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "fcc57d3a-6e0d-4706-b18f-9d9bab6ec805",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "0e4feed7-71b2-4cb6-a690-e2c949bffba5",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "c72a9bbe-82b4-411b-87ba-f4594da6e99f",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "93382680-231e-42af-9375-941359f471be",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "9f18efe5-95be-45cb-a074-824137113bf1",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "63f67e99-1253-4d5c-a433-a7833b02c4cd",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "9bb58842-0927-4adc-80e9-8ef834f1dcf7",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "bb8fa6d3-9011-4cf6-a11c-2a2050652f6c",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "756a9cbb-5ca7-4ac6-88e5-7db394266b95",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": ["query-clients"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "38a1e6ac-1ca5-4495-8a55-bcdae4a21073",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "28a211a7-9e04-4298-90af-cf26e87b7e33",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "e9cb2a57-bba7-447d-90d9-c3d47707dd5a",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-realms",
+                "query-clients",
+                "view-events",
+                "create-client",
+                "manage-identity-providers",
+                "manage-users",
+                "view-authorization",
+                "manage-realm",
+                "view-realm",
+                "manage-events",
+                "manage-authorization",
+                "view-clients",
+                "impersonation",
+                "query-users",
+                "view-identity-providers",
+                "view-users",
+                "query-groups",
+                "manage-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "6148bf3c-6892-46c9-bc24-ea0210dd2a8b",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "524797c9-a9d0-44a1-ae0f-f5b39be12bbf",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": ["query-users", "query-groups"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "c8e60197-59a1-470e-91ab-21a0b0bb14c6",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        },
+        {
+          "id": "a73ed5ce-505c-4ba2-a649-d52e5a9fe4ad",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5174189f-fd53-42a8-bee8-05f100d9f654",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "applicant-client": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "f0266c95-e9d3-41b8-8ccd-009cf9f3c4da",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "59002b1e-58a9-4b96-8ff0-4b08ed7657a1",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "bade7c59-33d9-4176-bf8c-3ba212d24077",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "fb9c271f-33ae-4c47-b074-c281dd90df70",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": ["manage-account-links"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "fc48462f-9c68-4f5b-9178-1b39249d88bd",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "9df4307c-24aa-41aa-beae-d9c8a140dbeb",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "b869fb80-da6f-42b0-8567-3cef38d88627",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "de69fefe-7008-4fa6-b5e7-8f489faf16c9",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": ["view-consent"]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "c0987f3a-2af5-41af-8e31-7949b4d23329",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        },
+        {
+          "id": "0727f8c6-6fdb-421c-80d8-5270b2380b68",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "45b9a412-9067-4246-8f23-55a7d9e50aff",
+    "name": "default-roles-applicant-realm",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "4d2114d6-7c03-4a09-b970-cf99cc5b6d57"
+  },
+  "requiredCredentials": ["password"],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": ["ES256"],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256"],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "23545263-1267-4f2a-8876-c6e6cf335b0f",
+      "username": "applicant1",
+      "firstName": "applicant1Fn",
+      "lastName": "applicant1Ln",
+      "email": "applicant1@localhost.localdomain",
+      "emailVerified": false,
+      "createdTimestamp": 1729884278340,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "a961decf-84ba-4844-80e0-43a7e27993c2",
+          "type": "password",
+          "createdDate": 1729884278355,
+          "secretData": "{\"value\":\"0cUwgVAlNvNLgHL0XiKvotpNhDyIs7fkgQk+Mr9xjHQ=\",\"salt\":\"ysMwD6ZxQ6DPDrBjhpcGlQ==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["default-roles-applicant-realm"],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": ["offline_access"]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": ["manage-account", "view-groups"]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "1f06a7d1-7d84-47f9-9319-f68db33542b6",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/applicant-realm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/realms/applicant-realm/account/*"],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "67af1493-9a63-4188-affb-211714760383",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/applicant-realm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/realms/applicant-realm/account/*"],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "9455faad-8ff3-4bcb-a607-35b9edd8d4ef",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "43a612b0-1238-43f4-902d-165983632d0d",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1274ab72-fdb3-4e9b-80bf-31960d285dd9",
+      "clientId": "applicant-client",
+      "name": "Civiform Applicant Client",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": ["http://localhost:9000/*"],
+      "webOrigins": ["http://localhost:9000/*"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1729823807",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "http://localhost:9000/*",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "59002b1e-58a9-4b96-8ff0-4b08ed7657a1",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "5174189f-fd53-42a8-bee8-05f100d9f654",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "a9b1d977-7394-456f-8e4f-936f801da109",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/applicant-realm/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": ["/admin/applicant-realm/console/*"],
+      "webOrigins": ["+"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "ce5e5dc7-938b-4b6a-b77f-f19b676c3e22",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "0982a763-7c4d-45e0-acb6-8d4d04958463",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "4909652e-739a-4770-9ec5-064836df79d9",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "37bf18fa-9105-40b3-9d93-c9d2ba384eac",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b25f0e1c-11ff-4197-85ce-cb483ab425a3",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "b32ef8eb-50a5-4ea8-aa65-d462207f46e2",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "46443298-5a3f-4e70-b914-1b6fb5e665fb",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "534c081a-7486-4e31-a765-4a03b6711bdc",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "45df7651-56ad-4302-8054-2dd0fc1c5823",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cff662c5-b04f-4111-b76c-3371beb71d53",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cd522b46-ae63-4c76-b030-5b81dfb06dfb",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "844c38a1-99b9-488e-addf-b49d501fed32",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "53fd1b85-4466-4b22-861c-343d309155e6",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f71d2062-5a0f-46cc-af28-0692159cbee1",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b05a9d94-a4b1-4d50-bb95-ec9198485878",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b83413f6-d7ad-4093-a27d-49b741db8d7d",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e30404f0-15f5-4c67-a1d0-ec33b53acdcd",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "1ff4ed85-1d6e-4a1e-88f2-4741a3ea45ad",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "34e1fa6f-033b-4ca6-8cd3-f2c3c609d94a",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "e6ef273c-7c0a-4333-9bfd-799731fb8c41",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c65dae81-784e-4b77-875b-b361d88880b4",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "239448e3-b96a-4706-8d0c-62b2f6b548ed",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c8a07be8-4a66-4157-90c2-096cd48c648e",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "4d7c3fb7-bcd8-4b6a-826b-40a7ef1c6799",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9b18d942-91f7-4db4-a539-d16a1f858a6d",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "69e3152d-cbd4-4381-905b-5ae3f9bceab7",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "5f5d1b81-811e-4f3c-8dd3-1f833daacacf",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "84de318d-342a-4bea-b749-456d4ed9f445",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "8dd174b5-8856-4444-95c4-2b2dd8ac4b48",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "2490c500-f4e8-4e61-bd30-937368cb5da5",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "905651df-0bee-4ae6-95fb-77ea253c7789",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "2298dd94-5a45-4d0a-bc45-e1998394242a",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "bbb7ddec-6215-47c4-935d-013d740815d0",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "59cc633d-cc80-4877-833f-fcd275f84425",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "32c7eaaf-6682-402e-85eb-31b1cff6e324",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "765cebaa-f7fd-4262-89b9-1d5f18954e6b",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "fb2484a3-3108-4abe-92ee-548c6ef646f3",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "6170f285-d95e-4c2a-ad6a-b0b95606e317",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1435a70b-8383-4420-940c-c37574bebdb8",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "00930449-d84d-4d25-9dc6-2e57c48b67b8",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "0116a8ac-68a3-45e9-a0cc-a1c1eeb5262c",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": ["jboss-logging"],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "7e530468-00bb-41db-bc25-e27a6f6fc98e",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": ["200"]
+        }
+      },
+      {
+        "id": "01cd6faa-b765-44a6-b073-2d3a85655573",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "79a85847-cd5a-4afc-add5-cb45a03bc435",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": ["true"]
+        }
+      },
+      {
+        "id": "37b73c2e-d925-4804-84e4-2b8c7f4c68a0",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "081a2d88-48d1-4b62-b1bb-0d70c90318a1",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "2c8d606b-6a93-457f-b46d-ee02b398ac5b",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": ["true"],
+          "client-uris-must-match": ["true"]
+        }
+      },
+      {
+        "id": "6eea37ca-05d0-4ac3-a76a-71c909b28206",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": ["true"]
+        }
+      },
+      {
+        "id": "f98f5d1f-0305-432f-8a72-c58f665fd76f",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "dbd7322a-164e-4709-8e4b-e85eac541cbe",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEowIBAAKCAQEAlezInUI+whNYF7CVYVzMDKOsWb7RUNJbPqnNoGJJ2T6HsJHFHtdfi0EeJQcDSzNEOp3pIB1Y12e5zxUuV0kjI2RK9fpjAxqopNsp9Sj6yOACXcXnf8bS/41v8Jgj+kcazqWhb8yuCoZuO3fOXxEmAmQQZ5RQhGivtFv6Ktp/GMHyS6DrGthmRPzt5U4q0X7s8BJOcQVSQBOEEMpMmFdOrHgNuANMBODIPSq2KKDXI7hixBGQbyYCnsq82NT2Zz7seV71U77f9vhoOCAz4A/Fa6WVrOO9bVI6arhkfPdk/QZ7jis8YEGjTFcR+68ZGOntGKKyynKB5qoW8IYHet1NOQIDAQABAoIBADzB458PXJ2L91RKZI87axnoLo2ELhGB3iZr7AAGNQVMOPMOcAMKpxapAg1hZS1RjmHu4q34FqvcxkksvUX0RsAuAc7jdMKqSBPfGYbX36IOXgcgj6uRqKqV5/ppvZLMxAlgyCalnRZ42i1RZRnTukKXyKohSewO/L2r1JsPRxiBydJSu+ZCzwKMgwNZrk+r+Z0bC9hLTjTR6iz4VKHWwKeC5jI2vVz9xvU7JN3txVGqsOjmNiTrkFui5BIsDuS4zA5ft1I+xN91VjFenxqi4Oww2GSqoI4zfx0kVLUOunylQWYt+ibDz7VsGEW36bIWFGCOYtuxR5gjmPmsHj5lRN0CgYEAyd9OGukKQES5K4ch4aWErMJPYs2sEaJTE3O364vDNJM4rI+h3ETtnDE0Xe3FqZriiEoOVpCrJ/+nDw825tpCqpLoErmcGQ1PuJWvZBnh3iOWJCVHt/hUdT6F1HQUcEtQPHEOU8t6hu2qBEXIvmqzGGvllBGqo5gWz9JHXhFlWFMCgYEAvh/EDwpTu0j+s1yEnsCY5RcYDUZNf2wUykQoVKvPSi9EZQMgdvPiDcfLfTQ/UuZ/Itvz1RBiJZJp4cUHLqDzV/PTfTrfoZQ6KPPpHEGnbO8dWMgc5rD0WZYnYgi37p45eGc7ia3Khy+hXU9+gprchO99k4aDMDbkAKyhRMlQIsMCgYEAn5YRp8JsoSvy+o8kYL65qN0fZutSyMn7RNhpICNn2Qs9dWVCvuAauyxGyq5qYU8ZIEbzGMnbFI7NIWGUtGD87N2f6xWiakeUq0Zh1g+D+FlHmyGBldUR53Ha2H4/nhpbvrxdaC7mmP4PNrt4G9g75uV9I1XoANX9yqLgWmQEKxMCgYAu/xsvvJXGDd0n6Q6/T0x8FKFVZrNxc/4PoZl2lKHA7L4zWfqEbPTMAz9By9B7ZY63xzcWy932+6JAtLt5wz9j1lnI8uykvEdEKEbPPUttmg3fDFhYjhVYr808ZntQ+LusD5igB92wXQ2+SxAyqKUqFykrdmynVmo14HZc0oaEkQKBgCGQ2XsX96EgSwGgsaDT2usEK9tNJtsf1kfHW9mVnI6zZBbG0UQydoYfSvektA0gWvPFiS4NeiDMDWVCt2i/7B28TnH1jFJvL5z8fA5heJXbVdG+51w8rJnuVTLdiZJoXgEXWe9yLxXbd1BFtyW/c3a+BFWb86cMzq6CnvWXcEM1"
+          ],
+          "certificate": [
+            "MIICrTCCAZUCBgGSwc7NjDANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA9hcHBsaWNhbnQtcmVhbG0wHhcNMjQxMDI1MDM1MTQ4WhcNMzQxMDI1MDM1MzI4WjAaMRgwFgYDVQQDDA9hcHBsaWNhbnQtcmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCV7MidQj7CE1gXsJVhXMwMo6xZvtFQ0ls+qc2gYknZPoewkcUe11+LQR4lBwNLM0Q6nekgHVjXZ7nPFS5XSSMjZEr1+mMDGqik2yn1KPrI4AJdxed/xtL/jW/wmCP6RxrOpaFvzK4Khm47d85fESYCZBBnlFCEaK+0W/oq2n8YwfJLoOsa2GZE/O3lTirRfuzwEk5xBVJAE4QQykyYV06seA24A0wE4Mg9KrYooNcjuGLEEZBvJgKeyrzY1PZnPux5XvVTvt/2+Gg4IDPgD8VrpZWs471tUjpquGR892T9BnuOKzxgQaNMVxH7rxkY6e0YorLKcoHmqhbwhgd63U05AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJV0qREIjjPBwj+75ifKxWMychSvzhf9F6AP5dGLkI4tU6CSPO4+sabSNK9Zm/vfPacMPTev0Dh/NVG1yqwuMcGUwou5PtB+xLOuuslj+aDGY6SlCD0/pWi8uqfeY11gJPdYF6QuoE7VpgBcXhUmnMNl7+8fxvIr5RgB+fB7VFahgwYstIf4TX4kWld2Dr7tIRyxvKGtLNKGyxOYt5t7s4WzAGOs82OT0JRV2jXfKFDaPA4zpum/OCF3x0XicTwZ/tHOwvzLLVAR1QElUmD5yIjtDl7QzMhPchoMTehwFmL54qae6YsLVFk+UJpxPq7Hdy4VFJgFTUMMImL4mZemVzk="
+          ],
+          "priority": ["100"],
+          "algorithm": ["RSA-OAEP"]
+        }
+      },
+      {
+        "id": "df354073-1501-48d4-8486-be2200716b7f",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "kid": ["244477cd-f0e0-4ec2-a1f0-df9310232ae8"],
+          "secret": [
+            "EDEJ5aklPM9lY1gITubBMzYArjYOclfNOoRWq-0QWaEmunl-EYuVQhdk-IuOmCtksVqAEPi6eUeofntur-ML4nt0lxeJIda-D5VmIQ-5PXFdpTGMth78xY0AqrFS7PtE-amBlyEkFuMnYYzkJ3jeixvjAAFprLkclHgrUG55KPE"
+          ],
+          "priority": ["100"],
+          "algorithm": ["HS512"]
+        }
+      },
+      {
+        "id": "63b801aa-af40-475c-93a9-7a764d89b2e8",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEpAIBAAKCAQEAt+RstnR0gu2HrrJj/J+SpgnMwoprGjCeB/xfeFq3CT7e7otGRkf/9E8RG5UFpvHbHw1eYihXfkPTLrP0Jf0ftcM+1ctTIGs2C5KbW4qlguz231+iBn2/GcCtdee9Wflmt66zdR2Q4YgbKxmiAnTwe9/U2dYHdr01g978U2Id5rw7MON9utpRiSUF8CXEXY3sF+MLUeDSdtLp5/r/aZfd3Se4nm1bkKjoOI2/Hm4tT/DgRh46ITiasgDmWFTPW8dqYO/CWFaIzehpIyOmuE7IzWzQCRD/1rNI2ys/TY2Hdz24y8/1VPRyVq5tz/FgrE2t83nkqnEyKF7c13yG2SDViwIDAQABAoIBAD9QIi3fgo3hgimfudUsi60nCpygU6e8vWw6dBRYB1TjlJXE1fk0qOdQoa9Ba6TC+JKEY86f3R/X8knOI21A7T4Dbwrk6kXrI7xwSZUG811UgNr/biWV/cm8EPzbQNJNkBQFzjuwZkWAOvpn5OO7p2C+++XUTtWO53HzwCRlT6404aV6OFnD1moNbQs3IbPGkw1u43VA9HN2RqKidXBq0/rYFmdhvFcP6YhPj5QY+9IiXvI5vIabCvm7Jo95DFBFDUrJXAWsGQIonZuwL9P0gJuREFtxFQ77BGeuSLEUNLmq42mpMkQgCWaSguVWNFgmlE5F3XEun22Zv5FtuM0Kd2ECgYEA+qYxB2EmteXdhpGTlOjS+a/3GHvAK6VF6KHcV11WOfIQdCzpqloD4/vksLXlKR1M58YOTOVZEk1++V4hAVleXTIwZRyB0X5Cdr7XVifolQQhy9cA2nnBFsjL2XocYr/Tbi1FUHj35iFqWyZ40rNjyr6nXmzeqHRMJJQOAU2qWP8CgYEAu9FnYTPZ0U2lLSFCB8JUlA5/P58Hcf05BkFu2Hu2LUVPQS6TCNZLsq7UQt+zuMhr9P/Cbak/reotyLuUYU30uDqywvIhEEeY4SSm8rZhVwwfLZ+k8quu2ws3l+9Xe2uWEqgzd0fg+8XaokCgPqnHktM59AfLQi3GPOEHY25413UCgYEA1FexF6BdbCJlzthLoA6ylWdWvX4xaohktlVR1w2yu/pvqAxYlMIXo7BFqNMgZfl1qrEmckymbhQLKvVsnrj4cZnQWAiTjkgZxIGe6lV6+6t5ejgWeABH7aaE1CRYIeyDEUb2/trMoUDT2o64M0BYnW1xW1R+OVX1H9PyHXaPhz8CgYAm72gw/GDBRQli66wWk7CY6NB0TfFrLgVuSI5EDpFbnSyq5I7SnCohJqEWI+3L9rB6n7KcrSNoWE2ZeVlvOovqzTBVvYAhMdZ9he2eDzTqqLal7JxzOigLfK3Pr2xBR7Jat8fDiIEZcJC8Zg1SMDwRMfynnB4E4BxibnvrnvEqKQKBgQClaWPu9FdT00awRYY1fsO88cmeXzOBWxaZBNSC4hYH4uvs1HFbihtxc2JiEw3Ynebqe03lWeJf3OtZjcYGK/SB5cWH32q+1zTDQHh9N/curWNwx9D/NYcCF3qkGFckLyEf9pg+nCkR08+p0gEEuUo/RTIh/6YbbvV9bkLTNY+ogQ=="
+          ],
+          "certificate": [
+            "MIICrTCCAZUCBgGSwc7OOjANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA9hcHBsaWNhbnQtcmVhbG0wHhcNMjQxMDI1MDM1MTQ4WhcNMzQxMDI1MDM1MzI4WjAaMRgwFgYDVQQDDA9hcHBsaWNhbnQtcmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC35Gy2dHSC7YeusmP8n5KmCczCimsaMJ4H/F94WrcJPt7ui0ZGR//0TxEblQWm8dsfDV5iKFd+Q9Mus/Ql/R+1wz7Vy1MgazYLkptbiqWC7PbfX6IGfb8ZwK11571Z+Wa3rrN1HZDhiBsrGaICdPB739TZ1gd2vTWD3vxTYh3mvDsw43262lGJJQXwJcRdjewX4wtR4NJ20unn+v9pl93dJ7iebVuQqOg4jb8ebi1P8OBGHjohOJqyAOZYVM9bx2pg78JYVojN6GkjI6a4TsjNbNAJEP/Ws0jbKz9NjYd3PbjLz/VU9HJWrm3P8WCsTa3zeeSqcTIoXtzXfIbZINWLAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJnrW8veqI8aoYLGNs3gzSTFgT/TFcJ0kyS8ZPb5ppotXQFYVwyDl6LWNpzmGbWdvpvsk4xfH50c9VXhygFRncci55b68Z076ll2ikbzfF59cJDKaTtQre1DuDwoxKBz+NMV0k/iPeBRp1hE/Hkc4CXtX9aNdk2ueNFf3deQwV9JslA6XKycDs+PTJTQNYFlLpIRXadiDHIEgQYZF0jR+nKoAH1lyRWml8yQ5DVb49vmxiBLCxeyDPDetHpwsInJ8NxTjP5rBB2IdkhkuWVam9WX73YoPkow9tOuGsdQ0VcAKBi5I15BBMqHm/vYBdiscISkrCZygjTjX8QrmaHG2zE="
+          ],
+          "priority": ["100"]
+        }
+      },
+      {
+        "id": "8c0cec21-858c-45a3-bc25-bc35fbfe4580",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "kid": ["699b9c9c-e331-4f5e-be35-5648fc4cf013"],
+          "secret": ["eS29qwU2n73FolQuilEJWQ"],
+          "priority": ["100"]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "59d3e2de-fff0-4195-b52d-9d481ee1ac5b",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "074d77da-ed94-4e21-ae00-326f08877ce5",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "28a84090-0dc7-4f89-98a8-f1213eeda13a",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3748e1f9-9a0f-4b88-9684-6c79045fc192",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4cc1b978-e9a4-4abd-a2b1-f11478326d6d",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4ad797ec-4bb8-40d8-8e78-53eebc1eeefc",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "472332d5-28fd-4578-a0e5-198dc0e7993f",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "dfae88b2-2b8b-43b6-bc0b-f0997455b513",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "90355ea4-242c-4c6b-9610-07e2dd0c5cf4",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "27d98e69-2e0b-461f-be58-102c543f9522",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2f8486f1-9a0f-4375-91d5-584b9715bd8b",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "649aa706-be70-402a-9e22-f3d40e23899f",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "014a8c41-50a3-4605-9c29-9da770b50267",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1d59df14-7ce3-4e55-8a61-de7eac2c3d1c",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a9d0f1ad-58bc-45e8-b3d4-44e0e87f9065",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "888ca351-fb27-4b2c-85c7-8d71357166de",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "aa841629-991a-4962-ac73-307df6535640",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e80512f3-4555-4789-b86b-91d78f04055e",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "45e6f599-7a62-4d90-9421-4b7246d40425",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "88ac4ba5-a822-44cc-b10a-a65ce28d5661",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "organizationsEnabled": "false",
+    "acr.loa.map": "{}"
+  },
+  "keycloakVersion": "25.0.6",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}


### PR DESCRIPTION
## Add the option of using Keycloak as local applicant and admin OIDC

> [!NOTE]
> All keys/secrets/passwords are for local development environments and are safe to store.

Uses [keycloak](https://www.keycloak.org/) as a local OIDC server for both applicant and admin. Each have completely separate realms.

**The dev-oidc server we currently use is still here and is the default.** That is unlikely to change anytime soon.

### Using Keycloak

One time setup step, but if you already have CiviForm running this should already be done. Must edit `/etc/hosts` and add

```
127.0.0.1 dev-oidc
```

Then run `bin/run-dev --keycloak`. Everything should just work.

## Configuration

### Master Realm
Item | Value
-|-
Master realm URI | http://dev-oidc:3390
username | admin
password | password

### Admin Realm
Item | Value
-|-
Realm Name | admin-realm
Discovery URI | http://dev-oidc:3390/realms/admin-realm/.well-known/openid-configuration
Client ID | admin-client
Client Secret | 6YgUE89gbd1KeCPAuCjnU1v4AmiI4IcP

### Applicant Realm
Item | Value
-|-
Realm Name | applicant-realm
Discovery URI | http://dev-oidc:3390/realms/applicant-realm/.well-known/openid-configuration
Client ID | applicant-client
Client Secret | 9ahHVoq5qu6Fussz1lf2AgLIzwrfLNqc

### Pre-defined User Accounts

Realm | User Type | User name | Password
-|-|-|-
Admin Realm | Civiform Admin | civiformadmin1 | password
Admin Realm | Program Admin | programadmin1 | password
Applicant Realm | Standard Applicant | applicant1 | password
