### PR TITLE
Set tab titles to match legacy tab titles

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -595,11 +595,15 @@ test.describe('applicant program index page', () => {
         await enableFeatureFlag(page, 'north_star_applicant_ui')
       })
 
-      test('validate initial page load as guest user', async ({page}) => {
+      test('validate initial page load as guest user', async ({
+        page,
+        applicantQuestions,
+      }) => {
         await validateScreenshot(
           page,
           'program-index-page-initial-load-northstar',
         )
+        await applicantQuestions.expectTitle(page, 'Find programs')
       })
 
       test('validate accessibility', async ({page}) => {

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -422,6 +422,11 @@ test.describe('address correction', () => {
           /* northStarEnabled= */ true,
         )
 
+        await applicantQuestions.expectTitle(
+          page,
+          'Address correction single-block, single-address program — 1 of 2',
+        )
+
         await applicantQuestions.answerAddressQuestion(
           'Legit Address',
           '',

--- a/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_flow.test.ts
@@ -92,11 +92,23 @@ test.describe('Applicant navigation flow', () => {
     })
 
     test.describe(
-      'review page with North Star enabled',
+      'flows with North Star enabled',
       {tag: ['@northstar']},
       () => {
         test.beforeEach(async ({page}) => {
           await enableFeatureFlag(page, 'north_star_applicant_ui')
+        })
+
+        test('validate block edit page title', async ({
+          page,
+          applicantQuestions,
+        }) => {
+          await applicantQuestions.clickApplyProgramButton(programName)
+
+          await applicantQuestions.expectTitle(
+            page,
+            'Test program for navigation flows — 1 of 6',
+          )
         })
 
         test('validate screenshot', async ({page, applicantQuestions}) => {

--- a/browser-test/src/applicant/northstar_program_summary.test.ts
+++ b/browser-test/src/applicant/northstar_program_summary.test.ts
@@ -8,7 +8,7 @@ import {
 
 test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
   test.describe('navigation with five blocks', () => {
-    const programName = 'Test program for navigation flows'
+    const programName = 'Test program for summary page'
     const programDescription = 'Test description'
     const dateQuestionText = 'date question text'
     const emailQuestionText = 'email question text'
@@ -117,6 +117,10 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       })
 
       await test.step('Verify program summary page', async () => {
+        await applicantQuestions.expectTitle(
+          page,
+          'Program application summary — Test program for summary page',
+        )
         await expect(page.getByText(programName)).toBeVisible()
         await expect(page.getByText(programDescription)).toBeVisible()
 

--- a/browser-test/src/applicant/northstar_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_upsell.test.ts
@@ -7,6 +7,7 @@ import {
   validateScreenshot,
   validateAccessibility,
   AdminPrograms,
+  ApplicantQuestions,
 } from '../support'
 import {Page} from 'playwright'
 
@@ -59,6 +60,7 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     await validateApplicationSubmittedPage(
       page,
       /* expectRelatedProgram= */ true,
+      applicantQuestions,
     )
 
     await test.step('Validate screenshot and accessibility', async () => {
@@ -97,6 +99,7 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     await validateApplicationSubmittedPage(
       page,
       /* expectRelatedProgram= */ false,
+      applicantQuestions,
     )
 
     await test.step('Validate that login dialog is shown when user clicks on apply to another program', async () => {
@@ -170,8 +173,11 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
   async function validateApplicationSubmittedPage(
     page: Page,
     expectRelatedProgram: boolean,
+    applicantQuestions: ApplicantQuestions,
   ) {
     await test.step('Validate application submitted page', async () => {
+      await applicantQuestions.expectTitle(page, 'Application confirmation')
+
       await expect(
         page.getByRole('heading', {name: programName, exact: true}),
       ).toBeVisible()

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -649,6 +649,8 @@ export class ApplicantQuestions {
 
   async expectIneligiblePage(northStar = false) {
     if (northStar) {
+      await expect(this.page).toHaveTitle('Ineligible for program')
+
       await expect(
         this.page
           .getByText('You may not be eligible for this program')
@@ -896,5 +898,9 @@ export class ApplicantQuestions {
     await expect(
       this.page.getByRole('heading', {name: 'may not be eligible'}),
     ).not.toBeAttached()
+  }
+
+  async expectTitle(page: Page, title: string) {
+    await expect(page).toHaveTitle(title)
   }
 }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -209,6 +209,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                         .setSuccessBannerMessage(flashSuccessBannerMessage)
                         .setEligibilityAlertSettings(eligibilityAlertSettings)
                         .setSummaryData(summaryData)
+                        .setProgramType(roApplicantProgramService.getProgramType())
                         .build();
                 return ok(northStarSummaryView.render(request, northStarParams))
                     .as(Http.MimeTypes.HTML);

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -352,6 +352,7 @@ public enum MessageKey {
   TITLE_EDIT_CLIENT("title.editClient"),
   TITLE_FIND_SERVICES_SECTION("title.getStartedSection"),
   TITLE_GET_STARTED("title.getStarted"),
+  TITLE_INELIGIBLE("title.ineligible"),
   TITLE_LOGIN("title.login"),
   TITLE_MY_APPLICATIONS_SECTION("title.myApplicationsSection"),
   TITLE_NO_CHANGES_TO_SAVE("title.noChangesToSave"),

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -112,6 +112,9 @@ public abstract class NorthStarBaseView {
           "loggedInAs", getAccountIdentifier(isTi, profile, applicantPersonalInfo, messages));
     }
 
+    // Default page title
+    context.setVariable("pageTitle", messages.at(MessageKey.CONTENT_FIND_PROGRAMS.getKeyName()));
+
     context.setVariable("isDevOrStaging", isDevOrStaging);
 
     maybeSetUpNotProductionBanner(context, request, messages);
@@ -221,5 +224,18 @@ public abstract class NorthStarBaseView {
             AlertType.EMERGENCY,
             ImmutableList.of());
     context.setVariable("notProductionAlertSettings", notProductionAlertSettings);
+  }
+
+  /** Create a page title for a step in the application process. */
+  protected String pageTitleWithBlockProgress(
+      String programTitle, int blockIndex, int totalBlockCount, Messages messages) {
+    // While applicant is filling out the application, include the block they are on as part of
+    // their progress.
+    blockIndex++;
+    // The summary page counts as a step
+    totalBlockCount++;
+    String blockNumberText =
+        messages.at(MessageKey.CONTENT_BLOCK_PROGRESS.getKeyName(), blockIndex, totalBlockCount);
+    return String.format("%s — %s", programTitle, blockNumberText);
   }
 }

--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -2,7 +2,8 @@
 <head th:fragment="pageHeaderScriptsAndLinks">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Title</title>
+
+  <title th:text="${pageTitle}"></title>
 
   <link th:href="${tailwindStylesheet}" type="text/css" rel="stylesheet" />
   <link th:href="${northStarStylesheet}" type="text/css" rel="stylesheet" />

--- a/server/app/views/applicant/NorthStarAddressCorrectionBlockView.java
+++ b/server/app/views/applicant/NorthStarAddressCorrectionBlockView.java
@@ -54,6 +54,14 @@ public class NorthStarAddressCorrectionBlockView extends NorthStarBaseView {
             params.applicantPersonalInfo(),
             params.messages());
 
+    String pageTitle =
+        pageTitleWithBlockProgress(
+            params.programTitle(),
+            params.blockIndex(),
+            params.blockList().size(),
+            params.messages());
+    context.setVariable("pageTitle", pageTitle);
+
     context.setVariable("programTitle", params.programTitle());
     context.setVariable("programDescription", params.programDescription());
     context.setVariable("confirmAddressAction", getFormAction(params, applicantRequestedAction));

--- a/server/app/views/applicant/NorthStarApplicantCommonIntakeUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantCommonIntakeUpsellView.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import modules.ThymeleafModule;
 import org.thymeleaf.TemplateEngine;
 import services.DeploymentType;
+import services.MessageKey;
 import services.settings.SettingsManifest;
 import views.NorthStarBaseView;
 
@@ -42,6 +43,9 @@ public class NorthStarApplicantCommonIntakeUpsellView extends NorthStarBaseView 
             Optional.of(params.profile()),
             params.applicantPersonalInfo(),
             params.messages());
+
+    context.setVariable(
+        "pageTitle", params.messages().at(MessageKey.TITLE_APPLICATION_CONFIRMATION.getKeyName()));
 
     context.setVariable("programTitle", params.programTitle().orElse(""));
     context.setVariable("programDescription", params.programDescription().orElse(""));

--- a/server/app/views/applicant/NorthStarApplicantIneligibleView.java
+++ b/server/app/views/applicant/NorthStarApplicantIneligibleView.java
@@ -56,6 +56,10 @@ public class NorthStarApplicantIneligibleView extends NorthStarBaseView {
             Optional.of(params.profile()),
             params.applicantPersonalInfo(),
             params.messages());
+
+    context.setVariable(
+        "pageTitle", params.messages().at(MessageKey.TITLE_INELIGIBLE.getKeyName()));
+
     ProgramDefinition program = params.programDefinition();
 
     Locale userLocale = params.messages().lang().toLocale();

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -69,6 +69,14 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
     context.setVariable("csrfToken", CSRF.getToken(request.asScala()).value());
     context.setVariable("applicationParams", applicationParams);
 
+    String pageTitle =
+        pageTitleWithBlockProgress(
+            applicationParams.programTitle(),
+            applicationParams.blockIndex(),
+            applicationParams.blockList().size(),
+            applicationParams.messages());
+    context.setVariable("pageTitle", pageTitle);
+
     // Progress bar
     ProgressBar progressBar =
         new ProgressBar(

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -15,9 +15,11 @@ import play.i18n.Messages;
 import play.mvc.Http.Request;
 import services.AlertSettings;
 import services.DeploymentType;
+import services.MessageKey;
 import services.applicant.AnswerData;
 import services.applicant.ApplicantPersonalInfo;
 import services.applicant.Block;
+import services.program.ProgramType;
 import services.settings.SettingsManifest;
 import views.NorthStarBaseView;
 
@@ -51,6 +53,15 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
             Optional.of(params.profile()),
             params.applicantPersonalInfo(),
             params.messages());
+
+    // Create a string such as "Program appplication summary - Pet Assistance Program"
+    String summarySubstring =
+        params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
+            ? params.messages().at(MessageKey.TITLE_COMMON_INTAKE_SUMMARY.getKeyName())
+            : params.messages().at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());
+    String pageTitle = String.format("%s — %s", summarySubstring, params.programTitle());
+    context.setVariable("pageTitle", pageTitle);
+
     context.setVariable("programTitle", params.programTitle());
     context.setVariable("programDescription", params.programDescription());
     context.setVariable("blocks", params.blocks());
@@ -188,6 +199,8 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
 
     abstract ImmutableList<AnswerData> summaryData();
 
+    abstract ProgramType programType();
+
     @AutoValue.Builder
     public abstract static class Builder {
 
@@ -221,6 +234,8 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
       public abstract Builder setEligibilityAlertSettings(AlertSettings eligibilityAlertSettings);
 
       public abstract Builder setSummaryData(ImmutableList<AnswerData> summaryData);
+
+      public abstract Builder setProgramType(ProgramType programType);
 
       public abstract Params build();
     }

--- a/server/app/views/applicant/NorthStarApplicantUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantUpsellView.java
@@ -53,6 +53,9 @@ public class NorthStarApplicantUpsellView extends NorthStarBaseView {
             params.applicantPersonalInfo(),
             params.messages());
 
+    context.setVariable(
+        "pageTitle", params.messages().at(MessageKey.TITLE_APPLICATION_CONFIRMATION.getKeyName()));
+
     context.setVariable("programTitle", params.programTitle().orElse(""));
     context.setVariable("programDescription", params.programDescription().orElse(""));
     context.setVariable("applicationId", params.applicationId());

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -64,6 +64,8 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
     ThymeleafModule.PlayThymeleafContext context =
         createThymeleafContext(request, applicantId, profile, personalInfo, messages);
 
+    context.setVariable("pageTitle", messages.at(MessageKey.CONTENT_FIND_PROGRAMS.getKeyName()));
+
     ImmutableList.Builder<ProgramSectionParams> sectionParamsBuilder = ImmutableList.builder();
 
     Optional<ProgramSectionParams> myApplicationsSection = Optional.empty();

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -409,6 +409,8 @@ title.programSummary=Program application summary
 # APPLICANT ELIGIBILITY - text related to applicant eligibility #
 #------------------------------------------------------------------------#
 
+# Tab title for ineligible page
+title.ineligible=Ineligible for program
 # Title on the page after it has been determined that the applicant is not eligible for a program. This text includes the program name.
 title.applicantNotEligible=Based on your responses to the following questions, you may not qualify for the {0}.
 # Title on the page after it has been determined that the client is not eligible for a program, when someone else is filling out the application on a client''s behalf. This text includes the program name.


### PR DESCRIPTION
### Description

Before: tab titles were "Title", in English, regardless of selected language

After: tab titles are the same as legacy pages (e.g. home page is "Find Programs", localized to the user's selected language)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

### Issue(s) this completes

Fixes #8734 