### PR TITLE
issue-9031 Update aria role as status on success message on confirmation page

### DIFF
--- a/server/app/views/applicant/ApplicantUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantUpsellTemplate.html
@@ -20,7 +20,7 @@
 
             <section class="section-external">
               <div
-                th:replace="~{components/AlertFragment :: alert(alertSettings=${successAlertSettings}, headingLevel='H2')}"
+                th:replace="~{components/AlertFragment :: alert(alertSettings=${successAlertSettings}, headingLevel='H2', role='status')}"
               ></div>
             </section>
 

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -3,7 +3,7 @@
   th:if="${alertSettings.title.isPresent()}"
   th:class="${'usa-alert usa-alert--' + alertSettings.alertType.name().toLowerCase()}"
   aria-live="polite"
-  role="alert"
+  th:attr="role=${role != null ? role : 'alert'}"
 >
   <div class="usa-alert__body">
     <h2


### PR DESCRIPTION
…ion page

### Description

pass in appropriate aria role attribute value to AlertFragment 


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [N/A] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [N/A] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

no database changes

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

N/A

#### User visible changes

- [N/A] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [N/A] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [N/A] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ran applicant/northstar_upsell.test.ts] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [N/A ] Manually tested at 200% size
- [N/A ] Manually evaluated tab order
- [N/A] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

N/A

### Instructions for manual testing

submit any application, use browser developer tool to verify the aria role attribute of the "You've submitted your ...." alert message is  set to role="status"

### Issue(s) this completes

Fixes #9031
