### PR TITLE
[Program Migration] Skip multioption admin name validation in program import

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -109,6 +109,8 @@ test.describe('program migration', () => {
     adminProgramMigration,
     adminTiGroups,
   }) => {
+    test.slow()
+
     await test.step('load import page', async () => {
       await loginAsAdmin(page)
       await enableFeatureFlag(page, 'program_migration_enabled')
@@ -240,16 +242,25 @@ test.describe('program migration', () => {
         'Sample Address Question',
         '',
       )
+      // replace one of the multi-option question admin names with an invalid admin name
+      // we should not be validating multi-option question admin names as a part of program migration
+      downloadedComprehensiveProgram = downloadedComprehensiveProgram.replace(
+        'chocolate',
+        'Chocolate ice cream',
+      )
+
       await adminProgramMigration.submitProgramJson(
         downloadedComprehensiveProgram,
       )
-      await adminProgramMigration.expectAlert(
+      const alert = await adminProgramMigration.expectAlert(
         'One or more question errors occured:',
         ALERT_ERROR,
       )
-      await adminProgramMigration.expectAlert(
+      await expect(alert).toContainText(
         'Administrative identifier cannot be blank.',
-        ALERT_ERROR,
+      )
+      await expect(alert).not.toContainText(
+        'Multi-option admin names can only contain lowercase letters, numbers, underscores, and dashes',
       )
     })
 

--- a/browser-test/src/support/admin_program_migration.ts
+++ b/browser-test/src/support/admin_program_migration.ts
@@ -67,6 +67,7 @@ export class AdminProgramMigration {
   }
 
   async submitProgramJson(content: string) {
+    await waitForPageJsLoad(this.page)
     await this.page.getByRole('textbox').fill(content)
     await this.clickButton('Preview program')
   }
@@ -75,6 +76,7 @@ export class AdminProgramMigration {
     const alert = this.page.getByRole('alert').filter({hasText: alertText})
     await expect(alert).toBeVisible()
     await expect(alert).toHaveClass(new RegExp(alertType))
+    return alert
   }
 
   async expectProgramImported(programName: string) {

--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -37,6 +37,7 @@ import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.OrNode;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
+import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
 import services.statuses.StatusDefinitions;
@@ -243,7 +244,16 @@ public class AdminImportController extends CiviFormController {
 
     ImmutableSet<CiviFormError> questionErrors =
         questions.stream()
-            .map(question -> question.validate())
+            .map(
+                question -> {
+                  if (question.getQuestionType().isMultiOptionType()) {
+                    MultiOptionQuestionDefinition multiOptionQuestion =
+                        (MultiOptionQuestionDefinition) question;
+                    multiOptionQuestion.setValidateQuestionOptionAdminNames(false);
+                    return multiOptionQuestion.validate();
+                  }
+                  return question.validate();
+                })
             .flatMap(errors -> errors.stream())
             .collect(ImmutableSet.toImmutableSet());
     if (!questionErrors.isEmpty()) {

--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -249,8 +249,9 @@ public class AdminImportController extends CiviFormController {
                   if (question.getQuestionType().isMultiOptionType()) {
                     MultiOptionQuestionDefinition multiOptionQuestion =
                         (MultiOptionQuestionDefinition) question;
-                    multiOptionQuestion.setValidateQuestionOptionAdminNames(false);
-                    return multiOptionQuestion.validate();
+                    return multiOptionQuestion
+                        .setValidateQuestionOptionAdminNames(false)
+                        .validate();
                   }
                   return question.validate();
                 })

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -88,8 +88,10 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
     return ImmutableSet.copyOf(Sets.intersection(questionTextLocales, getSupportedOptionLocales()));
   }
 
-  public void setValidateQuestionOptionAdminNames(boolean shouldValidateOptionAdminNames) {
+  public MultiOptionQuestionDefinition setValidateQuestionOptionAdminNames(
+      boolean shouldValidateOptionAdminNames) {
     this.validateQuestionOptionAdminNames = shouldValidateOptionAdminNames;
+    return this;
   }
 
   @Override

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -312,6 +312,27 @@ public class MultiOptionQuestionDefinitionTest {
   }
 
   @Test
+  public void
+      validate_validateQuestionOptionAdminNamesFalse_invalidOptionAdminNames_doesNotReturnError() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("test")
+            .setQuestionText(LocalizedStrings.withDefaultValue("test"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(1L, "a' invalid", LocalizedStrings.withDefaultValue("a")),
+            QuestionOption.create(2L, "b_valid", LocalizedStrings.withDefaultValue("b")));
+    MultiOptionQuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config, questionOptions, MultiOptionQuestionType.CHECKBOX);
+    question.setValidateQuestionOptionAdminNames(false);
+    assertThat(question.validate()).isEmpty();
+  }
+
+  @Test
   public void validate_withCapitalLetterInOptionAdminNames_returnsError() {
     QuestionDefinitionConfig config =
         QuestionDefinitionConfig.builder()

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -328,8 +328,7 @@ public class MultiOptionQuestionDefinitionTest {
     MultiOptionQuestionDefinition question =
         new MultiOptionQuestionDefinition(
             config, questionOptions, MultiOptionQuestionType.CHECKBOX);
-    question.setValidateQuestionOptionAdminNames(false);
-    assertThat(question.validate()).isEmpty();
+    assertThat(question.setValidateQuestionOptionAdminNames(false).validate()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
### Description

Validating that admin names for options in multi-option questions only contain certain characters is blocking Arkansas from importing some programs. This PR removes that validation step when importing a program. All other validation remains the same.

See [slack convo](https://civiform.slack.com/archives/C03KLLQQGTT/p1731006158358299) for more info.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Attempt to import the program json in the linked slack conversation. It should work with no errors!
