### PR TITLE
Adding applicant program list class

### DIFF
--- a/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
@@ -15,7 +15,7 @@ import {
 import {ProgramVisibility, QuestionSpec} from '../support/admin_programs'
 import {
   ApplicantProgramList,
-  ApplicationStatusCardGroupName,
+  CardSectionName,
 } from '../support/applicant_program_list'
 import {Browser, Locator, Page} from '@playwright/test'
 
@@ -182,18 +182,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
           await expect(
             applicantActor.getCardHeadingLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
         })
@@ -217,18 +217,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
 
@@ -240,12 +240,12 @@ test.describe(
         await test.step('check program list shows eligible tag', async () => {
           await expect(
             applicantActor.getCardEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).toBeVisible()
           await expect(
             applicantActor.getCardNotEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
         })
@@ -326,18 +326,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -355,18 +355,18 @@ test.describe(
         await test.step('As applicant - check program list has one in-progress application for program v1', async () => {
           await applicantActor.gotoApplicantHomePage()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -430,18 +430,18 @@ test.describe(
         await test.step('As applicant - check program list has one submitted application for program v1', async () => {
           await applicantActor.gotoApplicantHomePage()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
 
@@ -454,12 +454,12 @@ test.describe(
         await test.step('check program list shows eligible tag', async () => {
           await expect(
             applicantActor.getCardEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).toBeVisible()
           await expect(
             applicantActor.getCardNotEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
         })
@@ -657,18 +657,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
           await expect(
             applicantActor.getCardHeadingLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
         })
@@ -692,18 +692,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
 
@@ -715,12 +715,12 @@ test.describe(
         await test.step('check program list shows eligible tag', async () => {
           await expect(
             applicantActor.getCardEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).toBeVisible()
           await expect(
             applicantActor.getCardNotEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
         })
@@ -810,18 +810,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -839,18 +839,18 @@ test.describe(
         await test.step('As applicant - check program list has one in-progress application for program v2', async () => {
           await applicantActor.gotoApplicantHomePage()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -928,18 +928,18 @@ test.describe(
         await test.step('As applicant - check program list has one submitted application for program v3', async () => {
           await applicantActor.gotoApplicantHomePage()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
 
@@ -952,13 +952,13 @@ test.describe(
         await test.step('check program list shows eligible tag', async () => {
           await expect(
             applicantActor.getCardEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).toBeVisible()
 
           await expect(
             applicantActor.getCardNotEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
         })
@@ -1138,18 +1138,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
           await expect(
             applicantActor.getCardHeadingLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+              CardSectionName.ProgramsAndServices,
             ),
           ).toBeAttached()
         })
@@ -1173,18 +1173,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
 
@@ -1196,12 +1196,12 @@ test.describe(
         await test.step('check program list shows eligible tag', async () => {
           await expect(
             applicantActor.getCardEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).toBeVisible()
           await expect(
             applicantActor.getCardNotEligibleTagLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+              CardSectionName.MyApplications,
             ),
           ).not.toBeAttached()
         })
@@ -1291,18 +1291,18 @@ test.describe(
           await applicantActor.gotoApplicantHomePage()
 
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -1320,18 +1320,18 @@ test.describe(
         await test.step('As applicant - check program list has one in-progress application for program v2', async () => {
           await applicantActor.gotoApplicantHomePage()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.ProgramsAndServices,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.ProgramsAndServices,
             ),
           ).not.toBeAttached()
           await expect(
-            applicantActor.getCardListLocator(
-              ApplicationStatusCardGroupName.MyApplications,
+            applicantActor.getCardSectionLocator(
+              CardSectionName.MyApplications,
             ),
           ).toBeAttached()
 
           const headingLocator = applicantActor.getCardHeadingLocator(
-            ApplicationStatusCardGroupName.MyApplications,
+            CardSectionName.MyApplications,
           )
           await expect(headingLocator).toBeAttached()
           expect(
@@ -1740,55 +1740,43 @@ class FastForwardApplicantActor {
   }
 
   /**
-   * Get the card list locator for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * Get the card section locator for the desired application status card section name
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator to the card list
    */
-  getCardListLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
-    return this.applicantProgramList.getCardGroupLocator(
-      applicationStatusCardGroupName,
-    )
+  getCardSectionLocator(cardSectionName: CardSectionName): Locator {
+    return this.applicantProgramList.getCardSectionLocator(cardSectionName)
   }
 
   /**
    * Get the locator for program card heading in the desired list
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator for program card in the desired list
    */
-  getCardHeadingLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
+  getCardHeadingLocator(cardSectionName: CardSectionName): Locator {
     return this.applicantProgramList.getCardHeadingLocator(
-      applicationStatusCardGroupName,
+      cardSectionName,
       this.programName,
     )
   }
 
   /**
    * Get the eligibile tag for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator to the eligible tag
    */
-  getCardEligibleTagLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
-    return this.applicantProgramList.getCardEligibleTagLocator(
-      applicationStatusCardGroupName,
-    )
+  getCardEligibleTagLocator(cardSectionName: CardSectionName): Locator {
+    return this.applicantProgramList.getCardEligibleTagLocator(cardSectionName)
   }
 
   /**
    * Get the not eligibile tag for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator to the not eligible tag
    */
-  getCardNotEligibleTagLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
+  getCardNotEligibleTagLocator(cardSectionName: CardSectionName): Locator {
     return this.applicantProgramList.getCardNotEligibleTagLocator(
-      applicationStatusCardGroupName,
+      cardSectionName,
     )
   }
 

--- a/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
@@ -13,6 +13,10 @@ import {
   disableFeatureFlag,
 } from '../support'
 import {ProgramVisibility, QuestionSpec} from '../support/admin_programs'
+import {
+  ApplicantProgramList,
+  ApplicationStatusCardGroupName,
+} from '../support/applicant_program_list'
 import {Browser, Locator, Page} from '@playwright/test'
 
 test.describe(
@@ -1673,6 +1677,7 @@ class FastForwardApplicantActor {
   private programName: string
   private page: Page
   private applicantQuestions: ApplicantQuestions
+  private applicantProgramList: ApplicantProgramList
 
   /**
    * @constructor
@@ -1683,6 +1688,7 @@ class FastForwardApplicantActor {
     this.programName = programName
     this.page = page
     this.applicantQuestions = new ApplicantQuestions(page)
+    this.applicantProgramList = new ApplicantProgramList(page)
   }
 
   /**
@@ -1741,7 +1747,9 @@ class FastForwardApplicantActor {
   getCardListLocator(
     applicationStatusCardGroupName: ApplicationStatusCardGroupName,
   ): Locator {
-    return this.page.getByRole('region', {name: applicationStatusCardGroupName})
+    return this.applicantProgramList.getCardGroupLocator(
+      applicationStatusCardGroupName,
+    )
   }
 
   /**
@@ -1752,11 +1760,9 @@ class FastForwardApplicantActor {
   getCardHeadingLocator(
     applicationStatusCardGroupName: ApplicationStatusCardGroupName,
   ): Locator {
-    return this.getCardListLocator(applicationStatusCardGroupName).getByRole(
-      'heading',
-      {
-        name: this.programName,
-      },
+    return this.applicantProgramList.getCardHeadingLocator(
+      applicationStatusCardGroupName,
+      this.programName,
     )
   }
 
@@ -1768,8 +1774,8 @@ class FastForwardApplicantActor {
   getCardEligibleTagLocator(
     applicationStatusCardGroupName: ApplicationStatusCardGroupName,
   ): Locator {
-    return this.getCardListLocator(applicationStatusCardGroupName).locator(
-      '.cf-eligible-tag',
+    return this.applicantProgramList.getCardEligibleTagLocator(
+      applicationStatusCardGroupName,
     )
   }
 
@@ -1781,8 +1787,8 @@ class FastForwardApplicantActor {
   getCardNotEligibleTagLocator(
     applicationStatusCardGroupName: ApplicationStatusCardGroupName,
   ): Locator {
-    return this.getCardListLocator(applicationStatusCardGroupName).locator(
-      '.cf-not-eligible-tag',
+    return this.applicantProgramList.getCardNotEligibleTagLocator(
+      applicationStatusCardGroupName,
     )
   }
 
@@ -1819,17 +1825,9 @@ class FastForwardApplicantActor {
   }
 
   /**
-   * Navigates to the next page of an application
+   * Navigates to the review page of an application
    *
    * Must be on an application edit page
-   * @param question
-   */
-  async gotoNextPage() {
-    await this.applicantQuestions.clickNext()
-  }
-
-  /**
-   *
    */
   async gotoReviewPage() {
     await this.applicantQuestions.clickReview(true)
@@ -2056,14 +2054,4 @@ enum Block {
   Third = 'Screen 3',
   Fourth = 'Screen 4',
   Fifth = 'Screen 5',
-}
-
-/**
- * List of heading names used for different groups of application cards used in
- * this test suite. This is not a really a concrete system-wide term and is mostly
- * used in relation to what the user sees on the `/programs` page
- */
-enum ApplicationStatusCardGroupName {
-  MyApplications = 'My applications',
-  ProgramsAndServices = 'Programs and services',
 }

--- a/browser-test/src/support/applicant_program_list.ts
+++ b/browser-test/src/support/applicant_program_list.ts
@@ -13,104 +13,100 @@ export class ApplicantProgramList {
   }
 
   /**
-   * Get the card group locator for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
-   * @returns {Locator} Locator to the card group
+   * Get the card section locator for the desired application status card section name
+   * @param {CardSectionName} cardSectionName to find
+   * @returns {Locator} Locator to the card section
    */
-  getCardGroupLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
-    return this.page.getByRole('region', {name: applicationStatusCardGroupName})
+  getCardSectionLocator(cardSectionName: CardSectionName): Locator {
+    return this.page.getByRole('region', {name: cardSectionName})
   }
 
   /**
-   * Get the locator for program card heading in the desired group
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * Get the locator for program card heading in the desired section
+   * @param {CardSectionName} cardSectionName to find
    * @param {String} programName to find
-   * @returns {Locator} Locator for program card in the desired group
+   * @returns {Locator} Locator for program card in the desired section
    */
   getCardLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    cardSectionName: CardSectionName,
     programName: string,
   ): Locator {
-    return this.getCardGroupLocator(applicationStatusCardGroupName).getByRole(
-      'listitem',
-      {name: programName},
-    )
+    return this.getCardSectionLocator(cardSectionName).getByRole('listitem', {
+      name: programName,
+    })
   }
 
   /**
-   * Get the locator for program card heading in the desired group
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * Get the locator for program card heading in the desired section
+   * @param {CardSectionName} cardSectionName to find
    * @param {String} programName to find
-   * @returns {Locator} Locator for program card in the desired group
+   * @returns {Locator} Locator for program card in the desired section
    */
   getCardHeadingLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    cardSectionName: CardSectionName,
     programName: string,
   ): Locator {
-    return this.getCardGroupLocator(applicationStatusCardGroupName).getByRole(
-      'heading',
-      {name: programName},
-    )
+    return this.getCardSectionLocator(cardSectionName).getByRole('heading', {
+      name: programName,
+    })
   }
 
   /**
-   * Clicks the apply button for the specified program within the specified card group
+   * Clicks the apply button for the specified program within the specified card section
    *
    * @async
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {CardSectionName} cardSectionName to find
    * @param {String} programName to apply to
    */
   async clickApplyButton(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    cardSectionName: CardSectionName,
     programName: string,
   ): Promise<void> {
-    await this.getCardLocator(applicationStatusCardGroupName, programName)
+    await this.getCardLocator(cardSectionName, programName)
       .getByRole('link', {
-        name: this.getCardGroupApplyButtonText(applicationStatusCardGroupName),
+        name: this.getCardSectionApplyButtonText(cardSectionName),
       })
       .click()
   }
 
   /**
    * @private
-   * Get the label text for the specific card group
+   * Get the label text for the specific card section
    *
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {CardSectionName} cardSectionName to find
    * @returns {String} String of the context specific apply button label text
    */
-  private getCardGroupApplyButtonText(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): ApplicationStatusApplyButtonText {
-    return applicationStatusCardGroupName ==
-      ApplicationStatusCardGroupName.MyApplications
-      ? ApplicationStatusApplyButtonText.Edit
-      : ApplicationStatusApplyButtonText.ViewAndApply
+  private getCardSectionApplyButtonText(
+    cardSectionName: CardSectionName,
+  ): CardSectionApplyButtonText {
+    switch (cardSectionName) {
+      case CardSectionName.MyApplications:
+        return CardSectionApplyButtonText.Edit
+      case CardSectionName.ProgramsAndServices:
+        return CardSectionApplyButtonText.ViewAndApply
+      default:
+        throw new Error(`'${String(cardSectionName)}' is not supported.`)
+    }
   }
 
   /**
-   * Get the eligibility tag for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * Get the eligibility tag for the desired application status card section name
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator to the eligible tag
    */
-  getCardEligibleTagLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
-    return this.getCardGroupLocator(applicationStatusCardGroupName).locator(
+  getCardEligibleTagLocator(cardSectionName: CardSectionName): Locator {
+    return this.getCardSectionLocator(cardSectionName).locator(
       '.cf-eligible-tag',
     )
   }
 
   /**
-   * Get the not eligibility tag for the desired application status card group name
-   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * Get the not eligibility tag for the desired application status card section name
+   * @param {CardSectionName} cardSectionName to find
    * @returns {Locator} Locator to the not eligible tag
    */
-  getCardNotEligibleTagLocator(
-    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
-  ): Locator {
-    return this.getCardGroupLocator(applicationStatusCardGroupName).locator(
+  getCardNotEligibleTagLocator(cardSectionName: CardSectionName): Locator {
+    return this.getCardSectionLocator(cardSectionName).locator(
       '.cf-not-eligible-tag',
     )
   }
@@ -119,10 +115,10 @@ export class ApplicantProgramList {
 /**
  * @readonly
  * @enum {string}
- * List of heading names used for different groups of application cards used in this test
+ * List of heading names used for different groups of cards used in this test
  * suite. This is used in relation to what the user sees on the `/programs` page
  */
-export enum ApplicationStatusCardGroupName {
+export enum CardSectionName {
   MyApplications = 'My applications',
   ProgramsAndServices = 'Programs and services',
 }
@@ -131,9 +127,9 @@ export enum ApplicationStatusCardGroupName {
  * @private
  * @readonly
  * @enum {string}
- * List of button label text used within different groups of application cards.
+ * List of button label text used within different groups of cards.
  */
-enum ApplicationStatusApplyButtonText {
+enum CardSectionApplyButtonText {
   Edit = 'Edit',
   ViewAndApply = 'View and apply',
 }

--- a/browser-test/src/support/applicant_program_list.ts
+++ b/browser-test/src/support/applicant_program_list.ts
@@ -1,0 +1,139 @@
+import {Page, Locator} from '@playwright/test'
+
+/**
+ * Class for interacting with the applicant program list page
+ * @class
+ * @param {Page} page the Playwright page object in which to operate against
+ */
+export class ApplicantProgramList {
+  public page!: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Get the card group locator for the desired application status card group name
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @returns {Locator} Locator to the card group
+   */
+  getCardGroupLocator(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+  ): Locator {
+    return this.page.getByRole('region', {name: applicationStatusCardGroupName})
+  }
+
+  /**
+   * Get the locator for program card heading in the desired group
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {String} programName to find
+   * @returns {Locator} Locator for program card in the desired group
+   */
+  getCardLocator(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    programName: string,
+  ): Locator {
+    return this.getCardGroupLocator(applicationStatusCardGroupName).getByRole(
+      'listitem',
+      {name: programName},
+    )
+  }
+
+  /**
+   * Get the locator for program card heading in the desired group
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {String} programName to find
+   * @returns {Locator} Locator for program card in the desired group
+   */
+  getCardHeadingLocator(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    programName: string,
+  ): Locator {
+    return this.getCardGroupLocator(applicationStatusCardGroupName).getByRole(
+      'heading',
+      {name: programName},
+    )
+  }
+
+  /**
+   * Clicks the apply button for the specified program within the specified card group
+   *
+   * @async
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @param {String} programName to apply to
+   */
+  async clickApplyButton(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+    programName: string,
+  ): Promise<void> {
+    await this.getCardLocator(applicationStatusCardGroupName, programName)
+      .getByRole('link', {
+        name: this.getCardGroupApplyButtonText(applicationStatusCardGroupName),
+      })
+      .click()
+  }
+
+  /**
+   * @private
+   * Get the label text for the specific card group
+   *
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @returns {String} String of the context specific apply button label text
+   */
+  private getCardGroupApplyButtonText(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+  ): ApplicationStatusApplyButtonText {
+    return applicationStatusCardGroupName ==
+      ApplicationStatusCardGroupName.MyApplications
+      ? ApplicationStatusApplyButtonText.Edit
+      : ApplicationStatusApplyButtonText.ViewAndApply
+  }
+
+  /**
+   * Get the eligibility tag for the desired application status card group name
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @returns {Locator} Locator to the eligible tag
+   */
+  getCardEligibleTagLocator(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+  ): Locator {
+    return this.getCardGroupLocator(applicationStatusCardGroupName).locator(
+      '.cf-eligible-tag',
+    )
+  }
+
+  /**
+   * Get the not eligibility tag for the desired application status card group name
+   * @param {ApplicationStatusCardGroupName} applicationStatusCardGroupName to find
+   * @returns {Locator} Locator to the not eligible tag
+   */
+  getCardNotEligibleTagLocator(
+    applicationStatusCardGroupName: ApplicationStatusCardGroupName,
+  ): Locator {
+    return this.getCardGroupLocator(applicationStatusCardGroupName).locator(
+      '.cf-not-eligible-tag',
+    )
+  }
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ * List of heading names used for different groups of application cards used in this test
+ * suite. This is used in relation to what the user sees on the `/programs` page
+ */
+export enum ApplicationStatusCardGroupName {
+  MyApplications = 'My applications',
+  ProgramsAndServices = 'Programs and services',
+}
+
+/**
+ * @private
+ * @readonly
+ * @enum {string}
+ * List of button label text used within different groups of application cards.
+ */
+enum ApplicationStatusApplyButtonText {
+  Edit = 'Edit',
+  ViewAndApply = 'View and apply',
+}

--- a/browser-test/src/support/civiform_fixtures.ts
+++ b/browser-test/src/support/civiform_fixtures.ts
@@ -15,6 +15,7 @@ import {
 } from '.'
 import {AdminApiKeys} from './admin_api_keys'
 import {AdminProgramMigration} from './admin_program_migration'
+import {ApplicantProgramList} from './applicant_program_list'
 
 type CiviformFixtures = {
   adminApiKeys: AdminApiKeys
@@ -28,6 +29,7 @@ type CiviformFixtures = {
   adminProgramImage: AdminProgramImage
   adminSettings: AdminSettings
   applicantFileQuestion: ApplicantFileQuestion
+  applicantProgramList: ApplicantProgramList
   tiDashboard: TIDashboard
   adminTiGroups: AdminTIGroups
 }
@@ -75,6 +77,10 @@ export const test = base.extend<CiviformFixtures>({
 
   applicantFileQuestion: async ({page}, use) => {
     await use(new ApplicantFileQuestion(page))
+  },
+
+  applicantProgramList: async ({page}, use) => {
+    await use(new ApplicantProgramList(page))
   },
 
   tiDashboard: async ({page}, use) => {


### PR DESCRIPTION
### Description

Adding a new fixture class to represent the applicant program list screen, i.e. `/programs`. Since this is being extracted from my fast forward tests, also update those.

This class is northstar only. I'm not going to label it that way as nothing can/will use it that isn't northstar and it'll just end up being another cleanup task.

I'm calling it a `CardGroup`, that is the container of `Card`s. Calling it CardList seemed like it would imply it's a list type element.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)