### PR TITLE
Implement TI banner in North Star

### DIFF
--- a/browser-test/src/northstar_trusted_intermediary.test.ts
+++ b/browser-test/src/northstar_trusted_intermediary.test.ts
@@ -1,0 +1,46 @@
+import {test, expect} from './support/civiform_fixtures'
+import {
+  enableFeatureFlag,
+  ClientInformation,
+  loginAsTrustedIntermediary,
+  waitForPageJsLoad,
+} from './support'
+
+test.describe('Trusted intermediaries with North Star specific changes', () => {
+  test.beforeEach(async ({page}) => {
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+  })
+
+  test('sees client name and link in sub-banner while applying on behalf of applicant', async ({
+    page,
+    tiDashboard,
+  }) => {
+    await test.step('Navigate to TI dashboard', async () => {
+      await loginAsTrustedIntermediary(page)
+      await tiDashboard.gotoTIDashboardPage(page)
+      await waitForPageJsLoad(page)
+      const client: ClientInformation = {
+        emailAddress: 'fake12@sample.com',
+        firstName: 'first1',
+        middleName: 'middle',
+        lastName: 'last1',
+        dobDate: '2021-07-10',
+      }
+      await tiDashboard.createClient(client)
+      await tiDashboard.clickOnViewApplications()
+    })
+
+    await test.step('Verify header text and behavior', async () => {
+      await expect(page.getByText('Select a new client')).toBeVisible()
+      await expect(
+        page.getByText(
+          'You are applying for last1, first1. Are you trying to apply for a different client?',
+        ),
+      ).toBeVisible()
+
+      await page.getByRole('link', {name: 'Select a new client'}).click()
+      // Expect to return to TI dashboard
+      await expect(page.getByText('View and add clients')).toBeVisible()
+    })
+  })
+})

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -355,3 +355,7 @@ main {
 .auto-width {
   width: auto;
 }
+
+.ti-banner-internal {
+  display: inline;
+}

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -94,6 +94,8 @@ public abstract class NorthStarBaseView {
     context.setVariable("isTrustedIntermediary", isTi);
     context.setVariable("isGuest", isGuest);
     context.setVariable("hasProfile", profile.isPresent());
+    context.setVariable("applicantDisplayName", applicantPersonalInfo.getDisplayString(messages));
+    context.setVariable("tiDashboardHref", getTiDashboardHref());
     String logoutLink = org.pac4j.play.routes.LogoutController.logout().url();
     context.setVariable("logoutLink", logoutLink);
     // In Thymeleaf, it's impossible to add escaped text inside unescaped text, which makes it
@@ -237,5 +239,15 @@ public abstract class NorthStarBaseView {
     String blockNumberText =
         messages.at(MessageKey.CONTENT_BLOCK_PROGRESS.getKeyName(), blockIndex, totalBlockCount);
     return String.format("%s — %s", programTitle, blockNumberText);
+  }
+
+  private String getTiDashboardHref() {
+    return controllers.ti.routes.TrustedIntermediaryController.dashboard(
+            /* nameQuery= */ Optional.empty(),
+            /* dayQuery= */ Optional.empty(),
+            /* monthQuery= */ Optional.empty(),
+            /* yearQuery= */ Optional.empty(),
+            /* page= */ Optional.of(1))
+        .url();
   }
 }

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -53,6 +53,7 @@
     </div>
   </header>
   <div th:replace="~{this :: guestSessionAlert}"></div>
+  <div th:replace="~{this :: tiAlert}"></div>
 </th:block>
 
 <section
@@ -163,6 +164,30 @@
     </div>
   </section>
 </nav>
+
+<div th:fragment="tiAlert" th:if="${isTrustedIntermediary}">
+  <section
+    class="usa-site-alert usa-site-alert--info usa-site-alert--slim cf-alert"
+    id="ti-banner"
+  >
+    <div class="usa-alert" aria-role="status">
+      <div class="usa-alert__body">
+        <div class="ti-banner-internal">
+          <span
+            class="usa-alert__text"
+            th:text="#{banner.viewApplication(${applicantDisplayName})}"
+          ></span>
+          <a
+            th:href="${tiDashboardHref}"
+            th:text="#{link.selectNewClient}"
+            class="usa-link"
+            id="ti-clients-link"
+          ></a>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
 
 <div th:fragment="showDebugTools">
   <a


### PR DESCRIPTION
### Description

Implement TI banner in North Star. There are no official mocks. It's a simple re-implementation of this:

![image](https://github.com/user-attachments/assets/5047d62f-03c3-4a52-8489-36460a5e476e)

#### Before

<img width="1468" alt="TI-before" src="https://github.com/user-attachments/assets/500ac04a-53ad-44a6-ab3b-81a4a87add55">

#### After

<img width="1468" alt="TI-after" src="https://github.com/user-attachments/assets/67bd3c9d-246e-4d00-adde-410928ab7099">



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [n/a] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [n/a] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes
Fixes #9020
