### PR TITLE
Swap element dialog to div for USWDS compatibility

### DIFF
--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -4,7 +4,7 @@
   id="modal-container"
   class="display-none position-fixed height-viewport width-full z-100"
 >
-  <dialog
+  <div
     class="usa-modal cf-ns-modal"
     id="debug-content-modal"
     aria-labelledby="debug-content-modal-heading"
@@ -61,7 +61,7 @@
         ></svg>
       </button>
     </div>
-  </dialog>
+  </div>
 </div>
 
 <div
@@ -107,7 +107,7 @@
   ></div>
 </div>
 
-<dialog
+<div
   th:fragment="loginPromptModal(dialogId, bypassUrl, loginLink, descriptionText, bypassButtonText, onlyShowOnceGroup, showOnLoad)"
   class="usa-modal cf-ns-modal"
   th:id="${dialogId}"
@@ -164,10 +164,10 @@
       ></svg>
     </button>
   </div>
-</dialog>
+</div>
 
 <div th:fragment="blockValidation">
-  <dialog
+  <div
     class="usa-modal"
     id="validation-modal"
     aria-labelledby="validation-modal-heading"
@@ -209,7 +209,7 @@
         ></svg>
       </button>
     </div>
-  </dialog>
+  </div>
   <!--/* Create an invisible button that we will use to trigger this modal on load */-->
   <a
     id="invisible-validation-modal-button"
@@ -224,7 +224,7 @@
 
 <!-- TODO(#8707): Modal sometimes flashes in incorrect position -->
 <div th:fragment="preventDuplicateSubmission (programTitle, exitHref)">
-  <dialog
+  <div
     class="usa-modal is-hidden"
     id="duplicate-submission-modal"
     aria-labelledby="duplicate-submission-modal-heading"
@@ -275,7 +275,7 @@
         ></svg>
       </button>
     </div>
-  </dialog>
+  </div>
   <!--/* Create an invisible button that we will use to trigger this modal on load */-->
   <a
     id="invisible-duplicate-submission-modal-button"


### PR DESCRIPTION
### Description

Fixing nested dialog roles.

The USWDS modal javascript automatically adds role=dialog to their wrapper element. This means we can't use the dialog element in modals as it ends up with nested dialogs in the accessibility tree.

![image](https://github.com/user-attachments/assets/5d235b59-5cc8-4f86-b478-725d30630ecf)


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
