### PR TITLE
Mark icons as hidden

### DIFF
--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -80,6 +80,8 @@
 <svg
   th:fragment="icon(icon)"
   class="usa-icon"
+  aria-hidden="true"
+  role="img"
   th:attr="viewBox=${icon.getViewBox()}"
 >
   <path th:attr="d=${icon.path}"></path>


### PR DESCRIPTION
### Description

The svg icons should have `aria-hidden=true`. They are decorative and are always wrapped in an element with an aria-label denoting the button action already.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)

