### PR TITLE
Stop allowing questions with colliding keys

### DIFF
--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -21,6 +21,7 @@ import javax.inject.Provider;
 import models.QuestionModel;
 import models.QuestionTag;
 import models.VersionModel;
+import services.Path;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
@@ -247,15 +248,10 @@ public final class QuestionRepository {
    * themselves and previous versions, and new versions of an old question will conflict with the
    * old question.
    *
-   * <p>Questions collide if they share a {@link QuestionDefinition#getQuestionPathSegment()} and
-   * {@link QuestionDefinition#getEnumeratorId()}.
+   * <p>Questions collide if they share a name or a {@link QuestionDefinition#getQuestionNameKey()}.
    */
   public Optional<QuestionModel> findConflictingQuestion(QuestionDefinition newQuestionDefinition) {
-    ConflictDetector conflictDetector =
-        new ConflictDetector(
-            newQuestionDefinition.getEnumeratorId(),
-            newQuestionDefinition.getQuestionPathSegment(),
-            newQuestionDefinition.getName());
+    ConflictDetector conflictDetector = new ConflictDetector(newQuestionDefinition);
     database
         .find(QuestionModel.class)
         .setLabel("QuestionModel.findConflict")
@@ -310,15 +306,10 @@ public final class QuestionRepository {
 
   private final class ConflictDetector {
     private Optional<QuestionModel> conflictedQuestion = Optional.empty();
-    private final Optional<Long> enumeratorId;
-    private final String questionPathSegment;
-    private final String questionName;
+    private final QuestionDefinition newQuestionDefinition;
 
-    private ConflictDetector(
-        Optional<Long> enumeratorId, String questionPathSegment, String questionName) {
-      this.enumeratorId = checkNotNull(enumeratorId);
-      this.questionPathSegment = checkNotNull(questionPathSegment);
-      this.questionName = checkNotNull(questionName);
+    private ConflictDetector(QuestionDefinition questionDefinition) {
+      this.newQuestionDefinition = checkNotNull(questionDefinition);
     }
 
     private Optional<QuestionModel> getConflictedQuestion() {
@@ -327,10 +318,12 @@ public final class QuestionRepository {
 
     private boolean hasConflict(QuestionModel question) {
       QuestionDefinition definition = getQuestionDefinition(question);
-      boolean isSameName = definition.getName().equals(questionName);
-      boolean isSameEnumId = definition.getEnumeratorId().equals(enumeratorId);
-      boolean isSamePath = definition.getQuestionPathSegment().equals(questionPathSegment);
-      if (isSameName || (isSameEnumId && isSamePath)) {
+      boolean isSameName = definition.getName().equals(newQuestionDefinition.getName());
+      boolean isSamePath =
+          Path.create(definition.getQuestionNameKey())
+              .equals(Path.create(newQuestionDefinition.getQuestionNameKey()));
+
+      if (isSameName || isSamePath) {
         conflictedQuestion = Optional.of(question);
         return true;
       }

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -19,6 +19,7 @@ import repository.VersionRepository;
 import services.CiviFormError;
 import services.DeletionStatus;
 import services.ErrorAnd;
+import services.Path;
 import services.export.CsvExporterService;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.QuestionNotFoundException;
@@ -333,24 +334,13 @@ public final class QuestionService {
     if (maybeConflict.isPresent()) {
       QuestionModel conflict = maybeConflict.get();
       String errorMessage;
-      if (questionDefinition.getEnumeratorId().isEmpty()) {
-        errorMessage =
-            String.format(
-                "Administrative identifier '%s' generates JSON path '%s' which would conflict with"
-                    + " the existing question with admin ID '%s'",
-                questionDefinition.getName(),
-                questionDefinition.getQuestionPathSegment(),
-                questionRepository.getQuestionDefinition(conflict).getName());
-      } else {
-        errorMessage =
-            String.format(
-                "Administrative identifier '%s' with Enumerator ID %d generates JSON path '%s'"
-                    + " which would conflict with the existing question with admin ID '%s'",
-                questionDefinition.getName(),
-                questionDefinition.getEnumeratorId().get(),
-                questionDefinition.getQuestionPathSegment(),
-                questionRepository.getQuestionDefinition(conflict).getName());
-      }
+      errorMessage =
+          String.format(
+              "Administrative identifier '%s' generates JSON path '%s' which would conflict with"
+                  + " the existing question with admin ID '%s'",
+              questionDefinition.getName(),
+              Path.create(questionDefinition.getQuestionNameKey()).toString(),
+              questionRepository.getQuestionDefinition(conflict).getName());
       return ImmutableSet.of(CiviFormError.of(errorMessage));
     }
     return ImmutableSet.of();

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -95,12 +95,14 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void findConflictingQuestion_sameQuestionPathSegment_hasConflict() throws Exception {
+  public void findConflictingQuestion_sameQuestionNameKey_viaNumbers_hasConflict()
+      throws Exception {
+    // Name is `applicant address`, the generated key is `applicant_address`
     QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
-            .setName("applicant address!")
+            .setName("applicant address1") // key form is `applicant_address`
             .build();
 
     Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
@@ -109,19 +111,35 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void findConflictingQuestion_sameQuestionPathSegmentButDifferentEnumeratorId_ok()
+  public void findConflictingQuestion_sameQuestionNameKey_viaCapitalization_hasConflict()
       throws Exception {
+    // Name is `applicant address`, the generated key is `applicant_address`
     QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
             .clearId()
-            .setName("applicant_address")
-            .setEnumeratorId(Optional.of(1L))
+            .setName("applicant Address") // key form is `applicant_address`
             .build();
 
     Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
 
-    assertThat(maybeConflict).isEmpty();
+    assertThat(maybeConflict).contains(applicantAddress);
+  }
+
+  @Test
+  public void findConflictingQuestion_sameQuestionNameKey_viaPunctuation_hasConflict()
+      throws Exception {
+    // Name is `applicant address`, the generated key is `applicant_address`
+    QuestionModel applicantAddress = testQuestionBank.addressApplicantAddress();
+    QuestionDefinition newQuestionDefinition =
+        new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
+            .clearId()
+            .setName("applicant address!") // key form is `applicant_address`
+            .build();
+
+    Optional<QuestionModel> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+
+    assertThat(maybeConflict).contains(applicantAddress);
   }
 
   @Test

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -15,6 +15,7 @@ import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
+import services.Path;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
@@ -62,11 +63,10 @@ public class QuestionServiceTest extends ResetPostgres {
         .containsOnly(
             CiviFormError.of(
                 String.format(
-                    "Administrative identifier '%s' with Enumerator ID %d generates JSON path '%s'"
+                    "Administrative identifier '%s' generates JSON path '%s'"
                         + " which would conflict with the existing question with admin ID '%s'",
                     questionDefinition.getName(),
-                    householdMemberName.getEnumeratorId().get(),
-                    questionDefinition.getQuestionPathSegment(),
+                    Path.create(questionDefinition.getQuestionPathSegment()),
                     householdMemberName.getName())));
   }
 


### PR DESCRIPTION
### Description

Tightens the question admin name validation to prevent colliding question keys.

Question keys are derived from the question admin name by:
1. Stripping all characters that are not letters or spaces
2. Converting spaces to underscores
3. Keys are then only ever used in a path, which also lowercases them.

This means that the admin names `phone number` and `Phone Number1` both get transformed to `phone_number` when using them in a Path, so they point to the same place in the ApplicantData despite being different questions.

Currently, question admin names with colliding key forms are allowed to be created if:
- They have different casing. Eg `Phone Number` and `phone number`. This is because we compared the questionNameKey before converting it to a Path, which lowercases it.
- One is an enumerator and one is note, because the questionPathSegments are then `phone_number[]` and `phone_number`, respectively. This would could result in a JSON document with the same key pointing to both an array and a scalar.
- They are children of different enumerator questions. While these will never create problems in the document, it is still confusing.

This PR updates the validation to simply check if their names are the same and check if their key forms, as used in a Path, are the same.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


### Instructions for manual testing

Create a question with the admin name `phone number` and another with the admin name `Phone Number`, and notice that the second one throws an error.

### Issue(s) this completes

Part of #9212
