### PR TITLE
[Program Migration ] Prevent negative block ids

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -166,6 +166,19 @@ public class AdminImportController extends CiviFormController {
               .render());
     }
 
+    // Check that all block definition ids are positive numbers
+    for (BlockDefinition blockDefintion : program.blockDefinitions()) {
+      long blockId = blockDefintion.id();
+      if (blockId < 1) {
+        return ok(
+            adminImportViewPartial
+                .renderError(
+                    "Block definition ids must be greater than 0.",
+                    "Please check your block definition ids and try again.")
+                .render());
+      }
+    }
+
     // Check for other validation errors like invalid program admin names
     ImmutableList<String> notificationPreferences =
         program.notificationPreferences().stream()
@@ -262,7 +275,7 @@ public class AdminImportController extends CiviFormController {
           adminImportViewPartial
               .renderError(
                   "There was an error rendering your program.",
-                  "Please check your data and try again.")
+                  "Please check your data and try again. Error: " + e.getMessage())
               .render());
     }
   }

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -161,7 +161,7 @@ public final class AdminImportViewPartial extends BaseHtmlView {
                 .with(
                     asRedirectElement(
                             button("View program"),
-                            routes.AdminProgramBlocksController.edit(programId, 1).url())
+                            routes.AdminProgramBlocksController.index(programId).url())
                         .withClasses("usa-button", "mr-2"))
                 .condWith(
                     !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(request),

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -276,6 +276,25 @@ public class AdminImportControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void hxImportProgram_negativeBlockId_error() {
+    when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
+
+    // attempt to import a program with a negative block id
+    Result result =
+        controller.hxImportProgram(
+            fakeRequestBuilder()
+                .method("POST")
+                .bodyForm(ImmutableMap.of("programJson", PROGRAM_JSON_WITH_NEGATIVE_BLOCK_ID))
+                .build());
+
+    // see the error
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).contains("Block definition ids must be greater than 0.");
+    assertThat(contentAsString(result))
+        .contains("Please check your block definition ids and try again.");
+  }
+
+  @Test
   public void hxImportProgram_handlesServerError() {
     when(mockSettingsManifest.getProgramMigrationEnabled(any())).thenReturn(true);
 
@@ -1028,6 +1047,69 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "blockDefinitions" : [ {
                 "id" : 1,
+                "name" : "Screen 1",
+                "description" : "Screen 1 description",
+                "localizedName" : {
+                  "translations" : {
+                    "en_US" : "Screen 1"
+                  },
+                  "isRequired" : true
+                },
+                "localizedDescription" : {
+                  "translations" : {
+                    "en_US" : "Screen 1 description"
+                  },
+                  "isRequired" : true
+                },
+                "repeaterId" : null,
+                "hidePredicate" : null,
+                "optionalPredicate" : null,
+                "questionDefinitions" : [ ]
+              } ],
+              "statusDefinitions" : {
+                "statuses" : [ ]
+              },
+              "programType" : "DEFAULT",
+              "eligibilityIsGating" : true,
+              "acls" : {
+                "tiProgramViewAcls" : [ ]
+              },
+              "categories" : [ ],
+              "localizedSummaryImageDescription" : null
+            }
+          }
+      """;
+
+  public static final String PROGRAM_JSON_WITH_NEGATIVE_BLOCK_ID =
+      """
+      {
+            "program" : {
+              "id" : 9,
+              "adminName" : "no-questions",
+              "adminDescription" : "",
+              "externalLink" : "https://www.example.com",
+              "displayMode" : "PUBLIC",
+              "notificationPreferences" : [ ],
+              "localizedName" : {
+                "translations" : {
+                  "en_US" : "Program With No Questions"
+                },
+                "isRequired" : true
+              },
+              "localizedDescription" : {
+                "translations" : {
+                  "en_US" : "No questions"
+                },
+                "isRequired" : true
+              },
+              "localizedConfirmationMessage" : {
+                "translations" : {
+                  "en_US" : ""
+                },
+                "isRequired" : true
+              },
+              "blockDefinitions" : [ {
+                "id" : -1,
                 "name" : "Screen 1",
                 "description" : "Screen 1 description",
                 "localizedName" : {


### PR DESCRIPTION
### Description

This is a bug fix for program migration to prevent users from accidentally submitting negative block ids in the program json.

There are two other minor fixes here:
1. Including the original error text in the server error message so it is more informative
2. Redirecting to the first screen of the program when the user clicks the "View program" button, instead of the screen with block id "1" which could be in the middle of the program if the admin rearranged the screens.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #8649;
