### PR TITLE
Click to download files on summary page

### DIFF
--- a/browser-test/src/applicant/northstar_program_summary.test.ts
+++ b/browser-test/src/applicant/northstar_program_summary.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {
+  disableFeatureFlag,
   enableFeatureFlag,
   loginAsAdmin,
   logout,
@@ -126,6 +127,60 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
 
         await validateAccessibility(page)
       })
+    })
+  })
+
+  test('Click to download file', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+    applicantQuestions,
+  }) => {
+    const programName = 'Test program for single file upload'
+    const fileUploadQuestionText = 'Required file upload question'
+    const fileName = 'foo.txt'
+    const fileContent = 'some sample text'
+
+    // TODO(#8143): File uploads in North Star tests are blocked by CSP errors. After those
+    // errors are fixed, this entire test can run with north_star_applicant_ui enabled
+    await disableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('As admin, set up program', async () => {
+      await loginAsAdmin(page)
+
+      await adminQuestions.addFileUploadQuestion({
+        questionName: 'file-upload-test-q',
+        questionText: fileUploadQuestionText,
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['file-upload-test-q'],
+        programName,
+      )
+
+      await logout(page)
+    })
+
+    await test.step('Upload file', async () => {
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerFileUploadQuestion(fileContent, fileName)
+      await applicantQuestions.clickNext()
+    })
+
+    await test.step('Download file in North Star', async () => {
+      await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+      await applicantQuestions.applyProgram(
+        programName,
+        /* northStarEnabled= */ true,
+      )
+
+      await expect(page.getByText(fileName)).toBeVisible()
+
+      const downloadedFileContent =
+        await applicantQuestions.downloadSingleQuestionFromReviewPage(
+          /* northStarEnabled= */ true,
+        )
+      expect(downloadedFileContent).toEqual(fileContent)
     })
   })
 })

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -522,11 +522,15 @@ export class ApplicantQuestions {
     await this.page.click(`:nth-match(:text("Remove entity"), ${entityIndex})`)
   }
 
-  async downloadSingleQuestionFromReviewPage() {
+  async downloadSingleQuestionFromReviewPage(northStarEnabled = false) {
     // Assert that we're on the review page.
-    expect(await this.page.innerText('h2')).toContain(
-      'Program application summary',
-    )
+    if (northStarEnabled) {
+      await expect(this.page.getByText('Review and submit')).toBeVisible()
+    } else {
+      await expect(
+        this.page.getByText('Program application summary'),
+      ).toBeVisible()
+    }
 
     const [downloadEvent] = await Promise.all([
       this.page.waitForEvent('download'),

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -201,6 +201,10 @@ it is around the label */
   word-break: break-word;
 }
 
+.summary-download-file-link {
+  text-decoration-line: underline;
+}
+
 .summary-button-section {
   @include u-margin-top(3);
   margin-bottom: 0;

--- a/server/app/views/applicant/NorthStarAnswerData.java
+++ b/server/app/views/applicant/NorthStarAnswerData.java
@@ -11,9 +11,11 @@ import services.question.types.QuestionType;
 // It's safer to process data in Java than at runtime in Thymeleaf.
 public class NorthStarAnswerData implements Comparable<NorthStarAnswerData> {
   private final AnswerData answerData;
+  private final long applicantId;
 
-  public NorthStarAnswerData(AnswerData data) {
+  public NorthStarAnswerData(AnswerData data, long applicantId) {
     this.answerData = checkNotNull(data);
+    this.applicantId = applicantId;
   }
 
   public String blockId() {
@@ -60,6 +62,25 @@ public class NorthStarAnswerData implements Comparable<NorthStarAnswerData> {
       fileNames.add(fileName);
     }
     return ImmutableList.copyOf(fileNames);
+  }
+
+  public ImmutableList<String> urls() {
+    ArrayList<String> urls = new ArrayList<String>();
+
+    AnswerData data = this.answerData;
+    if (!data.encodedFileKeys().isEmpty()) {
+      for (int i = 0; i < data.encodedFileKeys().size(); i++) {
+        String encodedFileKey = data.encodedFileKeys().get(i);
+        String fileUrl = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
+        urls.add(fileUrl);
+      }
+    } else if (data.encodedFileKey().isPresent()) {
+      // TODO(#7493): When single encoded file key is deprecated, delete this branch
+      String encodedFileKey = data.encodedFileKey().get();
+      String fileUrl = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
+      urls.add(fileUrl);
+    }
+    return ImmutableList.copyOf(urls);
   }
 
   @Override

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -113,7 +113,7 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
 
     ImmutableList<NorthStarAnswerData> northStarSummaryData =
         params.summaryData().stream()
-            .map(datum -> new NorthStarAnswerData(datum))
+            .map(datum -> new NorthStarAnswerData(datum, params.applicantId()))
             .collect(ImmutableList.toImmutableList());
 
     ImmutableList<NorthStarBlockSummary> blockSummaries =

--- a/server/app/views/applicant/QuestionSummaryFragment.html
+++ b/server/app/views/applicant/QuestionSummaryFragment.html
@@ -17,10 +17,18 @@
 <th:block th:fragment="multilineAnswer(answerData)">
   <ol id="summary-multiline-list" class="grid-col-6 right-align">
     <li
-      th:each="answerLine : ${answerData.multilineAnswerText()}"
+      th:each="answerLine, status : ${answerData.multilineAnswerText()}"
       class="usa-prose"
+      th:with="useLink=${status.index < answerData.urls().size()}"
     >
+      <a
+        th:if="${useLink}"
+        th:text="${answerLine}"
+        th:href="${answerData.urls().get(status.index)}"
+        class="zero-margin summary-answer mobile-truncate-3 summary-download-file-link"
+      ></a>
       <span
+        th:if="${!useLink}"
         th:text="${answerLine}"
         class="zero-margin summary-answer mobile-truncate-3"
       ></span>


### PR DESCRIPTION
### Description

Applicant can click file names to download files on the North Star summary page.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible) (Better browser tests are blocked by #8143)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)


### Issue(s) this completes

Fixes #8985