### PR TITLE
Add cf-question-* classes to North Star question fragments

### DIFF
--- a/server/app/views/questiontypes/AddressQuestionFragment.html
+++ b/server/app/views/questiontypes/AddressQuestionFragment.html
@@ -2,6 +2,7 @@
   th:fragment="address (question, questionRendererParams, stateAbbreviations)"
   th:with="questionId=${'id-' + #strings.randomAlphanumeric(8)}"
   th:id="${questionId}"
+  class="cf-question-address"
   data-testid="questionRoot"
   data-load-question="true"
 >

--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -4,7 +4,7 @@
            multiSelectQuestion=${question.createMultiSelectQuestion()},
            hasErrors=${questionRendererParams.shouldShowErrors() && !multiSelectQuestion.getValidationErrors().isEmpty()}"
   th:id="${questionId}"
-  class="cf-applicant-question-field"
+  class="cf-question-checkbox cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >

--- a/server/app/views/questiontypes/CurrencyQuestionFragment.html
+++ b/server/app/views/questiontypes/CurrencyQuestionFragment.html
@@ -7,7 +7,7 @@
              questionErrors=${currencyQuestion.getValidationErrors().get(question.getContextualizedPath())},
              hasErrors=${questionRendererParams.shouldShowErrors() && !currencyQuestion.getValidationErrors().isEmpty()}"
   th:id="${questionId}"
-  th:class="cf-applicant-question-field"
+  class="cf-question-currency cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >

--- a/server/app/views/questiontypes/EmailQuestionFragment.html
+++ b/server/app/views/questiontypes/EmailQuestionFragment.html
@@ -6,7 +6,7 @@
               questionErrors=${emailQuestion.getValidationErrors().get(question.getContextualizedPath())},
               hasErrors=${questionRendererParams.shouldShowErrors() && !emailQuestion.getValidationErrors().isEmpty()}"
   th:id="${questionId}"
-  class="cf-applicant-question-field"
+  class="cf-question-email cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -5,6 +5,7 @@
              maxInputLength=10000,
              firstPathWithError=${nameQuestion.getFirstPathWithError()}"
   th:id="${questionId}"
+  class="cf-question-name"
   data-testid="questionRoot"
 >
   <!--/* Title and Help Text */-->

--- a/server/app/views/questiontypes/NumberQuestionFragment.html
+++ b/server/app/views/questiontypes/NumberQuestionFragment.html
@@ -7,7 +7,7 @@
              questionErrors=${numberQuestion.getValidationErrors().get(question.getContextualizedPath())},
              hasErrors=${questionRendererParams.shouldShowErrors() && !numberQuestion.getValidationErrors().isEmpty()}"
   th:id="${questionId}"
-  class="cf-applicant-question-field"
+  class="cf-question-number cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >

--- a/server/app/views/questiontypes/RadioButtonQuestionFragment.html
+++ b/server/app/views/questiontypes/RadioButtonQuestionFragment.html
@@ -4,7 +4,7 @@
   singleSelectQuestion=${question.createSingleSelectQuestion()},
   hasErrors=${questionRendererParams.shouldShowErrors() && !singleSelectQuestion.getValidationErrors().isEmpty()}"
   th:id="${questionId}"
-  class="cf-applicant-question-field"
+  class="cf-question-radio cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >


### PR DESCRIPTION
### Description

In legacy, each question has a cf-question-* class. Some browser tests use this class as a way to locate elements. Adding these classes are necessary to migrate browser tests such as #8896.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [n/a] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Part of #8791