### PR TITLE
Update nodejs version in tests

### DIFF
--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -y && \
     apt-get install -y ca-certificates curl gnupg && \
     # Add nodejs to repo
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     # Cleanup packages and update the repos
     apt-get remove -y --purge cmdtest && \
     apt-get update && \


### PR DESCRIPTION
### Description

Renovate updated nodejs from v20 to v22 recently. This updates the test runner to match versions.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
