### PR TITLE
[North Star] Page scroll to filter results after selecting program filters

### DIFF
--- a/server/app/views/applicant/ProgramFiltersFragment.html
+++ b/server/app/views/applicant/ProgramFiltersFragment.html
@@ -5,6 +5,7 @@
     class="grid-container"
     hx-get="/programs/hx/filter"
     hx-target="#not-started-programs"
+    hx-swap="innerHTML show:top"
   >
     <fieldset class="grid-row grid-gap">
       <legend th:text="#{label.programFilters}"></legend>


### PR DESCRIPTION
### Description

As requested by UX, we are scrolling to program filter results after the "Filter" button is clicked.

### Instructions for manual testing

1. If you haven't done this yet, seed the default categories by going to the Dev Tools and click "Seed programs and categories".
2. Enable the program filtering and North Star flags if you haven't already.
3. Log in as an admin and add a few categories to various programs.
4. Publish your changes.
5. Go to the landing page.
6. Select some category filters and click the "Filter" button.
7. Notice that the page scrolls to the top of the "Programs based on your selections" section.  The scroll position on Chrome seems a bit inconsistent, but positioning is consistent on Firefox.  

### Issue(s) this completes

Fixes #7813 
