### PR TITLE
Add min and max entities to enum button for disabling functionality to work

### DIFF
--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -57,6 +57,8 @@
       <button
         th:text="#{button.addEntity(${enumeratorQuestion.getEntityType()})}"
         id="enumerator-field-add-button"
+        th:attr="data-min-entities=${enumeratorQuestion.getMinEntities().isPresent() ? enumeratorQuestion.getMinEntities().getAsInt() : ''},
+                data-max-entities=${enumeratorQuestion.getMaxEntities().isPresent() ? enumeratorQuestion.getMaxEntities().getAsInt() : ''}"
         type="button"
         class="usa-button usa-button--outline margin-top-105"
       ></button>


### PR DESCRIPTION
### Description

This is checked [here](https://github.com/civiform/civiform/blob/2415824fc94d99fa72f0632e6445160c45f65933/server/app/assets/javascripts/enumerator.ts#L201), but currently it does nothing since these values are unset. Tests for this case are in the end to end enumerator tests, so will be added in https://github.com/civiform/civiform/issues/9073. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Set enumerator entity max and then check that the button gets disabled when approaching the max

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9068
