### PR TITLE
Re-enable Azure browser tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,8 @@ jobs:
       - name: Run tests
         run: bin/run-ts-tests
 
+  # Dynamically builds the matrix for the next job. Defaults to only aws. If the
+  # branch name contains azure we'll run against both aws and azure.
   setup-browser-test-matrix:
     runs-on: ubuntu-latest
 
@@ -66,6 +68,9 @@ jobs:
     steps:
       - id: build-matrix
         env:
+          # To get the branch name that we want we have to consider the event type. A PR will
+          # use the head_ref whereas a push event (i.e. pushing an approve pr to main) needs
+          # to look at the ref_name.
           BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
           # Temporarily ignore errors so we can check grep for matches
@@ -86,7 +91,6 @@ jobs:
     needs: setup-browser-test-matrix
     strategy:
       fail-fast: false
-      # Default to only aws. If the branch name contains azure use aws and azure
       matrix: ${{ fromJson(needs.setup-browser-test-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
@@ -139,20 +143,26 @@ jobs:
           CI: true
         run: bin/run-browser-tests-ci --shard=${{ matrix.shard_number }}/${{strategy.job-total}}
 
+      # We'll treat aws as the source of truth for images snapshots. Attempts to run both will
+      # end up with two places trying to update the same images.
       - name: Verify no new image snapshots added
         if: ${{ matrix.cloud == 'aws' }}
         # jest-image-snapshots automatically adds snapshot if it's missing.
         # Use git diff to fail if we detect new images.
         run: git add browser-test/image_snapshots ; git diff --compact-summary --exit-code HEAD
 
+      # Upload image diff files, these are the single image containing the before, after, and diff parts.
+      # We want this for aws and azure so we have access to what happened in failed tests.
       - name: Upload image diff outputs
-        if: ${{ matrix.cloud == 'aws' && failure() }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: image diff output directory (${{ matrix.cloud }}) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
           retention-days: 3
           path: browser-test/diff_output
 
+      # We only want updated snapshots for aws. Otherwise we'll hit conflicts if both aws and azure 
+      # attempt to update the same images
       - name: Upload updated snapshots
         if: ${{ matrix.cloud == 'aws' && failure() }}
         uses: actions/upload-artifact@v4
@@ -161,6 +171,8 @@ jobs:
           retention-days: 3
           path: browser-test/updated_snapshots
 
+      # Upload Playwright trace files and recorded videos. We want this for aws and azure so we 
+      # have access to what happened in failed tests.
       - name: Upload test videos on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,11 +57,37 @@ jobs:
       - name: Run tests
         run: bin/run-ts-tests
 
-  run_browser_tests_aws:
+  setup-browser-test-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+
+    steps:
+      - id: build-matrix
+        env:
+          BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          # Temporarily ignore errors so we can check grep for matches
+          set +e
+          echo "BranchName: ${{ env.BRANCH_NAME }}"
+          echo "${{ env.BRANCH_NAME }}" | grep --quiet --ignore-case "azure"
+          if [[ $? -eq 0 ]]; then
+              matrix='{"cloud": ["aws", "azure"], "shard_number": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}'
+          else
+              matrix='{"cloud": ["aws"], "shard_number": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}'
+          fi
+          # Re-enable error checking
+          set -e
+          echo "matrix=${matrix}"
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+
+  run_browser_tests:
+    needs: setup-browser-test-matrix
     strategy:
       fail-fast: false
-      matrix:
-        shard_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      # Default to only aws. If the branch name contains azure use aws and azure
+      matrix: ${{ fromJson(needs.setup-browser-test-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - name: check out ${{ env.GITHUB_REF }}
@@ -103,109 +129,48 @@ jobs:
           DOCKER_HUB_USERNAME: civiform
         run: bin/build-mock-web-services
 
-      - name: Bring up test env with Localstack
+      - name: Bring up test env with ${{ matrix.cloud }}
         env:
           CI: true
-        run: bin/run-browser-test-env --aws --ci
+        run: bin/run-browser-test-env --${{ matrix.cloud }} --ci
 
-      - name: Run browser tests with Localstack
+      - name: Run browser tests with ${{ matrix.cloud }}
         env:
           CI: true
         run: bin/run-browser-tests-ci --shard=${{ matrix.shard_number }}/${{strategy.job-total}}
 
       - name: Verify no new image snapshots added
+        if: ${{ matrix.cloud == 'aws' }}
         # jest-image-snapshots automatically adds snapshot if it's missing.
         # Use git diff to fail if we detect new images.
         run: git add browser-test/image_snapshots ; git diff --compact-summary --exit-code HEAD
 
       - name: Upload image diff outputs
+        if: ${{ matrix.cloud == 'aws' && failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: image diff output directory (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          name: image diff output directory (${{ matrix.cloud }}) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
           retention-days: 3
           path: browser-test/diff_output
-        if: failure()
 
       - name: Upload updated snapshots
+        if: ${{ matrix.cloud == 'aws' && failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: updated snapshots output directory (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          name: updated snapshots output directory (${{ matrix.cloud }}) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
           retention-days: 3
           path: browser-test/updated_snapshots
-        if: failure()
 
       - name: Upload test videos on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: tests videos (aws) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
+          name: tests videos (${{ matrix.cloud }}) - shard-${{ matrix.shard_number }}-run-${{ github.run_attempt }}
           retention-days: 3
           path: |
             browser-test/tmp/html-output/
             browser-test/tmp/videos/
-        if: failure()
-        
-      - name: Print logs on failure
-        if: failure()
-        run: cat .dockerlogs
 
-  run_browser_tests_azure:
-    if: false
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - name: check out ${{ env.GITHUB_REF }}
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build test app container
-        env:
-          DOCKER_BUILDKIT: 1
-        run: bin/build-dev
-      - name: Build browser testing container
-        env:
-          DOCKER_BUILDKIT: 1
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
-        run: bin/build-browser-tests
-      - name: Build dev-oidc
-        env:
-          DOCKER_BUILDKIT: 1
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
-        run: bin/build-dev-oidc
-      - name: Build localstack
-        env:
-          DOCKER_BUILDKIT: 1
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
-        run: bin/build-localstack-env
-      - name: Build mock-web-services
-        env:
-          DOCKER_BUILDKIT: 1
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: civiform
-        run: bin/build-mock-web-services
-      - name: Bring up test env with Azurite
-        env:
-          CI: true
-        run: bin/run-browser-test-env --azure --ci
-      - name: Run browser tests with Azurite
-        env:
-          CI: true
-        run: bin/run-browser-tests-azure
-      - name: Upload image diff outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: image diff output directory (azure) - run-${{ github.run_attempt }}
-          path: browser-test/diff_output
-        if: failure()
-      - name: Upload test videos on failure
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests videos (azure) - run-${{ github.run_attempt }}
-          path: browser-test/tmp
-        if: failure()
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs
@@ -235,3 +200,4 @@ jobs:
       - name: Print logs on failure
         if: failure()
         run: docker compose logs
+

--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -29,7 +29,9 @@ jobs:
     steps:
       - id: build-matrix
         env:
-          # Need to access the branch name differently between 
+          # To get the branch name that we want we have to consider the event type. A PR will
+          # use the head_ref whereas a push event (i.e. pushing an approve pr to main) needs
+          # to look at the ref_name.          
           BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
           # Temporarily ignore errors so we can check grep for matches

--- a/.github/workflows/tests_skip.yaml
+++ b/.github/workflows/tests_skip.yaml
@@ -20,16 +20,37 @@ jobs:
     steps:
       - run: 'echo "skipping"'
 
-  run_browser_tests_aws:
-    strategy:
-      matrix:
-        shard_number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  setup-browser-test-matrix:
     runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "skipping"'
 
-  run_browser_tests_azure:
-    if: false
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+
+    steps:
+      - id: build-matrix
+        env:
+          # Need to access the branch name differently between 
+          BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          # Temporarily ignore errors so we can check grep for matches
+          set +e
+          echo "BranchName: ${{ env.BRANCH_NAME }}"
+          echo "${{ env.BRANCH_NAME }}" | grep --quiet --ignore-case "azure"
+          if [[ $? -eq 0 ]]; then
+              matrix='{"cloud": ["aws", "azure"], "shard_number": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}'
+          else
+              matrix='{"cloud": ["aws"], "shard_number": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}'
+          fi
+          # Re-enable error checking
+          set -e
+          echo "matrix=${matrix}"
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+
+  run_browser_tests:
+    needs: setup-browser-test-matrix
+    strategy:
+      # Default to only aws. If the branch name contains azure use aws and azure
+      matrix: ${{ fromJson(needs.setup-browser-test-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'
@@ -43,3 +64,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "skipping"'
+

--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -4,7 +4,11 @@ import {BASE_URL} from './src/support/config'
 // For details see: https://playwright.dev/docs/api/class-testconfig
 
 export default defineConfig({
-  timeout: 90000,
+  // 45s was too small when run against the staging site. Trying to lower
+  // this a little bit again to find a middle ground. We could eventually
+  // make the timeout an environment variable so we can have a longer
+  // timeout for staging.
+  timeout: 80000, // 80s
   testDir: './src',
   // Exit with error immediately if test.only() or test.describe.only()
   // was committed
@@ -13,7 +17,11 @@ export default defineConfig({
   globalSetup: './src/setup/global-setup.ts',
   fullyParallel: false,
   workers: 1,
-  retries: process.env.CI === 'true' ? 1 : 0,
+  // For us, having retries enabled does not appear to have been particularly
+  // beneficial. Instead it makes failues end up taking 2 * timeout. As long
+  // as retain-on-failure used below works correctly we're probably fine not
+  // retrying.
+  retries: 0,
   outputDir: './tmp/test-output',
   expect: {
     toHaveScreenshot: {
@@ -25,8 +33,10 @@ export default defineConfig({
     },
   },
   use: {
-    trace: process.env.CI === 'true' ? 'on-first-retry' : 'on',
-    video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',
+    // retain-on-failure should remove trace and video files when a test succeeds allowing
+    // for minimizing cloud storage needs.
+    trace: process.env.CI === 'true' ? 'retain-on-failure' : 'on',
+    video: process.env.RECORD_VIDEO === 'true' ? 'retain-on-failure' : 'off',
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'
   },


### PR DESCRIPTION
### Description

Removes the disabled Azure job. Makes the AWS job generic. Dynamically builds the strategy matrix used to generate the browser test shards. Normal operation will remain running with localstack/aws. 

If your branch has `azure` in the name if will run 10 shards of the browser tests for AWS and 10 for Azure. This is done as a temporary measure to allow for CI to run Azure tests, but also to not block the rest of development.

All tests will be run now, and certain to fail at first. Once we get all the tests running we can remove the branch naming check and run them all the time.

#### Branch protection

I will have to re-jigger the requirements in the branch protection rules as the new name of the jobs are different.

#### Playwright config

I made some adjustments to the Playwright config. It should still only upload traces for failed tests, not passed ones. But instead of recording on retry we record the first try. This is to allow nixing the retry count which doesn't seem to have been all the helpful. Also trying to lower the 90 second time again. 45s is known to be too small, lets try 80s.

If it doesn't work right I'll have to add some environment variables to override some settings at runtime. Otherwise the Azure tests, which fail, take two hours to run for each shard due to the amount of failures. The coming no-op AzurePublicStorage class will probably help a sizable number of tests to pass.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
