### PR TITLE
On summary page, add spacing below alert

### DIFF
--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -24,6 +24,11 @@
             <div
               th:replace="~{components/AlertFragment :: alert(alertSettings=${eligibilityAlertSettings}, headingLevel='H2')}"
             ></div>
+            <!-- If an alert is visible, add some extra spacing. -->
+            <div
+              th:if="${eligibilityAlertSettings.title.isPresent()}"
+              class="section-spacing"
+            ></div>
 
             <div
               th:replace="~{applicant/ApplicantBaseFragment :: requiredFieldsExplanation}"


### PR DESCRIPTION
### Description

On the summary page, add spacing below the alert.

#### Before

<img width="2177" alt="Before" src="https://github.com/user-attachments/assets/adc841b0-c33a-4562-a197-0f049e258118">

#### After

<img width="2177" alt="After" src="https://github.com/user-attachments/assets/eefa3239-657d-4dc8-a8fb-4f11c8c183b0">

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
